### PR TITLE
NAS-112033 / 21.10 / NAS-112033: Hide reset button on disabled inputs

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
+++ b/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
@@ -105,7 +105,7 @@ export class FormInputComponent implements Field {
   }
 
   shouldShowResetInput(): boolean {
-    return this.hasValue() && !this.config.readonly && !this.config.togglePw && this.config.inputType !== 'password';
+    return this.hasValue() && !this.config.readonly && !this.config.togglePw && this.config.inputType !== 'password' && !this.config.disabled;
   }
 
   resetInput(): void {

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -254,8 +254,12 @@ input.mat-input-element::placeholder {
   border: solid 1px var(--lines);
   box-sizing: border-box;
   color: var(--fg1);
-  color: var(--fg1);
   padding: 8px;
+
+  &[disabled] {
+    cursor: not-allowed;
+    opacity: 0.38;
+  }
 }
 
 .form-element,

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -315,6 +315,7 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
   .mat-form-field .mat-select.mat-select-disabled .mat-select-arrow,
   .mat-select-disabled .mat-select-value {
     @include variable(color, --fg2, $fg2);
+    cursor: not-allowed;
     opacity: 0.38;
   }
 
@@ -324,6 +325,7 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
 
   .mat-checkbox-disabled .mat-checkbox-label {
     @include variable(color, --grey, #4d4d4d);
+    cursor: not-allowed;
     opacity: 0.6;
   }
 


### PR DESCRIPTION
Hide reset button and update cursor and opacity for disabled inputs
![Kapture 2021-09-21 at 19 23 30](https://user-images.githubusercontent.com/351613/134209737-4121abf1-c1df-4849-92e8-e2b412d5d354.gif)

Testing: Go to Storage and choose Edit Options of some dataset, it is a good example