### PR TITLE
NAS-112334 / 22.02 / NAS-112334: Applications add route - default route - truenas scale

### DIFF
--- a/src/app/services/network.service.ts
+++ b/src/app/services/network.service.ts
@@ -45,7 +45,7 @@ export class NetworkService {
   }
 
   getV4Netmasks(): Option[] {
-    return Array(33).fill(0).map(
+    return Array(34).fill(0).map(
       (x, i) => {
         if (i == 0) {
           return { label: '---------', value: '' };


### PR DESCRIPTION
Testing: 

1. Apps -> Launch Docker Image. Networking -> Add external interface -> IPAM Type Static. 
2. Choose "add route" 
   - enter "route destination IP / subnet":  0.0.0.0 / 0
   - you'll need to enter "gateway IP", for example 192.168.1.1
3. Submit docker image
4. Navigate to installed apps, locate your docker image, and open "edit" - and assert that "route destination IP  / subnet" equal to 0.0.0.0 / 0