### PR TITLE
NAS-110665 / 12.0 / NAS-110665 - Fixing cloudcredential form + OpenStack Swift

### DIFF
--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -602,7 +602,7 @@ export class CloudCredentialsFormComponent {
               value: 3,
             },
           ],
-          value: '0',
+          value: 0,
           relation: [
             {
               action: 'SHOW',

--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -893,7 +893,7 @@ export class CloudCredentialsFormComponent {
                 value: 'OPENSTACK_SWIFT',
               }, {
                 name: 'auth_version-OPENSTACK_SWIFT',
-                value: '3',
+                value: 3,
               }],
             },
           ],
@@ -912,7 +912,7 @@ export class CloudCredentialsFormComponent {
                 value: 'OPENSTACK_SWIFT',
               }, {
                 name: 'auth_version-OPENSTACK_SWIFT',
-                value: '3',
+                value: 3,
               }],
             },
           ],
@@ -963,7 +963,7 @@ export class CloudCredentialsFormComponent {
                 value: 'OPENSTACK_SWIFT',
               }, {
                 name: 'auth_version-OPENSTACK_SWIFT',
-                value: '3',
+                value: 3,
               }],
             },
           ],
@@ -1357,7 +1357,7 @@ export class CloudCredentialsFormComponent {
     const tenantIdCtrl = entityForm.formGroup.controls['tenant_id-OPENSTACK_SWIFT'];
     entityForm.formGroup.controls['auth_version-OPENSTACK_SWIFT'].valueChanges.subscribe(
       (res) => {
-        if (res === '1') {
+        if (res === 1) {
           this.setFieldRequired('tenant-OPENSTACK_SWIFT', false, entityForm);
           this.setFieldRequired('tenant_id-OPENSTACK_SWIFT', false, entityForm);
         } else if ((tenantCtrl.value === undefined || tenantCtrl.value === '')
@@ -1496,7 +1496,7 @@ export class CloudCredentialsFormComponent {
         field_name += '-' + provider;
       }
       if (entityForm.formGroup.controls[field_name]) {
-        entityForm.formGroup.controls[field_name].setValue(field_name == 'auth_version-OPENSTACK_SWIFT' ? entityForm.wsResponseIdx[i].toString() : entityForm.wsResponseIdx[i]);
+        entityForm.formGroup.controls[field_name].setValue(entityForm.wsResponseIdx[i]);
       }
     }
   }


### PR DESCRIPTION
**Setup:**
1. `docker pull openstackswift/saio`
2. `docker run -d -p 8080:8080 openstackswift/saio`
2. If you are using local middleware, you can skip this test. Otherwise you need to expose local openstackswift to the world. You can do this by setting up a tunnel with https://ngrok.com. Something like `ngrok tcp 8080`
3. Go to System -> Cloud Credentials -> Add.
4. Add a new OpenStack Swift credential, where 
UserName: `test:tester`
Password: `testing`
Auth URL: If local: `http://127.0.0.1/auth/v1.0`, otherwise `http://ngrokurlandport/auth/v1.0`, something similar to `http://8.tcp.ngrok.io:16358/auth/v1.0`
Auth Version: `v1`
Tenant Name: `test`
5. Verify Credentials.

**To test:**
- That Advanced options change when Auth Version is changed.
- That when form is saved and then edited, Auth Version is populated and form still works correctly.

Also approve: https://github.com/truenas/webui/pull/5648