### PR TITLE
NAS-113817 / 22.02 / NAS-113817: Errors in EntityJobComponent cannot be closed

### DIFF
--- a/src/app/pages/common/entity/entity-job/entity-job.component.html
+++ b/src/app/pages/common/entity/entity-job/entity-job.component.html
@@ -47,25 +47,40 @@
 </mat-dialog-content>
 
 <div mat-dialog-actions>
-  <button
-    mat-button
-    *ngIf="showAbortButton && job?.state === JobState.Running"
-    ix-auto
-    ix-auto-type="button"
-    ix-auto-identifier="ABORT"
-    (click)="abortJob()"
-  >
-    {{ 'Abort' | translate }}
-  </button>
-  <button
-    *ngIf="showCloseButton"
-    class="mat-dialog-close"
-    mat-icon-button
-    mat-dialog-close="close"
-    ix-auto
-    ix-auto-type="button"
-    ix-auto-identifier="CLOSE"
-  >
-    <mat-icon>remove</mat-icon>
-  </button>
+  <ng-container *ngIf="job?.state === JobState.Failed; then buttonsFailed else buttonsDefault"></ng-container>
+  <ng-template #buttonsFailed>
+    <button
+        class="mat-dialog-close"
+        mat-icon-button
+        mat-dialog-close="close"
+        ix-auto
+        ix-auto-type="button"
+        ix-auto-identifier="CLOSE"
+      >
+      <mat-icon>close</mat-icon>
+    </button>
+  </ng-template>
+  <ng-template #buttonsDefault>
+    <button
+        mat-button
+        *ngIf="showAbortButton && job?.state === JobState.Running"
+        ix-auto
+        ix-auto-type="button"
+        ix-auto-identifier="ABORT"
+        (click)="abortJob()"
+      >
+      {{ 'Abort' | translate }}
+    </button>
+    <button
+        *ngIf="showCloseButton"
+        class="mat-dialog-close"
+        mat-icon-button
+        mat-dialog-close="close"
+        ix-auto
+        ix-auto-type="button"
+        ix-auto-identifier="CLOSE"
+      >
+      <mat-icon>remove</mat-icon>
+    </button>
+  </ng-template>
 </div>


### PR DESCRIPTION
There are 2 different buttons displayed depending on the job's status.
For failed jobs there's a new "X" button. It's always displayed for failed jobs.
For all other jobs we have the "minimize" button as before. It's displayed 

Testing: clicking Send Test Email with incorrect parameters in Alerts -> Email.