### PR TITLE
NAS-111908: Fixed setting of source or destination path depending on direction

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -564,16 +564,14 @@ export class CloudsyncFormComponent implements FormConfiguration {
 
   dataHandler(entityForm: EntityFormComponent): void {
     const data = entityForm.wsResponse;
-    if (data.include && data.include.length) {
-      data.path_source = data.include.map((p: string) => data.path + '/' + p.split('/')[1]);
-    } else {
+    if(data.direction === Direction.Pull) {
       data.path_destination = data.path;
-    }
-    if (data.attributes.include && data.attributes.include.length) {
       data.attributes.folder_source = data.attributes.include.map((p: string) => data.attributes.folder + '/' + p.split('/')[1]);
     } else {
       data.attributes.folder_destination = data.attributes.folder;
+      data.path_source = data.include.map((p: string) => data.path + '/' + p.split('/')[1]);
     }
+    
     for (const i in data) {
       const fg = entityForm.formGroup.controls[i];
       if (fg) {


### PR DESCRIPTION
NAS-111908

To test, create a PUSH cloud sync task and then edit it and change it to a PULL task. Previously, the path for destination directory was not properly entered when you open the edit form on this PULL task (See video attached with the ticket on Jira). It should load fine now.