### PR TITLE
Remove cancel button from replication wizard

### DIFF
--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
@@ -59,6 +59,7 @@ export class ReplicationWizardComponent implements WizardConfiguration {
   summaryTitle = T('Replication Summary');
   pk: number;
   saveSubmitText = T('START REPLICATION');
+  hideCancel = true;
 
   protected entityWizard: EntityWizardComponent;
   custActions = [{


### PR DESCRIPTION
This PR affects the replication wizard found on the data-protection dashboard.
All the other forms on the dashboard omit cancel buttons and instead allow users to either click outside of the side panel or click the "X" close button at the top right of the panel.

To test:
- Make sure there is no cancel button on the replication wizard.
- The wizard should close when the user clicks the close button or clicks outside the form.