### PR TITLE
NAS-112312 / 21.10 / determine changelog size dynamically

### DIFF
--- a/src/app/pages/applications/dialogs/chart-upgrade/chart-upgrade-dialog.component.scss
+++ b/src/app/pages/applications/dialogs/chart-upgrade/chart-upgrade-dialog.component.scss
@@ -28,7 +28,7 @@
 
     .mat-expansion-panel-body {
       margin-left: 5px;
-      max-height: 150px;
+      max-height: 40vh;
       overflow-y: auto;
       padding: 0;
     }


### PR DESCRIPTION
This changes the size of the changelog displayed from a fixed 150px to 40vh.

It's tested by making the screen smaller and bigger and on smaller screens (up to about 500 height) it responds about the same as 150px fixed, but on bigger screens it gives significantly more reading-room.

In the future this can be increased even further, but currently that is not possible due to NAS-112313, as setting the height to 50-60vh increases the display size at which the overlapping buttons from NAS-112313 appear.

**Why turn the colors around?**

Having the right-side text portion (label) white, turned out to extremely highlight the fact it was below the App name. Turning the colors around removed that annoying effect.

It also fitted within the theme of this section, where previously the important things (App Name and version) where also "highlighted" in white.