### PR TITLE
NAS-110981 / 21.08 / Fix text alignment on volume list

### DIFF
--- a/src/app/pages/common/entity/entity-form/entity-form.component.scss
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.scss
@@ -44,7 +44,7 @@
 
 /* Imported from embedded */
 /* Embedded Form Styles */
-.mat-content {
+:host .mat-content {
   height: 100%;
   overflow: visible;
   padding: 0;


### PR DESCRIPTION
[Original PR](https://github.com/truenas/webui/pull/5557) was based on `release/21.06-BETA.1` branch. This one is on top of `master` branch.

> The problem is entity-form adds global styles when opening a wizard. It affects .mat-content class in the volume list so that styles should be isolated into components.
> 
> How to test?
> * Open the Storage page, click the Import button, and then check the volume header it shouldn't be sticky to the top.
> * Please check the video in JIRA ticket