### PR TITLE
NAS-111431 / 12.0 / Enclosures should listen for global resilver events

### DIFF
--- a/src/app/components/common/topbar/topbar.component.ts
+++ b/src/app/components/common/topbar/topbar.component.ts
@@ -206,19 +206,18 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
       }
     });
 
-    this.ws.subscribe('zfs.pool.scan').subscribe((res) => {
-      if (res && res.fields.scan.function.indexOf('RESILVER') > -1) {
-        this.resilveringDetails = res.fields;
+    this.core.register({
+      observerClass: this,
+      eventName: 'Resilvering',
+    }).subscribe((evt: CoreEvent) => {
+      if (evt.data.scan.state == 'FINISHED') {
+        this.showResilvering = false;
+        this.resilveringDetails = '';
+      } else {
+        this.resilveringDetails = evt.data;
         this.showResilvering = true;
       }
     });
-
-    setInterval(() => {
-      if (this.resilveringDetails && this.resilveringDetails.scan.state == 'FINISHED') {
-        this.showResilvering = false;
-        this.resilveringDetails = '';
-      }
-    }, 2500);
 
     this.core.register({
       observerClass: this,

--- a/src/app/core/services/disk-state.service.ts
+++ b/src/app/core/services/disk-state.service.ts
@@ -20,6 +20,8 @@ export class DiskStateService extends BaseService {
 
   protected onAuthenticated(evt: CoreEvent) {
     this.authenticated = true;
+
+    // Check for Disk Presence
     this.ws.sub('disk.query').subscribe((res) => {
       // A couple of notes about what to expect in the response.
       // Cleared:boolean is a property in the response that seems to indicate removal
@@ -29,6 +31,13 @@ export class DiskStateService extends BaseService {
 
       if (res && res.cleared) {
         this.core.emit({ name: 'DiskRemoved', data: res, sender: this });
+      }
+    });
+
+    // Check for Pool Status
+    this.ws.subscribe('zfs.pool.scan').subscribe((res) => {
+      if (res.fields.scan.function == 'RESILVER') {
+        this.core.emit({ name: 'Resilvering', data: res.fields, sender: this });
       }
     });
   }

--- a/src/app/pages/system/viewenclosure/view-enclosure.component.ts
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.ts
@@ -137,6 +137,10 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
       this.system.sensorData = evt.data;
     });
 
+    core.register({ observerClass: this, eventName: 'Resilvering' }).subscribe((evt: CoreEvent) => {
+      if (evt.data.scan.state == 'FINISHED') this.fetchData();
+    });
+
     core.register({ observerClass: this, eventName: 'DisksChanged' }).subscribe((evt: CoreEvent) => {
       if (evt.data.cleared) {
         // Extra actions if disk is removed
@@ -168,6 +172,7 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
   }
 
   fetchData() {
+    console.warn('Fetching Data...');
     this.core.emit({ name: 'DisksRequest', sender: this });
   }
 


### PR DESCRIPTION
Testing:
- Remove a disk from a pool that has a spare
- Put the disk back
- Make sure the resilver icon shows up on the topbar
- The disk should reappear and should be presented as part of the pool again AFTER the resilver process completes