### PR TITLE
NAS-111465 / 21.08 / NAS-111465 - Redirect to an ACL Editor after home share is created

### DIFF
--- a/src/app/enums/acl-type.enum.ts
+++ b/src/app/enums/acl-type.enum.ts
@@ -17,6 +17,7 @@ export enum DefaultAclType {
   Nfs4Home = 'NFS4_HOME',
   Nfs4DomainHome = 'NFS4_DOMAIN_HOME',
   PosixOpen = 'POSIX_OPEN',
+  PosixHome = 'POSIX_HOME',
   PosixRestricted = 'POSIX_RESTRICTED',
   Open = 'OPEN',
   Restricted = 'RESTRICTED',

--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -351,7 +351,7 @@ export type ApiDirectory = {
   };
   'filesystem.listdir': { params: ListdirQueryParams; response: FileRecord[] };
   'filesystem.stat': { params: [/* path */ string]; response: FileSystemStat };
-  'filesystem.default_acl_choices': { params: void; response: DefaultAclType[] };
+  'filesystem.default_acl_choices': { params: [/* path */ string]; response: DefaultAclType[] };
   'filesystem.get_default_acl': { params: [DefaultAclType]; response: NfsAclItem[] | PosixAclItem[] };
   'filesystem.statfs': { params: [/* path */ string]; response: Statfs };
   'filesystem.getacl': { params: AclQueryParams; response: Acl };

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -381,7 +381,7 @@ export class SMBFormComponent implements FormConfiguration {
     ) {
       this.restartService(entityForm, 'allowdeny');
     } else {
-      this.checkACLactions(entityForm);
+      this.checkAclActions(entityForm);
     }
   }
 
@@ -409,7 +409,7 @@ export class SMBFormComponent implements FormConfiguration {
                 '250px',
               )
               .pipe(untilDestroyed(this)).subscribe(() => {
-                this.checkACLactions(entityForm);
+                this.checkAclActions(entityForm);
               });
           },
           (err) => {
@@ -418,21 +418,20 @@ export class SMBFormComponent implements FormConfiguration {
           },
         );
       } else {
-        source === 'timemachine' ? this.checkAllowDeny(entityForm) : this.checkACLactions(entityForm);
+        source === 'timemachine' ? this.checkAllowDeny(entityForm) : this.checkAclActions(entityForm);
       }
     });
   }
 
