### PR TITLE
NAS-110760 / 21.08 / Making multiselect respect pagination and filter

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.html
@@ -111,10 +111,11 @@
         <!-- Multiselect Checkboxes -->
         <ng-container *ngIf="column == 'multiselect'" matColumnDef="{{column}}" sticky>
           <th class="multiselect-column" mat-header-cell *matHeaderCellDef>
-            <mat-checkbox [indeterminate]="selection.hasValue() && !isAllSelected"
-              color="primary"
-              (change)="$event ? masterToggle() : null"
+            <mat-checkbox
+              [indeterminate]="selection.hasValue() && !isAllSelected"
               [checked]="selection.hasValue() && isAllSelected"
+              color="primary"
+              (change)="masterToggle($event)"
               ix-auto ix-auto-type="checkbox" ix-auto-identifier="title">
             </mat-checkbox>
           </th>
@@ -122,7 +123,7 @@
             <mat-checkbox
               color="primary"
               (click)="$event.stopPropagation()"
-              (change)="$event ? selection.toggle(element) : null"
+              (change)="$event ? toggleSelection(element) : null"
               [checked]="selection.isSelected(element)"
               ix-auto ix-auto-type="checkbox"
               [ix-auto-identifier]="element[conf.rowIdentifier || 'name']">
@@ -205,6 +206,7 @@
 
   <mat-card-footer style="padding: 0 !important" *ngIf="conf.config.paging">
     <mat-paginator
+      (page)="pageChanged()"
       [pageIndex]="paginationPageIndex"
       [pageSize]="paginationPageSize"
       [pageSizeOptions]="paginationPageSizeOptions"

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -226,9 +226,8 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     const showingRows = currentlyShowingRows;
     return this.currentRows.filter((row) => {
-      const identifier = this.conf.rowIdentifier || 'name';
       const index = showingRows.findIndex((showingRow: any) => {
-        return showingRow[identifier] === row[identifier];
+        return showingRow['multiselect_id'] === row['multiselect_id'];
       });
       return index >= 0;
     });
@@ -659,6 +658,9 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
       this.configureEmptyTable(this.firstUse ? EmptyType.first_use : EmptyType.no_page_data);
     }
 
+    for (let i = 0; i < this.currentRows.length; i++) {
+      this.currentRows[i].multiselect_id = i;
+    }
     this.dataSource = new MatTableDataSource(this.currentRows);
     this.dataSource.sort = this.sort;
 

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -216,20 +216,15 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
     this.selection.clear();
   }
 
-  get rowsCurrentlyOnScreen(): any[] {
+  get currentRowsThatAreOnScreenToo(): any[] {
     let currentlyShowingRows = [...this.dataSource.filteredData];
     if (this.dataSource.paginator) {
       const start = this.dataSource.paginator.pageIndex * this.dataSource.paginator.pageSize;
-
       const rowsCount = currentlyShowingRows.length < start + this.dataSource.paginator.pageSize
         ? currentlyShowingRows.length - start : this.dataSource.paginator.pageSize;
       currentlyShowingRows = currentlyShowingRows.splice(start, rowsCount);
     }
-    return currentlyShowingRows;
-  }
-
-  get currentRowsThatAreOnScreenToo(): any[] {
-    const showingRows = this.rowsCurrentlyOnScreen;
+    const showingRows = currentlyShowingRows;
     return this.currentRows.filter((row) => {
       const identifier = this.conf.rowIdentifier || 'name';
       const index = showingRows.findIndex((showingRow: any) => {
@@ -1163,19 +1158,16 @@ export class EntityTableComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   masterToggle(event: MatCheckboxChange): void {
-    const showingRows = this.rowsCurrentlyOnScreen;
+    const showingRows = this.currentRowsThatAreOnScreenToo;
     this.isAllSelected = event.checked;
 
-    event.checked
-      ? this.currentRows.forEach((row) => {
-        const identifier = this.conf.rowIdentifier || 'name';
-        const index = showingRows.findIndex((showingRow: any) => {
-          return showingRow[identifier] === row[identifier];
-        });
-        if (index !== -1) {
-          this.selection.select(row);
-        }
-      }) : this.selection.clear();
+    if (event.checked) {
+      showingRows.forEach((row) => {
+        this.selection.select(row);
+      });
+    } else {
+      this.selection.clear();
+    }
   }
 
   getFirstKey(): string {

--- a/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
@@ -83,7 +83,7 @@ export class SnapshotListComponent implements EntityTableConfig {
   ];
   // End the show/hide section
 
-  rowIdentifier = 'dataset';
+  rowIdentifier = 'name';
   config: EntityTableConfigConfig = {
     paging: true,
     sorting: { columns: this.columns },


### PR DESCRIPTION
NAS-110760

What to test
- Selecting values on the table should trigger `indeterminate` state on the multi-select checkbox in the table header
- Selecting all values one by one or clicking the multi-select checkbox should select all the rows currently visible on the screen and only those rows. i.e., rows from other pages or filtered out rows shouldn't be selected
- De-selecting one row should put the multi-select checkbox back into `indeterminate` state
- Check if changing the `rowIdentifier` for `SnapshotsListComponent` has had any effect on that page
- Multi-select now depends on the `rowIdentifier` or `'name'` field in either/or relationship. If `rowIdentifier` is not set `'name'` field will be used
- Other components that use multi-select should have the unique `rowIdentifier` too i.e., something that's unique across all rows