### PR TITLE
NAS-113701 / 22.02-RC.2 / Alerts email form

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/dynamic-field/dynamic-field.scss
+++ b/src/app/pages/common/entity/entity-form/components/dynamic-field/dynamic-field.scss
@@ -19,6 +19,7 @@
 }
 
 :host mat-icon.paragraph-icon {
+  align-self: center;
   font-size: 40px;
   height: 40px;
   width: 40px;

--- a/src/app/pages/system/email/email.component.ts
+++ b/src/app/pages/system/email/email.component.ts
@@ -325,6 +325,8 @@ export class EmailComponent implements FormConfiguration {
       if (!isSmtpMethod) {
         // switches from SMTP to Gmail Oauth method and disable smtp
         emailConfig.smtp = false;
+        emailConfig.fromemail = '';
+        emailConfig.fromname = '';
         this.smtp.setValue(false);
       }
     } else {

--- a/src/app/pages/system/email/email.component.ts
+++ b/src/app/pages/system/email/email.component.ts
@@ -182,7 +182,7 @@ export class EmailComponent implements FormConfiguration {
         {
           type: 'paragraph',
           name: 'oauth_applied',
-          paraText: 'Oauth credentials have been applied.',
+          paraText: 'Gmail credentials have been applied.',
           isLargeText: true,
           paragraphIcon: 'check_circle',
           paragraphIconSize: '24px',


### PR DESCRIPTION
Test that both Gmail and ordinary email forms can be saved in Alerts -> Email.
Requires fresh middleware.