### PR TITLE
NAS-111749 / 21.08 / Fix empty IP addresses on network widget

### DIFF
--- a/src/app/core/components/widgets/widget-network/widget-network.component.html
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.html
@@ -9,7 +9,26 @@
             ix-auto ix-auto-type="button" ix-auto-identifier="goBack">
             <mat-icon (click)="goBack()" class="back-arrow">chevron_left</mat-icon>
           </button>
-          <h3 class="mat-card-title-text"><div class="card-title-text">{{title | translate}}</div></h3>
+          <h3 class="mat-card-title-text">
+            <div class="card-title-text">{{title | translate}}</div>
+          </h3>
+
+          <div class="controls">
+            <a
+              mat-icon-button
+              ix-auto
+              ix-auto-type="button"
+              ix-auto-identifier="networkReports"
+              [routerLink]="['/reportsdashboard/network']"
+            >
+              <mat-icon role="img"
+                matTooltip="{{'Network Reports' | translate}}"
+                matTooltipPosition="above"
+                aria-label="Network Reports">
+                  insert_chart
+              </mat-icon>
+            </a>
+          </div>
         </mat-toolbar-row>
         <div>
           <div class="card-body" [style.padding]="paddingTop + 'px ' + paddingX + 'px ' + paddingBottom + 'px'">
@@ -19,15 +38,6 @@
                   <div class="nic-info" fxLayout="column" fxLayoutAlign="start stretch">
                     <div class="info-header" fxLayout="row" fxLayoutAlign="start start">
                       <h4 class="info-header-title">{{nic.state.name}}</h4>
-                      <button mat-icon-button class="" (click)="router.navigate(['reportsdashboard/network'])"
-                        ix-auto="network" ix-auto-type="button" ix-auto-identifier="networkReports">
-                        <mat-icon role="img"
-                          matTooltip="{{'Network Reports' | translate}}"
-                          matTooltipPosition="above"
-                          aria-label="Network Reports">
-                            insert_chart
-                        </mat-icon>
-                      </button>
                     </div>
                     <div class="info-body" fxLayout="row" fxFlex fxLayoutAlign="space-between stretch">
                       <ul>

--- a/src/app/core/components/widgets/widget-network/widget-network.component.html
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.html
@@ -71,13 +71,13 @@
                     </div>
                   </div>
                   <div class="nic-chart" fxFlex *ngIf="availableNics.length <= 3">
-                    <div class="chart-body" [ngClass]="{ 'chart-body-errors': emptyChartConf && emptyChartConf.type == emptyTypes.Errors}">
+                    <div class="chart-body" [ngClass]="{ 'chart-body-errors': nicInfoMap[nic.state.name]?.emptyConfig?.type === emptyTypes.Errors}">
                       <view-chart-area *ngIf="nicInfoMap && nicInfoMap[nic.state.name].chartData; else emptychart"
                         [data]="nicInfoMap[nic.state.name]?.chartData"
                         [options]="chartOptions">
                       </view-chart-area>
                       <ng-template #emptychart>
-                        <entity-empty [conf]="emptyChartConf"></entity-empty>
+                        <entity-empty [conf]="nicInfoMap[nic.state.name]?.emptyConfig"></entity-empty>
                       </ng-template>
                     </div>
                   </div>

--- a/src/app/core/components/widgets/widget-network/widget-network.component.html
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.html
@@ -66,7 +66,7 @@
                       <ul fxFlex="70" class="detail-info" *ngIf="availableNics.length === 1" fxLayout="column" fxLayoutAlign="space-between start">
                         <li><span class="label">{{ 'Media Type' | translate }}:</span> {{ nic.state.active_media_type }}</li>
                         <li><span class="label">{{ 'Media Subtype' | translate }}:</span> {{ nic.state.active_media_subtype }}</li>
-                        <li><span class="label">{{ 'IP Addresses' | translate }}:</span> {{ nicInfoMap[nic.state.name]?.ip }}</li>
+                        <li><span class="label">{{ 'IP Address' | translate }}:</span> {{ nicInfoMap[nic.state.name]?.ip }}</li>
                       </ul>
                     </div>
                   </div>

--- a/src/app/core/components/widgets/widget-network/widget-network.component.html
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.html
@@ -18,7 +18,7 @@
                 <div class="tile" [fxLayout]="availableNics.length === 1 ? 'column' : 'row'" fxFill fxLayoutAlign="start stretch" >
                   <div class="nic-info" fxLayout="column" fxLayoutAlign="start stretch">
                     <div class="info-header" fxLayout="row" fxLayoutAlign="start start">
-                      <span>{{nic.state.name}}</span>
+                      <h4 class="info-header-title">{{nic.state.name}}</h4>
                       <button mat-icon-button class="" (click)="router.navigate(['reportsdashboard/network'])"
                         ix-auto="network" ix-auto-type="button" ix-auto-identifier="networkReports">
                         <mat-icon role="img"
@@ -49,7 +49,7 @@
                           <span *ngIf="nic.state.link_state !== LinkState.Up">{{ 'No Traffic' | translate }}</span>
                         </li>
                         <li fxLayout="row" fxLayoutAlign="start center" *ngIf="availableNics.length > 1">
