### PR TITLE
NAS-109975 / 21.04 / Cleanup the Domain_list when doing ACME creation

### DIFF
--- a/src/app/pages/credentials/certificates-dash/forms/certificate-acme-add.component.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/certificate-acme-add.component.ts
@@ -95,18 +95,13 @@ export class CertificateAcmeAddComponent {
           name: 'domains',
           placeholder: '',
           hideButton: true,
+          width: '100%',
           templateListField: [
-            {
-              type: 'paragraph',
-              name: 'vert_spacer',
-              paraText: '',
-              width: '5%'
-            },
             {
               type: 'paragraph',
               name: 'name_text',
               paraText: '',
-              width: '25%',
+              width: '100%',
             },
             {
               type: 'select',
@@ -188,7 +183,7 @@ export class CertificateAcmeAddComponent {
             const name_text_fc = _.find(controls, {name: 'name_text'});
             const auth_fc = _.find(controls, {name: 'authenticators'});
             this.domainList.controls[i].controls['name_text'].setValue(domains[i]);
-            name_text_fc.paraText = domains[i];
+            name_text_fc.paraText = "<b>"+domains[i]+"</b>";
             auth_fc.options = this.dns_map.options;
           }
         }


### PR DESCRIPTION
Currently the ACME creation modal looks like this:

![image](https://user-images.githubusercontent.com/7613738/113135221-28717680-9222-11eb-935a-b889ccb21dcd.png)

This is obviously not acceptable.

This PR changes it to look like this instead:

![image](https://user-images.githubusercontent.com/7613738/113135296-417a2780-9222-11eb-9550-6ca84777f238.png)


It's a relatively simple fix with no expected side effects.