### PR TITLE
NAS-111284 / 21.08 / NAS-111284 - Do not allow root dataset to be edited

### DIFF
--- a/src/app/enums/acl-type.enum.ts
+++ b/src/app/enums/acl-type.enum.ts
@@ -1,6 +1,7 @@
 export enum AclType {
   Nfs4 = 'NFS4',
   Posix1e = 'POSIX1E',
+  Off = 'OFF',
 }
 
 export enum AclMode {

--- a/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.html
+++ b/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.html
@@ -3,7 +3,7 @@
     <div class="sidebar-title">{{ 'Dataset Permissions' | translate }}</div>
 
     <a
-      *ngIf="acl"
+      *ngIf="canEditPermissions"
       class="action"
       [attr.title]="'Edit permissions' | translate"
       [routerLink]="editPermissionsUrl"

--- a/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.ts
+++ b/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.ts
@@ -43,6 +43,11 @@ export class PermissionsSidebarComponent implements OnInit, OnChanges {
     return ['/storage/id', this.dataset.pool, 'dataset', 'acl', this.dataset.id];
   }
 
+  get canEditPermissions(): boolean {
+    const isRootDataset = (this.dataset.mountpoint.match(/\//g) || []).length <= 2;
+    return this.acl && !isRootDataset;
+  }
+
   ngOnInit(): void {
     this.store.state$
       .pipe(untilDestroyed(this))


### PR DESCRIPTION
Two things to test:
1. Root dataset in every pool should not have pencil edit icon in view permissions sidebar.
2. If you create dataset with acltype = OFF, and then go to edit permissions, you should not see Set ACL button. You should still see this button on datasets with other acltype.