-                          <span class="icon empty"></span>
+                          <span class="icon address"><mat-icon [matTooltip]="'IP Address' | translate">settings_ethernet</mat-icon></span>
                           <span>{{ nicInfoMap[nic.state.name]?.ip }}</span>
                         </li>
                       </ul>
@@ -62,8 +62,8 @@
                   </div>
                   <div class="nic-chart" fxFlex *ngIf="availableNics.length <= 3">
                     <div class="chart-body" [ngClass]="{ 'chart-body-errors': emptyChartConf && emptyChartConf.type == emptyTypes.Errors}">
-                      <view-chart-area *ngIf="nicInfoMap && nicInfoMap[nic.state.name].chartData; else emptychart" 
-                        [data]="nicInfoMap[nic.state.name]?.chartData" 
+                      <view-chart-area *ngIf="nicInfoMap && nicInfoMap[nic.state.name].chartData; else emptychart"
+                        [data]="nicInfoMap[nic.state.name]?.chartData"
                         [options]="chartOptions">
                       </view-chart-area>
                       <ng-template #emptychart>

--- a/src/app/core/components/widgets/widget-network/widget-network.component.scss
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.scss
@@ -3,11 +3,6 @@
   width: 600px;
 }
 
-ul {
-  margin: 0;
-  padding-left: 0;
-}
-
 .widget mat-card-content {
   width: 100%;
 }
