### PR TITLE
NAS-111414 / 21.08 / Treat removing vdev in the UI as a job

### DIFF
--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -137,6 +137,7 @@ import { VmDevice } from 'app/interfaces/vm-device.interface';
 import { WebDavShare } from 'app/interfaces/web-dav-share.interface';
 import { WebdavConfig, WebdavConfigUpdate } from 'app/interfaces/webdav-config.interface';
 import { ZfsSnapshot } from 'app/interfaces/zfs-snapshot.interface';
+import { PoolRemoveParams } from './pool-remove.interface';
 
 /**
  * API definitions for `call` and `job` methods.
@@ -557,7 +558,7 @@ export type ApiDirectory = {
   'pool.dataset.export_key': { params: any; response: any };
   'pool.offline': { params: any; response: any };
   'pool.online': { params: any; response: any };
-  'pool.remove': { params: any; response: any };
+  'pool.remove': { params: PoolRemoveParams; response: any };
   'pool.detach': { params: any; response: any };
   'pool.export': { params: PoolExportParams; response: void };
   'pool.passphrase': { params: any; response: any };

--- a/src/app/interfaces/pool-remove.interface.ts
+++ b/src/app/interfaces/pool-remove.interface.ts
@@ -1,0 +1,6 @@
+export type PoolRemoveParams = [
+  /* id */ number,
+  {
+    label: string | number;
+  },
+];

--- a/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
+++ b/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
@@ -414,17 +414,7 @@ export class VolumeStatusComponent implements OnInit, OnDestroy {
           filter(Boolean),
           untilDestroyed(this),
         ).subscribe(() => {
-          this.loader.open();
-          this.ws.call('pool.remove', [this.pk, { label: row.guid }]).pipe(untilDestroyed(this)).subscribe(
-            () => {
-              this.getData();
-              this.loader.close();
-            },
-            (err) => {
-              this.loader.close();
-              new EntityUtils().handleWSError(this, err, this.dialogService);
-            },
-          );
+          this.poolRemove(this.pk, row.guid);
         });
       },
       isHidden: false,
@@ -542,17 +532,7 @@ export class VolumeStatusComponent implements OnInit, OnDestroy {
           filter(Boolean),
           untilDestroyed(this),
         ).subscribe(() => {
-          this.loader.open();
-          this.ws.call('pool.remove', [this.pk, { label: row.guid }]).pipe(untilDestroyed(this)).subscribe(
-            () => {
-              this.getData();
-              this.loader.close();
-            },
-            (err) => {
-              this.loader.close();
-              new EntityUtils().handleWSError(this, err, this.dialogService);
-            },
-          );
+          this.poolRemove(this.pk, row.guid);
         });
       },
     }];
@@ -660,5 +640,21 @@ export class VolumeStatusComponent implements OnInit, OnDestroy {
     const diskForm = new DiskFormComponent(this.router, this.ws, this.aroute);
     diskForm.inIt(pk);
     this.modalService.open('slide-in-form', diskForm);
+  }
+
+  poolRemove(id: number, label: number | string): void {
+    const dialogRef = this.matDialog.open(EntityJobComponent, {
+      data: { title: helptext.remove_disk.title },
+      disableClose: true,
+    });
+    dialogRef.componentInstance.setCall('pool.remove', [id, { label }]);
+    dialogRef.componentInstance.submit();
+    dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
+      this.dialogService.closeAllDialogs();
+      this.getData();
+    });
+    dialogRef.componentInstance.failure.pipe(untilDestroyed(this)).subscribe((error) => {
+      new EntityUtils().handleWSError(this, error, this.dialogService);
+    });
   }
 }


### PR DESCRIPTION
How to test:

- Go to the Storage page
- Create a new pool with 2 disks and pick `STRIPE`
- Click on pool options and choose `Status`
- Click the three dots menu on disk and choose `Remove`

You'll see something like:
![image](https://user-images.githubusercontent.com/351613/128014591-5d9a63ce-6c79-4de1-8d37-9f76a1666a99.png)
