### PR TITLE
NAS-113646 / 13.0 / Added fix for length check

### DIFF
--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -136,7 +136,7 @@ export class StorageService {
       sorter = bytes.concat(kbytes, mbytes, gbytes, tbytes);
 
       // Select disks where last two chars = a digit and the one letter space abbrev
-    } else if (typeof (tempArr[n]) === 'string'
+    } else if (typeof (tempArr[n]) === 'string' && tempArr[n].length >= 2
       && tempArr[n][tempArr[n].length - 1].match(/[KMGTB]/)
       && tempArr[n][tempArr[n].length - 2].match(/[0-9]/)) {
       let B = []; let K = []; let M = []; let G = []; let


### PR DESCRIPTION
To reproduce this bug, create two smb shares at least and name the first one any letter out of `KMGTB` like `B` or `G`. If that doesn't work rename the other one to this.