### PR TITLE
NAS-112560 / 21.10 / NAS-112560: Preserve whitespace and use monospace font

### DIFF
--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -641,10 +641,12 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
         background: var(--contrast-darker);
         border: 1px solid var(--lines);
         color: var(--fg2);
-        height: calc(100%);
+        font-family: 'Droid Sans Mono', 'Courier New', Courier, monospace;
+        height: 100%;
         min-height: 100px;
         overflow: auto;
         padding: 1rem;
+        white-space: pre-wrap;
       }
     }
   }


### PR DESCRIPTION
style improvements for trackback area

before:
![image](https://user-images.githubusercontent.com/351613/134954894-0690f350-226e-4dfe-b7b2-78034695dde6.png)

after:
![image](https://user-images.githubusercontent.com/351613/134954911-37ed5189-8186-4690-9592-fcc3d0efb13b.png)
