### PR TITLE
NAS-113586 / 22.02 / NAS-113586: Correct hostname used for global config

### DIFF
--- a/src/app/pages/network/network.component.ts
+++ b/src/app/pages/network/network.component.ts
@@ -256,7 +256,7 @@ export class NetworkComponent extends ViewControllerComponent implements OnInit,
         this.globalSettingsWidget.data.ipv4 = summary.default_routes.filter((item) => ipRegex.v4().test(item));
         this.globalSettingsWidget.data.ipv6 = summary.default_routes.filter((item) => ipRegex.v6().test(item));
 
-        this.globalSettingsWidget.data.hostname = networkConfig.hostname;
+        this.globalSettingsWidget.data.hostname = networkConfig.hostname_local;
         this.globalSettingsWidget.data.domain = networkConfig.domain;
         this.globalSettingsWidget.data.netwait = networkConfig.netwait_enabled ? this.translate.instant('ENABLED') : this.translate.instant('DISABLED');
         const tempArr: string[] = [];


### PR DESCRIPTION
To test, go to an HA Scale System. On the dashboard, initiate failover for node A or node B hostname. Whichever node is "active" (not on stand by) should be shown as `Hostname` in the `Global Configuration` card on the `Network` page.