### PR TITLE
NAS-110535 / 22.02 / NAS-110535: Custom subscription to console messages

### DIFF
--- a/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
@@ -6,6 +6,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatDrawerMode, MatSidenav } from '@angular/material/sidenav';
 import { NavigationEnd, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { UUID } from 'angular2-uuid';
 import { ConsolePanelDialogComponent } from 'app/components/common/dialog/console-panel/console-panel-dialog.component';
 import { CoreService } from 'app/core/services/core-service/core.service';
 import { LayoutService } from 'app/core/services/layout.service';
@@ -43,6 +44,8 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
   isOpen = false;
   notificPanelClosed = false;
   menuName: string;
+  readonly consoleMsgsSubName = 'filesystem.file_tail_follow:/var/log/messages:500';
+  consoleMsgsSubscriptionId: string = null;
   subs: SubMenuItem[];
   copyrightYear = this.localeService.getCopyrightYearFromBuildTime();
 
@@ -197,9 +200,8 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
   }
 
   getLogConsoleMsg(): void {
-    const subName = 'filesystem.file_tail_follow:/var/log/messages:500';
-
-    this.ws.sub(subName).pipe(untilDestroyed(this)).subscribe((res) => {
+    this.consoleMsgsSubscriptionId = UUID.UUID();
+    this.ws.sub(this.consoleMsgsSubName, this.consoleMsgsSubscriptionId).pipe(untilDestroyed(this)).subscribe((res) => {
       if (res && res.data && typeof res.data === 'string') {
         this.consoleMsg = this.accumulateConsoleMsg(res.data, 3);
       }
@@ -235,6 +237,8 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
   onShowConsoleFooterBar(data: boolean): void {
     if (data && this.consoleMsg == '') {
       this.getLogConsoleMsg();
+    } else if (!data) {
+      this.ws.unsub(this.consoleMsgsSubName, this.consoleMsgsSubscriptionId);
     }
 
     this.isShowFooterConsole = data;

--- a/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
@@ -246,7 +246,7 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
       dialogRef.componentInstance.consoleMsg = this.accumulateConsoleMsg('', 500);
     });
 
-    dialogRef.afterClosed().pipe(untilDestroyed(this)).subscribe(() => {
+    dialogRef.beforeClosed().pipe(untilDestroyed(this)).subscribe(() => {
       clearInterval(dialogRef.componentInstance.intervalPing);
       sub.unsubscribe();
     });

--- a/src/app/enums/api-event-message.enum.ts
+++ b/src/app/enums/api-event-message.enum.ts
@@ -3,7 +3,11 @@ export enum ApiEventMessage {
   Added = 'added',
   Result = 'result',
   Connected = 'connected',
+  Connect = 'connect',
   NoSub = 'nosub',
+  UnSub = 'unsub',
   Pong = 'pong',
   Sub = 'sub',
+  Ping = 'ping',
+  Method = 'method',
 }

--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -19,7 +19,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import * as _ from 'lodash';
 import { Observable, Subscription } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { delay, filter } from 'rxjs/operators';
 import { FormConfiguration } from 'app/interfaces/entity-form.interface';
 import { FieldSets } from 'app/pages/common/entity/entity-form/classes/field-sets';
 import { WebSocketService, SystemGeneralService, DialogService } from 'app/services';
@@ -496,7 +496,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
       this.loader.open();
       this.loaderOpen = true;
       this.submitFunction(value)
-        .pipe(untilDestroyed(this)).subscribe(
+        .pipe(delay(10000), untilDestroyed(this)).subscribe(
           (res) => {
             this.loader.close();
             this.loaderOpen = false;

--- a/src/app/pages/common/entity/entity-form/entity-form.component.ts
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.ts
@@ -19,7 +19,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import * as _ from 'lodash';
 import { Observable, Subscription } from 'rxjs';
-import { delay, filter } from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 import { FormConfiguration } from 'app/interfaces/entity-form.interface';
 import { FieldSets } from 'app/pages/common/entity/entity-form/classes/field-sets';
 import { WebSocketService, SystemGeneralService, DialogService } from 'app/services';
@@ -496,7 +496,7 @@ export class EntityFormComponent implements OnInit, OnDestroy, OnChanges, AfterV
       this.loader.open();
       this.loaderOpen = true;
       this.submitFunction(value)
-        .pipe(delay(10000), untilDestroyed(this)).subscribe(
+        .pipe(untilDestroyed(this)).subscribe(
           (res) => {
             this.loader.close();
             this.loaderOpen = false;

--- a/src/app/services/app-loader/app-loader.component.html
+++ b/src/app/services/app-loader/app-loader.component.html
@@ -5,5 +5,5 @@
   </div>
 </div>
 <div *ngIf="isShowConsole" fxLayoutAlign="center center">
-  <button mat-button color="primary" (click)="onOpenConsole()">{{ 'Console' | translate }}</button>
+  <button mat-button color="primary" (click)="onShowConsolePanel()">{{ 'Console' | translate }}</button>
 </div>

--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -227,7 +227,7 @@ export class WebSocketService {
 
     const uuid = subscriptionId || UUID.UUID();
     const payload = { id: uuid, name: api, msg: 'sub' };
-    const obs$ = new Observable((observer: Subscriber<T>) => {
+    return new Observable((observer: Subscriber<T>) => {
       this.pendingSubs[nom].observers[uuid] = observer;
       this.send(payload);
 
@@ -240,7 +240,6 @@ export class WebSocketService {
       };
       return observer;
     });
-    return obs$;
   }
 
   /**

--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -247,12 +247,12 @@ export class WebSocketService {
    * @param api The api end point to unsubscribe from
    * @param subscriptionId The subscription Id used to setup the subscription in the `sub(api, subscriptionId)` method
    */
-  unsub(api: string, id: string): void {
+  unsub(api: string, subscriptionId: string): void {
     const nom = api.replace('.', '_');
-    if (this.pendingSubs[nom].observers[id]) {
-      this.send({ id, msg: ApiEventMessage.UnSub });
-      this.pendingSubs[nom].observers[id].unsubscribe();
-      delete this.pendingSubs[nom].observers[id];
+    if (this.pendingSubs[nom].observers[subscriptionId]) {
+      this.send({ id: subscriptionId, msg: ApiEventMessage.UnSub });
+      this.pendingSubs[nom].observers[subscriptionId].unsubscribe();
+      delete this.pendingSubs[nom].observers[subscriptionId];
       if (!this.pendingSubs[nom].observers) {
         delete this.pendingSubs[nom];
       }


### PR DESCRIPTION
To test,
1. Go to `System Settings` -> `General` -> `GUI Settings` and make sure `Show Console Messages` checkbox is checked before saving.
2. Go to `Shares` -> `Block (iSCSI) Shares Targets` Configure and on the next page, `Total Global Configuration` tab selected, just tap on `Save` button. The loader should open. Here I've added a delay of 10 seconds so testing this PR is easier. (Will remove the delay before merging). The loader should be showing the `Console` button underneath the spinner. Click on that button.
3. Previously, opening the console dialog like this would cause the UI to completely crash and reload. It shouldn't happen now.
Let me know if there are any questions.