### PR TITLE
NAS-112436 / 12.0 / Update error-dialog component

### DIFF
--- a/src/app/pages/common/error-dialog/error-dialog.component.html
+++ b/src/app/pages/common/error-dialog/error-dialog.component.html
@@ -4,7 +4,7 @@
 </h1>
 <div mat-dialog-content id="err-md-content">
   <div id="err-message-wrapper"><span [innerHTML]="message"></span></div>
-  <div class="more-info" (click)="toggleOpen($event)" *ngIf="backtrace"
+  <div class="more-info" (click)="toggleOpen($event)" *ngIf="backtrace" fxLayoutAlign="start center"
     ix-auto
     ix-auto-type="button"
     ix-auto-identifier="backtrace-toggle">

--- a/src/app/pages/common/error-dialog/error-dialog.component.scss
+++ b/src/app/pages/common/error-dialog/error-dialog.component.scss
@@ -1,0 +1,8 @@
+.more-info {
+  cursor: pointer;
+  margin: 8px 0;
+
+  mat-icon {
+    margin-right: 4px;
+  }
+}

--- a/src/app/services/job.service.ts
+++ b/src/app/services/job.service.ts
@@ -40,9 +40,9 @@ export class JobService {
 
     if (job.error) {
       if (job.logs_path) {
-        this.dialog.errorReport(T('Error'), job.error, job.exception, job);
+        this.dialog.errorReport(T('Error'), `<pre>${job.error}</pre>`, job.exception, job);
       } else {
-        this.dialog.errorReport(T('Error'), job.error, job.exception);
+        this.dialog.errorReport(T('Error'), `<pre>${job.error}</pre>`, job.exception);
       }
     } else if (job.logs_excerpt === '') {
       this.dialog.report(globalHelptext.noLogDilaog.title, globalHelptext.noLogDilaog.message);

--- a/src/assets/styles/themes/ix-blue.scss
+++ b/src/assets/styles/themes/ix-blue.scss
@@ -848,8 +848,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     @include variable(color, --yellow-txt, $yellow-txt);
   }
 
-  // These last two were a result of a backport. 
-  // 12.1 has --contrast-lighter and --contrast-darker vars 
+  // These last two were a result of a backport.
+  // 12.1 has --contrast-lighter and --contrast-darker vars
   // but 12.0 theme service does not create these
   // so we will use --alt-bg1 instead
   .fn-theme-contrast-darker{
@@ -1551,6 +1551,8 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
 
   confirm-dialog pre,
   error-dialog pre {
+      display: block;
+      font-family: monospace;
       overflow-x: auto;
       white-space: pre-wrap;
       white-space: -moz-pre-wrap;
@@ -1768,7 +1770,7 @@ $primary-dark: darken( map-get($md-primary, 500), 8% );
     background: var(--bg1);
   }
 
-  openvpn-client-edit .buttons, 
+  openvpn-client-edit .buttons,
   openvpn-server-edit .buttons {
     margin-top: 1rem
   }


### PR DESCRIPTION
Improvements for error-dialog component

Preview:
![image](https://user-images.githubusercontent.com/351613/139066579-8519467a-d540-46a6-a474-c2aea140016c.png)

Testing:

- Go to `Tasks -> Cloud Sync` and click on the `Failed` status button to check it.