### PR TITLE
NAS-109667 / 21.04 / Rename "ACME DNS Authenticators"

### DIFF
--- a/src/app/pages/credentials/certificates-dash/certificates-dash.component.ts
+++ b/src/app/pages/credentials/certificates-dash/certificates-dash.component.ts
@@ -154,7 +154,7 @@ export class CertificatesDashComponent implements OnInit, OnDestroy {
       {
         name: 'acme-dns',
         tableConf: {
-          title: T('ACME DNS Authenticators'),
+          title: T('ACME DNS-Authenticators'),
           queryCall: 'acme.dns.authenticator.query',
           deleteCall: 'acme.dns.authenticator.delete',
           complex: false,


### PR DESCRIPTION
This PR renames `ACME DNS Authenticators` to `ACME DNS-Authenticators`.

To put more emphasis on the fact it's a list of "DNS-Authenticators", not "ACMEdns Authenticators" (which is also commonly writhen as "ACME-DNS authenticators")