### PR TITLE
NAS-110603 / 12.0 / Fix identify button and enclosure selector issues

### DIFF
--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
@@ -230,7 +230,7 @@
             <disk-ui [data]="selectedDisk"></disk-ui><!-- disk icon + labels -->
             <div class="capacity">{{converter(selectedDisk.size)}}</div>
             <div class="disk-actions">
-              <button *ngIf="isIdentifiable === true" id="identify-btn" mat-button color="primary" (click)="toggleSlotStatus()">Identify Drive</button>
+              <button *ngIf="isIdentifiable" id="identify-btn" mat-button color="primary" (click)="toggleSlotStatus()">Identify Drive</button>
             </div>
           </div>
   

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
@@ -230,7 +230,7 @@
             <disk-ui [data]="selectedDisk"></disk-ui><!-- disk icon + labels -->
             <div class="capacity">{{converter(selectedDisk.size)}}</div>
             <div class="disk-actions">
-              <button id="identify-btn" mat-button color="primary" (click)="toggleSlotStatus()">Identify Drive</button>
+              <button *ngIf="isIdentifiable === true" id="identify-btn" mat-button color="primary" (click)="toggleSlotStatus()">Identify Drive</button>
             </div>
           </div>
   

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
@@ -121,6 +121,16 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
     return Object.keys(selectedEnclosure.poolKeys);
   }
 
+  private _isIdentifiable = true;
+  get isIdentifiable() {
+    if (this.view == 'rear') {
+      const index: number = this.system.rearIndex ? this.system.rearIndex : this.selectedEnclosure.enclosureKey;
+      const result: boolean = this.system.enclosures[index].elements[0].has_slot_status;
+      return result;
+    }
+    return this._isIdentifiable;
+  }
+
   selectedVdevDisks: string[];
   selectedDisk: any;
 

--- a/src/app/pages/system/viewenclosure/view-enclosure.component.html
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.html
@@ -44,7 +44,7 @@
   </div>
   
   <!-- Enclosure Selector -->
-  <div fxFlex="240px" fxFlex.lt-lg="180px" #navigation  *ngIf="events && system && system.pools && system.enclosures && system.enclosures.length > 1 && supportedHardware" class="enclosure-selector" [ngClass.lt-lg]="lt-lg">
+  <div fxFlex="240px" fxFlex.lt-lg="180px" #navigation  *ngIf="showEnclosureSelector" class="enclosure-selector" [ngClass.lt-lg]="lt-lg">
     <ng-container *ngFor="let enclosure of system.profile; let i = index">
       <div *ngIf="enclosure.enclosureKey != system.rearIndex" (click)="selectEnclosure(i)" class="enclosure enclosure-{{i}} {{selectedEnclosure.enclosureKey == i ? 'active' : '' }} ">
         <div *ngIf="system.enclosures[enclosure.enclosureKey].label == system.enclosures[enclosure.enclosureKey].name">{{enclosure.model}} ({{i}})</div>

--- a/src/app/pages/system/viewenclosure/view-enclosure.component.ts
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.ts
@@ -46,6 +46,20 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
   spinner = true;
 
   supportedHardware = false;
+
+  get showEnclosureSelector(): boolean {
+    if (!this.system || !this.events || !this.system.pools || !this.system.enclosures || this.supportedHardware !== true) return false;
+
+    // These conditions are here because M series actually reports a separate chassis for
+    // the rear bays. SystemProfiler will store a rearIndex value for those machines.
+    if (this.system && this.system.rearIndex && this.system.profile.length > 2) {
+      return true;
+    } if (this.system && !this.system.rearIndex && this.system.profile.length > 1) {
+      return true;
+    }
+    return false;
+  }
+
   system_manufacturer: string;
   private _system_product;
   get system_product() {


### PR DESCRIPTION
- Use enclosure.query's has_slot_status to determine if rear bays are identifiable.
- Enclosure Selector UI should only be visible if there are actually multiple enclosures. I noticed it was showing on M Series due to M series reporting rear bays as a separate chassis. This is now fixed