### PR TITLE
NAS-112059 / 21.10 / Use iX Blue + Dark Blue for official Apps

### DIFF
--- a/src/app/pages/applications/applications.component.scss
+++ b/src/app/pages/applications/applications.component.scss
@@ -51,15 +51,11 @@ mat-tab-group {
         margin: 0 16px 16px;
         text-align: center;
 
-        .partner-badge {
-          background-color: var(--yellow);
-        }
-
         .train-badge {
           background-color: #00000052;
         }
       }
-    }
+	  }
 
     .content {
       left: 15px;

--- a/src/app/pages/applications/applications.component.scss
+++ b/src/app/pages/applications/applications.component.scss
@@ -55,7 +55,7 @@ mat-tab-group {
           background-color: #00000052;
         }
       }
-	  }
+    }
 
     .content {
       left: 15px;

--- a/src/app/pages/applications/applications.component.scss
+++ b/src/app/pages/applications/applications.component.scss
@@ -45,6 +45,10 @@ mat-tab-group {
         }
       }
 
+      .badge-official {
+        background-color: var(--primary) !important;
+      }
+
       .badge-area {
         background-color: var(--yellow);
         color: rgba($color: #000, $alpha: 1);

--- a/src/app/pages/applications/catalog/catalog.component.html
+++ b/src/app/pages/applications/catalog/catalog.component.html
@@ -24,7 +24,7 @@
               {{ item.catalog.train }}
             </div>
           </div>
-        <div class="badge-area" *ngIf="item.catalog.label != 'OFFICIAL'">
+          <div class="badge-area" *ngIf="item.catalog.label != 'OFFICIAL'">
             <div class="capitalized-text">
               {{ item.catalog.label }}
             </div>

--- a/src/app/pages/applications/catalog/catalog.component.html
+++ b/src/app/pages/applications/catalog/catalog.component.html
@@ -16,8 +16,16 @@
           <div class="logo">
             <img [src]="item.icon_url" [src-fallback]="imagePlaceholder"/>
           </div>
-          <div class="badge-area">
-            <div class="partner-badge capitalized-text">
+          <div class="badge-area" style="background-color: var(--primary)" *ngIf="item.catalog.label == 'OFFICIAL'">
+            <div class="capitalized-text" >
+              {{ item.catalog.label }}
+            </div>
+            <div class="train-badge capitalized-text">
+              {{ item.catalog.train }}
+            </div>
+          </div>
+        <div class="badge-area" *ngIf="item.catalog.label != 'OFFICIAL'">
+            <div class="capitalized-text">
               {{ item.catalog.label }}
             </div>
             <div class="train-badge capitalized-text">

--- a/src/app/pages/applications/catalog/catalog.component.html
+++ b/src/app/pages/applications/catalog/catalog.component.html
@@ -16,7 +16,7 @@
           <div class="logo">
             <img [src]="item.icon_url" [src-fallback]="imagePlaceholder"/>
           </div>
-          <div class="badge-area" style="background-color: var(--primary)" *ngIf="item.catalog.label == 'OFFICIAL'">
+          <div class="badge-area badge-official" *ngIf="item.catalog.label == 'OFFICIAL'">
             <div class="capitalized-text" >
               {{ item.catalog.label }}
             </div>

--- a/src/app/pages/applications/chart-releases/chart-releases.component.html
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.html
@@ -5,7 +5,7 @@
         <div class="logo">
           <img [src]="item.chart_metadata.icon" [src-fallback]="imagePlaceholder"/>
         </div>
-          <div class="badge-area" style="background-color: var(--primary)" *ngIf="item.catalog == 'OFFICIAL'">
+          <div class="badge-area badge-official" *ngIf="item.catalog == 'OFFICIAL'">
             <div class="capitalized-text" >
              {{ item.catalog }}
             </div>

--- a/src/app/pages/applications/chart-releases/chart-releases.component.html
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.html
@@ -5,14 +5,22 @@
         <div class="logo">
           <img [src]="item.chart_metadata.icon" [src-fallback]="imagePlaceholder"/>
         </div>
-        <div class="badge-area">
-          <div class="partner-badge capitalized-text">
-            {{ item.catalog }}
+          <div class="badge-area" style="background-color: var(--primary)" *ngIf="item.catalog == 'OFFICIAL'">
+            <div class="capitalized-text" >
+		     {{ item.catalog }}
+            </div>
+            <div class="train-badge capitalized-text">
+              {{ item.catalog_train }}
+            </div>
           </div>
-          <div class="train-badge capitalized-text">
-            {{ item.catalog_train }}
+          <div class="badge-area" *ngIf="item.catalog != 'OFFICIAL'">
+            <div class="capitalized-text">
+              {{ item.catalog }}
+            </div>
+            <div class="train-badge capitalized-text">
+              {{ item.catalog_train }}
+            </div>
           </div>
-        </div>
         <mat-checkbox color="primary" class="bulk-checkbox" [(ngModel)]="item.selected" (change)="onChangeCheck()"></mat-checkbox>
       </div>
       <div class="content-box"  (click)="showChartEvents(item.name)">

--- a/src/app/pages/applications/chart-releases/chart-releases.component.html
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.html
@@ -7,7 +7,7 @@
         </div>
           <div class="badge-area" style="background-color: var(--primary)" *ngIf="item.catalog == 'OFFICIAL'">
             <div class="capitalized-text" >
-		     {{ item.catalog }}
+             {{ item.catalog }}
             </div>
             <div class="train-badge capitalized-text">
               {{ item.catalog_train }}


### PR DESCRIPTION
As explained in NAS-112059 people are too easily confused between official and community Apps at the moment.

This PR gives two color options:
- Official in a combination of iX Blue and Dark blue
- Community in Yellow and the original disgusting dark yellow.

For Bluefin this, most likely, would need to be redesigned to deal with more than just two color options, but for Anglefish this solves the problem without too much code redundency imho.

**Before:**
![image](https://user-images.githubusercontent.com/7613738/133502749-13732fea-820c-465c-b72e-ac5ab1a5c6c8.png)

**After:**
![image](https://user-images.githubusercontent.com/7613738/134148645-23879636-c93b-4c56-afe4-347d24ae8924.png)