@@ -41,6 +36,10 @@ mat-grid-list {
   &.nics-1 .tile {
     padding: 12px 16px;
 
+    .info-body ul {
+      width: auto;
+    }
+
     .detail-info li {
       line-height: 20px;
     }
@@ -52,17 +51,13 @@ mat-grid-list {
     .nic-info {
       width: 205px;
     }
-
-    ul {
-      width: 100%;
-    }
   }
 
   &.nics-3 .tile {
     padding: 4px 4px 4px 16px;
 
     .nic-info {
-      width: 150px;
+      width: 175px;
     }
 
     .info-header {
@@ -213,12 +208,21 @@ mat-grid-list {
   }
 
   ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
     text-align: left;
+    width: 100%;
 
     li {
       line-height: 18px;
-      overflow: hidden;
-      white-space: nowrap;
+      min-width: 0;
+
+      span:nth-child(2) {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 }

--- a/src/app/core/components/widgets/widget-network/widget-network.component.scss
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.scss
@@ -34,10 +34,6 @@ mat-grid-list {
   &.nics-1 .tile {
     padding: 12px 16px;
 
-    .info-header {
-      height: 35px;
-    }
-
     .detail-info li {
       line-height: 20px;
     }
@@ -114,8 +110,12 @@ mat-grid-list {
 }
 
 .info-header {
-  font-size: 24px;
-  height: 40px;
+  margin-bottom: 10px;
+
+  .info-header-title {
+    font-size: 24px;
+    line-height: 1.25;
+  }
 
   .mat-icon-button {
     height: 30px;
@@ -159,6 +159,15 @@ mat-grid-list {
       .mat-icon {
         font-size: 24px;
         height: 24px;
+      }
+    }
+
+    &.address {
+      .mat-icon {
+        font-size: 20px;
+        line-height: 20px;
+        position: relative;
+        top: 1px;
       }
     }
   }

--- a/src/app/core/components/widgets/widget-network/widget-network.component.scss
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.scss
@@ -195,5 +195,9 @@ mat-grid-list {
 }
 
 .chart-body.chart-body-errors {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
   margin: 8px;
 }

--- a/src/app/core/components/widgets/widget-network/widget-network.component.scss
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.scss
@@ -50,7 +50,11 @@ mat-grid-list {
     padding: 12px 16px;
 
     .nic-info {
-      width: 170px;
+      width: 205px;
+    }
+
+    ul {
+      width: 100%;
     }
   }
 
@@ -61,16 +65,33 @@ mat-grid-list {
       width: 150px;
     }
 
+    .info-header {
+      margin-bottom: 4px;
+    }
+
     .info-body {
       font-size: 12px;
-    }
 
-    .info-body .line-state {
-      padding: 0;
-    }
+      span.icon {
+        height: 18px;
+        min-width: 24px;
+        width: 24px;
 
-    .info-body ul li {
-      line-height: 15px;
+        .mat-icon {
+          font-size: 18px;
+          height: 22px;
+          line-height: 18px;
+          width: 22px;
+        }
+      }
+
+      .line-state {
+        padding: 0;
+      }
+
+      ul li {
+        line-height: 15px;
+      }
     }
   }
 
@@ -107,7 +128,6 @@ mat-grid-list {
 
 .nic-info {
   font-size: 12px;
-  padding-right: 10px;
 
   .divider {
     background-color: var(--lines);
@@ -147,10 +167,13 @@ mat-grid-list {
   }
 
   span.icon {
-    display: inline-block;
+    cursor: default;
+    display: inline-flex;
     height: 22px;
+    justify-content: center;
+    min-width: 26px;
     text-align: center;
-    width: 25px;
+    width: 26px;
 
     &.up {
       color: var(--green);
@@ -182,8 +205,7 @@ mat-grid-list {
   .mat-icon {
     font-size: 22px;
     line-height: 22px;
-    margin-left: -5px;
-    margin-top: 0;
+    margin: 0;
 
     &.mdi-set {
       margin-top: 0;

--- a/src/app/core/components/widgets/widget-network/widget-network.component.scss
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.scss
@@ -26,6 +26,13 @@ ul {
   margin-right: 6px;
 }
 
+.controls {
+  color: var(--fg2);
+  position: absolute;
+  right: 16px;
+  top: 0;
+}
+
 mat-grid-list {
   &:not(.nics-1) .tile {
     background-color: var(--bg1);

--- a/src/app/core/components/widgets/widget-network/widget-network.component.ts
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.ts
@@ -16,7 +16,6 @@ import { EmptyConfig, EmptyType } from 'app/pages/common/entity/entity-empty/ent
 import { TableService } from 'app/pages/common/entity/table/table.service';
 import { ReportsService } from 'app/pages/reports-dashboard/reports.service';
 import { WebSocketService } from 'app/services';
-import { LocaleService } from 'app/services/locale.service';
 import { T } from 'app/translate-marker';
 
 interface NicInfo {
@@ -119,7 +118,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements AfterView
 
   constructor(
     public router: Router, private ws: WebSocketService,
-    private locale: LocaleService, private reportsService: ReportsService,
+    private reportsService: ReportsService,
     private tableService: TableService, public translate: TranslateService,
   ) {
     super(translate);

--- a/src/app/core/components/widgets/widget-network/widget-network.component.ts
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.ts
@@ -259,12 +259,17 @@ export class WidgetNetworkComponent extends WidgetComponent implements AfterView
   }
 
   getIpAddress(nic: BaseNetworkInterface): string {
-    let ip = '0';
-    if (nic.aliases) {
-      const filtered = nic.aliases.filter((item: NetworkInterfaceAlias) =>
+    let ip = '–';
+    if (nic.state.aliases) {
+      const addresses = nic.state.aliases.filter((item: NetworkInterfaceAlias) =>
         [NetworkInterfaceAliasType.Inet, NetworkInterfaceAliasType.Inet6].includes(item.type));
-      if (filtered.length > 0) {
-        ip = filtered[0].address + '/' + filtered[0].netmask;
+
+      if (addresses.length > 0) {
+        ip = addresses[0].address + '/' + addresses[0].netmask;
+
+        if (addresses.length >= 2) {
+          ip += ` (+${addresses.length - 1})`; /* show that interface has additional addresses */
+        }
       }
     }
 

--- a/src/app/core/components/widgets/widget-network/widget-network.component.ts
+++ b/src/app/core/components/widgets/widget-network/widget-network.component.ts
@@ -27,6 +27,7 @@ interface NicInfo {
   lastSent: number;
   lastReceived: number;
   chartData: ChartData;
+  emptyConfig?: EmptyConfig;
 }
 
 interface NicInfoMap {
@@ -43,13 +44,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements AfterView
   @Input() stats: any;
   @Input() nics: BaseNetworkInterface[];
 
-  emptyTypes = EmptyType;
-  emptyChartConf: EmptyConfig = {
-    type: EmptyType.Loading,
-    large: false,
-    title: T('Loading'),
-  };
-
+  readonly emptyTypes = EmptyType;
   private utils: WidgetUtils;
   LinkState = LinkState;
   title = T('Network');
@@ -209,6 +204,11 @@ export class WidgetNetworkComponent extends WidgetComponent implements AfterView
         lastSent: 0,
         lastReceived: 0,
         chartData: null,
+        emptyConfig: {
+          type: EmptyType.Loading,
+          large: false,
+          title: T('Loading'),
+        },
       };
     });
   }
@@ -329,14 +329,14 @@ export class WidgetNetworkComponent extends WidgetComponent implements AfterView
       },
       () => {
         // Handle the error
-        const errorString = T('Error getting chart data');
-        this.chartDataError(errorString);
+        const errorString = this.translate.instant(T('Error getting chart data'));
+        this.nicInfoMap[nic.name].emptyConfig = this.chartDataError(errorString);
       });
     });
   }
 
-  chartDataError(err: string): void {
-    this.emptyChartConf = {
+  chartDataError(err: string): EmptyConfig {
+    return {
       type: EmptyType.Errors,
       large: false,
       compact: true,


### PR DESCRIPTION
Changes:

- fix empty IP addresses
- replace `IP Addresses: 0` with `IP Addresses: –` when no data is available
- alignment for interface name and report icon
- added icon for IP addresses when nics > 1 
- display `(+1)` if there are >= 2 IP addresses is available 
- align entity-empty on center

Preview:
![image](https://user-images.githubusercontent.com/351613/128741779-90f48d1f-0014-4eea-b63b-0695f88f59fe.png)
![image](https://user-images.githubusercontent.com/351613/128741905-c8eddc9a-1d39-4ae5-a698-4a0afc76f512.png)

 