### PR TITLE
NAS-112316 / 21.10 / Cleanup Apps version references

### DIFF
--- a/src/app/pages/applications/applications.component.scss
+++ b/src/app/pages/applications/applications.component.scss
@@ -161,9 +161,9 @@ mat-tab-group {
         color: var(--fg2);
         white-space: nowrap;
       }
+
       .version-label {
         color: var(--fg2);
-        padding-right: 5px;
         white-space: nowrap;
       }
 

--- a/src/app/pages/applications/applications.component.scss
+++ b/src/app/pages/applications/applications.component.scss
@@ -161,6 +161,11 @@ mat-tab-group {
         color: var(--fg2);
         white-space: nowrap;
       }
+      .version-label {
+        color: var(--fg2);
+        padding-right: 5px;
+        white-space: nowrap;
+      }
 
       .version-value {
         color: rgba(255, 255, 255, 0.5);

--- a/src/app/pages/applications/chart-releases/chart-releases.component.html
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.html
@@ -22,8 +22,8 @@
             <span class="update-label" matTooltip="Available version: {{ item.human_latest_version }}">{{ 'Update available' | translate}}</span>
           </div>
           <ng-template #elseBlock><div class="update-label">{{ 'Up to date' | translate }}</div></ng-template>
-          <div class="version-label">{{ 'Container Version' | translate }}:<span class="version" textLimiter threshold="50" content="{{ item.chart_metadata.appVersion}}"></span></div>
-          <div class="version-label">{{ 'App Version' | translate }}:<span class="version" textLimiter threshold="50" content="{{ item.version}}"></span></div>
+          <div class="version-label">{{ 'Container Version' | translate }}:<span class="version-value" textLimiter threshold="50" content="{{ item.chart_metadata.appVersion}}"></span></div>
+          <div class="version-label">{{ 'App Version' | translate }}:<span class="version-value" textLimiter threshold="50" content="{{ item.version}}"></span></div>
         </div>
 
         <div class="chart-button-row" fxLayout="row" fxLayoutAlign="end end" (click)="$event.stopPropagation()">

--- a/src/app/pages/applications/chart-releases/chart-releases.component.html
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.html
@@ -18,11 +18,12 @@
       <div class="content-box"  (click)="showChartEvents(item.name)">
         <div class="content">
           <strong class="chart-name" textLimiter threshold="20" content="{{ item.name }}"></strong>
-          <div><span class="version" textLimiter threshold="50" content="{{ item.human_version}}"></span></div>
           <div *ngIf="item.update_available || item.container_images_update_available; else elseBlock">
             <span class="update-label" matTooltip="Available version: {{ item.human_latest_version }}">{{ 'Update available' | translate}}</span>
           </div>
           <ng-template #elseBlock><div class="update-label">{{ 'Up to date' | translate }}</div></ng-template>
+          <div class="version-label">{{ 'Container Version' | translate }}:<span class="version" textLimiter threshold="50" content="{{ item.chart_metadata.appVersion}}"></span></div>
+          <div class="version-label">{{ 'App Version' | translate }}:<span class="version" textLimiter threshold="50" content="{{ item.version}}"></span></div>
         </div>
 
         <div class="chart-button-row" fxLayout="row" fxLayoutAlign="end end" (click)="$event.stopPropagation()">

--- a/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.html
+++ b/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.html
@@ -3,19 +3,21 @@
     <div class="logo">
       <img [src]="catalogApp.chart_metadata.icon" [src-fallback]="imagePlaceholder"/>
     </div>
-    <div fxLayout="colomn" fxLayoutAlign="start center">
+    <div fxLayout="column" fxLayoutAlign="center flex-start">
       <div fxLayout="row" fxLayoutAlign="start center">
         <strong class="chart-name">{{ catalogApp.name }}</strong>
-        <span class="value">{{ appStatus() | translate }}</span>
-        <mat-icon *ngIf="getUpdateVersionTooltip()" class="version-tooltip" matTooltip="{{ getUpdateVersionTooltip() }}">info</mat-icon>
       </div>
-      <div fxLayout="row" fxLayoutAlign="start center">
-        <span class="version-label">{{ 'Container Version' | translate }}:</span>
-        <span class="version"> {{ catalogApp.chart_metadata.appVersion }}</span>
+      <div fxLayout="row" fxLayoutAlign="flex-start center">
+        <span class="top-label">{{ appStatus() | translate }}</span>
+        <mat-icon *ngIf="getUpdateVersionTooltip()" class="version-tooltip" matTooltip="{{ getUpdateVersionTooltip() }}">info</mat-icon>
+      </div> 
+      <div fxLayout="row" fxLayoutAlign="flex-start center">
+        <span class="top-label">{{ 'Container Version' | translate }}:</span>
+        <span class="top-value"> {{ catalogApp.chart_metadata.appVersion }}</span>
       </div>  
-      <div fxLayout="row" fxLayoutAlign="start center">
-        <span class="version-label">{{ 'App Version' | translate }}:</span>
-        <span class="version"> {{ catalogApp.version }}</span>
+      <div fxLayout="row" fxLayoutAlign="flex-start flex-start">
+        <span class="top-label">{{ 'App Version' | translate }}:</span>
+        <span class="top-value"> {{ catalogApp.version }}</span>
       </div>
     </div>
   </div>

--- a/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.html
+++ b/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.html
@@ -3,11 +3,20 @@
     <div class="logo">
       <img [src]="catalogApp.chart_metadata.icon" [src-fallback]="imagePlaceholder"/>
     </div>
-    <div fxLayout="row" fxLayoutAlign="start center">
-      <strong class="chart-name">{{ catalogApp.name }}</strong>
-      <span class="version"> {{ catalogApp.human_version }}</span>
-      <span class="value">{{ appStatus() | translate }}</span>
-      <mat-icon *ngIf="getUpdateVersionTooltip()" class="version-tooltip" matTooltip="{{ getUpdateVersionTooltip() }}">info</mat-icon>
+    <div fxLayout="colomn" fxLayoutAlign="start center">
+      <div fxLayout="row" fxLayoutAlign="start center">
+        <strong class="chart-name">{{ catalogApp.name }}</strong>
+        <span class="value">{{ appStatus() | translate }}</span>
+        <mat-icon *ngIf="getUpdateVersionTooltip()" class="version-tooltip" matTooltip="{{ getUpdateVersionTooltip() }}">info</mat-icon>
+      </div>
+      <div fxLayout="row" fxLayoutAlign="start center">
+        <span class="version-label">{{ 'Container Version' | translate }}:</span>
+        <span class="version"> {{ catalogApp.chart_metadata.appVersion }}</span>
+      </div>  
+      <div fxLayout="row" fxLayoutAlign="start center">
+        <span class="version-label">{{ 'App Version' | translate }}:</span>
+        <span class="version"> {{ catalogApp.version }}</span>
+      </div>
     </div>
   </div>
   <div class="ports">

--- a/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.scss
+++ b/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.scss
@@ -26,7 +26,9 @@
     }
   }
 
