### PR TITLE
NAS-112974 / 12.0 / Fix CSS rule hiding div 

### DIFF
--- a/src/app/pages/system/viewenclosure/view-enclosure.component.css
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.css
@@ -116,3 +116,12 @@ nav.view-nav-bar{
 .lt-lg.enclosure-selector{
   color: var(--red);
 }
+
+.enclosure-disks {
+  padding: 64px;
+}
+
+.enclosure-disks.rackmount {
+  height: calc(100vh - 88px);
+  overflow: auto;
+}

--- a/src/app/pages/system/viewenclosure/view-enclosure.component.html
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.html
@@ -19,7 +19,7 @@
     </div>
   
     <ng-container *ngIf="supportedHardware">
-      <div *ngIf="!system.platform.includes('MINI'); else mini" style="padding:64px;">
+      <div *ngIf="!system.platform.includes('MINI'); else mini" class="enclosure-disks rackmount">
         <enclosure-disks style.padding="32px 0 0 0"  
           *ngIf="events && system && system.pools && selectedEnclosure" 
           [controller-events]="events" 
@@ -30,7 +30,7 @@
       </div>
   
       <ng-template #mini>
-        <div style="padding:64px;">
+        <div class="enclosure-disks">
           <enclosure-disks-mini style.padding="32px 0 0 0"  
             *ngIf="events && system && system.pools && selectedEnclosure" 
             [controller-events]="events" 


### PR DESCRIPTION
Test on a system with 3 or more shelves :

- Go to System/View Enclosure
- Disks view and enclosure selector should always be reachable
- They both should also hide scroll bars if enough vertical space exists to show the entire element
- On the disks view, make sure the "Edit Label" button works on the top right corner of the mat-card.