### PR TITLE
NAS-110348 / 13.0 / Fixed property name returned from middleware on error to remove dots

### DIFF
--- a/src/app/pages/jails/jail-form/jail-form.component.ts
+++ b/src/app/pages/jails/jail-form/jail-form.component.ts
@@ -1280,19 +1280,18 @@ export class JailFormComponent implements OnInit, AfterViewInit {
       });
       dialogRef.componentInstance.failure.subscribe((res) => {
         dialogRef.close();
+        if (res.error.indexOf('[EINVAL]') == -1) {
+          return new EntityUtils().handleWSError(this, res, this.dialogService);
+        }
         // show error inline if error is EINVAL
-        if (res.error.indexOf('[EINVAL]') > -1) {
-          res.error = res.error.substring(9).split(':');
-          const fieldSplit = res.error[0].split('.');
-          const field = fieldSplit[fieldSplit.length - 1];
-          const error = res.error[1];
-          const fc = _.find(this.formFields, { name: field });
-          if (fc && !fc['isHidden']) {
-            fc['hasErrors'] = true;
-            fc['errors'] = error;
-          }
-        } else {
-          new EntityUtils().handleWSError(this, res, this.dialogService);
+        res.error = res.error.substring(9).split(':');
+        const fieldSplit = res.error[0].split('.');
+        const field = fieldSplit[fieldSplit.length - 1];
+        const error = res.error[1];
+        const fc = _.find(this.formFields, { name: field });
+        if (fc && !fc['isHidden']) {
+          fc['hasErrors'] = true;
+          fc['errors'] = error;
         }
       });
     } else {

--- a/src/app/pages/jails/jail-form/jail-form.component.ts
+++ b/src/app/pages/jails/jail-form/jail-form.component.ts
@@ -1283,7 +1283,8 @@ export class JailFormComponent implements OnInit, AfterViewInit {
         // show error inline if error is EINVAL
         if (res.error.indexOf('[EINVAL]') > -1) {
           res.error = res.error.substring(9).split(':');
-          const field = res.error[0];
+          const fieldSplit = res.error[0].split('.');
+          const field = fieldSplit[fieldSplit.length - 1];
           const error = res.error[1];
           const fc = _.find(this.formFields, { name: field });
           if (fc && !fc['isHidden']) {


### PR DESCRIPTION
To test,
- Go to the jails page and click on the `Add` button to create a new jail
- Click on the `Advanced Jail Creation` button
- Select an `IPv4 Interface` and type in an IP that's already in use by the system. (It can be the ip that your NAS system points to. E.g, 192.168.18.21).
- Add a name for the jail and select any release version
- Click on save and you should see the validation error returned by middleware in red under the relevant form field.
- Do the same for the Jail creation wizard by clicking `Next` on step 2
 
Previously the error failed to appear under the form field. The flashing dialog is intentional. This is what was meant to happen.