### PR TITLE
NAS-113604 / 22.02-RC.2 / Keep sidenav state in user preferences

### DIFF
--- a/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
@@ -170,9 +170,11 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
       setTimeout(() => {
         this.sideNav.open();
       });
+      this.layoutService.isMenuCollapsed = this.prefService.preferences.sidenavStatus.isCollapsed;
+      this.isSidenavCollapsed = this.prefService.preferences.sidenavStatus.isCollapsed;
+    } else {
+      this.layoutService.isMenuCollapsed = false;
     }
-    this.layoutService.isMenuCollapsed = this.prefService.preferences.sidenavStatus.isCollapsed;
-    this.isSidenavCollapsed = this.prefService.preferences.sidenavStatus.isCollapsed;
     this.cd.detectChanges();
   }
 

--- a/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
+++ b/src/app/components/common/layouts/admin-layout/admin-layout.component.ts
@@ -9,6 +9,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { ConsolePanelDialogComponent } from 'app/components/common/dialog/console-panel/console-panel-dialog.component';
 import { CoreService } from 'app/core/services/core-service/core.service';
 import { LayoutService } from 'app/core/services/layout.service';
+import { PreferencesService } from 'app/core/services/preferences.service';
 import { ProductType } from 'app/enums/product-type.enum';
 import { ForceSidenavEvent } from 'app/interfaces/events/force-sidenav-event.interface';
 import { SidenavStatusEvent } from 'app/interfaces/events/sidenav-status-event.interface';
@@ -63,27 +64,28 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
     private sysGeneralService: SystemGeneralService,
     private localeService: LocaleService,
     private layoutService: LayoutService,
