### PR TITLE
NAS-112920 / 22.02-RC.2 / NAS-112920: Fix reporting database message

### DIFF
--- a/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
+++ b/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
@@ -346,7 +346,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements AfterView
   }
 
   chartDataError(err: WebsocketError, nic: BaseNetworkInterface): EmptyConfig {
-    if ([ReportingDatabaseError.FailedExport, ReportingDatabaseError.InvalidTimestamp].includes(err.error)) {
+    if (err.error === ReportingDatabaseError.InvalidTimestamp) {
       const errorMessage = err.reason ? err.reason.replace('[EINVALIDRRDTIMESTAMP] ', '') : null;
       const helpMessage = this.translate.instant('You can clear reporting database and start data collection immediately.');
       return {

--- a/src/app/pages/reports-dashboard/components/report/report.component.ts
+++ b/src/app/pages/reports-dashboard/components/report/report.component.ts
@@ -391,12 +391,7 @@ export class ReportComponent extends WidgetComponent implements AfterViewInit, O
   }
 
   handleError(evt: CoreEvent): void {
-    if (evt.data?.name === 'FetchingError'
-      && [
-        ReportingDatabaseError.FailedExport,
-        ReportingDatabaseError.InvalidTimestamp,
-      ].includes(evt.data?.data?.error)
-    ) {
+    if (evt.data?.name === 'FetchingError' && evt.data?.data?.error === ReportingDatabaseError.InvalidTimestamp) {
       const err = evt.data.data;
       this.report.errorConf = {
         type: EmptyType.Errors,


### PR DESCRIPTION
Changes:

- Do not show `reporting database is broken` message for InvalidExport error

Testing:
On the Reporting or Network widget on the main dashboard, make sure that `The reporting database is broken` message with action to fix database is appeared only when middleware returns error with code 206 (EINVALIDRRDTIMESTAMP)