### PR TITLE
NAS-113723 / 22.02 / Enabling/Updating Information within Proactive Support not available

### DIFF
--- a/src/app/helptext/system/support.ts
+++ b/src/app/helptext/system/support.ts
@@ -28,6 +28,8 @@ export const helptextSystemSupport = {
     dialog_title: T('Settings saved'),
     dialog_mesage: T('Successfully saved proactive support settings.'),
     dialog_err: T('Error Saving Proactive Support Settings'),
+    dialog_unavailable_title: T('Warning'),
+    dialog_unavailable_warning: T('Proactive support settings is not available.'),
   },
 
   token: {

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -8,7 +8,6 @@ import { SupportConfig, SupportConfigUpdate } from 'app/interfaces/support.inter
 import { EntityFormComponent } from 'app/pages/common/entity/entity-form/entity-form.component';
 import { FieldConfig } from 'app/pages/common/entity/entity-form/models/field-config.interface';
 import { FieldSet } from 'app/pages/common/entity/entity-form/models/fieldset.interface';
-import { RelationAction } from 'app/pages/common/entity/entity-form/models/relation-action.enum';
 import { WebSocketService } from 'app/services/';
 import { AppLoaderService } from 'app/services/app-loader/app-loader.service';
 import { DialogService } from 'app/services/dialog.service';
@@ -43,13 +42,6 @@ export class ProactiveComponent implements FormConfiguration {
           placeholder: helptext.proactive.pc_name_placeholder,
           required: true,
           validation: helptext.proactive.pc_validation,
-          relation: [{
-            action: RelationAction.Disable,
-            when: [{
-              name: 'enabled',
-              value: false,
-            }],
-          }],
         },
         {
           type: 'input',
@@ -57,13 +49,6 @@ export class ProactiveComponent implements FormConfiguration {
           placeholder: helptext.proactive.pc_title_placeholder,
           required: true,
           validation: helptext.proactive.pc_validation,
-          relation: [{
-            action: RelationAction.Disable,
-            when: [{
-              name: 'enabled',
-              value: false,
-            }],
-          }],
         },
         {
           type: 'input',
@@ -71,13 +56,6 @@ export class ProactiveComponent implements FormConfiguration {
           placeholder: helptext.proactive.pc_email_placeholder,
           required: true,
           validation: helptext.proactive.pc_email_validation,
-          relation: [{
-            action: RelationAction.Disable,
-            when: [{
-              name: 'enabled',
-              value: false,
-            }],
-          }],
         },
         {
           type: 'input',
@@ -85,13 +63,6 @@ export class ProactiveComponent implements FormConfiguration {
           placeholder: helptext.proactive.pc_phone_placeholder,
           required: true,
           validation: helptext.proactive.pc_validation,
-          relation: [{
-            action: RelationAction.Disable,
-            when: [{
-              name: 'enabled',
-              value: false,
-            }],
-          }],
         },
       ],
     },
@@ -110,13 +81,6 @@ export class ProactiveComponent implements FormConfiguration {
           placeholder: helptext.proactive.sec_name_placeholder,
           required: true,
           validation: helptext.proactive.pc_validation,
-          relation: [{
-            action: RelationAction.Disable,
-            when: [{
-              name: 'enabled',
-              value: false,
-            }],
-          }],
         },
         {
           type: 'input',
@@ -124,13 +88,6 @@ export class ProactiveComponent implements FormConfiguration {
           placeholder: helptext.proactive.sec_title_placeholder,
           required: true,
           validation: helptext.proactive.pc_validation,
-          relation: [{
-            action: RelationAction.Disable,
-            when: [{
-              name: 'enabled',
-              value: false,
-            }],
-          }],
         },
         {
           type: 'input',
@@ -138,13 +95,6 @@ export class ProactiveComponent implements FormConfiguration {
           placeholder: helptext.proactive.sec_email_placeholder,
           validation: helptext.proactive.sec_email_validation,
           required: true,
-          relation: [{
-            action: RelationAction.Disable,
-            when: [{
-              name: 'enabled',
-              value: false,
-            }],
-          }],
         },
         {
           type: 'input',
@@ -152,13 +102,6 @@ export class ProactiveComponent implements FormConfiguration {
           placeholder: helptext.proactive.sec_phone_placeholder,
           required: true,
           validation: helptext.proactive.pc_validation,
-          relation: [{
-            action: RelationAction.Disable,
-            when: [{
-              name: 'enabled',
-              value: false,
-            }],
-          }],
         },
       ],
     },
@@ -192,38 +135,36 @@ export class ProactiveComponent implements FormConfiguration {
       'secondary_title',
       'secondary_email',
       'secondary_phone',
-      'proactive_title',
     ];
 
     const proactiveParatext = [
-      'proactive_instructions',
       'proactive_title',
       'proactive_second_title',
     ];
 
-    setTimeout(() => {
-      this.ws.call('support.is_available').pipe(untilDestroyed(this)).subscribe((res) => {
-        if (!res) {
-          proactiveFields.forEach((field) => {
-            this.entityEdit.setDisabled(field, true, false);
-            proactiveParatext.forEach((i) => {
-              document.getElementById(i).style.opacity = '0.38';
-            });
-          });
-          this.saveButtonEnabled = false;
-        } else {
-          this.getContacts();
-          this.saveButtonEnabled = true;
-          this.ws.call('support.is_available_and_enabled').pipe(untilDestroyed(this)).subscribe((res) => {
-            if (res) {
-              this.entityEdit.formGroup.controls['enabled'].setValue(true);
-            } else {
-              this.entityEdit.formGroup.controls['enabled'].setValue(false);
-            }
-          });
-        }
-      });
-    }, 1000);
+    this.ws.call('support.is_available').pipe(untilDestroyed(this)).subscribe((res) => {
+      if (!res) {
+        this.saveButtonEnabled = false;
+        proactiveFields.forEach((field) => {
+          this.entityEdit.setDisabled(field, true, false);
+        });
+        proactiveParatext.forEach((i) => {
+          document.getElementById(i).style.opacity = '0.38';
+        });
+        this.dialogService.info(helptext.proactive.dialog_unavailable_title,
+          helptext.proactive.dialog_unavailable_warning, '500px', 'warning', true);
+      } else {
+        this.getContacts();
+        this.saveButtonEnabled = true;
+        this.ws.call('support.is_available_and_enabled').pipe(untilDestroyed(this)).subscribe((res) => {
+          if (res) {
+            this.entityEdit.formGroup.controls['enabled'].setValue(true);
+          } else {
+            this.entityEdit.formGroup.controls['enabled'].setValue(false);
+          }
+        });
+      }
+    });
   }
 
   getContacts(): void {
@@ -240,10 +181,7 @@ export class ProactiveComponent implements FormConfiguration {
   }
 
   beforeSubmit(data: any): void {
-    delete data.proactive_instructions;
     delete data.proactive_second_title;
-    delete data.proactive_section_border;
-    delete data.proactive_section_title;
     delete data.proactive_title;
     if (!data.enabled) {
       data.enabled = false;

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -151,6 +151,7 @@ export class ProactiveComponent implements FormConfiguration {
         proactiveParatext.forEach((i) => {
           document.getElementById(i).style.opacity = '0.38';
         });
+        this.modalService.closeSlideIn();
         this.dialogService.info(helptext.proactive.dialog_unavailable_title,
           helptext.proactive.dialog_unavailable_warning, '500px', 'warning', true);
       } else {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2127,6 +2127,7 @@
   "Privileged": "",
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",
   "Product:": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1539,6 +1539,7 @@
   "Pre Init": "",
   "Preferred Trains": "",
   "Privileged": "",
+  "Proactive support settings is not available.": "",
   "Product:": "",
   "Production Status": "",
   "Properties Exclude": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -615,6 +615,7 @@
   "Pre-script": "",
   "Preferred Trains": "",
   "Privileged": "",
+  "Proactive support settings is not available.": "",
   "Production Status": "",
   "Provide access to node network namespace for the workload.": "",
   "Pull": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2325,6 +2325,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -524,6 +524,7 @@
   "Prefer": "",
   "Preferred Trains": "",
   "Privileged": "",
+  "Proactive support settings is not available.": "",
   "Product:": "",
   "Production Status": "",
   "Properties Exclude": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2266,6 +2266,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2119,6 +2119,7 @@
   "Privileged": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2547,6 +2547,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2462,6 +2462,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2459,6 +2459,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2385,6 +2385,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -828,6 +828,7 @@
   "Prevent the user from logging in or  using password-based services until this option is unset. Locking an  account is only possible when <b>Disable Password</b> is <i>No</i> and  a <b>Password</b> has been created for the account.": "",
   "Priority Code Point": "",
   "Privileged": "",
+  "Proactive support settings is not available.": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",
   "Product:": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2567,6 +2567,7 @@
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -225,6 +225,7 @@
   "Post Init": "",
   "Post-script": "",
   "Pre Init": "",
+  "Proactive support settings is not available.": "",
   "Product:": "",
   "Production Status": "",
   "REAR": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1852,6 +1852,7 @@
   "Privileged": "",
   "Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in FreeNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",
   "Proactive Support can notify iXsystems by email when TrueNAS hardware conditions require attention.": "",
+  "Proactive support settings is not available.": "",
   "Proceed with Update": "",
   "Proceed with upgrading the pool? WARNING: Upgrading a pool is a one-way operation that might make some features of the pool incompatible with older versions of TrueNAS: ": "",
   "Product:": "",


### PR DESCRIPTION
Displayed warning dialog and disabled all the inputs when proactive support is not available