### PR TITLE
NAS-112770 / 22.02-RC.2 / bootenv-create & bootenv-rename is now bootenv-form (based on ix-forms)

### DIFF
--- a/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.html
+++ b/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.html
@@ -1,0 +1,24 @@
+<mat-progress-bar *ngIf="isFormLoading" mode="indeterminate"></mat-progress-bar>
+<mat-card>
+  <mat-card-content>
+    <form [formGroup]="form" class="ix-form-container" (submit)="onSubmit()">
+      <ix-fieldset [title]="'Settings' | translate">
+        <ix-input
+            formControlName="name"
+            [label]="'Name' | translate"
+            [required]="true"
+            [tooltip]="tooltips.name"
+          ></ix-input>
+      </ix-fieldset>
+
+      <div class="form-actions">
+        <button
+              mat-button
+              type="submit"
+              [disabled]="form.invalid || isFormLoading"
+              color="primary"
+            >{{ 'Save' | translate }}</button>
+      </div>
+    </form>
+  </mat-card-content>
+</mat-card>

--- a/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.html
+++ b/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.html
@@ -1,7 +1,7 @@
 <mat-progress-bar *ngIf="isFormLoading" mode="indeterminate"></mat-progress-bar>
 <mat-card>
   <mat-card-content>
-    <form [formGroup]="form" class="ix-form-container" (submit)="onSubmit()">
+    <form [formGroup]="formGroup" class="ix-form-container" (submit)="onSubmit()">
       <ix-fieldset [title]="'Settings' | translate">
         <ix-input
             formControlName="name"
@@ -15,7 +15,7 @@
         <button
               mat-button
               type="submit"
-              [disabled]="form.invalid || isFormLoading"
+              [disabled]="formGroup.invalid || isFormLoading"
               color="primary"
             >{{ 'Save' | translate }}</button>
       </div>

--- a/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.html
+++ b/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.html
@@ -4,20 +4,20 @@
     <form [formGroup]="formGroup" class="ix-form-container" (submit)="onSubmit()">
       <ix-fieldset [title]="'Settings' | translate">
         <ix-input
-            formControlName="name"
-            [label]="'Name' | translate"
-            [required]="true"
-            [tooltip]="tooltips.name"
+          formControlName="name"
+          [label]="'Name' | translate"
+          [required]="true"
+          [tooltip]="tooltips.name"
           ></ix-input>
       </ix-fieldset>
 
       <div class="form-actions">
         <button
-              mat-button
-              type="submit"
-              [disabled]="formGroup.invalid || isFormLoading"
-              color="primary"
-            >{{ 'Save' | translate }}</button>
+          mat-button
+          type="submit"
+          [disabled]="formGroup.invalid || isFormLoading"
+          color="primary"
+          >{{ 'Save' | translate }}</button>
       </div>
     </form>
   </mat-card-content>

--- a/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.scss
+++ b/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.scss
@@ -1,0 +1,11 @@
+.form-actions {
+  margin: 8px 10px;
+}
+
+mat-progress-bar {
+  left: -20px;
+  position: relative;
+  top: -10px;
+  width: calc(100% + 40px);
+  z-index: 10005;
+}

