### PR TITLE
NAS-112109 / 12.0 / Handling broken reporting database

### DIFF
--- a/src/app/pages/reportsdashboard/components/report/report.component.css
+++ b/src/app/pages/reportsdashboard/components/report/report.component.css
@@ -33,7 +33,7 @@
 }
 
 .legend {
-  display:table; 
+  display:table;
 }
 
 .legend-group-wrapper {
@@ -374,7 +374,7 @@ div.line-chart-tools ul{
 div.line-chart-tools li{}
 
 div.line-chart-tools .tool-icon{
-  width:64px; 
+  width:64px;
   font-size:18px;
 }
 
@@ -498,7 +498,7 @@ height:calc(100% - 48px);
   background-color:rgba(0,0,0,0.1);
   height:45%;
   text-align: left;
-  padding: 16px; 
+  padding: 16px;
 }
 
 .title-wrapper .title{
@@ -672,7 +672,17 @@ h3 {
   flex-direction: column;
 }
 
-.empty-icon {
+.empty-icon,
+.error-icon {
   font-size: 3rem;
   padding-right: 21px;
+}
+
+.error-icon {
+  color: var(--red);
+}
+
+.error-title {
+  font-size: 1.25rem;
+  margin: 1rem 0;
 }

--- a/src/app/pages/reportsdashboard/components/report/report.component.html
+++ b/src/app/pages/reportsdashboard/components/report/report.component.html
@@ -4,7 +4,7 @@
       <mat-toolbar-row fxLayout="row" fxLayoutWrap fxLayoutAlign="space-between start" fxFlex="100" class="mat-card-toolbar">
         <mat-card-title fxFlex="65%">
           <h3>
-            {{reportTitle}} 
+            {{reportTitle}}
             <span *ngIf="multipathTitle">
               {{multipathTitle}}
               <mat-icon class="multipath-icon" role="img" svgIcon="multipath"></mat-icon>
@@ -12,7 +12,7 @@
           </h3>
         </mat-card-title>
         <!-- Controls/Tools -->
-        <div fxFlex="calc(35%)" class="line-chart-tools-wrapper" *ngIf="!report.empty">
+        <div fxFlex="calc(35%)" class="line-chart-tools-wrapper" *ngIf="!report.empty && !report.error">
           <div class="line-chart-tools" *ngIf="localControls">
             <button class="tool-icon" mat-icon-button [disabled]="timeZoomIndex >= (zoomLevels.length - 1)" (click)="timeZoomIn()"
               ix-auto ix-auto-type="button" ix-auto-identifier="{{reportTitle}}_zoomIn">
@@ -40,6 +40,20 @@
 
         <mat-card-content fxLayout="row wrap" fxLayout.gt-xs="row wrap" fxLayoutAlign="space-between start" fxFlex="100">
 
+          <ng-container *ngIf="report.error">
+            <div class="chart-wrapper-outer" fxFlex="calc(100% - 400px)">
+              <div class="chart-wrapper-empty">
+                <div class="chart-wrapper-child">
+                  <div>
+                    <mat-icon class="error-icon"fontSet="mdi-set" fontIcon="mdi-alert-octagon"></mat-icon>
+                  </div>
+                  <h4 class="error-title">{{ report.error.title }}</h4>
+                  <button mat-raised-button color="primary" (click)="report.error.button.click()">{{ report.error.button.text }}</button>
+                </div>
+              </div>
+            </div>
+          </ng-container>
+
           <ng-container *ngIf="report.empty">
             <div class="chart-wrapper-outer" fxFlex="calc(100% - 400px)">
               <div class="chart-wrapper-empty">
@@ -54,8 +68,8 @@
               </div>
             </div>
           </ng-container>
-          
-          <ng-container *ngIf="!report.empty">
+
+          <ng-container *ngIf="!report.empty && !report.error">
             <div class="chart-wrapper-outer" fxFlex="calc(100% - 400px)">
               <div class="chart-wrapper" >
                 <linechart
@@ -70,8 +84,8 @@
                   interactive="false">
                 </linechart>
               </div>
-  
-  
+
+
             <!-- Legend Section -->
             <div class="legend-wrapper timestamps">
               <!-- Time Stamps -->
@@ -79,7 +93,7 @@
                 <div >
                   <span *ngIf="data && legendData">
                     <h4>
-                      <strong>Start:</strong> 
+                      <strong>Start:</strong>
                       <span style="font-weight:normal;">&nbsp;&nbsp;{{startTime}}</span>
                       <br ngClass.gt-sm="hidden">
                       <span style="margin-left:0px;" class="text-small"> ({{timezone}})</span>
@@ -92,7 +106,7 @@
                 <div >
                   <span *ngIf="data && legendData">
                     <h4>
-                      <strong>End:</strong> 
+                      <strong>End:</strong>
                       <span style="font-weight:normal;">&nbsp;&nbsp;{{endTime}}</span>
                       <br ngClass.gt-sm="hidden">
                       <span style="opacity:0;" class="text-small"> ({{timezone}})</span>
@@ -101,16 +115,16 @@
                 </div>
               </div>
             </div>
-  
+
             </div>
-  
+
             <section class="legend" #legendElement fxFlex="400px" fxLayout="column" fxLayoutAlign="start"  >
-  
+
             <div *ngIf="report && data && data.legend" class="legend-timestamp" fxFlex="32px">
               <div >
                 <span *ngIf="data && legendData && legendData.xHTML">
                   <h4>
-                    <strong>Time:</strong> 
+                    <strong>Time:</strong>
                     <span *ngIf="legendData && legendData.xHTML" style="font-weight:normal;">
                       &nbsp;&nbsp;
                       {{legendData.xHTML}}
@@ -119,7 +133,7 @@
                 </span>
               </div>
             </div>
-  
+
             <div *ngIf="report && data && data.legend" class="legend-group-wrapper" fxFlex="calc(100% - 64px)" >
               <table class="legend-table">
                 <!-- Table Header-->
@@ -131,11 +145,11 @@
                     </th>
                   </ng-container>
                 </tr>
-  
+
                 <!-- Table Rows -->
                 <tr class="legend-group"
                   *ngFor="let legendItem of data.legend; let i=index">
-  
+
                     <td class="legend-label" >
                       <!--Legend Label-->
                       <div *ngIf="chartColors && legendItem"
@@ -143,35 +157,35 @@
                         [style.background-color]="chartColors[i]" >
                         </div>
                       <span class="legend-item"><strong>{{legendItem}}</strong></span>
-  
+
                       <span *ngIf="legendData && legendData.series">
                         <span  class="tooltip-value" >
                            <span style="font-weight:normal;"> : {{legendData.series[i].yHTML}}</span>
                         </span>
                       </span>
                     </td>
-  
+
                   <!-- Aggregations -->
                   <ng-container *ngIf="data && data.aggregations">
                     <td style="opacity:0.75; border:red;"
                       *ngFor="let key of aggregationKeys"
                       class="report-analytics" >
-  
+
                       <span>
                         {{data.aggregations[key][i] ? data.aggregations[key][i] : 'null'}}
                       </span>
-  
+
                     </td>
                   </ng-container>
                 </tr>
               </table>
-  
+
               </div>
             </section>
           </ng-container>
           <!--<viewchartline fxFlex="100" fxFlexAlign="end" #chartCpu width="600" height="160" [style.display]="isFlipped ? 'none': 'block'"></viewchartline>-->
           <!-- Chart -->
-          
+
 
         </mat-card-content>
 

--- a/src/app/pages/reportsdashboard/components/report/report.component.ts
+++ b/src/app/pages/reportsdashboard/components/report/report.component.ts
@@ -1,10 +1,11 @@
+import { DialogService } from '../../../../services/dialog.service';
 import {
   Component, AfterViewInit, AfterContentInit, Input, ViewChild, OnDestroy, OnChanges, ElementRef,
 } from '@angular/core';
 import { CoreServiceInjector } from 'app/core/services/coreserviceinjector';
 import { CoreService, CoreEvent } from 'app/core/services/core.service';
 import { WebSocketService } from 'app/services/';
-import { ReportsService } from '../../reports.service';
+import { ReportingDatabaseError, ReportsService } from '../../reports.service';
 import { MaterialModule } from 'app/appMaterial.module';
 import { Subject } from 'rxjs/Subject';
 import { NgForm } from '@angular/forms';
@@ -21,6 +22,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { LocaleService } from 'app/services/locale.service';
 
 import { T } from '../../../../translate-marker';
+import { filter, take } from 'rxjs/operators';
 
 interface DateTime {
   dateFormat: string;
@@ -53,6 +55,7 @@ export interface Report {
   identifiers?: string[];
   isRendered?: boolean[];
   empty?: EmptyReportMessage;
+  error?: EmptyReportMessage;
 }
 
 export interface EmptyReportMessage {
@@ -174,15 +177,19 @@ export class ReportComponent extends WidgetComponent implements AfterViewInit, A
     return result.toLowerCase() !== 'invalid date' ? result : null;
   }
 
-  constructor(public router: Router,
+  constructor(
+    public router: Router,
     public translate: TranslateService,
     private rs: ReportsService,
     private ws: WebSocketService,
-    protected localeService: LocaleService) {
+    protected localeService: LocaleService,
+    protected dialog: DialogService,
+  ) {
     super(translate);
 
     this.core.register({ observerClass: this, eventName: 'ReportData-' + this.chartId }).subscribe((evt: CoreEvent) => {
       this.data = evt.data;
+      this.handleError(evt);
     });
 
     this.core.register({ observerClass: this, eventName: 'LegendEvent-' + this.chartId }).subscribe((evt: CoreEvent) => {
@@ -410,6 +417,33 @@ export class ReportComponent extends WidgetComponent implements AfterViewInit, A
       if (form.value[i]) {
         filtered.push(i);
       }
+    }
+  }
+
+  handleError(evt: CoreEvent): void {
+    if (evt.data && evt.data.name === 'FetchingError' && evt.data.data.error === ReportingDatabaseError.InvalidTimestamp) {
+      const err = evt.data.data;
+      const errorMessage = err.reason ? err.reason.replace('[EINVALIDRRDTIMESTAMP] ', '') : null;
+      const helpMessage = this.translate.instant('You can clear reporting database and start data collection immediately.');
+      const message = errorMessage ? `${errorMessage}<br>${helpMessage}` : helpMessage;
+      this.report.error = {
+        title: this.translate.instant('The reporting database is broken'),
+        message,
+        button: {
+          text: this.translate.instant('Fix database'),
+          click: () => {
+            this.dialog.confirm({
+              title: this.translate.instant('The reporting database is broken'),
+              message,
+              buttonMsg: this.translate.instant('Clear'),
+            }).pipe(filter(Boolean), take(1)).subscribe(() => {
+              this.ws.call('reporting.clear').pipe(take(1)).subscribe(() => {
+                window.location.reload();
+              });
+            });
+          },
+        },
+      };
     }
   }
 }

--- a/src/app/pages/reportsdashboard/reports-utils.worker.ts
+++ b/src/app/pages/reportsdashboard/reports-utils.worker.ts
@@ -351,5 +351,8 @@ addEventListener('message', ({ data }) => {
       output = processCommands(evt.data);
       emit({ name: 'ReportData', data: output, sender: evt.sender });
       break;
+    case 'FetchingError':
+      emit({ name: 'ReportData', data, sender: evt.sender });
+      break;
   }
 });


### PR DESCRIPTION
Manual port of #5885

Preview:
![image](https://user-images.githubusercontent.com/351613/133467116-8ffdb6e1-545b-4054-a9bf-b213f19e62b3.png)
![image](https://user-images.githubusercontent.com/351613/133467129-1cd7c4be-04dd-447b-9de0-6117b7008f36.png)

How to test?

- Go to `Shell`
- Update system time to future, type `date 2110011307` for example
- Clear reporting database `midclt call reporting.clear`
- Go to Reporting, wait a couple of minutes to collect some data
- Reboot the system, type `reboot`
- Wait until the system is loaded
- Go to Reporting
- Fix reporting database

FreeBSD behaves differently from Debian, you may notice a warning in shell:
```
Warning: settings changed through the CLI are not written to the configuration database and will be reset on reboot.
```
It means if you change the date and make a reboot it will revert date changes.
So, the idea is to set the future time, then reset reporting database, collect some data, and then make a reboot. The date will be reverted and you'll get `Error: 206` from API.