### PR TITLE
NAS-112298 / 21.10 / NAS-112298: Make reboot page more reliable

### DIFF
--- a/src/app/views/others/reboot/reboot.component.html
+++ b/src/app/views/others/reboot/reboot.component.html
@@ -1,13 +1,31 @@
 <div id="wrapper">
   <mat-card id="shutdown-card">
     <mat-card-content id="message">{{ "System is restarting..." | translate }}</mat-card-content>
-    <mat-icon svgIcon="truenas_core_logo_full" *ngIf="product_type === ProductType.Core; else isTruenas" class="logo" alt="TrueNAS CORE logo"></mat-icon>
+    <mat-icon
+      *ngIf="productType === ProductType.Core; else isTruenas"
+      svgIcon="truenas_core_logo_full"
+      class="logo"
+      alt="TrueNAS CORE logo"
+    ></mat-icon>
     <ng-template #isTruenas>
-      <mat-icon *ngIf="product_type === ProductType.Enterprise" class="logo" svgIcon="truenas_enterprise_logo_full" alt="TrueNAS ENTERPRISE logo"></mat-icon>
-      <mat-icon *ngIf="product_type === ProductType.Scale || product_type == ProductType.ScaleEnterprise" class="logo" svgIcon="truenas_scale_logo_full" alt="TrueNAS SCALE logo"></mat-icon>
+      <mat-icon
+        *ngIf="productType === ProductType.Enterprise"
+        class="logo"
+        svgIcon="truenas_enterprise_logo_full"
+        alt="TrueNAS ENTERPRISE logo"
+      ></mat-icon>
+      <mat-icon
+        *ngIf="productType === ProductType.Scale || productType == ProductType.ScaleEnterprise"
+        class="logo"
+        svgIcon="truenas_scale_logo_full"
+        alt="TrueNAS SCALE logo"
+      ></mat-icon>
     </ng-template>
     <div>
-      <span fxFlex class="copyright-txt">TrueNAS {{product_type}}® © {{copyrightYear}} - <a href="http://www.ixsystems.com" target="_blank" title="iXsystems, Inc."> iXsystems, Inc</a>.</span>
+      <span fxFlex class="copyright-txt">
+        TrueNAS {{productType}}® © {{copyrightYear}} -
+        <a href="http://www.ixsystems.com" target="_blank" title="iXsystems, Inc."> iXsystems, Inc</a>.
+      </span>
     </div>
   </mat-card>
 </div>

