### PR TITLE
NAS-105663 / 12.0 / The dataset will be expanded after coming back from 'Edit Options' or 'Edit Permission' pages

### DIFF
--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -405,6 +405,9 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
   }
 
   goBack() {
+    if (this.conf.goBack) {
+      return this.conf.goBack();
+    }
     let route = this.conf.route_cancel;
     if (!route) {
       route = this.conf.route_success;

--- a/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-acl/dataset-acl.component.ts
@@ -6,7 +6,7 @@ import { TranslateService } from '@ngx-translate/core';
 import {
   FormGroup,
 } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, NavigationExtras, Router } from '@angular/router';
 import * as _ from 'lodash';
 import { Subscription } from 'rxjs';
 
@@ -806,9 +806,10 @@ export class DatasetAclComponent implements OnDestroy {
     this.dialogRef.componentInstance.success.subscribe((res) => {
       this.entityForm.success = true;
       this.dialogRef.close();
+      const navigationExtras: NavigationExtras = { state: { highlightDataset: this.datasetId } };
       this.router.navigate(new Array('/').concat(
         this.route_success,
-      ));
+      ), navigationExtras);
     });
     this.dialogRef.componentInstance.failure.subscribe((res) => {
     });
@@ -868,9 +869,10 @@ export class DatasetAclComponent implements OnDestroy {
         this.dialogRef.componentInstance.success.subscribe((res) => {
           this.entityForm.success = true;
           this.dialogRef.close();
+          const navigationExtras: NavigationExtras = { state: { highlightDataset: this.datasetId } };
           this.router.navigate(new Array('/').concat(
             this.route_success,
-          ));
+          ), navigationExtras);
         });
         this.dialogRef.componentInstance.failure.subscribe((err) => {
           new EntityUtils().handleWSError(this.entityForm, err);
@@ -878,5 +880,10 @@ export class DatasetAclComponent implements OnDestroy {
       },
     };
     this.dialogService.dialogFormWide(conf);
+  }
+
+  goBack() {
+    const navigationExtras: NavigationExtras = { state: { highlightDataset: this.datasetId } };
+    this.router.navigate(new Array('/').concat(this.route_success), navigationExtras);
   }
 }

--- a/src/app/pages/storage/volumes/datasets/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-form/dataset-form.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, NavigationExtras, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 import * as _ from 'lodash';
@@ -1567,6 +1567,7 @@ export class DatasetFormComponent implements Formconfiguration {
       this.loader.close();
       const parentPath = `/mnt/${this.parent}`;
       this.ws.call('filesystem.acl_is_trivial', [parentPath]).subscribe((res) => {
+        const navigationExtras: NavigationExtras = { state: { highlightDataset: this.pk } };
         if (res === false) {
           this.dialogService.confirm(helptext.afterSubmitDialog.title,
             helptext.afterSubmitDialog.message, true, helptext.afterSubmitDialog.actionBtn, false, '', '', '', '',
@@ -1578,13 +1579,13 @@ export class DatasetFormComponent implements Formconfiguration {
             } else {
               this.router.navigate(new Array('/').concat(
                 this.route_success,
-              ));
+              ), navigationExtras);
             }
           });
         } else {
           this.router.navigate(new Array('/').concat(
             this.route_success,
-          ));
+          ), navigationExtras);
         }
       });
     }, (res) => {
@@ -1594,6 +1595,7 @@ export class DatasetFormComponent implements Formconfiguration {
   }
 
   goBack() {
-    this.router.navigate(new Array('/').concat(this.route_success));
+    const navigationExtras: NavigationExtras = { state: { highlightDataset: this.pk } };
+    this.router.navigate(new Array('/').concat(this.route_success), navigationExtras);
   }
 }

--- a/src/app/pages/storage/volumes/datasets/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-form/dataset-form.component.ts
@@ -1592,4 +1592,8 @@ export class DatasetFormComponent implements Formconfiguration {
       new EntityUtils().handleWSError(this.entityForm, res);
     });
   }
+
+  goBack() {
+    this.router.navigate(new Array('/').concat(this.route_success));
+  }
 }

--- a/src/app/pages/storage/volumes/datasets/dataset-permissions/dataset-permissions.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-permissions/dataset-permissions.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, NavigationExtras, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
 import { FieldSet } from 'app/pages/common/entity/entity-form/models/fieldset.interface';
