### PR TITLE
NAS-109847 / 21.04 / Cannot create docker containers without some fields / NAS-109847

### DIFF
--- a/src/app/pages/applications/forms/chart-release-add.component.ts
+++ b/src/app/pages/applications/forms/chart-release-add.component.ts
@@ -425,7 +425,7 @@ export class ChartReleaseAddComponent implements OnDestroy {
     }
 
     let ext_interfaces = [];
-    if (data.externalInterfaces[0].hostInterface) {
+    if (data.externalInterfaces && data.externalInterfaces.length > 0 && data.externalInterfaces[0].hostInterface) {
       data.externalInterfaces.forEach(i => {
         if (i.ipam !== 'static') {
           ext_interfaces.push(


### PR DESCRIPTION
externalInterfaces can now be left out of the form when adding (i.e. no empty external interface needs to be given when it is not needed).