### PR TITLE
NAS-111460 / 21.08 / Fixed bug with wrong reassignment of variable

### DIFF
--- a/src/app/pages/system/general-settings/gui-form/gui-form.component.ts
+++ b/src/app/pages/system/general-settings/gui-form/gui-form.component.ts
@@ -183,7 +183,6 @@ export class GuiFormComponent implements FormConfiguration {
     this.https_port = this.configData.ui_httpsport;
     this.redirect = this.configData.ui_httpsredirect;
     if (this.configData.ui_certificate && this.configData.ui_certificate.id) {
-      (this.configData['ui_certificate'] as any) = this.configData.ui_certificate.id.toString();
       this.guicertificate = this.configData.ui_certificate.id.toString();
     }
     this.addresses = this.configData['ui_address'];
@@ -216,7 +215,7 @@ export class GuiFormComponent implements FormConfiguration {
         for (const id in res) {
           this.ui_certificate.options.push({ label: res[id], value: id });
         }
-        entityEdit.formGroup.controls['ui_certificate'].setValue(this.configData.ui_certificate);
+        entityEdit.formGroup.controls['ui_certificate'].setValue(this.configData.ui_certificate.id.toString());
       });
 
     const httpsprotocolsField = this.fieldSets


### PR DESCRIPTION
NAS-111460

To Test
1. Open the GUI Settings form in the System -> General Settings page
2. On the form, previous data should load Ok and you shouldn't see empty fields