### PR TITLE
NAS-113860 / 22.02 / Remove Authority Key Identifier option from CSR form

### DIFF
--- a/src/app/pages/credentials/certificates-dash/forms/certificate-add.component.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/certificate-add.component.ts
@@ -1005,7 +1005,7 @@ export class CertificateAddComponent implements WizardConfiguration {
               for (const item of data[key]) {
                 (certExtensions as any)[typeProp[0]][item] = true;
               }
-            } else {
+            } else if (!key.startsWith('AuthorityKeyIdentifier')) {
               (certExtensions as any)[typeProp[0]][typeProp[1]] = data[key];
             }
           }

--- a/src/app/pages/credentials/certificates-dash/forms/certificate-add.component.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/certificate-add.component.ts
@@ -1008,7 +1008,7 @@ export class CertificateAddComponent implements WizardConfiguration {
               for (const item of data[key]) {
                 (certExtensions as any)[typeProp[0]][item] = true;
               }
-            } else if (!key.startsWith('AuthorityKeyIdentifier')) {
+            } else {
               (certExtensions as any)[typeProp[0]][typeProp[1]] = data[key];
             }
           }

--- a/src/app/pages/credentials/certificates-dash/forms/certificate-add.component.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/certificate-add.component.ts
@@ -786,6 +786,9 @@ export class CertificateAddComponent implements WizardConfiguration {
         this.csrFields.forEach((field) => this.hideField(field, false));
         this.extensionFields.forEach((field) => this.hideField(field, false));
 
+        this.hideField('AuthorityKeyIdentifier-enabled', true);
+        this.hideField('AuthorityKeyIdentifier', true);
+
         // This block makes the form reset its 'disabled/hidden' settings on switch of type
         if (this.getField('key_type').value === 'RSA') {
           this.setDisabled('ec_curve', true);
@@ -1012,6 +1015,9 @@ export class CertificateAddComponent implements WizardConfiguration {
           delete data[key];
         }
       });
+      if (data.create_type === 'CERTIFICATE_CREATE_CSR') {
+        delete certExtensions['AuthorityKeyIdentifier'];
+      }
       data['cert_extensions'] = certExtensions;
 
       delete data['profiles'];


### PR DESCRIPTION
The error was from `AuthorityKeyIdentifier.enabled`. 
Kept to use `AuthorityKeyIdentifier.authority_cert_issuer` and `AuthorityKeyIdentifier.extension_critical`.