### PR TITLE
NAS-111469 / 21.08 / Add inline options for form-radio.

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/form-radio/form-radio.component.html
+++ b/src/app/pages/common/entity/entity-form/components/form-radio/form-radio.component.html
@@ -4,8 +4,8 @@
     <tooltip *ngIf="config.tooltip" [header]="config.placeholder" [message]="config.tooltip" [position]="config.tooltipPosition ? config.tooltipPosition : null" [style.margin-left.px]="5"></tooltip>
   </div>
   <mat-radio-group [formControlName]="config.name" id="{{config.name}}_radiogroup" (change)="onChangeRadio($event)"
-    ix-auto ix-auto-type="radio-group" ix-auto-identifier="{{config.name}}">
-    <div *ngFor="let option of config.options" fxLayout="row">
+    [fxLayout]="radioLayout" ix-auto ix-auto-type="radio-group" ix-auto-identifier="{{config.name}}">
+    <div *ngFor="let option of config.options" [fxFlex.gt-md]="radioFlex" fxFlex="100%">
         <mat-radio-button [checked]="option.value === radioValue" [value]="option.value" id="{{config.name}}_{{option.value}}_radiobutton"
           ix-auto
           ix-auto-type="radio"

--- a/src/app/pages/common/entity/entity-form/components/form-radio/form-radio.component.ts
+++ b/src/app/pages/common/entity/entity-form/components/form-radio/form-radio.component.ts
@@ -20,6 +20,19 @@ export class FormRadioComponent implements Field, OnInit, OnDestroy {
   radioValue: any;
   valueChangesSubscription: Subscription;
 
+  get radioLayout(): string {
+    return this.config.inlineFields ? 'row wrap' : 'column';
+  }
+
+  get radioFlex(): string {
+    if (this.radioLayout == 'column') return '100%';
+
+    if (this.radioLayout == 'row wrap' && this.config.inlineFieldFlex) {
+      return this.config.inlineFieldFlex;
+    }
+    return '50%';
+  }
+
   constructor(public translate: TranslateService) {}
 
   ngOnInit(): void {

--- a/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
+++ b/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
@@ -51,6 +51,8 @@ export interface FieldConfig<P = any> {
   initial?: string;
   initialCount?: number;
   inlineLabel?: string;
+  inlineFields?: boolean;
+  inlineFieldFlex?: string;
   inputType?: string;
   inputUnit?: InputUnitConfig;
   isDoubleConfirm?: boolean;

--- a/src/app/pages/storage/volumes/permissions/components/edit-nfs-ace/edit-nfs-ace-field-set.ts
+++ b/src/app/pages/storage/volumes/permissions/components/edit-nfs-ace/edit-nfs-ace-field-set.ts
@@ -81,6 +81,8 @@ export function getEditNfsAceFieldSet(userService: UserService): FieldSet[] {
         {
           type: 'radio',
           name: 'type',
+          inlineFields: true,
+          inlineFieldFlex: '25%',
           placeholder: helptext.dataset_acl_type_placeholder,
           tooltip: helptext.dataset_acl_type_tooltip,
           options: helptext.dataset_acl_type_options,
@@ -98,6 +100,7 @@ export function getEditNfsAceFieldSet(userService: UserService): FieldSet[] {
         {
           type: 'radio',
           name: 'permissionType',
+          inlineFields: true,
           required: true,
           placeholder: helptext.dataset_acl_perms_type_placeholder,
           tooltip: helptext.dataset_acl_perms_type_tooltip,
@@ -151,6 +154,7 @@ export function getEditNfsAceFieldSet(userService: UserService): FieldSet[] {
         {
           type: 'radio',
           name: 'flagsType',
+          inlineFields: true,
           required: true,
           placeholder: helptext.dataset_acl_flags_type_placeholder,
           tooltip: helptext.dataset_acl_flags_type_tooltip,


### PR DESCRIPTION
Testing:
- ACL editor should have inline radio buttons for the "ACL Type", "Permissions Type" and "Flags Type" fields.
- Make sure other forms with radios keep column layout by default. (Import disk form is a good one to test)
- When browser window gets too narrow, inline radio buttons should revert to column layout