-  .ports,
+  .ports {
+    padding-top: 15px;
+  }
 
   .resource {
     padding: 5px 0;
@@ -35,22 +37,22 @@
   }
 
   .chart-name {
-    font-size: 20px;
+    font-size: 22px;
     font-weight: bold;
-    margin-right: 10px;
   }
 
-  .version {
+  .top-label {
     font-size: 14px;
+    padding-right: 10px;
   }
 
-  .version-label {
-    margin-right: 10px;
+  .top-value {
     opacity: 0.5;
   }
 
   .version-tooltip {
-    margin-left: 10px;
+    font-size: 22px;
+    padding-right: 10px;
   }
 
   .value {

--- a/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.scss
+++ b/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.scss
@@ -44,6 +44,11 @@
     font-size: 14px;
   }
 
+  .version-label {
+    margin-right: 10px;
+    opacity: 0.5;
+  }
+
   .version-tooltip {
     margin-left: 10px;
   }


### PR DESCRIPTION
**General overview:**
This should improve the version references for Apps in the bigger overview portions of the UI, by splitting the long weird string with `_` in the middle into two parts:
"Container Version" which translates to chart.yaml->appVersion
"App Version" which translates to chart.yaml->Version

**Why Container version?**
In almost any cases the appVersion is used to signify the version of the included application. However, we needed something to differentiate it from `App version`. Hence "Container version" to signify it has nothing to do with the App, but rather with the container inside.

**What does not change with this PR:**
- The shorts-style version: containerversion_appversion  (One might want to replace the `_` with `/` though), it still has a place to give a quick overview.
- The Available Apps overview: It doesn't have the space to apply the same changes and needs additional consideration, so it keeps using short-style version
- The information dialogs on-hover when an update is available: These still use the short-style version.