### PR TITLE
Removed extra dot

### DIFF
--- a/src/app/helptext/about.ts
+++ b/src/app/helptext/about.ts
@@ -17,7 +17,7 @@ export default {
   contactA: T('Does your business need'),
   contactB: T('Enterprise level'),
   contactC: T('support and services? Contact'),
-  contactD: T('iXsystems for more information.'),
+  contactD: T('iXsystems for more information'),
 
   opensourceA: T('is Free and'),
   opensourceB: T('Open Source'),


### PR DESCRIPTION
I removed the dot which was causing the final About window to have two dots on the end of the sentence: "Does your business need Enterprise level support and services? Contact iXsystems for more information.."