@@ -260,6 +260,8 @@ export class DatasetPermissionsComponent implements OnDestroy {
   }
 
   customSubmit(data) {
+    const navigationExtras: NavigationExtras = { state: { highlightDataset: this.datasetId } };
+
     this.dialogRef = this.mdDialog.open(EntityJobComponent, { data: { title: T('Saving Permissions') } });
     this.dialogRef.componentInstance.setDescription(T('Saving Permissions...'));
     this.dialogRef.componentInstance.setCall(this.updateCall, [this.datasetId, data]);
@@ -269,10 +271,15 @@ export class DatasetPermissionsComponent implements OnDestroy {
       this.dialogRef.close();
       this.router.navigate(new Array('/').concat(
         this.route_success,
-      ));
+      ), navigationExtras);
     });
     this.dialogRef.componentInstance.failure.subscribe((err) => {
       console.error(err);
     });
+  }
+
+  goBack() {
+    const navigationExtras: NavigationExtras = { state: { highlightDataset: this.datasetId } };
+    this.router.navigate(new Array('/').concat(this.route_success), navigationExtras);
   }
 }

--- a/src/app/pages/storage/volumes/zvol/zvol-form/zvol-form.component.ts
+++ b/src/app/pages/storage/volumes/zvol/zvol-form/zvol-form.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Validators, ValidationErrors, FormControl } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, NavigationExtras, Router } from '@angular/router';
 import { Subscription, combineLatest } from 'rxjs';
 import * as _ from 'lodash';
 
@@ -877,13 +877,13 @@ export class ZvolFormComponent implements Formconfiguration {
       if (res[0].volsize.parsed % volblocksize_integer_value !== 0) {
         rounded_vol_size = res[0].volsize.parsed + (volblocksize_integer_value - res[0].volsize.parsed % volblocksize_integer_value);
       }
-
+      const navigationExtras: NavigationExtras = { state: { highlightDataset: this.parent } };
       if (!this.edit_data.volsize || this.edit_data.volsize >= rounded_vol_size) {
         this.ws.call('pool.dataset.update', [this.parent, this.edit_data]).subscribe((restPostResp) => {
           this.loader.close();
           this.router.navigate(new Array('/').concat(
             this.route_success,
-          ));
+          ), navigationExtras);
         }, (eres) => {
           this.loader.close();
           new EntityUtils().handleWSError(this.entityForm, eres);
@@ -895,8 +895,14 @@ export class ZvolFormComponent implements Formconfiguration {
     });
   }
 
+  goBack() {
+    const navigationExtras: NavigationExtras = { state: { highlightDataset: this.parent } };
+    this.router.navigate(new Array('/').concat(this.route_success), navigationExtras);
+  }
+
   customSubmit(body: any) {
     this.loader.open();
+    const navigationExtras: NavigationExtras = { state: { highlightDataset: this.parent } };
 
     if (this.isNew === true) {
       this.addSubmit(body).subscribe((restPostResp) => {
@@ -904,7 +910,7 @@ export class ZvolFormComponent implements Formconfiguration {
 
         this.router.navigate(new Array('/').concat(
           this.route_success,
-        ));
+        ), navigationExtras);
       }, (res) => {
         this.loader.close();
         new EntityUtils().handleWSError(this.entityForm, res);


### PR DESCRIPTION
NAS-105663

How/What to test:

- Create nested datasets in a pool
- Go to any level of choice in datasets and open 'Edit Options' or 'Edit Permission' or 'Acl Manager' pages on that dataset
- When you come back after cancelling or successfully saving the settings, the exact same dataset should be expanded automatically
e.g.,

If you have the following datasets in your pool

`pool`

- `ds` -> `ds-ds` -> `ds-ds-ds`

- `dss` -> `dss2`

Currently, when you go to `Edit Options` or `Edit Permissions` or `Acl Manager` page for dataset `ds-ds` and come back by cancelling or saving your changes, all the datasets are automatically collapsed.

With these changes, when you go to edit any aforementioned settings on `ds-ds` dataset and come back to the pools page by cancelling or saving those settings, the `EntityTreeTable` should be expanded up to that dataset automatically. i.e., 
`pool` -> `ds` -> `ds-ds`

Read ticket description and comments for more explanation or drop me a message