--- a/src/app/views/others/reboot/reboot.component.ts
+++ b/src/app/views/others/reboot/reboot.component.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
@@ -16,18 +17,24 @@ import { LocaleService } from 'app/services/locale.service';
   styleUrls: ['./reboot.component.scss'],
 })
 export class RebootComponent implements OnInit {
-  product_type: ProductType;
+  productType: ProductType;
   copyrightYear = this.localeService.getCopyrightYearFromBuildTime();
 
   readonly ProductType = ProductType;
 
-  constructor(protected ws: WebSocketService, protected router: Router,
-    protected loader: AppLoaderService, public translate: TranslateService,
-    protected dialogService: DialogService, protected dialog: MatDialog,
-    private sysGeneralService: SystemGeneralService, private localeService: LocaleService) {
-    this.ws = ws;
+  constructor(
+    protected ws: WebSocketService,
+    protected router: Router,
+    protected loader: AppLoaderService,
+    public translate: TranslateService,
+    protected dialogService: DialogService,
+    protected dialog: MatDialog,
+    private sysGeneralService: SystemGeneralService,
+    private localeService: LocaleService,
+    private location: Location,
+  ) {
     this.sysGeneralService.getProductType$.pipe(untilDestroyed(this)).subscribe((res) => {
-      this.product_type = res as ProductType;
+      this.productType = res as ProductType;
     });
   }
 
@@ -44,10 +51,13 @@ export class RebootComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.product_type = window.localStorage.getItem('product_type') as ProductType;
+    this.productType = window.localStorage.getItem('product_type') as ProductType;
+
+    // Replace URL so that we don't reboot again if page is refreshed.
+    this.location.replaceState('/session/signin');
 
     this.dialog.closeAll();
-    this.ws.call('system.reboot', {}).pipe(untilDestroyed(this)).subscribe(
+    this.ws.call('system.reboot').pipe(untilDestroyed(this)).subscribe(
       () => {
       },
       (res) => { // error on reboot
@@ -62,7 +72,7 @@ export class RebootComponent implements OnInit {
         this.loader.open();
         setTimeout(() => {
           this.isWSConnected();
-        }, 1000);
+        }, 3000);
       },
     );
   }

--- a/src/app/views/others/shutdown/shutdown.component.html
+++ b/src/app/views/others/shutdown/shutdown.component.html
@@ -2,13 +2,31 @@
 <div id="wrapper">
   <mat-card id="shutdown-card">
     <mat-card-content id="shutdown-message">{{ "System is shutting down..." | translate }}</mat-card-content>
-    <mat-icon svgIcon="truenas_core_logo_full" *ngIf="product_type === ProductType.Core; else isTruenas" class="logo" alt="TrueNAS CORE logo"></mat-icon>
+    <mat-icon
+      *ngIf="productType === ProductType.Core; else isTruenas"
+      svgIcon="truenas_core_logo_full"
+      class="logo"
+      alt="TrueNAS CORE logo"
+    ></mat-icon>
     <ng-template #isTruenas>
-      <mat-icon *ngIf="product_type === ProductType.Enterprise" class="logo" svgIcon="truenas_enterprise_logo_full" alt="TrueNAS ENTERPRISE logo"></mat-icon>
-      <mat-icon *ngIf="product_type === ProductType.Scale || product_type == ProductType.ScaleEnterprise" class="logo" svgIcon="truenas_scale_logo_full" alt="TrueNAS SCALE logo"></mat-icon>
+      <mat-icon
+        *ngIf="productType === ProductType.Enterprise"
+        class="logo"
+        svgIcon="truenas_enterprise_logo_full"
+        alt="TrueNAS ENTERPRISE logo"
+      ></mat-icon>
+      <mat-icon
+        *ngIf="productType === ProductType.Scale || productType == ProductType.ScaleEnterprise"
+        class="logo"
+        svgIcon="truenas_scale_logo_full"
+        alt="TrueNAS SCALE logo"
+      ></mat-icon>
     </ng-template>
     <div>
-      <span fxFlex class="copyright-txt">TrueNAS {{product_type}}® © {{copyrightYear}} - <a href="http://www.ixsystems.com" target="_blank" title="iXsystems, Inc."> iXsystems, Inc</a>.</span>
+      <span fxFlex class="copyright-txt">
+        TrueNAS {{productType}}® © {{copyrightYear}} -
+        <a href="http://www.ixsystems.com" target="_blank" title="iXsystems, Inc."> iXsystems, Inc</a>.
+      </span>
     </div>
   </mat-card>
 </div>

--- a/src/app/views/others/shutdown/shutdown.component.ts
+++ b/src/app/views/others/shutdown/shutdown.component.ts
@@ -15,7 +15,7 @@ import { LocaleService } from 'app/services/locale.service';
   styleUrls: ['./shutdown.component.scss'],
 })
 export class ShutdownComponent implements OnInit {
-  product_type: ProductType;
+  productType: ProductType;
   copyrightYear = this.localeService.getCopyrightYearFromBuildTime();
 
   readonly ProductType = ProductType;
@@ -30,7 +30,7 @@ export class ShutdownComponent implements OnInit {
     private localeService: LocaleService,
   ) {
     this.sysGeneralService.getProductType$.pipe(untilDestroyed(this)).subscribe((res) => {
-      this.product_type = res as ProductType;
+      this.productType = res as ProductType;
     });
   }
 


### PR DESCRIPTION
Testing:
1. Reboot the system via topbar menu.
2. Observe that you see a blue reboot screen as opposed to being redirected to a disconnected page right away.
3. Observe that URL is changed to signin, so that if user reloads, he will not trigger reboot again.