### PR TITLE
NAS-112158 / 21.10 / NAS-112158: Fetched latest values from FormControl instead of config

### DIFF
--- a/src/app/pages/storage/volumes/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.ts
+++ b/src/app/pages/storage/volumes/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.ts
@@ -160,7 +160,7 @@ export class DatasetAclEditorComponent implements OnInit {
 
   onSavePressed(): void {
     this.store.saveAcl({
-      recursive: this.saveParameters.get('recursive').value,
+      recursive: !!(this.saveParameters.get('recursive').value),
       traverse: !!(this.saveParameters.get('recursive').value && this.saveParameters.get('traverse').value),
       owner: this.ownerFormGroup.get('owner').value,
       ownerGroup: this.ownerFormGroup.get('ownerGroup').value,

--- a/src/app/pages/storage/volumes/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.ts
+++ b/src/app/pages/storage/volumes/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.ts
@@ -160,8 +160,8 @@ export class DatasetAclEditorComponent implements OnInit {
 
   onSavePressed(): void {
     this.store.saveAcl({
-      recursive: this.recursiveFieldConfig.value,
-      traverse: this.recursiveFieldConfig.value && this.traverseFieldConfig.value,
+      recursive: this.saveParameters.get('recursive').value,
+      traverse: !!(this.saveParameters.get('recursive').value && this.saveParameters.get('traverse').value),
       owner: this.ownerFormGroup.get('owner').value,
       ownerGroup: this.ownerFormGroup.get('ownerGroup').value,
     });


### PR DESCRIPTION
NAS-112158
Test "Apply Permissions Recursively" and "Apply permissions to child datasets" fields in ACL Editor by setting them to different pairs of values.