### PR TITLE
NAS-112981 / 22.02-RC.2 / NAS-112981: Following a job when job_id is returned in ldap config up…

### DIFF
--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -139,7 +139,7 @@ import {
 } from 'app/interfaces/keychain-credential.interface';
 import { KmipConfig, KmipConfigUpdate } from 'app/interfaces/kmip-config.interface';
 import { KubernetesConfig, KubernetesConfigUpdate } from 'app/interfaces/kubernetes-config.interface';
-import { LdapConfig, LdapConfigUpdate } from 'app/interfaces/ldap-config.interface';
+import { LdapConfig, LdapConfigUpdate, LdapConfigUpdateResult } from 'app/interfaces/ldap-config.interface';
 import { LldpConfig, LldpConfigUpdate } from 'app/interfaces/lldp-config.interface';
 import { MailConfig, MailConfigUpdate, SendMailParams } from 'app/interfaces/mail-config.interface';
 import { Multipath } from 'app/interfaces/multipath.interface';
@@ -612,7 +612,7 @@ export type ApiDirectory = {
 
   // Ldap
   'ldap.ssl_choices': { params: void; response: string[] };
-  'ldap.update': { params: [LdapConfigUpdate]; response: LdapConfig };
+  'ldap.update': { params: [LdapConfigUpdate]; response: LdapConfigUpdateResult };
   'ldap.schema_choices': { params: void; response: string[] };
   'ldap.config': { params: void; response: LdapConfig };
 

--- a/src/app/interfaces/ldap-config.interface.ts
+++ b/src/app/interfaces/ldap-config.interface.ts
@@ -21,4 +21,8 @@ export interface LdapConfig {
   validate_certificates: boolean;
 }
 
+export interface LdapConfigUpdateResult extends LdapConfig {
+  job_id: number;
+}
+
 export type LdapConfigUpdate = Omit<LdapConfig, 'id' | 'cert_name' | 'uri_list'>;

--- a/src/app/pages/directory-service/components/active-directory/active-directory.component.ts
+++ b/src/app/pages/directory-service/components/active-directory/active-directory.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -40,7 +40,6 @@ export class ActiveDirectoryComponent implements FormConfiguration {
   protected nss_info: FormSelectConfig;
   adStatus = false;
   entityEdit: EntityFormComponent;
-  protected dialogRef: MatDialogRef<EntityJobComponent, void>;
   custActions = [
     {
       id: helptext.activedirectory_custactions_basic_id,
@@ -456,17 +455,17 @@ export class ActiveDirectoryComponent implements FormConfiguration {
 
   // Shows starting progress as a job dialog
   showStartingJob(jobId: number): void {
-    this.dialogRef = this.dialog.open(EntityJobComponent, { data: { title: T('Start') }, disableClose: true });
-    this.dialogRef.componentInstance.jobId = jobId;
-    this.dialogRef.componentInstance.wsshow();
-    this.dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
-      this.dialogRef.close();
+    const dialogRef = this.dialog.open(EntityJobComponent, { data: { title: T('Start') }, disableClose: true });
+    dialogRef.componentInstance.jobId = jobId;
+    dialogRef.componentInstance.wsshow();
+    dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
+      dialogRef.close();
       this.modalService.refreshTable();
     });
-    this.dialogRef.componentInstance.failure.pipe(untilDestroyed(this)).subscribe((error) => {
+    dialogRef.componentInstance.failure.pipe(untilDestroyed(this)).subscribe((error) => {
       new EntityUtils().handleWSError(this, error, this.dialogservice);
       this.modalService.refreshTable();
-      this.dialogRef.close();
+      dialogRef.close();
     });
   }
 }

--- a/src/app/pages/directory-service/components/ldap/ldap.component.ts
+++ b/src/app/pages/directory-service/components/ldap/ldap.component.ts
@@ -1,19 +1,23 @@
 import { Component } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { TranslateService } from '@ngx-translate/core';
 import * as _ from 'lodash';
 import { Observable } from 'rxjs';
 import helptext from 'app/helptext/directory-service/ldap';
 import global_helptext from 'app/helptext/global-helptext';
 import { FormConfiguration, FormCustomAction } from 'app/interfaces/entity-form.interface';
-import { LdapConfig, LdapConfigUpdate } from 'app/interfaces/ldap-config.interface';
+import { LdapConfig, LdapConfigUpdate, LdapConfigUpdateResult } from 'app/interfaces/ldap-config.interface';
 import { WebsocketError } from 'app/interfaces/websocket-error.interface';
 import { EntityFormComponent } from 'app/pages/common/entity/entity-form/entity-form.component';
 import {
   FieldConfig, FormSelectConfig,
 } from 'app/pages/common/entity/entity-form/models/field-config.interface';
 import { FieldSet } from 'app/pages/common/entity/entity-form/models/fieldset.interface';
+import { EntityJobComponent } from 'app/pages/common/entity/entity-job/entity-job.component';
+import { EntityUtils } from 'app/pages/common/entity/utils';
 import {
   SystemGeneralService,
   WebSocketService,
@@ -26,7 +30,6 @@ import { ModalService } from 'app/services/modal.service';
   selector: 'app-ldap',
   template: '<entity-form [conf]="this"></entity-form>',
 })
-
 export class LdapComponent implements FormConfiguration {
   title: string = helptext.title;
   isEntity = false;
@@ -60,7 +63,7 @@ export class LdapComponent implements FormConfiguration {
       name: helptext.ldap_custactions_clearcache_name,
       function: () => {
         this.systemGeneralService.refreshDirServicesCache().pipe(untilDestroyed(this)).subscribe(() => {
-          this.dialogservice.info(helptext.ldap_custactions_clearcache_dialog_title,
+          this.dialogService.info(helptext.ldap_custactions_clearcache_dialog_title,
             helptext.ldap_custactions_clearcache_dialog_message);
         });
       },
@@ -217,11 +220,13 @@ export class LdapComponent implements FormConfiguration {
   }
 
   constructor(
-    protected router: Router,
-    protected ws: WebSocketService,
+    private router: Router,
+    private ws: WebSocketService,
     private modalService: ModalService,
-    private dialogservice: DialogService,
-    protected systemGeneralService: SystemGeneralService,
+    private dialogService: DialogService,
+    private matDialog: MatDialog,
+    private systemGeneralService: SystemGeneralService,
+    private translate: TranslateService,
   ) { }
 
   resourceTransformIncomingRestData(data: LdapConfig): any {
@@ -328,5 +333,32 @@ export class LdapComponent implements FormConfiguration {
       errorText = T('Invalid credentials. Please try again.');
     }
     this.entityForm.error = errorText;
+  }
+
+  responseOnSubmit(result: LdapConfigUpdateResult): void {
+    if (result.job_id) {
+      this.showUpdateJob(result.job_id);
+    }
+  }
+
+  showUpdateJob(jobId: number): void {
+    const dialogRef = this.matDialog.open(
+      EntityJobComponent,
+      {
+        data: { title: this.translate.instant('Setting up LDAP') },
+        disableClose: true,
+      },
+    );
+    dialogRef.componentInstance.jobId = jobId;
+    dialogRef.componentInstance.wsshow();
+    dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
+      dialogRef.close();
+      this.modalService.refreshTable();
+    });
+    dialogRef.componentInstance.failure.pipe(untilDestroyed(this)).subscribe((error) => {
+      new EntityUtils().handleWSError(this, error, this.dialogService);
+      this.modalService.refreshTable();
+      dialogRef.close();
+    });
   }
 }

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2626,6 +2626,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1729,6 +1729,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings Requiring Re-Initialization": "",
   "Setup Method": "",
   "Several providers are supported. If a specific  provider is not listed, select <i>Custom Provider</i> and enter the  information in the <i>Custom Server</i> and <i>Custom Path</i> fields.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -675,6 +675,7 @@
   "Set ACL": "",
   "Set font size": "",
   "Set to prevent the zvol from being modified.": "",
+  "Setting up LDAP": "",
   "Settings Requiring Re-Initialization": "",
   "Shell": "",
   "Shell Commands": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2873,6 +2873,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings Requiring Re-Initialization": "",
   "Setup Method": "",
   "Several providers are supported. If a specific  provider is not listed, select <i>Custom Provider</i> and enter the  information in the <i>Custom Server</i> and <i>Custom Path</i> fields.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -586,6 +586,7 @@
   "Set ACL": "",
   "Set font size": "",
   "Set to prevent the zvol from being modified.": "",
+  "Setting up LDAP": "",
   "Settings Requiring Re-Initialization": "",
   "Share ACL": "",
   "Sharing Platform": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2840,6 +2840,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2614,6 +2614,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3122,6 +3122,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3034,6 +3034,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3034,6 +3034,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2926,6 +2926,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1009,6 +1009,7 @@
   "Set to use encryption when replicating data. Additional encryption options will appear.": "",
   "Set to use the <i>Schedule</i> in place  of the <i>Replicate Specific Snapshots</i> time frame. The Schedule values are  read over the <i>Replicate Specific Snapshots</i> time frame.": "",
   "Setting this option changes the destination dataset to be read-only. To continue using the default or existing dataset read permissions, leave this option unset.": "",
+  "Setting up LDAP": "",
   "Settings Requiring Re-Initialization": "",
   "Share ACL": "",
   "Sharing Platform": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3142,6 +3142,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -238,6 +238,7 @@
   "Select Client Certificate": "",
   "Sent": "",
   "Set font size": "",
+  "Setting up LDAP": "",
   "Shell Commands": "",
   "Show Built-in Groups": "",
   "Show Built-in Users": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2284,6 +2284,7 @@
   "Setting this option is discouraged as it increases security risk.": "",
   "Setting this option reduces the security of the connection, so only use it if the client does not understand reused SSL sessions.": "",
   "Setting this option will result in timeouts if <b>identd</b> is not running on the client.": "",
+  "Setting up LDAP": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",
   "Setup Method": "",


### PR DESCRIPTION
Testing: make sure middleware is fresh, use ldap credentials from here https://confluence.ixsystems.com/display/QE/Directory+Servers+and+other+resources+for+testing and see that:
1. When config is saved, job dialog may be shown.
2. Directory Services page is refreshed.