### PR TITLE
NAS-111877 / 21.08-BETA.1 / NAS-111877: Closing loader after navigating to Rsync Module form. (by undsoft)

### DIFF
--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -709,6 +709,10 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
   ngOnDestroy(): void {
     if (typeof (this.sub) !== 'undefined' && typeof (this.sub.unsubscribe) !== 'undefined') {
       this.sub.unsubscribe();
+      if (this.loaderOpen) {
+        this.loader.close();
+        this.loaderOpen = false;
+      }
     }
   }
 }


### PR DESCRIPTION
Basically in every place where we have tabs and navigate away from entity-form to something else the loader would not close.

Multiple places to check:
1. Services -> Rsync -> Rsync Modules
2. Sharing -> iSCSI Configure -> Targets

Original PR: https://github.com/truenas/webui/pull/5805
Jira URL: https://jira.ixsystems.com/browse/NAS-111877