### PR TITLE
NAS-112427 / 22.02-RC.2 / NAS-112427: Fixed ACL group name when group is deleted

### DIFF
--- a/src/app/pages/storage/volumes/permissions/components/view-trivial-permissions/trivial-permissions.component.ts
+++ b/src/app/pages/storage/volumes/permissions/components/view-trivial-permissions/trivial-permissions.component.ts
@@ -33,12 +33,12 @@ export class TrivialPermissionsComponent {
     return [
       {
         type: PermissionsItemType.User,
-        name: stat.user,
+        name: stat.user == null ? 'User ID: ' + stat.uid.toString() : stat.user,
         description: posixPermissionsToDescription(this.translate, permissions.owner),
       },
       {
         type: PermissionsItemType.Group,
-        name: stat.group,
+        name: stat.group == null ? 'Group ID: ' + stat.gid.toString() : stat.group,
         description: posixPermissionsToDescription(this.translate, permissions.group),
       },
       {

--- a/src/app/pages/storage/volumes/permissions/components/view-trivial-permissions/trivial-permissions.component.ts
+++ b/src/app/pages/storage/volumes/permissions/components/view-trivial-permissions/trivial-permissions.component.ts
@@ -33,12 +33,12 @@ export class TrivialPermissionsComponent {
     return [
       {
         type: PermissionsItemType.User,
-        name: stat.user == null ? 'User ID: ' + stat.uid.toString() : stat.user,
+        name: stat.user == null ? 'User - ' + stat.uid.toString() : stat.user,
         description: posixPermissionsToDescription(this.translate, permissions.owner),
       },
       {
         type: PermissionsItemType.Group,
-        name: stat.group == null ? 'Group ID: ' + stat.gid.toString() : stat.group,
+        name: stat.group == null ? 'Group - ' + stat.gid.toString() : stat.group,
         description: posixPermissionsToDescription(this.translate, permissions.group),
       },
       {

--- a/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.ts
+++ b/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { AclType } from 'app/enums/acl-type.enum';
+import { NfsAclTag } from 'app/enums/nfs-acl.enum';
 import { Acl } from 'app/interfaces/acl.interface';
 import { Dataset } from 'app/interfaces/dataset.interface';
 import { FileSystemStat } from 'app/interfaces/filesystem-stat.interface';
@@ -55,12 +56,12 @@ export class PermissionsSidebarComponent implements OnInit, OnChanges {
         this.isLoading = state.isLoading;
         this.acl = state.acl;
         this.stat = state.stat;
-        if (this.acl) {
+        if (this.acl && this.acl.acltype === AclType.Nfs4) {
           for (const acl of this.acl.acl) {
-            if (acl.tag.toLowerCase().includes('owner') && acl.who == null) {
+            if (acl.tag === NfsAclTag.Owner && acl.who == null) {
               acl.who = this.acl.uid.toString();
             }
-            if (acl.tag.toLowerCase().includes('group') && acl.who == null) {
+            if ((acl.tag === NfsAclTag.Group || acl.tag === NfsAclTag.UserGroup) && acl.who == null) {
               acl.who = this.acl.gid.toString();
             }
           }

--- a/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.ts
+++ b/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.ts
@@ -56,7 +56,7 @@ export class PermissionsSidebarComponent implements OnInit, OnChanges {
         this.isLoading = state.isLoading;
         this.acl = state.acl;
         this.stat = state.stat;
-        if (this.acl && this.acl.acltype === AclType.Nfs4) {
+        if (this.acl && this.acl.acl && this.acl.acltype === AclType.Nfs4) {
           for (const acl of this.acl.acl) {
             if (acl.tag === NfsAclTag.Owner && acl.who == null) {
               acl.who = this.acl.uid.toString();

--- a/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.ts
+++ b/src/app/pages/storage/volumes/permissions/containers/permissions-sidebar/permissions-sidebar.component.ts
@@ -55,6 +55,17 @@ export class PermissionsSidebarComponent implements OnInit, OnChanges {
         this.isLoading = state.isLoading;
         this.acl = state.acl;
         this.stat = state.stat;
+        if (this.acl) {
+          for (const acl of this.acl.acl) {
+            if (acl.tag.toLowerCase().includes('owner') && acl.who == null) {
+              acl.who = this.acl.uid.toString();
+            }
+            if (acl.tag.toLowerCase().includes('group') && acl.who == null) {
+              acl.who = this.acl.gid.toString();
+            }
+          }
+        }
+
         this.cdr.markForCheck();
       });
   }


### PR DESCRIPTION
The ticket has a description of the issue. Check if the 'User ID: 111' seems like a good idea for trivial permissions in the sidebar when the user/group has been deleted. Or should it just be '111'