### PR TITLE
NAS-112057 / 21.10 / Apps: Make "Installed Applications" the default tab

### DIFF
--- a/src/app/pages/applications/applications.component.html
+++ b/src/app/pages/applications/applications.component.html
@@ -1,12 +1,12 @@
 <div fxLayout=row>
   <mat-tab-group animationDuration="0ms" [selectedIndex]="selectedIndex" (selectedTabChange)="refresh($event)">
-    <mat-tab label="{{ 'Available Applications' | translate}}"
-          ix-auto ix-auto-type="tab" ix-auto-identifier="catalog">
-      <app-catalog (updateTab)="updateTab($event)"></app-catalog>
-    </mat-tab>
     <mat-tab label="{{ 'Installed Applications' | translate}}"
           ix-auto ix-auto-type="tab" ix-auto-identifier="charts">
       <app-charts (updateTab)="updateTab($event)"></app-charts>
+    </mat-tab>
+    <mat-tab label="{{ 'Available Applications' | translate}}"
+          ix-auto ix-auto-type="tab" ix-auto-identifier="catalog">
+      <app-catalog (updateTab)="updateTab($event)"></app-catalog>
     </mat-tab>
     <mat-tab label="{{ 'Manage Catalogs' | translate}}"
           ix-auto ix-auto-type="tab" ix-auto-identifier="manage-catalog">

--- a/src/app/pages/applications/applications.component.ts
+++ b/src/app/pages/applications/applications.component.ts
@@ -29,8 +29,8 @@ import { ManageCatalogsComponent } from './manage-catalogs/manage-catalogs.compo
   encapsulation: ViewEncapsulation.None,
 })
 export class ApplicationsComponent implements OnInit, AfterViewInit {
-  @ViewChild(CatalogComponent, { static: false }) private catalogTab: CatalogComponent;
   @ViewChild(ChartReleasesComponent, { static: false }) private chartTab: ChartReleasesComponent;
+  @ViewChild(CatalogComponent, { static: false }) private catalogTab: CatalogComponent;
   @ViewChild(ManageCatalogsComponent, { static: false }) private manageCatalogTab: ManageCatalogsComponent;
   @ViewChild(DockerImagesComponent, { static: false }) private dockerImagesTab: DockerImagesComponent;
   selectedIndex = 0;
@@ -57,18 +57,12 @@ export class ApplicationsComponent implements OnInit, AfterViewInit {
     this.setupToolbar();
 
     this.modalService.refreshTable$.pipe(untilDestroyed(this)).subscribe(() => {
-      this.refreshTab(true);
+      this.refreshTab();
     });
   }
 
   ngAfterViewInit(): void {
-    // If the route parameter "tabIndex" is 1, switch tab to "Installed applications".
-    this.aroute.params.pipe(untilDestroyed(this)).subscribe((params) => {
-      if (params['tabIndex'] == 1) {
-        this.selectedIndex = 1;
-        this.refreshTab();
-      }
-    });
+    this.refreshTab();
   }
 
   setupToolbar(): void {
@@ -78,12 +72,8 @@ export class ApplicationsComponent implements OnInit, AfterViewInit {
         this.filterString = evt.data.filter;
       }
 
-      if (evt.data.event_control == 'catalogs') {
-        this.selectedCatalogOptions = evt.data.catalogs;
-      }
-
-      this.catalogTab.onToolbarAction(evt);
       this.chartTab.onToolbarAction(evt);
+      this.catalogTab.onToolbarAction(evt);
       this.manageCatalogTab.onToolbarAction(evt);
       this.dockerImagesTab.onToolbarAction(evt);
     });