--- a/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.spec.ts
+++ b/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.spec.ts
@@ -1,0 +1,85 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
+import { IxFormsModule } from 'app/pages/common/ix/ix-forms.module';
+import { IxFormHarness } from 'app/pages/common/ix/testing/ix-form.harness';
+import { BootEnvironmentFormComponent } from 'app/pages/system/bootenv/bootenv-form/bootenv-form.component';
+import { WebSocketService } from 'app/services';
+import { IxModalService } from 'app/services/ix-modal.service';
+
+describe('BootEnvironmentFormComponent', () => {
+  let spectator: Spectator<BootEnvironmentFormComponent>;
+  let loader: HarnessLoader;
+  let ws: WebSocketService;
+  const createComponent = createComponentFactory({
+    component: BootEnvironmentFormComponent,
+    imports: [
+      IxFormsModule,
+      ReactiveFormsModule,
+    ],
+    providers: [
+      mockWebsocket([
+        mockCall('bootenv.create'),
+        mockCall('bootenv.update'),
+      ]),
+      mockProvider(IxModalService),
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createComponent();
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+    ws = spectator.inject(WebSocketService);
+  });
+
+  /*
+  * Create
+  */
+  describe('creating a boot environment', () => {
+    beforeEach(() => {
+      spectator.component.setupForm();
+    });
+
+    it('sends a create payload to websocket and closes modal when save is pressed', async () => {
+      const form = await loader.getHarness(IxFormHarness);
+      const fields = { name: 'myBootEnv' };
+
+      await form.fillForm({
+        Name: fields.name,
+      });
+
+      const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await saveButton.click();
+
+      expect(ws.call).toHaveBeenCalledWith('bootenv.create', [fields]);
+    });
+  });
+
+  /*
+  * Rename
+  */
+  describe('renaming a boot environment', () => {
+    beforeEach(() => {
+      spectator.component.setupForm('myBootEnv');
+    });
+
+    it('sends an update payload to websocket and closes modal when save is pressed', async () => {
+      const form = await loader.getHarness(IxFormHarness);
+      const fields = { name: 'updated' };
+      await form.fillForm({
+        Name: fields.name,
+      });
+
+      const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await saveButton.click();
+
+      expect(ws.call).toHaveBeenCalledWith('bootenv.update', [
+        spectator.component.currentName,
+        fields,
+      ]);
+    });
+  });
+});

--- a/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.ts
+++ b/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.ts
@@ -1,7 +1,7 @@
 import {
   ChangeDetectionStrategy, Component,
 } from '@angular/core';
-import { FormBuilder, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
@@ -21,9 +21,9 @@ import { IxModalService } from 'app/services/ix-modal.service';
 })
 export class BootEnvironmentFormComponent {
   private rename = false;
-  private currentName?: string;
+  currentName?: string;
 
-  form = this.formBuilder.group({
+  formGroup: FormGroup = this.formBuilder.group({
     name: ['', [Validators.required, regexValidator(this.bootEnvService.bootenv_name_regex)]],
   });
 
@@ -41,19 +41,21 @@ export class BootEnvironmentFormComponent {
     private modalService: IxModalService,
   ) {}
 
-  setupForm(name?: string): void {
+  setupForm(name?: string): FormGroup {
     if (name) {
       this.rename = true;
       this.currentName = name;
-      this.form.patchValue({
+      this.formGroup.patchValue({
         name,
       });
     }
+
+    return this.formGroup;
   }
 
   onSubmit(): void {
     const fields = {
-      name: this.form.value.name,
+      name: this.formGroup.value.name,
     };
 
     if (this.rename) {

--- a/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.ts
+++ b/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.ts
@@ -16,7 +16,6 @@ import { IxModalService } from 'app/services/ix-modal.service';
   selector: 'app-bootenv-form',
   templateUrl: './bootenv-form.component.html',
   styleUrls: ['./bootenv-form.component.scss'],
-  providers: [BootEnvService, TranslateService],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BootEnvironmentFormComponent {

--- a/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.ts
+++ b/src/app/pages/system/bootenv/bootenv-form/bootenv-form.component.ts
@@ -1,0 +1,88 @@
+import {
+  ChangeDetectionStrategy, Component,
+} from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
+import { helptext_system_bootenv } from 'app/helptext/system/boot-env';
+import { regexValidator } from 'app/pages/common/entity/entity-form/validators/regex-validation';
+import { EntityUtils } from 'app/pages/common/entity/utils';
+import { BootEnvService, WebSocketService } from 'app/services';
+import { IxModalService } from 'app/services/ix-modal.service';
+
+@UntilDestroy()
+@Component({
+  selector: 'app-bootenv-form',
+  templateUrl: './bootenv-form.component.html',
+  styleUrls: ['./bootenv-form.component.scss'],
+  providers: [BootEnvService, TranslateService],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BootEnvironmentFormComponent {
+  private rename = false;
+  private currentName?: string;
+
+  form = this.formBuilder.group({
+    name: ['', [Validators.required, regexValidator(this.bootEnvService.bootenv_name_regex)]],
+  });
+
+  isFormLoading = false;
+
+  readonly tooltips = {
+    name: helptext_system_bootenv.create_name_tooltip,
+  };
+
+  constructor(
+    private translate: TranslateService,
+    private formBuilder: FormBuilder,
+    private ws: WebSocketService,
+    private bootEnvService: BootEnvService,
+    private modalService: IxModalService,
+  ) {}
+
+  setupForm(name?: string): void {
+    if (name) {
+      this.rename = true;
+      this.currentName = name;
+      this.form.patchValue({
+        name,
+      });
+    }
+  }
+
+  onSubmit(): void {
+    const fields = {
+      name: this.form.value.name,
+    };
+
+    if (this.rename) {
+      const update$: Observable<unknown> = this.ws.call('bootenv.update', [
+        this.currentName,
+        fields,
+      ]);
+
+      update$.pipe(untilDestroyed(this)).subscribe(() => {
+        this.isFormLoading = false;
+        this.modalService.close();
+      }, (error) => {
+        this.isFormLoading = false;
+        this.modalService.close();
+        new EntityUtils().handleWSError(this, error);
+      });
+    } else {
+      const create$: Observable<unknown> = this.ws.call('bootenv.create', [fields]);
+
+      create$.pipe(untilDestroyed(this)).subscribe(() => {
+        this.isFormLoading = false;
+        this.modalService.close();
+      }, (error) => {
+        this.isFormLoading = false;
+        this.modalService.close();
+        new EntityUtils().handleWSError(this, error);
+      });
+    }
+
+    this.isFormLoading = true;
+  }
+}

--- a/src/app/pages/system/bootenv/bootenv-list/bootenv-list.component.ts
+++ b/src/app/pages/system/bootenv/bootenv-list/bootenv-list.component.ts
@@ -16,8 +16,10 @@ import { FieldConfig } from 'app/pages/common/entity/entity-form/models/field-co
 import { EntityTableComponent } from 'app/pages/common/entity/entity-table/entity-table.component';
 import { EntityTableAction, EntityTableConfig } from 'app/pages/common/entity/entity-table/entity-table.interface';
 import { EntityUtils } from 'app/pages/common/entity/utils';
+import { BootEnvironmentFormComponent } from 'app/pages/system/bootenv/bootenv-form/bootenv-form.component';
 import { DialogService, WebSocketService, SystemGeneralService } from 'app/services';
 import { AppLoaderService } from 'app/services/app-loader/app-loader.service';
+import { IxModalService } from 'app/services/ix-modal.service';
 import { LocaleService } from 'app/services/locale.service';
 import { StorageService } from 'app/services/storage.service';
 import { BootenvRow } from './bootenv-row.interface';
@@ -33,7 +35,6 @@ export class BootEnvironmentListComponent implements EntityTableConfig {
   title = T('Boot Environments');
   resource_name = 'system/bootenv';
   queryCall = 'bootenv.query' as const;
-  route_add: string[] = ['system', 'boot', 'create'];
   protected route_delete: string[] = ['system', 'boot', 'delete'];
   wsDelete = 'bootenv.delete' as const;
   wsMultiDelete = 'core.bulk' as const;
@@ -58,6 +59,7 @@ export class BootEnvironmentListComponent implements EntityTableConfig {
     protected localeService: LocaleService,
     private sysGeneralService: SystemGeneralService,
     protected translate: TranslateService,
+    private modalService: IxModalService,
   ) {}
 
   columns = [
@@ -113,6 +115,10 @@ export class BootEnvironmentListComponent implements EntityTableConfig {
 
   afterInit(entityList: EntityTableComponent): void {
     this.entityList = entityList;
+
+    this.modalService.onClose.pipe(untilDestroyed(this)).subscribe(() => {
+      this.entityList.getData();
+    });
   }
 
   isActionVisible(actionId: string): boolean {
@@ -146,7 +152,8 @@ export class BootEnvironmentListComponent implements EntityTableConfig {
       label: T('Rename'),
       id: 'rename',
       onClick: (row: BootenvRow) => {
-        this._router.navigate(['/', 'system', 'boot', 'rename', row.id]);
+        const modal = this.modalService.open(BootEnvironmentFormComponent, this.translate.instant('Create Boot Environment'));
+        modal.setupForm(row.id);
       },
     });
 
@@ -312,6 +319,12 @@ export class BootEnvironmentListComponent implements EntityTableConfig {
 
   getAddActions(): EntityTableAction[] {
     return [{
+      label: T('Add'),
+      onClick: () => {
+        const modal = this.modalService.open(BootEnvironmentFormComponent, this.translate.instant('Create Boot Environment'));
+        modal.setupForm();
+      },
+    }, {
       label: T('Stats/Settings'),
       onClick: () => {
         this.sysGeneralService.getAdvancedConfig$.pipe(untilDestroyed(this)).subscribe((res) => {

--- a/src/app/pages/system/system.module.ts
+++ b/src/app/pages/system/system.module.ts
@@ -15,7 +15,6 @@ import { AlertServiceListComponent } from 'app/pages/system/alert-service/alert-
 import { LocalizationForm2Component } from 'app/pages/system/general-settings/localization-form2/localization-form2.component';
 import { NtpServerFormComponent } from 'app/pages/system/general-settings/ntp-servers/ntp-server-form/ntp-server-form.component';
 import { ManualUpdateComponent } from 'app/pages/system/update/manual-update/manual-update.component';
-import { BootEnvService } from 'app/services';
 import { CoreComponents } from '../../core/components/core-components.module';
 import { EntityModule } from '../common/entity/entity.module';
 import { AdvancedSettingsComponent } from './advanced/advanced-settings.component';
@@ -106,7 +105,6 @@ import { EnclosureModule } from './view-enclosure/enclosure.module';
     SystemDatasetPoolComponent,
   ],
   providers: [
-    BootEnvService,
     TranslateService,
   ],
   entryComponents: [QrDialogComponent],

--- a/src/app/pages/system/system.module.ts
+++ b/src/app/pages/system/system.module.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { QRCodeModule } from 'angular2-qrcode';
 import { MarkdownModule } from 'ngx-markdown';
 import { NgxUploaderModule } from 'ngx-uploader';
@@ -15,6 +15,7 @@ import { AlertServiceListComponent } from 'app/pages/system/alert-service/alert-
 import { LocalizationForm2Component } from 'app/pages/system/general-settings/localization-form2/localization-form2.component';
 import { NtpServerFormComponent } from 'app/pages/system/general-settings/ntp-servers/ntp-server-form/ntp-server-form.component';
 import { ManualUpdateComponent } from 'app/pages/system/update/manual-update/manual-update.component';
+import { BootEnvService } from 'app/services';
 import { CoreComponents } from '../../core/components/core-components.module';
 import { EntityModule } from '../common/entity/entity.module';
 import { AdvancedSettingsComponent } from './advanced/advanced-settings.component';
@@ -103,6 +104,10 @@ import { EnclosureModule } from './view-enclosure/enclosure.module';
     CronFormComponent,
     CronListComponent,
     SystemDatasetPoolComponent,
+  ],
+  providers: [
+    BootEnvService,
+    TranslateService,
   ],
   entryComponents: [QrDialogComponent],
 })

--- a/src/app/pages/system/system.module.ts
+++ b/src/app/pages/system/system.module.ts
@@ -30,9 +30,8 @@ import { AlertServiceComponent } from './alert-service/alert-service/alert-servi
 import { AlertConfigComponent } from './alert/alert.component';
 import { BootEnvAttachFormComponent } from './bootenv/bootenv-attach/bootenv-attach-form.component';
 import { BootEnvironmentCloneComponent } from './bootenv/bootenv-clone/bootenv-clone.component';
-import { BootEnvironmentCreateComponent } from './bootenv/bootenv-create/bootenv-create.component';
+import { BootEnvironmentFormComponent } from './bootenv/bootenv-form/bootenv-form.component';
 import { BootEnvironmentListComponent } from './bootenv/bootenv-list/bootenv-list.component';
-import { BootEnvironmentRenameComponent } from './bootenv/bootenv-rename/bootenv-rename.component';
 import { BootEnvReplaceFormComponent } from './bootenv/bootenv-replace/bootenv-replace-form.component';
 import { BootStatusListComponent } from './bootenv/bootenv-status/bootenv-status.component';
 import { EmailComponent } from './email/email.component';
@@ -68,8 +67,7 @@ import { EnclosureModule } from './view-enclosure/enclosure.module';
     LocalizationForm2Component,
     BootEnvironmentListComponent,
     BootEnvironmentCloneComponent,
-    BootEnvironmentRenameComponent,
-    BootEnvironmentCreateComponent,
+    BootEnvironmentFormComponent,
     BootStatusListComponent,
     BootEnvAttachFormComponent,
     BootEnvReplaceFormComponent,

--- a/src/app/pages/system/system.routing.ts
+++ b/src/app/pages/system/system.routing.ts
@@ -15,9 +15,8 @@ import { AlertServiceComponent } from './alert-service/alert-service/alert-servi
 import { AlertConfigComponent } from './alert/alert.component';
 import { BootEnvAttachFormComponent } from './bootenv/bootenv-attach/bootenv-attach-form.component';
 import { BootEnvironmentCloneComponent } from './bootenv/bootenv-clone/bootenv-clone.component';
-import { BootEnvironmentCreateComponent } from './bootenv/bootenv-create/bootenv-create.component';
+import { BootEnvironmentFormComponent } from './bootenv/bootenv-form/bootenv-form.component';
 import { BootEnvironmentListComponent } from './bootenv/bootenv-list/bootenv-list.component';
-import { BootEnvironmentRenameComponent } from './bootenv/bootenv-rename/bootenv-rename.component';
 import { BootEnvReplaceFormComponent } from './bootenv/bootenv-replace/bootenv-replace-form.component';
 import { BootStatusListComponent } from './bootenv/bootenv-status/bootenv-status.component';
 import { EmailComponent } from './email/email.component';
@@ -61,28 +60,19 @@ export const routes: Routes = [
         path: 'clone/:pk',
         component: BootEnvironmentCloneComponent,
         data: { title: T('Clone'), breadcrumb: T('Clone') },
-      },
-      {
-        path: 'rename/:pk',
-        component: BootEnvironmentRenameComponent,
-        data: { title: T('Rename'), breadcrumb: T('Rename') },
-      },
-      {
+      }, {
         path: 'create',
-        component: BootEnvironmentCreateComponent,
+        component: BootEnvironmentFormComponent,
         data: { title: T('Add'), breadcrumb: T('Add') },
-      },
-      {
+      }, {
         path: 'status',
         component: BootStatusListComponent,
         data: { title: T('Status'), breadcrumb: T('Status') },
-      },
-      {
+      }, {
         path: 'attach/:pk',
         component: BootEnvAttachFormComponent,
         data: { title: T('Attach'), breadcrumb: ('Attach') },
-      },
-      {
+      }, {
         path: 'replace/:pk',
         component: BootEnvReplaceFormComponent,
         data: { title: T('Replace'), breadcrumb: T('Replace') },
@@ -117,8 +107,7 @@ export const routes: Routes = [
         path: 'add',
         component: TunableFormComponent,
         data: { title: T('Add'), breadcrumb: T('Add') },
-      },
-      {
+      }, {
         path: 'edit/:pk',
         component: TunableFormComponent,
         data: { title: T('Edit'), breadcrumb: T('Edit') },
@@ -133,8 +122,7 @@ export const routes: Routes = [
           path: '',
           component: UpdateComponent,
           data: { title: T('Update'), breadcrumb: T('Update') },
-        },
-        {
+        }, {
           path: 'manualupdate',
           data: { title: T('Manual Update'), breadcrumb: T('Manual Update') },
           children: [
@@ -151,13 +139,11 @@ export const routes: Routes = [
       path: 'email',
       component: EmailComponent,
       data: { title: T('Email'), breadcrumb: T('Email'), icon: 'email' },
-    },
-    {
+    }, {
       path: 'alertsettings',
       component: AlertConfigComponent,
       data: { title: T('Alert Settings'), breadcrumb: T('Alert Settings'), icon: 'notifications_active' },
-    },
-    {
+    }, {
       path: 'alertservice',
       data: { title: T('Alert Services'), breadcrumb: T('Alert Services'), icon: 'notifications' },
       children: [{
@@ -178,8 +164,7 @@ export const routes: Routes = [
       path: 'failover',
       component: FailoverComponent,
       data: { title: T('Failover'), breadcrumb: T('Failover'), icon: 'device_hub' },
-    },
-    {
+    }, {
       path: 'support',
       data: { title: T('Support'), breadcrumb: T('Support'), icon: 'perm_phone_msg' },
       children: [
@@ -187,30 +172,25 @@ export const routes: Routes = [
           path: '',
           component: SupportComponent,
           data: { title: T('Support'), breadcrumb: T('Support') },
-        },
-        {
+        }, {
           path: 'eula',
           component: EulaComponent,
           data: { title: T('EULA'), breadcrumb: T('EULA') },
         },
       ],
-    },
-    {
+    }, {
       path: 'two-factor',
       component: TwoFactorComponent,
       data: { title: T('Two-Factor Auth'), breadcrumb: T('Two-Factor Auth') },
-    },
-    {
+    }, {
       path: 'services',
       component: ServicesComponent,
       data: { title: T('Services'), breadcrumb: T('Services') },
-    },
-    {
+    }, {
       path: 'shell',
       component: ShellComponent,
       data: { title: T('Shell'), breadcrumb: T('Shell') },
-    },
-    {
+    }, {
       path: 'cron',
       data: { title: 'Cron Jobs', breadcrumb: 'Cron Jobs', icon: 'event_note' },
       children: [{

--- a/src/app/pages/system/system.routing.ts
+++ b/src/app/pages/system/system.routing.ts
@@ -15,7 +15,6 @@ import { AlertServiceComponent } from './alert-service/alert-service/alert-servi
 import { AlertConfigComponent } from './alert/alert.component';
 import { BootEnvAttachFormComponent } from './bootenv/bootenv-attach/bootenv-attach-form.component';
 import { BootEnvironmentCloneComponent } from './bootenv/bootenv-clone/bootenv-clone.component';
-import { BootEnvironmentFormComponent } from './bootenv/bootenv-form/bootenv-form.component';
 import { BootEnvironmentListComponent } from './bootenv/bootenv-list/bootenv-list.component';
 import { BootEnvReplaceFormComponent } from './bootenv/bootenv-replace/bootenv-replace-form.component';
 import { BootStatusListComponent } from './bootenv/bootenv-status/bootenv-status.component';
@@ -60,10 +59,6 @@ export const routes: Routes = [
         path: 'clone/:pk',
         component: BootEnvironmentCloneComponent,
         data: { title: T('Clone'), breadcrumb: T('Clone') },
-      }, {
-        path: 'create',
-        component: BootEnvironmentFormComponent,
-        data: { title: T('Add'), breadcrumb: T('Add') },
       }, {
         path: 'status',
         component: BootStatusListComponent,

--- a/src/app/services/boot-env.service.ts
+++ b/src/app/services/boot-env.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class BootEnvService {
   bootenv_name_regex = /^[^\/ *\'"?@!#$%^&()+=~<>;`\\]+$/;
 }

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -706,6 +706,7 @@
   "Country: ": "",
   "Crash reporting": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -428,6 +428,7 @@
   "Could not extend Vdev.": "",
   "Could not replace disk.": "",
   "Country: ": "",
+  "Create Boot Environment": "",
   "Create New": "",
   "Create Virtual Machine": "",
   "Create a custom ACL": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -151,6 +151,7 @@
   "Container port": "",
   "Containers": "",
   "Control": "",
+  "Create Boot Environment": "",
   "Create New": "",
   "Create a new account": "",
   "Create custom schedule": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -684,6 +684,7 @@
   "Country: ": "",
   "Crash reporting": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create New": "",
   "Create Passphrase": "",
   "Create SSH Connection": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -108,6 +108,7 @@
   "Connecting to {product}": "",
   "Console": "",
   "Contact": "",
+  "Create Boot Environment": "",
   "Create a new account": "",
   "Create {vdevs} new {vdevType} data vdevs using {used} ({size}) {type}s and leaving {remaining} of those drives unused.": "",
   "Credential": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -604,6 +604,7 @@
   "Could not replace disk.": "",
   "Country: ": "",
   "Crash reporting": "",
+  "Create Boot Environment": "",
   "Create New": "",
   "Create Virtual Machine": "",
   "Create a custom ACL": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -542,6 +542,7 @@
   "Could not replace disk.": "",
   "Country: ": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create Certificate": "",
   "Create New": "",
   "Create SSH Connection": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -777,6 +777,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -707,6 +707,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -690,6 +690,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -728,6 +728,7 @@
   "Country: ": "",
   "Crash reporting": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -186,6 +186,7 @@
   "Could not extend Vdev.": "",
   "Could not replace disk.": "",
   "Country: ": "",
+  "Create Boot Environment": "",
   "Create New": "",
   "Create Virtual Machine": "",
   "Create a new Target or choose an existing target for this share.": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -795,6 +795,7 @@
   "Crash reporting": "",
   "Create": "",
   "Create ACME Certificate": "",
+  "Create Boot Environment": "",
   "Create CA": "",
   "Create Certificate": "",
   "Create New": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -50,6 +50,7 @@
   "Cloud sync <i>{taskName}</i> stopped.": "",
   "Collapse": "",
   "Connecting to {product}": "",
+  "Create Boot Environment": "",
   "Create a new account": "",
   "Create {vdevs} new {vdevType} data vdevs using {used} ({size}) {type}s and leaving {remaining} of those drives unused.": "",
   "DELETE DATASET": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -547,6 +547,7 @@
   "Could not find a group name for this group ID.": "",
   "Could not find a user name for this user ID.": "",
   "Could not replace disk.": "",
+  "Create Boot Environment": "",
   "Create New": "",
   "Create a custom ACL": "",
   "Create a new Target or choose an existing target for this share.": "",


### PR DESCRIPTION
To test:
- Go to system/boot 
- Add a new boot environment from top actions menu btn
- Rename a bootenv using row actions.
- Make sure both forms successfully submit and close
- Make sure validation on name field works properly (description is in the tooltip)