### PR TITLE
NAS-111931 / 21.10 / NAS-111931: Adapt disk name retrieval to Linux naming conventions

### DIFF
--- a/src/app/core/classes/system-profiler.ts
+++ b/src/app/core/classes/system-profiler.ts
@@ -190,14 +190,12 @@ export class SystemProfiler {
       const stats: any = {}; // Store stats from pool.query disk info
 
       if (vdev.children.length == 0 && vdev.device) {
-        const spl = vdev.device.split('p');
-        const name = spl[0];
+        const name = vdev.disk;
         v.disks[name] = -1; // no children so we use this as placeholder
       } else if (vdev.children.length > 0) {
         vdev.children.forEach((disk, dIndex) => {
           if (disk.device && disk.status != 'REMOVED') {
-            const spl = disk.disk.split('p'); // was disk.device
-            const name = spl[0];
+            const name = disk.disk;
             v.disks[name] = dIndex;
             stats[name] = disk.stats;
           }


### PR DESCRIPTION
PR testing needs iX rackmount hardware with enclosure support and a pool with spares. (tn27 should be preconfigured)
To test, simply make sure the spares are being presented as members of the pool.