+    private prefService: PreferencesService,
   ) {
     // detect server type
-    sysGeneralService.getProductType$.pipe(untilDestroyed(this)).subscribe((res) => {
+    this.sysGeneralService.getProductType$.pipe(untilDestroyed(this)).subscribe((res) => {
       this.productType = res as ProductType;
     });
 
     // Close sidenav after route change in mobile
-    router.events.pipe(untilDestroyed(this)).subscribe((routeChange) => {
+    this.router.events.pipe(untilDestroyed(this)).subscribe((routeChange) => {
       if (routeChange instanceof NavigationEnd && this.isMobile) {
         this.sideNav.close();
       }
     });
     // Watches screen size and open/close sidenav
-    media.media$.pipe(untilDestroyed(this)).subscribe((change: MediaChange) => {
+    this.media.media$.pipe(untilDestroyed(this)).subscribe((change: MediaChange) => {
       this.isMobile = this.layoutService.isMobile;
       this.updateSidenav();
       core.emit({ name: 'MediaChange', data: change, sender: this });
     });
 
     // Subscribe to Preference Changes
-    core.register({
+    this.core.register({
       observerClass: this,
       eventName: 'UserPreferencesChanged',
     }).pipe(untilDestroyed(this)).subscribe((evt: UserPreferencesChangedEvent) => {
@@ -91,21 +93,21 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
     });
 
     // Listen for system information changes
-    core.register({
+    this.core.register({
       observerClass: this,
       eventName: 'SysInfo',
     }).pipe(untilDestroyed(this)).subscribe((evt: SysInfoEvent) => {
       this.hostname = evt.data.hostname;
     });
 
-    core.register({
+    this.core.register({
       observerClass: this,
       eventName: 'ForceSidenav',
     }).pipe(untilDestroyed(this)).subscribe((evt: ForceSidenavEvent) => {
       this.updateSidenav(evt.data);
     });
 
-    core.register({
+    this.core.register({
       observerClass: this,
       eventName: 'SidenavStatus',
     }).pipe(untilDestroyed(this)).subscribe((evt: SidenavStatusEvent) => {
@@ -169,8 +171,8 @@ export class AdminLayoutComponent implements OnInit, AfterViewChecked {
         this.sideNav.open();
       });
     }
-
-    this.layoutService.isMenuCollapsed = false;
+    this.layoutService.isMenuCollapsed = this.prefService.preferences.sidenavStatus.isCollapsed;
+    this.isSidenavCollapsed = this.prefService.preferences.sidenavStatus.isCollapsed;
     this.cd.detectChanges();
   }
 

--- a/src/app/components/common/navigation/navigation.component.html
+++ b/src/app/components/common/navigation/navigation.component.html
@@ -30,7 +30,7 @@
         <span>{{item.name | translate}}</span>
       </a>
       <a *ngIf="item.type === 'slideOut'" name="{{item.name.replace(' ', '_')}}-menu" (click)="toggleMenu(item.state, item.sub)" class="sidenav-link">
-        <span class="menu-item-tooltip" [matTooltip]="item.tooltip" matTooltipPosition="above"></span>
+        <span class="menu-item-tooltip" [matTooltip]="item.tooltip" matTooltipPosition="right"></span>
         <mat-icon>{{item.icon}}</mat-icon>
         <span>{{item.name | translate}}</span>
         <span fxFlex></span>

--- a/src/app/components/common/topbar/topbar.component.ts
+++ b/src/app/components/common/topbar/topbar.component.ts
@@ -312,8 +312,10 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
       isCollapsed: this.layoutService.isMenuCollapsed,
     };
 
-    this.prefService.preferences.sidenavStatus = data;
-    this.prefService.savePreferences();
+    if (!this.layoutService.isMobile) {
+      this.prefService.preferences.sidenavStatus = data;
+      this.prefService.savePreferences();
+    }
 
     this.core.emit({
       name: 'SidenavStatus',

--- a/src/app/core/services/preferences.service.ts
+++ b/src/app/core/services/preferences.service.ts
@@ -45,6 +45,11 @@ export class PreferencesService {
     showGroupListMessage: true,
     expandAvailablePlugins: true,
     storedValues: {}, // For key/value pairs to save most recent values in form fields, etc
+    sidenavStatus: {
+      isCollapsed: false,
+      isOpen: true,
+      mode: 'over',
+    },
   };
 
   preferences: Preferences;

--- a/src/app/interfaces/events/sidenav-status-event.interface.ts
+++ b/src/app/interfaces/events/sidenav-status-event.interface.ts
@@ -1,11 +1,13 @@
 import { MatDrawerMode } from '@angular/material/sidenav';
 
+export interface SidenavStatusData {
+  isOpen: boolean;
+  mode: MatDrawerMode;
+  isCollapsed: boolean;
+}
+
 export interface SidenavStatusEvent {
   name: 'SidenavStatus';
   sender: unknown;
-  data: {
-    isOpen: boolean;
-    mode: MatDrawerMode;
-    isCollapsed: boolean;
-  };
+  data: SidenavStatusData;
 }

--- a/src/app/interfaces/preferences.interface.ts
+++ b/src/app/interfaces/preferences.interface.ts
@@ -1,3 +1,5 @@
+import { SidenavStatusData } from 'app/interfaces/events/sidenav-status-event.interface';
+
 interface Column {
   name: string;
   prop: string;
@@ -17,6 +19,7 @@ export interface Preferences {
   timestamp: string;
   userTheme: string;
   customThemes: { [theme: string]: any }[];
+  sidenavStatus: SidenavStatusData;
 
   /**
    * @deprecated

--- a/src/assets/styles/other/_fn-styles.scss
+++ b/src/assets/styles/other/_fn-styles.scss
@@ -1092,6 +1092,7 @@ div.hopscotch-bubble .hopscotch-nav-button.prev:hover {
 
 .collapsed-menu .sidebar-panel .sidebar-list-item {
   border-left: 0 solid rgba(0, 0, 0, 0) !important;
+  width: 100% !important;
 }
 
 .collapsed-menu .sidebar-panel .navigation-hold,

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -1591,7 +1591,7 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
   }
 
   .sidebar-panel.mat-sidenav .sidebar-list-item:hover {
-    border-left: 6px solid rgba(0, 0, 0, 0.045);
+    border-left: 6px solid var(--hover-bg);
   }
 
   .sidenav-link:hover,


### PR DESCRIPTION
Changes:

- Save the sidenav state when clicking on the hamburger icon to user preferences and restore it on each page reload
- Fix 6px pixels on left when hovering on menu items when `collapsed: false`
- Fix 6px pixels on right  when `collapsed: true`
- Fix tooltip position for some items when `collapsed: true`

Known issues:

- Sometimes, you may see slide-out animation on page reload when the sidenav collapsed

Testing:

- Make sure these changes do not introduce new bugs
- Try to switch between Mobile / Desktop and check how it is going
