### PR TITLE
NAS-112068 / 21.10 / Dynamic width of chart update/status and eventlog.

### DIFF
--- a/src/app/pages/applications/chart-releases/chart-releases.component.ts
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.ts
@@ -293,8 +293,9 @@ export class ChartReleasesComponent implements OnInit {
       this.appLoaderService.close();
 
       const dialogRef = this.mdDialog.open(ChartUpgradeDialog, {
-        width: '500px',
-        maxWidth: '500px',
+        width: '50vw',
+        minWidth: '500px',
+        maxWidth: '1000px',
         data: {
           appInfo: catalogApp,
           upgradeSummary: res,

--- a/src/app/pages/applications/chart-releases/chart-releases.component.ts
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.ts
@@ -295,7 +295,7 @@ export class ChartReleasesComponent implements OnInit {
       const dialogRef = this.mdDialog.open(ChartUpgradeDialog, {
         width: '50vw',
         minWidth: '500px',
-        maxWidth: '1000px',
+        maxWidth: '750px',
         data: {
           appInfo: catalogApp,
           upgradeSummary: res,
@@ -621,8 +621,9 @@ export class ChartReleasesComponent implements OnInit {
     const catalogApp = this.chartItems[name];
     if (catalogApp) {
       this.mdDialog.open(ChartEventsDialog, {
-        width: '686px',
-        maxWidth: '686px',
+        width: '50vw',
+        minWidth: '650px',
+        maxWidth: '850px',
         data: catalogApp,
       });
     }

--- a/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.scss
+++ b/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.scss
@@ -73,7 +73,7 @@
 
   .mat-expansion-panel-body {
     margin-left: 5px;
-    max-height: 150px;
+    max-height: 40vh;
     overflow-y: auto;
     padding: 0 !important;
   }


### PR DESCRIPTION
With this PR the width of the Chart-Status and Upgrade modals are made more dynamic.
The minimum width is set to the current fixed-width, while the maximum is set a few hunderd pixels higher.
In between the size will be based on 50vh.

This also ports the recent patch that shows more of the Release notes, to the chart summary, primarily the app eventlog.

It basically solves the remaining issues regarding sizing of those modals as stated in NAS-112068

**Example showing the combined effect of these measures on a 4K display:**
![image](https://user-images.githubusercontent.com/7613738/133510036-910833d3-add6-46e1-bedb-5379ac85c5b2.png)
