### PR TITLE
DOCS-2692 / 22.02-RC.1 / Fixed and improved test_NAS_T0962.py

### DIFF
--- a/tests/bdd/ha-bhyve02/test_NAS_T0962.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0962.py
@@ -215,10 +215,8 @@ def click_initiate_failover_click_the_confirm_checkbox_and_press_failover(driver
 def wait_for_the_login_page_to_appear(driver):
     """Wait for the login page to appear."""
     # to make sure the UI is refresh for the login page
-    assert wait_on_element(driver, 180, '//input[@data-placeholder="Username"]')
-    # time.sleep(10)
-    # driver.refresh()
-    assert wait_on_element(driver, 180, '//p[text()="HA is enabled."]')
+    assert wait_on_element(driver, 240, '//input[@data-placeholder="Username"]')
+    assert wait_on_element(driver, 240, '//p[text()="HA is enabled."]')
 
 
 @then(parsers.parse('at the login page, enter "{user}" and "{password}"'))


### PR DESCRIPTION
Added code to wait for HA is enabled at login, before login in
Changed the step after failover login to "on the Dashboard, wait for the Active Directory service"
Added code to make set that directories service is up and tall task are completed before running info
Change both wait_on_element before login to 4 minutes

Test results in the ticket https://jira.ixsystems.com/browse/DOCS-2692