### PR TITLE
NAS-112189 / 22.02 / NAS-112189: No Scrollbar For Selecting SSL Certs For K8S Ingress

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.html
+++ b/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.html
@@ -51,52 +51,50 @@
         <span *ngFor="let value of customTriggerValue; last as isLast"> {{ value }}{{ isLast ? '' : ', ' }} </span>
       </mat-select-trigger>
 
-      <div *ngIf="formReady">
-        <mat-selection-list>
-          <ng-container *ngFor="let option of config.options; let i = index">
-            <!-- if disabled -->
-            <mat-option
-              *ngIf="option.disable && !option.hiddenFromDisplay"
-              [value]="option.value"
-              disabled
-              ix-auto
-              ix-auto-type="option"
-              ix-auto-identifier="{{ config.placeholder }}_{{ option.label }}"
-            >
-              <span *ngIf="config.multiple">
-                <mat-icon *ngIf="selectStates[i]" class="fn-checked">check_circle</mat-icon>
-                <mat-icon *ngIf="!selectStates[i]" class="fn-unchecked">remove</mat-icon>
-              </span>
-              {{ option.label | translate }}
-              <span *ngIf="shouldAlertOnOption(option)" class="alert-icon">
-                <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-alert"></mat-icon>
-              </span>
-            </mat-option>
+      <ng-container *ngIf="formReady">
+        <ng-container *ngFor="let option of config.options; let i = index">
+          <!-- if disabled -->
+          <mat-option
+            *ngIf="option.disable && !option.hiddenFromDisplay"
+            [value]="option.value"
+            disabled
+            ix-auto
+            ix-auto-type="option"
+            ix-auto-identifier="{{ config.placeholder }}_{{ option.label }}"
+          >
+            <span *ngIf="config.multiple">
+              <mat-icon *ngIf="selectStates[i]" class="fn-checked">check_circle</mat-icon>
+              <mat-icon *ngIf="!selectStates[i]" class="fn-unchecked">remove</mat-icon>
+            </span>
+            {{ option.label | translate }}
+            <span *ngIf="shouldAlertOnOption(option)" class="alert-icon">
+              <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-alert"></mat-icon>
+            </span>
+          </mat-option>
 
-            <!-- else -->
-            <mat-option
-              *ngIf="!option?.disable"
-              [value]="option.value"
-              (click)="onToggleSelect(option)"
-              ix-auto
-              ix-auto-type="option"
-              ix-auto-identifier="{{ config.placeholder }}_{{ option.label }}"
-              [class.text-wrap]="config.enableTextWrapForOptions"
-            >
-              <span *ngIf="config.multiple">
-                <mat-icon *ngIf="selectStates[i]" class="fn-checked">check_circle</mat-icon>
-                <mat-icon *ngIf="!selectStates[i]" class="fn-unchecked">remove</mat-icon>
-              </span>
-              {{ option.label | translate }}
-              <span *ngIf="shouldAlertOnOption(option)" class="alert-icon">
-                <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-alert"></mat-icon>
-              </span>
-            </mat-option>
-          </ng-container>
-        </mat-selection-list>
-      </div>
+          <!-- else -->
+          <mat-option
+            *ngIf="!option?.disable"
+            [value]="option.value"
+            (click)="onToggleSelect(option)"
+            ix-auto
+            ix-auto-type="option"
+            ix-auto-identifier="{{ config.placeholder }}_{{ option.label }}"
+            [class.text-wrap]="config.enableTextWrapForOptions"
+          >
+            <span *ngIf="config.multiple">
+              <mat-icon *ngIf="selectStates[i]" class="fn-checked">check_circle</mat-icon>
+              <mat-icon *ngIf="!selectStates[i]" class="fn-unchecked">remove</mat-icon>
+            </span>
+            {{ option.label | translate }}
+            <span *ngIf="shouldAlertOnOption(option)" class="alert-icon">
+              <mat-icon role="img" fontSet="mdi-set" fontIcon="mdi-alert"></mat-icon>
+            </span>
+          </mat-option>
+        </ng-container>
+      </ng-container>
 
-      <div *ngIf="!formReady || config.options.length == 0">
+      <ng-container *ngIf="!formReady || config.options.length == 0">
         <ng-container>
           <mat-option
             disabled
@@ -108,7 +106,7 @@
             {{ config.zeroStateMessage ? config.zeroStateMessage : '--' }}
           </mat-option>
         </ng-container>
-      </div>
+      </ng-container>
     </mat-select>
   </mat-form-field>
   <div class="margin-for-error">

--- a/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.scss
+++ b/src/app/pages/common/entity/entity-form/components/form-select/form-select.component.scss
@@ -19,11 +19,6 @@
   padding: 8px;
 }
 
-mat-selection-list {
-  max-height: 400px;
-  overflow: auto;
-}
-
 :host-context(app-system-alert) {
   .inline-label label.label.input-select {
     padding: 8px !important;

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -1496,7 +1496,7 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
   }
 
   .mat-select-panel {
-    max-height: 60vh !important;
+    max-height: 50vh !important; // values over 50vh will push last visible element out the screen
   }
 
   tree-viewport {


### PR DESCRIPTION
Testing: 
1. Credentials -> Certificates
   - add certificate authority
   - add 10 certificates (Internal Certificate) -or- temporary adjust src\app\pages\common\entity\utils.ts:347
2. Apps -> Available -> Minio -> Install
3. On step 3, keep resizing your browser, until you reach height ~900px
   - and "Certificate" dropdown box should be exactly in the middle (vertically)
   - and List of certificates should be dropped  _down_ (not up)
      ![image](https://user-images.githubusercontent.com/20611516/147098010-9422bcd9-6dab-4ec2-bd58-57505ae0ccd2.png)
4. Scroll the list all the way down - you should be able to reach the last list item. No list item should fall off the screen. 

This PR is re-work of previous PRs:
   https://github.com/truenas/webui/pull/3558
   https://github.com/truenas/webui/pull/4561
   https://github.com/truenas/webui/pull/4564