### PR TITLE
NAS-107309 / 12.0 / Add ZSTD and ZSTD-FAST to WebUI (by Ornias1993)

### DIFF
--- a/src/app/pages/storage/volumes/datasets/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-form/dataset-form.component.ts
@@ -170,6 +170,10 @@ export class DatasetFormComponent implements Formconfiguration{
         options: [
           { label: 'off', value: 'OFF' },
           { label: 'lz4 (recommended)', value: 'LZ4' ,},
+          { label: 'zstd (default level, 3)', value: 'ZSTD' },
+          { label: 'zstd (Medium, slow)', value: 'ZSTD-5' },
+          { label: 'zstd (Maximum, very slow)', value: 'ZSTD-7' },
+          { label: 'zstd-fast (default level, 1)', value: 'ZSTD-FAST' },
           { label: 'gzip (fastest)', value: 'GZIP-1' },
           { label: 'gzip (default level, 6)', value: 'GZIP' },
           { label: 'gzip (maximum, slow)', value: 'GZIP-9' },

--- a/src/app/pages/storage/volumes/zvol/zvol-form/zvol-form.component.ts
+++ b/src/app/pages/storage/volumes/zvol/zvol-form/zvol-form.component.ts
@@ -178,6 +178,10 @@ export class ZvolFormComponent {
       options: [
         {label : T('Off'), value : "OFF"},
         {label : T('lz4 (recommended)'), value : "LZ4"},
+        {label : T('zstd (default level, 3)'), value : "ZSTD" },
+        {label : T('zstd (Medium, slow)'), value : "ZSTD-5" },
+        {label : T('zstd (Maximum, very slow)'), value : "ZSTD-7" },
+        {label : T('zstd-fast (default level, 1)'), value : "ZSTD-FAST" },
         {label : T('gzip (default level, 6)'), value : "GZIP"},
         {label : T('gzip (fastest)'), value : "GZIP-1"},
         {label : T('gzip (maximum, slow)'), value : "GZIP-9"},


### PR DESCRIPTION
Openzfs2.0 adds ZSTD and ZSTD-fast compression.
See: openzfs/zfs/pull/10278

This commit adds the following compression values to be accepted by the pool middleware:
- ZSTD
- ZSTD-5
- ZSTD-7
- ZSTD-FAST

These levels give an acceptable and balanced spread of both compression ratio and performance.
(see graphs in openzfs/zfs/pull/10278 )

Notes:
- **Requires an update to OpenZFS before being able to be used**
- Might also want to backport to 12U1 or even 12RC1
- Related middleware changes are also required, see: freenas/freenas/pull/5517

Signed-off-by: Kjeld Schouten-Lebbing <kjeld@schouten-lebbing.nl>

Original PR: https://github.com/freenas/webui/pull/4559