### PR TITLE
NAS-110459 / 21.06 / NAS-110459: Fixing DNS Authenticator form in some scenarios

### DIFF
--- a/src/app/enums/dns-authenticator-type.enum.ts
+++ b/src/app/enums/dns-authenticator-type.enum.ts
@@ -1,0 +1,4 @@
+export enum DnsAuthenticatorType {
+  Route53 = 'route53',
+  Cloudflare = 'cloudflare',
+}

--- a/src/app/enums/schema.enum.ts
+++ b/src/app/enums/schema.enum.ts
@@ -1,0 +1,4 @@
+export enum SchemaType {
+  String = 'string',
+  Null = 'null',
+}

--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -5,6 +5,11 @@ import { Acl } from 'app/interfaces/acl.interface';
 import { PullContainerImageParams } from 'app/interfaces/container-image.interface';
 import { Catalog } from 'app/interfaces/catalog.interface';
 import { Dataset, ExtraDatasetQueryOptions } from 'app/interfaces/dataset.interface';
+import {
+  AuthenticatorSchema,
+  CreateDnsAuthenticator,
+  DnsAuthenticator, UpdateDnsAuthenticator,
+} from 'app/interfaces/dns-authenticator.interface';
 import { FileSystemStat } from 'app/interfaces/filesystem-stat.interface';
 import {
   IscsiAuthAccess, IscsiExtent,
@@ -37,10 +42,10 @@ export type ApiDirectory = {
   'afp.config': { params: any; response: any };
 
   // Acme
-  'acme.dns.authenticator.query': { params: any; response: any };
-  'acme.dns.authenticator.create': { params: any; response: any };
-  'acme.dns.authenticator.update': { params: any; response: any };
-  'acme.dns.authenticator.authenticator_schemas': { params: any; response: any };
+  'acme.dns.authenticator.query': { params: void; response: DnsAuthenticator[] };
+  'acme.dns.authenticator.create': { params: CreateDnsAuthenticator; response: DnsAuthenticator };
+  'acme.dns.authenticator.update': { params: [number, UpdateDnsAuthenticator]; response: DnsAuthenticator };
+  'acme.dns.authenticator.authenticator_schemas': { params: void; response: AuthenticatorSchema[] };
 
   // Alert
   'alert.list': { params: any; response: any };

--- a/src/app/interfaces/dns-authenticator.interface.ts
+++ b/src/app/interfaces/dns-authenticator.interface.ts
@@ -1,0 +1,36 @@
+import { DnsAuthenticatorType } from 'app/enums/dns-authenticator-type.enum';
+import { Schema } from 'app/interfaces/schema.interface';
+
+export type DnsAuthenticator = CloudflareDnsAuthenticator | Route53DnsAuthenticator;
+
+export interface CloudflareDnsAuthenticator {
+  id: number;
+  name: string;
+  authenticator: DnsAuthenticatorType.Cloudflare;
+  attributes: {
+    // Either
+    api_token?: string;
+
+    // Or
+    cloudflare_email?: string;
+    api_key?: string;
+  };
+}
+
+export interface Route53DnsAuthenticator {
+  id: number;
+  name: string;
+  authenticator: DnsAuthenticatorType.Route53;
+  attributes: {
+    access_key_id: string;
+    secret_access_key: string;
+  };
+}
+
+export interface AuthenticatorSchema {
+  key: DnsAuthenticatorType;
+  schema: Schema[];
+}
+
+export type CreateDnsAuthenticator = Omit<DnsAuthenticator, 'id'>;
+export type UpdateDnsAuthenticator = Omit<DnsAuthenticator, 'id' | 'authenticator'>;

--- a/src/app/interfaces/schema.interface.ts
+++ b/src/app/interfaces/schema.interface.ts
@@ -1,0 +1,8 @@
+import { SchemaType } from 'app/enums/schema.enum';
+
+export interface Schema {
+  title: string;
+  type: SchemaType | SchemaType[];
+  _name_: string;
+  _required_: boolean;
+}

--- a/src/app/pages/credentials/certificates-dash/certificates-dash.component.ts
+++ b/src/app/pages/credentials/certificates-dash/certificates-dash.component.ts
@@ -190,7 +190,6 @@ export class CertificatesDashComponent implements OnInit, OnDestroy {
           },
         },
       },
-
     ];
   }
 

--- a/src/app/pages/credentials/certificates-dash/forms/certificate-acme-add.component.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/certificate-acme-add.component.ts
@@ -139,7 +139,7 @@ export class CertificateAcmeAddComponent implements FormConfiguration {
   }
 
   preInit(entityForm: EntityFormComponent): void {
-    this.ws.call('acme.dns.authenticator.query').subscribe((authenticators: any[]) => {
+    this.ws.call('acme.dns.authenticator.query').subscribe((authenticators) => {
       this.dns_map = _.find(this.fieldSets[2].config[0].templateListField, { name: 'authenticators' });
       authenticators.forEach((item) => {
         this.dns_map.options.push({ label: item.name, value: item.id });


### PR DESCRIPTION
How to test:
Credentials -> Certificates -> ACME DNS-Authenticators
When cloudflare is selected, either 'email' + 'API key' or 'API token' need to be added, but not both.
There was a bug when user touched email field, but then cleaned it, and actually filled in API token.
Plus, would be good to do general regression testing on the form.