### PR TITLE
NAS-0: Hide Cloud Sync encryption key & salt

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -355,6 +355,8 @@ export class CloudsyncFormComponent implements FormConfiguration {
           name: 'encryption_password',
           placeholder: helptext.encryption_password_placeholder,
           tooltip: helptext.encryption_password_tooltip,
+          inputType: 'password',
+          togglePw: true,
           isHidden: true,
           relation: [
             {
@@ -371,6 +373,8 @@ export class CloudsyncFormComponent implements FormConfiguration {
           name: 'encryption_salt',
           placeholder: helptext.encryption_salt_placeholder,
           tooltip: helptext.encryption_salt_tooltip,
+          inputType: 'password',
+          togglePw: true,
           isHidden: true,
           relation: [
             {


### PR DESCRIPTION
This PR hides the encryption password and salt on Cloud Sync pages, in the same way as all other secret fields elsewhere in the UI.