### PR TITLE
NAS-112283 / 21.10 / NAS-112283: Fix text overflow for motd banner

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table.component.scss
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.scss
@@ -306,12 +306,6 @@ div#cardHeaderContainer {
   border-right: 1px solid var(--lines);
 }
 
-.text-overflow-ellipsis {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 button div.label-warning-icon {
   display: inline;
 }

--- a/src/app/pages/common/entity/table/table.component.scss
+++ b/src/app/pages/common/entity/table/table.component.scss
@@ -37,12 +37,6 @@ div.table-container {
   }
 }
 
-.text-overflow-ellipsis {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .table-component {
   max-width: 100%;
   table-layout: fixed;

--- a/src/app/pages/system/advanced/advanced-settings.component.html
+++ b/src/app/pages/system/advanced/advanced-settings.component.html
@@ -28,7 +28,7 @@
           <mat-list>
             <mat-list-item *ngFor="let item of card.items" class="card-list-item">
               <span class="label">{{ item.label | translate }}:</span>
-              <span class="value">{{ item.value | translate }}</span>
+              <span class="value text-overflow-ellipsis">{{ item.value | translate }}</span>
             </mat-list-item>
           </mat-list>
         </ng-template>

--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -4,6 +4,7 @@
 
 // Older scss files
 @import 'other/fonts';
+@import 'other/helpers';
 @import 'other/tn-styles';
 @import 'other/fn-styles';
 @import 'other/egret_overrides';

--- a/src/assets/styles/other/_helpers.scss
+++ b/src/assets/styles/other/_helpers.scss
@@ -1,0 +1,7 @@
+// Globally available helpers
+
+.text-overflow-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
How to test?

1. Go to `System Settings -> Advanced`
2. Update `MOTD Banner` using the example below
```
████████ ██████  ██    ██ ███████ ███    ██  █████  ███████ 
   ██    ██   ██ ██    ██ ██      ████   ██ ██   ██ ██      
   ██    ██████  ██    ██ █████   ██ ██  ██ ███████ ███████ 
   ██    ██   ██ ██    ██ ██      ██  ██ ██ ██   ██      ██ 
   ██    ██   ██  ██████  ███████ ██   ████ ██   ██ ███████                                                 
```