### PR TITLE
fix German 'State' translation

### DIFF
--- a/src/assets/i18n/de.po
+++ b/src/assets/i18n/de.po
@@ -13520,7 +13520,7 @@ msgid "Starting job..."
 msgstr "Starte Auftrag..."
 
 msgid "State"
-msgstr "Zustand"
+msgstr "Region"
 
 msgid "State: "
 msgstr ""


### PR DESCRIPTION
The word "State" is used in the context of a location of an organization in the CA and Certificate creation wizard. "State" can be translated into multiple words in German.
- "Zustand" refers to a state of something
- "Region" refers to a location