### PR TITLE
NAS-112240 / 21.10 / NAS-112240: Add GPU config checkbox to app settings

### DIFF
--- a/src/app/helptext/apps/apps.ts
+++ b/src/app/helptext/apps/apps.ts
@@ -143,6 +143,9 @@ export default {
       placeholder: T('Enable Container Image Updates'),
       tooltip: T(''),
     },
+    configure_gpus: {
+      placeholder: T('Enable GPU support'),
+    },
   },
 
   charts: {

--- a/src/app/interfaces/kubernetes-config.interface.ts
+++ b/src/app/interfaces/kubernetes-config.interface.ts
@@ -22,4 +22,5 @@ export interface KubernetesConfigUpdate {
   route_v4_interface: string;
   service_cidr: string;
   migrate_applications?: boolean;
+  configure_gpus?: boolean;
 }

--- a/src/app/modules/tooltip/tooltip.module.ts
+++ b/src/app/modules/tooltip/tooltip.module.ts
@@ -11,7 +11,7 @@ import { TooltipComponent } from 'app/modules/tooltip/tooltip.component';
   imports: [
     CommonModule,
     NgxPopperjsModule,
-    TranslateModule.forChild(),
+    TranslateModule,
     CommonDirectivesModule,
     MaterialModule,
   ],

--- a/src/app/pages/applications/forms/kubernetes-settings.component.ts
+++ b/src/app/pages/applications/forms/kubernetes-settings.component.ts
@@ -67,6 +67,12 @@ export class KubernetesSettingsComponent implements FormConfiguration {
           tooltip: helptext.kubForm.enable_container_image_update.tooltip,
           value: true,
         },
+        {
+          type: 'checkbox',
+          name: 'configure_gpus',
+          placeholder: helptext.kubForm.configure_gpus.placeholder,
+          value: true,
+        },
       ],
     },
     {
@@ -125,7 +131,7 @@ export class KubernetesSettingsComponent implements FormConfiguration {
 
     const setV4InterfaceControl$ = this.appService.getInterfaces().pipe(
       tap((interfaces) => {
-        const v4InterfaceControl: FormSelectConfig = _.find(this.fieldSets[1].config, { name: 'route_v4_interface' });
+        const v4InterfaceControl: FormSelectConfig = _.find(this.fieldSets[0].config, { name: 'route_v4_interface' });
         interfaces.forEach((i) => {
           v4InterfaceControl.options.push({ label: i.name, value: i.name });
         });

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1041,6 +1041,7 @@
   "Enable Display": "",
   "Enable FSRVP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",
   "Enable Password Toggle": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -603,6 +603,7 @@
   "Enable Container Image Updates": "",
   "Enable Display": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable Network Performance Statistics": "",
   "Enable SMTP configuration": "",
   "Enable a Display (Virtual Network Computing) remote connection. Requires <i>UEFI</i> booting.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -211,6 +211,7 @@
   "Enable ACL support for the SMB share.": "",
   "Enable Container Image Updates": "",
   "Enable Display": "",
+  "Enable GPU support": "",
   "Enable SMTP configuration": "",
   "Enable a Display (Virtual Network Computing) remote connection. Requires <i>UEFI</i> booting.": "",
   "Enabling allows using a password to authenticate  the SSH login. <i>Warning:</i> when directory services are enabled, allowing password  authentication can grant access to all users imported by the directory service.<br>  Disabling changes authentication to require keys for all users. This requires  <a href=\"http://the.earth.li/&percnt;7Esgtatham/putty/0.55/htmldoc/Chapter8.html\" target=\"_blank\">additional setup</a>  on both the SSH client and server.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1021,6 +1021,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -124,6 +124,7 @@
   "Edit ISCSI Target": "",
   "Edit Kerberos Keytab": "",
   "Edit Kerberos Realm": "",
+  "Enable GPU support": "",
   "Enable SMB2/3 Durable Handles": "",
   "Enabling allows using a password to authenticate  the SSH login. <i>Warning:</i> when directory services are enabled, allowing password  authentication can grant access to all users imported by the directory service.<br>  Disabling changes authentication to require keys for all users. This requires  <a href=\"http://the.earth.li/&percnt;7Esgtatham/putty/0.55/htmldoc/Chapter8.html\" target=\"_blank\">additional setup</a>  on both the SSH client and server.": "",
   "Ensure Display Device": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -891,6 +891,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -871,6 +871,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1174,6 +1174,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1088,6 +1088,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1080,6 +1080,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1118,6 +1118,7 @@
   "Enable Display": "",
   "Enable FSRVP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -312,6 +312,7 @@
   "Enable Container Image Updates": "",
   "Enable Display": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable Network Performance Statistics": "",
   "Enable SMTP configuration": "",
   "Enable a Display (Virtual Network Computing) remote connection. Requires <i>UEFI</i> booting.": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1198,6 +1198,7 @@
   "Enable FSRVP": "",
   "Enable FXP": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable NFSv4": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -41,6 +41,7 @@
   "Delete {n, plural, one {# user} other {# users}} with this primary group?": "",
   "Delete {name}?": "",
   "EMAIL": "",
+  "Enable GPU support": "",
   "Ensure Display Device": "",
   "Error starting service OpenVPN {serviceLabel}": "",
   "Error starting service {service}.": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -805,6 +805,7 @@
   "Enable Container Image Updates": "",
   "Enable Display": "",
   "Enable GMail OAuth authentication.": "",
+  "Enable GPU support": "",
   "Enable Netwait Feature": "",
   "Enable Network Performance Statistics": "",
   "Enable Password Toggle": "",


### PR DESCRIPTION
This actually does 3 things:
- Main dashboard will now properly show uptime and other parametrized strings.
- In Apps -> Advanced settings route v4 select will be properly populated.
- In same place there is now a new checkbox for GPU support.