### PR TITLE
NAS-113607 / 22.02-RC.2 / NAS-113607: Fix data protection dashboard

### DIFF
--- a/src/app/pages/common/entity/table/table.component.html
+++ b/src/app/pages/common/entity/table/table.component.html
@@ -23,7 +23,7 @@
   </mat-toolbar-row>
 
 <mat-card-content class="table-container">
-  <div class="table-container" #table [class.empty]="dataSource && !dataSource.length">
+  <div class="table-container" #table [class.empty]="dataSource && !dataSource.length" [class.loading]="!tableConf.tableComponent">
     <table *ngIf="dataSource && dataSource.length > 0" mat-table [dataSource]="displayedDataSource" class="table-component">
       <ng-container *ngIf="_tableConf.complex; then complex else simple"></ng-container>
       <!-- Simple Info Column -->

--- a/src/app/pages/common/entity/table/table.component.scss
+++ b/src/app/pages/common/entity/table/table.component.scss
@@ -32,8 +32,13 @@ div.table-container {
   max-width: 100%;
   padding: 0;
 
+  &.loading {
+    height: 100%;
+    padding: 12px;
+  }
+
   &.empty {
-    height: calc(100% - 41px);
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
Changes:

- Remove `this.parent` references
- Style improvements for loading and empty states (added some space)

Testing:
- Make sure that the dashboard can load each card successfully.
- Extra check for the Cloud Sync Tasks when some task is disabled

