### PR TITLE
NAS-112588 / 21.10 / Add missing clear button on the search field

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.html
@@ -1,5 +1,7 @@
 <!-- START OF CONTROLS SECTION -->
 <div *ngIf="entity && conf" fxFlex class="entity-table-controls" fxLayout="row wrap" fxLayoutAlignGap="16px" fxLayoutAlign="end center">
+
+  <!-- TODO: Replace with ix-input when its ready -->
   <div class="form-element search-field" id="row-filter">
     <mat-form-field floatPlaceholder="never">
       <span matPrefix><mat-icon>search</mat-icon></span>
@@ -10,6 +12,14 @@
         ix-auto
         ix-auto-type="input"
         ix-auto-identifier="Filter {{entity.conf.title}}">
+
+      <span
+        class="reset-filter-icon"
+        [class.invisible]="!filterValue || filterValue.length == 0"
+        matSuffix
+      >
+        <mat-icon (click)="resetFilter()" role="img" fontSet="mdi-set" fontIcon="mdi-close-circle"></mat-icon>
+      </span>
     </mat-form-field>
   </div>
 

--- a/src/app/pages/common/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.html
@@ -154,7 +154,13 @@
   <!-- OLD TEMPLATE END -->
   <!--</div>-->
 
-  <mat-spinner [diameter]='40' id="entity-spinner" *ngIf="(!entity.showDefaults && entity.showSpinner)" #entityspinner>
+  <mat-spinner
+    [diameter]="40"
+    id="entity-spinner"
+    *ngIf="!entity.showDefaults && entity.showSpinner"
+    #entityspinner
+    style="margin-left: 8px;"
+  >
   </mat-spinner>
 
   <ng-container *ngIf="conf && conf.custActions">
@@ -173,7 +179,7 @@
     </span>
   </ng-container>
 
-  <div id='config' *ngIf="conf.globalConfig">
+  <div id="config" *ngIf="conf.globalConfig">
     <button
       mat-icon-button
       id="{{ conf.globalConfig.id }}"

--- a/src/app/pages/common/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.html
@@ -154,15 +154,6 @@
   <!-- OLD TEMPLATE END -->
   <!--</div>-->
 
-  <mat-spinner
-    [diameter]="40"
-    id="entity-spinner"
-    *ngIf="!entity.showDefaults && entity.showSpinner"
-    #entityspinner
-    style="margin-left: 8px;"
-  >
-  </mat-spinner>
-
   <ng-container *ngIf="conf && conf.custActions">
     <span *ngFor="let custBtn of conf.custActions">
       <button
@@ -191,6 +182,15 @@
       <ng-template #settingsIcon><mat-icon>settings</mat-icon></ng-template>
     </button>
   </div>
+
+  <mat-spinner
+    [diameter]="40"
+    id="entity-spinner"
+    *ngIf="!entity.showDefaults && entity.showSpinner"
+    #entityspinner
+    style="margin-left: 8px;"
+  >
+  </mat-spinner>
 
   <!-- END OF CONTROLS SECTION -->
 

--- a/src/app/pages/common/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.ts
@@ -19,6 +19,7 @@ export class EntityTableAddActionsComponent implements GlobalAction, OnInit, Aft
   @ViewChild('filter', { static: false }) filter: ElementRef;
   @Input() entity: EntityTableComponent;
   conf: EntityTableAddActionsConfig;
+  filterValue = '';
 
   actions: EntityTableAction[];
   menuTriggerMessage = 'Click for options';
@@ -56,8 +57,15 @@ export class EntityTableAddActionsComponent implements GlobalAction, OnInit, Aft
         distinctUntilChanged(),
       )
         .pipe(untilDestroyed(this)).subscribe(() => {
+          this.filterValue = this.filter.nativeElement.value;
           this.entity.filter(this.filter.nativeElement.value);
         });
     }
+  }
+
+  resetFilter(): void {
+    this.filterValue = '';
+    this.filter.nativeElement.value = '';
+    this.entity.filter('');
   }
 }

--- a/src/app/pages/storage/volumes/volume-list-controls/volumes-list-controls.component.html
+++ b/src/app/pages/storage/volumes/volume-list-controls/volumes-list-controls.component.html
@@ -105,4 +105,13 @@
       </a>
     </mat-menu>
   </div>
+
+  <mat-spinner
+    [diameter]="40"
+    *ngIf="!entity.showDefaults && entity.showSpinner"
+    id="entity-spinner"
+    #entityspinner
+    style="margin-left: 8px;"
+  >
+  </mat-spinner>
 </div>

--- a/src/app/pages/storage/volumes/volume-list-controls/volumes-list-controls.component.html
+++ b/src/app/pages/storage/volumes/volume-list-controls/volumes-list-controls.component.html
@@ -1,6 +1,7 @@
 <div *ngIf="entity && conf" fxFlex class="entity-table-controls" fxLayout="row wrap" fxLayoutAlignGap="16px" fxLayoutAlign="end center">
 
   <!-- SEARCH -->
+  <!-- TODO: Replace with ix-input when its ready -->
   <div class="form-element" id="row-filter">
     <mat-form-field floatPlaceholder="auto">
       <span matPrefix style="cursor: default; user-select: none;"><mat-icon>search</mat-icon></span>
@@ -11,7 +12,7 @@
         ix-auto-identifier="Filter {{entity.title}}">
       <span
         class="reset-filter-icon"
-        [class.hidden]="!filterValue || filterValue.length == 0"
+        [class.invisible]="!filterValue || filterValue.length == 0"
         matSuffix
       >
         <mat-icon (click)="resetDatasetFilter()" role="img" fontSet="mdi-set" fontIcon="mdi-close-circle"></mat-icon>

--- a/src/app/pages/storage/volumes/volume-list-controls/volumes-list-controls.component.scss
+++ b/src/app/pages/storage/volumes/volume-list-controls/volumes-list-controls.component.scss
@@ -3,12 +3,3 @@
   margin-top: -1px;
 }
 
-.reset-filter-icon {
-  cursor: pointer;
-  opacity: 0.5;
-  user-select: none;
-}
-
-.reset-filter-icon mat-icon {
-  font-size: 150%;
-}

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -1771,4 +1771,19 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
     opacity: 0.38;
   }
 
+  .reset-filter-icon {
+    cursor: pointer;
+    opacity: 0.5;
+    user-select: none;
+
+    mat-icon {
+      font-size: 150%;
+    }
+
+    &.invisible {
+      opacity: 0;
+      pointer-events: none;
+      visibility: hidden;
+    }
+  }
 } // end of ix theme


### PR DESCRIPTION
Changes:

- Added missing clear button for the entity-table-actions component
- Added missing spinner for volume-list-actions component (the only one loading indicator on that page)
- Moved spinner to the end on the actions toolbar
- Sync styles

To test:

- Check the search field on the Storage and Snapshots (or another entity table) pages
- Check spinner on the actions toolbar (Storage/Snapshots)