### PR TITLE
NAS-111755 / 21.08 / Job should call error method when job is FAILED

### DIFF
--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -246,9 +246,8 @@ export class WebSocketService {
         this.subscribe('core.get_jobs').pipe(untilDestroyed(this)).subscribe((event) => {
           if (event.id == job_id) {
             observer.next(event.fields);
-            if (event.fields.state === JobState.Success || event.fields.state == JobState.Failed) {
-              observer.complete();
-            }
+            if (event.fields.state === JobState.Success) observer.complete();
+            if (event.fields.state === JobState.Failed) observer.error(event.fields);
           }
         });
       });


### PR DESCRIPTION
Steps to reproduce.
1) Create VM with two pools
2) SSH into server and `cd /var/db/system/samba4`
3) Move system dataset to a different pool via System/Advanced page
4) Form should show dialog with traceback message (as opposed to silently failing like it does currently)