-  checkACLactions(entityForm: EntityFormComponent): void {
+  checkAclActions(entityForm: EntityFormComponent): void {
     const sharePath: string = entityForm.formGroup.get('path').value;
     const datasetId = sharePath.replace('/mnt/', '');
     const poolName = datasetId.split('/')[0];
     const homeShare = entityForm.formGroup.get('home').value;
-    // TODO: Incorrect url https://jira.ixsystems.com/browse/NAS-111465
-    const ACLRoute = ['storage', 'pools', 'id', poolName, 'dataset', 'acl', datasetId];
+    const aclRoute = ['storage', 'id', poolName, 'dataset', 'acl', datasetId];
 
     if (homeShare && entityForm.isNew) {
-      this.router.navigate(['/'].concat(ACLRoute), { queryParams: { homeShare: true } });
+      this.router.navigate(['/'].concat(aclRoute), { queryParams: { homeShare: true } });
       return;
     }
     // If this call returns true OR an [ENOENT] err comes back, just return to table
@@ -469,7 +468,7 @@ export class SMBFormComponent implements FormConfiguration {
               }),
               tap(([doConfigureACL]) => {
                 if (doConfigureACL) {
-                  this.router.navigate(['/'].concat(ACLRoute));
+                  this.router.navigate(['/'].concat(aclRoute));
                 } else {
                   this.dialog.closeAllDialogs();
                 }

--- a/src/app/pages/storage/volumes/permissions/components/select-preset-modal/select-preset-modal.component.ts
+++ b/src/app/pages/storage/volumes/permissions/components/select-preset-modal/select-preset-modal.component.ts
@@ -10,7 +10,7 @@ import { RelationAction } from 'app/pages/common/entity/entity-form/models/relat
 import { FieldRelationService } from 'app/pages/common/entity/entity-form/services/field-relation.service';
 import { SelectPresetModalConfig } from 'app/pages/storage/volumes/permissions/interfaces/select-preset-modal-config.interface';
 import { DatasetAclEditorStore } from 'app/pages/storage/volumes/permissions/stores/dataset-acl-editor.store';
-import { WebSocketService } from 'app/services';
+import { AppLoaderService, WebSocketService } from 'app/services';
 
 const usePresetFieldName = 'usePreset';
 const presetFieldName = 'preset';
@@ -65,6 +65,7 @@ export class SelectPresetModalComponent implements OnInit {
   constructor(
     private dialogRef: MatDialogRef<SelectPresetModalComponent>,
     private ws: WebSocketService,
+    private loader: AppLoaderService,
     private aclEditorStore: DatasetAclEditorStore,
     private fieldRelationService: FieldRelationService,
     @Inject(MAT_DIALOG_DATA) public data: SelectPresetModalConfig,
@@ -85,10 +86,12 @@ export class SelectPresetModalComponent implements OnInit {
   }
 
   private loadOptions(): void {
+    this.loader.open();
     this.ws.call('filesystem.default_acl_choices', [this.data.datasetPath])
       .pipe(untilDestroyed(this))
       .subscribe((choices) => {
         this.presetFieldConfig.options = choices.map((choice) => ({ label: choice, value: choice }));
+        this.loader.close();
       });
   }
 

--- a/src/app/pages/storage/volumes/permissions/components/select-preset-modal/select-preset-modal.component.ts
+++ b/src/app/pages/storage/volumes/permissions/components/select-preset-modal/select-preset-modal.component.ts
@@ -62,10 +62,6 @@ export class SelectPresetModalComponent implements OnInit {
     required: true,
   };
 
-  // TODO: To be handled by middleware https://jira.ixsystems.com/browse/NAS-111447
-  readonly posixDefaults = [DefaultAclType.PosixOpen, DefaultAclType.PosixRestricted];
-  readonly nfsDefaults = [DefaultAclType.Nfs4Open, DefaultAclType.Nfs4Restricted, DefaultAclType.Nfs4Home];
-
   constructor(
     private dialogRef: MatDialogRef<SelectPresetModalComponent>,
     private ws: WebSocketService,
@@ -89,15 +85,11 @@ export class SelectPresetModalComponent implements OnInit {
   }
 
   private loadOptions(): void {
-    this.ws.call('filesystem.default_acl_choices').pipe(untilDestroyed(this)).subscribe((choices) => {
-      this.presetFieldConfig.options = choices
-        .filter((choice) => {
-          return this.data.isNfsAcl
-            ? this.nfsDefaults.includes(choice)
-            : this.posixDefaults.includes(choice);
-        })
-        .map((choice) => ({ label: choice, value: choice }));
-    });
+    this.ws.call('filesystem.default_acl_choices', [this.data.datasetPath])
+      .pipe(untilDestroyed(this))
+      .subscribe((choices) => {
+        this.presetFieldConfig.options = choices.map((choice) => ({ label: choice, value: choice }));
+      });
   }
 
   onContinuePressed(): void {

--- a/src/app/pages/storage/volumes/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.ts
+++ b/src/app/pages/storage/volumes/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.ts
@@ -126,13 +126,14 @@ export class DatasetAclEditorComponent implements OnInit {
       data: {
         allowCustom: false,
         isNfsAcl: this.isNfsAcl,
+        datasetPath: this.fullDatasetPath,
       } as SelectPresetModalConfig,
     });
   }
 
   private onFirstLoad(): void {
     if (this.isHomeShare) {
-      this.store.usePreset(DefaultAclType.Home);
+      this.store.usePreset(this.isNfsAcl ? DefaultAclType.Nfs4Home : DefaultAclType.PosixHome);
     } else {
       this.showPresetModalIfNeeded();
     }
@@ -152,6 +153,7 @@ export class DatasetAclEditorComponent implements OnInit {
       data: {
         allowCustom: true,
         isNfsAcl: this.isNfsAcl,
+        datasetPath: this.fullDatasetPath,
       } as SelectPresetModalConfig,
     });
   }

--- a/src/app/pages/storage/volumes/permissions/interfaces/select-preset-modal-config.interface.ts
+++ b/src/app/pages/storage/volumes/permissions/interfaces/select-preset-modal-config.interface.ts
@@ -1,4 +1,5 @@
 export interface SelectPresetModalConfig {
   isNfsAcl: boolean;
   allowCustom: boolean;
+  datasetPath: string;
 }


### PR DESCRIPTION
1. Use cloud vm for testing. I've hot-pached middleware there with latest changes.
2. Create datasets with POSIX and NFS acl type.
3. Create SMB share in Sharing dashboard pointing at NFS dataset. Use Purpose that will allow you to enable Home Share in advanced settings.
4. You should get redirected to an acl editor with some aces already preset.
5. Delete share and create new pointing to POSIX dataset.
6. Check that Use Preset button acl editor works.