### PR TITLE
NAS-111019 / 22.02-RC.2 / Allow Kubernetes ServiceLB to be turned off

### DIFF
--- a/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.html
+++ b/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.html
@@ -32,6 +32,11 @@
           formControlName="configure_gpus"
           [label]="'Enable GPU support' | translate"
         ></ix-checkbox>
+		
+        <ix-checkbox
+          formControlName="servicelb"
+          [label]="'Enable Integrated Loadbalancer' | translate"
+        ></ix-checkbox>
       </ix-fieldset>
       <ix-fieldset [title]="'Settings Requiring Re-Initialization' | translate">
         <p class="help-text">

--- a/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.spec.ts
+++ b/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.spec.ts
@@ -33,6 +33,7 @@ describe('KubernetesSettingsComponent', () => {
           route_v4_interface: 'enp0s7',
           route_v4_gateway: '10.123.45.1',
           configure_gpus: true,
+          servicelb: true,
           cluster_cidr: '172.16.0.0/16',
           service_cidr: '172.17.0.0/16',
           cluster_dns_ip: '172.17.0.1',
@@ -79,6 +80,7 @@ describe('KubernetesSettingsComponent', () => {
       'Route v4 Gateway': '10.123.45.1',
       'Enable Container Image Updates': true,
       'Enable GPU support': true,
+      'Enable Integrated Loadbalancer': true,
       'Cluster CIDR': '172.16.0.0/16',
       'Service CIDR': '172.17.0.0/16',
       'Cluster DNS IP': '172.17.0.1',
@@ -93,6 +95,7 @@ describe('KubernetesSettingsComponent', () => {
       'Route v4 Gateway': '10.123.45.13',
       'Enable Container Image Updates': false,
       'Enable GPU support': false,
+      'Enable Integrated Loadbalancer': false,
     });
 
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -104,6 +107,7 @@ describe('KubernetesSettingsComponent', () => {
       route_v4_interface: 'enp0s8',
       route_v4_gateway: '10.123.45.13',
       configure_gpus: false,
+      servicelb: false,
       cluster_cidr: '172.16.0.0/16',
       service_cidr: '172.17.0.0/16',
       cluster_dns_ip: '172.17.0.1',

--- a/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
+++ b/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
@@ -34,6 +34,7 @@ export class KubernetesSettingsComponent implements OnInit {
     route_v4_gateway: [''],
     enable_container_image_update: [true],
     configure_gpus: [true],
+    servicelb: [true],
     cluster_cidr: ['', Validators.required],
     service_cidr: ['', Validators.required],
     cluster_dns_ip: ['', Validators.required],


### PR DESCRIPTION
This is the UI portion of the changes proposed here:
https://github.com/truenas/middleware/pull/7834

Submitted as draft, till above PR is merged...

Once https://github.com/truenas/middleware/pull/7834 is merged, this can be used for users to easily disable the default integrated loadbalancer without issue to run their own prefered loadbalancer.

It's important to note why the text refers to "Integrated Loadbalancer", which might seem vague.
However: It is refered to either "ServiceLB" and "Klipper" all-over-the-place and neither name is very descriptive, so just calling it the "integrated loadbalancer" might be the most descriptive option. The target users (who want to run their own Loadbalancer) most likely already knows what this refers to anyway.

**Screenshot of the proposed change:**
![image](https://user-images.githubusercontent.com/7613738/141020035-7c4bea49-66d7-499b-8b52-ecfbc411d0fc.png)
