### PR TITLE
NAS-112820 / 22.02-RC.2 / NAS-112820: Concat instead of map to retain Generate New option

### DIFF
--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
@@ -847,10 +847,11 @@ export class ReplicationWizardComponent implements WizardConfiguration {
 
     const privateKeyField = _.find(this.dialogFieldConfig, { name: 'private_key' }) as FormSelectConfig;
     this.keychainCredentialService.getSSHKeys().pipe(untilDestroyed(this)).subscribe((keyPairs) => {
-      privateKeyField.options = keyPairs.map((keypair) => ({
+      const keypairOptions = keyPairs.map((keypair) => ({
         label: keypair.name,
         value: String(keypair.id),
       }));
+      privateKeyField.options = privateKeyField.options.concat(keypairOptions);
     });
 
     const ssh_credentials_source_field = _.find(this.source_fieldSet.config, { name: 'ssh_credentials_source' }) as FormSelectConfig;


### PR DESCRIPTION
To test:

- Pull up the Replication Wizard from the Data Protection page
- Set your source or destination to "On aDifferent System"
- Set the "SSH Connection" field to "Create New"
- This will generate a dialog that contains a form with a "Private Key"  select field. Make sure that field's first option is "Generate New" and select it.
- Submit the form and the next time you try to go through the wizard, the SSH Connection you just created should be available in the form