### PR TITLE
NAS-112801 / 22.02-RC.2 / NAS-112801: Fixing pool status page when pool has spares (by undsoft)

### DIFF
--- a/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
+++ b/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
@@ -453,7 +453,7 @@ export class VolumeStatusComponent implements OnInit, OnDestroy {
     } else if (category == 'spare') {
       _.find(actions, { id: 'online' }).isHidden = true;
       _.find(actions, { id: 'offline' }).isHidden = true;
-      _.find(actions, { id: 'Replace' }).isHidden = true;
+      _.find(actions, { id: 'replace' }).isHidden = true;
     } else if (category == 'cache') {
       _.find(actions, { id: 'online' }).isHidden = true;
       _.find(actions, { id: 'offline' }).isHidden = true;


### PR DESCRIPTION
Smallest PR ever.

To test: create a pool with a spare, on dashboard in Storage widget click on drive icon to get to pool status page. Observe that it's not broken.

Original PR: https://github.com/truenas/webui/pull/6012
Jira URL: https://jira.ixsystems.com/browse/NAS-112801