### PR TITLE
NAS-110917 / None / Fix [object Object] in dropdown menu

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.ts
+++ b/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.ts
@@ -56,7 +56,7 @@ export class FormSelectComponent implements Field, AfterViewInit, AfterViewCheck
   ngAfterViewInit(): void {
     // Change the value of null to 'null_value' string
     this.config.options = this.config.options.map((option) => {
-      if (!option.value) option = { label: option, value: option };
+      if (!option.hasOwnProperty('value')) option = { label: option, value: option };
 
       option.value = this.entityUtils.changeNull2String(option.value);
 


### PR DESCRIPTION
Fix for `[object Object]` in form-select component.

How to test it?
- Go to Credentials -> Local Users -> Edit user and check "Disable Password" menu items.
- Go to Data Protection -> Add Replication Task  -> Check "Load Previous Replication Task" menu items