### PR TITLE
NAS-112976 / 22.02-RC.2 / Fixed values for frequency in alert settings

### DIFF
--- a/src/app/pages/system/alert/alert.component.ts
+++ b/src/app/pages/system/alert/alert.component.ts
@@ -70,9 +70,12 @@ export class AlertConfigComponent implements OnInit {
     this.ws.call('alert.list_policies').pipe(untilDestroyed(this)).subscribe(
       (policies) => {
         this.settingOptions = policies.map((policy) => {
-          const label: string = policy;
+          let label: string = policy;
+          if (policy === AlertPolicy.Immediately) {
+            label = policy + ' (Default)';
+          }
 
-          return { label, value: label };
+          return { label, value: policy };
         });
       },
       (error) => {


### PR DESCRIPTION
In alert settings, the frequency dropdowns for all options should show `Immediately (Default)` selected if that's the selected value (wasn't happening before. If `IMMEDIATELY` was selected you'd get empty drop downs).
When selecting `IMMEDIATELY (Default)`, the value shouldn't have `(Default)` in it.
NAS-112976