### PR TITLE
NAS-113867 / 22.02 / NAS-113867: Unit tests should not be making real network requests

### DIFF
--- a/src/app/core/testing/classes/mock-websocket.service.ts
+++ b/src/app/core/testing/classes/mock-websocket.service.ts
@@ -30,6 +30,8 @@ export class MockWebsocketService extends WebSocketService {
     this.call = jest.fn();
     this.job = jest.fn();
     this.subscribe = jest.fn(() => of());
+    this.socket.send = jest.fn();
+    this.socket.close = jest.fn();
     when(this.call).mockImplementation((method: ApiMethod, args: unknown[]) => {
       throw Error(`Unmocked websocket call ${method} with ${JSON.stringify(args)}`);
     });


### PR DESCRIPTION
Several tests were crashing when `environment.remote` was reachable via network
For example at localization-form.component.spec.ts