### PR TITLE
NAS-112510 / 21.10 / Filter svclb from pod selector

### DIFF
--- a/src/app/pages/applications/chart-releases/chart-releases.component.ts
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.ts
@@ -501,6 +501,15 @@ export class ChartReleasesComponent implements OnInit {
     this.refreshToolbarMenus();
   }
 
+  filterPodNames(podList: string[]): string[] {
+    for (const entry of podList) {
+      if (entry.includes('svclb')) {
+        podList = podList.filter((name) => name !== entry);
+      }
+    }
+    return podList;
+  }
+
   openShell(name: string): void {
     this.podList = [];
     this.podDetails = {};
@@ -510,6 +519,7 @@ export class ChartReleasesComponent implements OnInit {
       this.appLoaderService.close();
       this.podDetails = { ...res };
       this.podList = Object.keys(this.podDetails);
+      this.podList = this.filterPodNames(this.podList);
       if (this.podList.length == 0) {
         this.dialogService.confirm({
           title: helptext.podConsole.nopod.title,
@@ -549,6 +559,7 @@ export class ChartReleasesComponent implements OnInit {
       this.appLoaderService.close();
       this.podDetails = { ...res };
       this.podList = Object.keys(this.podDetails);
+      this.podList = this.filterPodNames(this.podList);
       if (this.podList.length == 0) {
         this.dialogService.confirm({
           title: helptext.podConsole.nopod.title,

--- a/src/app/pages/applications/chart-releases/chart-releases.component.ts
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.ts
@@ -501,15 +501,6 @@ export class ChartReleasesComponent implements OnInit {
     this.refreshToolbarMenus();
   }
 
-  filterPodNames(podList: string[]): string[] {
-    for (const entry of podList) {
-      if (entry.includes('svclb')) {
-        podList = podList.filter((name) => name !== entry);
-      }
-    }
-    return podList;
-  }
-
   openShell(name: string): void {
     this.podList = [];
     this.podDetails = {};
@@ -519,7 +510,8 @@ export class ChartReleasesComponent implements OnInit {
       this.appLoaderService.close();
       this.podDetails = { ...res };
       this.podList = Object.keys(this.podDetails);
-      this.podList = this.filterPodNames(this.podList);
+      /** Ensure the podlist does not contain internal pods for the Service Loadbalancer */
+      this.podList = this.podList.filter((pod: string) => !pod.includes('svclb'));
       if (this.podList.length == 0) {
         this.dialogService.confirm({
           title: helptext.podConsole.nopod.title,
@@ -559,7 +551,8 @@ export class ChartReleasesComponent implements OnInit {
       this.appLoaderService.close();
       this.podDetails = { ...res };
       this.podList = Object.keys(this.podDetails);
-      this.podList = this.filterPodNames(this.podList);
+      /** Ensure the podlist does not contain internal pods for the Service Loadbalancer */
+      this.podList = this.podList.filter((pod: string) => !pod.includes('svclb'));
       if (this.podList.length == 0) {
         this.dialogService.confirm({
           title: helptext.podConsole.nopod.title,


### PR DESCRIPTION
This PR removes all "Service Loadbalancer" pods from the log and shell selector.
These pods are created by the K3S ServiceLoadbalancer and their logs have no value for the user.

They also lead to significant confusion, with users submitting the wrong logs.

**Before:**
---
![image](https://user-images.githubusercontent.com/7613738/134503451-6eceec18-e611-469e-9d12-71fd67296e7c.png)

![image](https://user-images.githubusercontent.com/7613738/134503471-22546436-c333-497a-bc8c-f7aa3db10e2a.png)



**After:**
---
![image](https://user-images.githubusercontent.com/7613738/134503288-6c6c0c20-fdd2-4cf9-b221-1e1492ff13a6.png)

![image](https://user-images.githubusercontent.com/7613738/134503488-71183708-1cf6-4f17-9ef0-755bd0b0070e.png)
