### PR TITLE
NAS-111747 / 21.08 / NAS-111747 - Fixing Cloud Credential form when Angular extension is i…

### DIFF
--- a/src/app/pages/credentials/backup-credentials/forms/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/forms/cloud-credentials-form.component.ts
@@ -1434,7 +1434,7 @@ export class CloudCredentialsFormComponent implements FormConfiguration {
     window.addEventListener('message', method, false);
 
     function doAuth(message: any, selectedProvider: string): void {
-      if (message.data.oauth_portal) {
+      if ('oauth_portal' in message.data) {
         if (message.data.error) {
           dialogService.errorReport(T('Error'), message.data.error);
         } else {
@@ -1451,8 +1451,9 @@ export class CloudCredentialsFormComponent implements FormConfiguration {
         if (selectedProvider === 'ONEDRIVE') {
           getOnedriveList(message.data);
         }
+
+        window.removeEventListener('message', method);
       }
-      window.removeEventListener('message', method);
     }
   }
 


### PR DESCRIPTION
1. Install Angular extension in Chrome and enable it.
2. Go to Cloud Credentials.
3. Open Chrome inspector.
4. Add new cloud credential -> google drive and login.
5. Observe that form is filled in.
6. Approve this ticket.
7. Go drink some tea.