### PR TITLE
[Apps] Change default catalog branch to main

### DIFF
--- a/src/app/pages/applications/forms/catalog-add-form.component.ts
+++ b/src/app/pages/applications/forms/catalog-add-form.component.ts
@@ -59,7 +59,7 @@ export class CatalogAddFormComponent implements FormConfiguration {
           name: 'branch',
           placeholder: helptext.catalogForm.branch.placeholder,
           tooltip: helptext.catalogForm.branch.tooltip,
-          value: 'master',
+          value: 'main',
         },
       ],
     },


### PR DESCRIPTION
"main" is the current default for github, as people make more community catalogs, it's likely most are made on github.

Note:
Someone confirmed thats also the default for gitlab.