### PR TITLE
NAS-110960 / None / NAS-110960 - Fixing CPU Model dropdown

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.ts
+++ b/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.ts
@@ -56,7 +56,7 @@ export class FormSelectComponent implements Field, AfterViewInit, AfterViewCheck
   ngAfterViewInit(): void {
     // Change the value of null to 'null_value' string
     this.config.options = this.config.options.map((option) => {
-      if (!option.value) option = { label: option, value: option };
+      if (!option.hasOwnProperty('value')) option = { label: option, value: option };
 
       option.value = this.entityUtils.changeNull2String(option.value);
 

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -1,7 +1,9 @@
 import { Component } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { DatasetType } from 'app/enums/dataset-type.enum';
-import { VmBootloader, VmDeviceType, VmTime } from 'app/enums/vm.enum';
+import {
+  VmBootloader, VmCpuMode, VmDeviceType, VmTime,
+} from 'app/enums/vm.enum';
 import { ProductType } from '../../../enums/product-type.enum';
 import {
   RestService, WebSocketService, NetworkService, StorageService, SystemGeneralService,
@@ -52,7 +54,7 @@ export class VMWizardComponent {
   vcpus = 1;
   cores = 1;
   threads = 1;
-  mode: string;
+  mode: VmCpuMode;
   model: string | null;
   private currentStep = 0;
   title = helptext.formTitle;
@@ -222,6 +224,17 @@ export class VMWizardComponent {
           ],
           value: '',
           isHidden: true,
+          relation: [
+            {
+              action: 'SHOW',
+              when: [
+                {
+                  name: 'cpu_mode',
+                  value: VmCpuMode.Custom,
+                },
+              ],
+            },
+          ],
         },
         {
           type: 'input',
@@ -616,6 +629,10 @@ export class VMWizardComponent {
         this.getFormControlFromFieldName('cpu_mode').valueChanges.subscribe((mode) => {
           this.mode = mode;
           this.summary[T('CPU Mode')] = mode;
+
+          if (mode !== VmCpuMode.Custom) {
+            delete this.summary[T('CPU Model')];
+          }
         });
         this.getFormControlFromFieldName('cpu_model').valueChanges.subscribe((model) => {
           this.model = model;
@@ -975,7 +992,7 @@ export class VMWizardComponent {
 
     if (this.productType.includes(ProductType.Scale)) {
       vmPayload['cpu_mode'] = value.cpu_mode;
-      vmPayload['cpu_model'] = value.cpu_model === '' ? null : value.cpu_model;
+      vmPayload['cpu_model'] = (value.cpu_model === '' || value.cpu_mode !== VmCpuMode.Custom) ? null : value.cpu_model;
     }
 
     vmPayload['memory'] = value.memory;


### PR DESCRIPTION
Testing:
- Make sure that when creating a VM there is no "[Object object]" in CPU Model dropdown.
- Make sure that CPU Model is only shown when CPU Mode = Custom.