### PR TITLE
NAS-113000 / 12.0 / Fixed idmap form

### DIFF
--- a/src/app/pages/directoryservice/idmap-form/idmap-form.component.ts
+++ b/src/app/pages/directoryservice/idmap-form/idmap-form.component.ts
@@ -207,13 +207,17 @@ export class IdmapFormComponent {
           options: helptext.idmap.linked_service.options,
         },
         {
-          type: 'input',
+          type: 'select',
           name: 'ldap_server',
           placeholder: helptext.idmap.ldap_server.placeholder,
           tooltip: helptext.idmap.ldap_server.tooltip,
+          options: [
+            { label: 'Standalone', value: 'STANDALONE' },
+            { label: 'AD', value: 'AD' },
+          ],
         },
         {
-          type: 'input',
+          type: 'checkbox',
           name: 'ldap_realm',
           placeholder: helptext.idmap.ldap_realm.placeholder,
           tooltip: helptext.idmap.ldap_realm.tooltip,
@@ -231,7 +235,7 @@ export class IdmapFormComponent {
           tooltip: helptext.idmap.bind_path_group.tooltip,
         },
         {
-          type: 'input',
+          type: 'checkbox',
           name: 'user_cn',
           placeholder: helptext.idmap.user_cn.placeholder,
           tooltip: helptext.idmap.user_cn.tooltip,

--- a/src/app/pages/directoryservice/idmap-form/idmap-form.component.ts
+++ b/src/app/pages/directoryservice/idmap-form/idmap-form.component.ts
@@ -8,6 +8,7 @@ import { ValidationService, IdmapService, DialogService } from '../../../service
 import { EntityJobComponent } from 'app/pages/common/entity/entity-job/entity-job.component';
 import { EntityUtils } from '../../common/entity/utils';
 import helptext from '../../../helptext/directoryservice/idmap';
+import { T } from 'app/translate-marker';
 
 @Component({
   selector: 'app-idmap-form',
@@ -212,8 +213,8 @@ export class IdmapFormComponent {
           placeholder: helptext.idmap.ldap_server.placeholder,
           tooltip: helptext.idmap.ldap_server.tooltip,
           options: [
-            { label: 'Standalone', value: 'STANDALONE' },
-            { label: 'AD', value: 'AD' },
+            { label: T('Standalone'), value: 'STANDALONE' },
+            { label: T('AD'), value: 'AD' },
           ],
         },
         {


### PR DESCRIPTION
To test, on TrueNAS Core, go to `Directory Services` -> `Active Directory` -> `Advanced Options` -> `Edit Idmap` -> `Add`
Next, on the field named `Idmap Backend` select the option `RCF2307`. Check that the relevant fields have correct types. Also check form submission.