### PR TITLE
NAS-113598 / 22.02-RC.2 / NAS-113598: Added navigation on cancel click

### DIFF
--- a/src/app/pages/storage/volumes/datasets/dataset-unlock/unlock-dialog/unlock-dialog.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-unlock/unlock-dialog/unlock-dialog.component.ts
@@ -56,6 +56,9 @@ export class UnlockDialogComponent {
   cancel(): void {
     this.dialogRef.close(false);
     this.parent.dialogOpen = false;
+    if (this.final) {
+      this.parent.goBack();
+    }
   }
 
   showError(dataset: { name: string; unlock_error?: string }): void {


### PR DESCRIPTION
To test,
1. Create encrypted datasets on a pool
2. Export dataset keys from the pool `cog` icon drop down. (Not dataset three dot menu)
3. Export/Disconnect the pool
4. Import the same pool again
5. You should see a prompt that asks if you want to unlock your locked datasets
6. Click on `Continue`
7. Provide the dataset keys json file you downloaded in step 2
8. Click on save and follow the process.
9. On the last `Close` button when you're done unlocking datasets, you should be navigated to the `Storage` page again automatically