@@ -117,6 +107,26 @@ export class ApplicationsComponent implements OnInit, AfterViewInit {
     // TODO: Error prone if index is changed
     switch (this.selectedIndex) {
       case 0:
+        search.placeholder = helptext.installedPlaceholder;
+        const bulk = {
+          name: 'bulk',
+          label: helptext.bulkActions.title,
+          type: 'menu',
+          options: helptext.bulkActions.options,
+        };
+        if (this.isSelectedAll) {
+          bulk.options[0].label = helptext.bulkActions.unSelectAll;
+        } else {
+          bulk.options[0].label = helptext.bulkActions.selectAll;
+        }
+        bulk.options.forEach((option) => {
+          if (option.value != 'select_all') {
+            option.disabled = !this.isSelectedOneMore;
+          }
+        });
+        this.toolbarConfig.controls.push(bulk);
+        break;
+      case 1:
         search.placeholder = helptext.availablePlaceholder;
         this.toolbarConfig.controls.push({
           name: 'refresh_all',
@@ -136,26 +146,6 @@ export class ApplicationsComponent implements OnInit, AfterViewInit {
           value: this.selectedCatalogOptions,
           customTriggerValue: helptext.catalogs,
         });
-        break;
-      case 1:
-        search.placeholder = helptext.installedPlaceholder;
-        const bulk = {
-          name: 'bulk',
-          label: helptext.bulkActions.title,
-          type: 'menu',
-          options: helptext.bulkActions.options,
-        };
-        if (this.isSelectedAll) {
-          bulk.options[0].label = helptext.bulkActions.unSelectAll;
-        } else {
-          bulk.options[0].label = helptext.bulkActions.selectAll;
-        }
-        bulk.options.forEach((option) => {
-          if (option.value != 'select_all') {
-            option.disabled = !this.isSelectedOneMore;
-          }
-        });
-        this.toolbarConfig.controls.push(bulk);
         break;
       case 2:
         search.placeholder = helptext.catalogPlaceholder;
@@ -240,17 +230,12 @@ export class ApplicationsComponent implements OnInit, AfterViewInit {
     }
   }
 
-  refreshTab(switchToAppTab = false): void {
+  refreshTab(): void {
     this.updateToolbar();
     if (this.selectedIndex == 0) {
-      if (switchToAppTab) {
-        this.selectedIndex = 1;
-        this.chartTab.refreshChartReleases();
-      } else {
-        this.catalogTab.loadCatalogs();
-      }
-    } else if (this.selectedIndex == 1) {
       this.chartTab.refreshChartReleases();
+    } else if (this.selectedIndex == 1) {
+      this.catalogTab.loadCatalogs();
     } else if (this.selectedIndex == 2) {
       this.manageCatalogTab.refresh();
     } else if (this.selectedIndex == 3) {

--- a/src/app/pages/applications/catalog/catalog.component.ts
+++ b/src/app/pages/applications/catalog/catalog.component.ts
@@ -235,6 +235,7 @@ export class CatalogComponent implements OnInit {
     this.appService.getKubernetesConfig().pipe(untilDestroyed(this)).subscribe((config) => {
       if (!config.pool) {
         this.selectPool();
+        this.updateTab.emit({ name: ApplicationUserEventName.SwitchTab, value: 1 });
       } else {
         this.selectedPool = config.pool;
       }

--- a/src/app/pages/applications/chart-releases/chart-releases.component.ts
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.ts
@@ -163,7 +163,7 @@ export class ChartReleasesComponent implements OnInit {
   }
 
   viewCatalog(): void {
-    this.updateTab.emit({ name: ApplicationUserEventName.SwitchTab, value: 0 });
+    this.updateTab.emit({ name: ApplicationUserEventName.SwitchTab, value: 1 });
   }
 
   showLoadStatus(type: EmptyType): void {


### PR DESCRIPTION
This changes the default tab for the Applications interface when clicking "Apps" from the Menu to "Installed Applications".

**Confirmed working when used with pre-configured pool:**
- Clicking "Apps in the Nav menu" -> lands on "Installed Applications"
- Switching between all possible tab combinations
- Using the bulk tools in  "Installed Applications"
- Referesh button on "Available Applications" 
- setup modal
- poolselector pop-up


Might need (considerable?) extra work for the pool selection popup on new systems though, which isn't my strongsuit, Feel free to fork and finish if so :)