### PR TITLE
NAS-113386 / 12.0 / R50B only has 2 rear slots

### DIFF
--- a/src/app/core/classes/hardware/r50b.ts
+++ b/src/app/core/classes/hardware/r50b.ts
@@ -98,9 +98,9 @@ export class R50B extends Chassis {
       this.rear.driveTrayHandlePath = 'assets/images/hardware/r50/r50_rear_960w_drivetray_handle.png';
       this.rear.columns = 1;
       this.rear.rows = 3;
-      this.rear.slotRange = { start: 49, end: 51 };
+      this.rear.slotRange = { start: 49, end: 50 };
 
-      this.rear.totalDriveTrays = 3;
+      this.rear.totalDriveTrays = 2;
     }
   }
 


### PR DESCRIPTION
To test, go to tn30 and check the rear view of the R50B enclosure.
There should only be 2 drive slots in there.