### PR TITLE
NAS-112517 / 21.10 / NAS-112517: Update entity table when row is deleted when filter is used

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,7 +120,6 @@ module.exports = {
         "no-prototype-builtins": "off",
         "prefer-promise-reject-errors": "off",
         "import/no-cycle": "off",
-        "no-self-assign": "off",
         "no-async-promise-executor": "off",
         "no-bitwise": "off",
         "@typescript-eslint/member-ordering": "off",

--- a/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
+++ b/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
@@ -31,6 +31,9 @@ export interface BaseFieldConfig<P = any> {
   id?: string;
   isHidden?: boolean;
   name: string;
+  /**
+   * @deprecated Capture parent with an arrow function instead.
+   */
   parent?: P;
   placeholder?: string;
   readonly?: boolean;

--- a/src/app/pages/common/entity/entity-table/entity-table.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.component.ts
@@ -651,7 +651,7 @@ export class EntityTableComponent<Row = any> implements OnInit, AfterViewChecked
       this.paginationPageIndex = 0;
       this.showDefaults = true;
     }
-    if ((this.expandedRows === 0 || !this.asyncView || this.excuteDeletion || this.needRefreshTable) && this.filterValue === '') {
+    if (this.expandedRows === 0 || !this.asyncView || this.excuteDeletion || this.needRefreshTable) {
       this.excuteDeletion = false;
       this.needRefreshTable = false;
 

--- a/src/app/pages/storage/snapshots/snapshot-list/snapshot-list-row.interface.ts
+++ b/src/app/pages/storage/snapshots/snapshot-list/snapshot-list-row.interface.ts
@@ -1,6 +1,7 @@
 import { ZfsSnapshot } from 'app/interfaces/zfs-snapshot.interface';
 
 export type SnapshotListRow = {
+  id: string;
   used: string;
   created: string;
   referenced: string;

--- a/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
@@ -188,6 +188,7 @@ export class SnapshotListComponent implements EntityTableConfig {
       const [datasetName, snapshotName] = row.name.split('@');
 
       const transformedRow = {
+        id: row.name,
         dataset: datasetName,
         snapshot: snapshotName,
         properties: row.properties,

--- a/src/app/pages/storage/vmware-snapshot/vmware-snapshot/vmware-snapshot-form.component.ts
+++ b/src/app/pages/storage/vmware-snapshot/vmware-snapshot/vmware-snapshot-form.component.ts
@@ -161,12 +161,6 @@ export class VmwareSnapshotFormComponent implements FormConfiguration {
     });
   }
 
-  beforeSubmit(value: any): void {
-    if (value.filesystem !== undefined) {
-      value.filesystem = value.filesystem;
-    }
-  }
-
   customSubmit(value: any): void {
     const payload = {
       datastore: value.datastore,


### PR DESCRIPTION
Reproduction steps are in the ticket.
Main change is in `entity-table.component.ts`. This change is somewhat risky, because I don't know why it was there in the first place.

Some additional cleanup included.