### PR TITLE
NAS-113876 / 22.02 / NAS-113876: Remove IPv6 validation on Scale HA

### DIFF
--- a/src/app/helptext/network/interfaces/interfaces-form.ts
+++ b/src/app/helptext/network/interfaces/interfaces-form.ts
@@ -114,7 +114,6 @@ export default {
 
   failover_alias_set_error: T('An IP address must be provided for\
  each controller and the virtual interface.'),
-  failover_alias_v6_error: T('IPv6 addresses are not allowed for HA.'),
 
   vlan_pint_placeholder: T('Parent Interface'),
   vlan_pint_tooltip: T('Select the VLAN Parent Interface. Usually an Ethernet\

--- a/src/app/pages/network/forms/interfaces-form.component.ts
+++ b/src/app/pages/network/forms/interfaces-form.component.ts
@@ -4,7 +4,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import * as ipRegex from 'ip-regex';
-import isCidr from 'is-cidr';
 import * as _ from 'lodash';
 import { ViewControllerComponent } from 'app/core/components/view-controller/view-controller.component';
 import {
@@ -489,7 +488,6 @@ export class InterfacesFormComponent extends ViewControllerComponent implements 
         });
         if (isHa) {
           this.entityForm.formGroup.controls['aliases'].valueChanges.pipe(untilDestroyed(this)).subscribe((res: any[]) => {
-            let v6Found = false;
             let mismatchFound = false;
             res.forEach((alias) => {
               const address = alias['address'];
@@ -501,17 +499,8 @@ export class InterfacesFormComponent extends ViewControllerComponent implements 
               ) {
                 mismatchFound = true;
               }
-              if (isCidr.v6(address)
-                  || isCidr.v6(failoverAddress)
-                  || isCidr.v6(virtualAddress)) {
-                v6Found = true;
-              }
             });
-            if (v6Found) {
-              this.aliasesField.hasErrors = true;
-              this.aliasesField.errors = helptext.failover_alias_v6_error;
-              this.saveButtonEnabled = false;
-            } else if (mismatchFound) {
+            if (mismatchFound) {
               this.aliasesField.hasErrors = true;
               this.aliasesField.errors = helptext.failover_alias_set_error;
               this.saveButtonEnabled = false;

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1484,7 +1484,6 @@
   "IPMI flash duration": "",
   "IPv4": "",
   "IPv6": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISO save location": "",
   "ISO upload location": "",
   "Icon URL": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -991,7 +991,6 @@
   "IPMI flash duration": "",
   "IPv4": "",
   "IPv6": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISO save location": "",
   "ISO upload location": "",
   "Icon URL": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -2431,7 +2431,6 @@
   "IPv6 Address": "Dirección IPv6",
   "IPv6 Default Gateway": "Puerta de enlace IPv6 predeterminada",
   "IPv6 Prefix Length": "Longitud del prefijo IPv6",
-  "IPv6 addresses are not allowed for HA.": "Las direcciones IPv6 no están permitidas para HA.",
   "ISNS Servers": "Servidores ISNS",
   "ISO save location": "Ubicación de guardado ISO",
   "ISO upload location": "Ubicación de carga ISO",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1581,7 +1581,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -2432,7 +2432,6 @@
   "IPv6 Address": "Adresse IPv6",
   "IPv6 Default Gateway": "Passerelle IPv6 par défaut",
   "IPv6 Prefix Length": "Longueur du préfixe IPv6",
-  "IPv6 addresses are not allowed for HA.": "Les adresses IPv6 ne sont pas autorisées pour HA.",
   "ISNS Servers": "Serveurs ISNS",
   "ISO save location": "Emplacement d'enregistrement ISO",
   "ISO upload location": "Emplacement d'upload ISO",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1482,7 +1482,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1391,7 +1391,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1763,7 +1763,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1680,7 +1680,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1676,7 +1676,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1656,7 +1656,6 @@
   "IPMI flash duration": "",
   "IPv4": "",
   "IPv6": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISO save location": "",
   "ISO upload location": "",
   "Icon URL": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -489,7 +489,6 @@
   "IPMI flash duration": "",
   "IPv4": "",
   "IPv6": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "Identify Drive": "",
   "Identify the purpose for this public key. Typically used for end entity certificates. Multiple usages can be selected. Do not mark this extension critical when the <i>Usage</i> is <i>ANY_EXTENDED_KEY_USAGE</i>.<br><br> Using both <b>Extended Key Usage</b> and <b>Key Usage</b> extensions requires that the purpose of the certificate is consistent with both extensions. See <a href=\"https://www.ietf.org/rfc/rfc3280.txt\" target=\"_blank\">RFC 3280, section 4.2.1.13</a> for more details.": "",
   "Idle": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1779,7 +1779,6 @@
   "IPv6 Address": "",
   "IPv6 Default Gateway": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISNS Servers": "",
   "ISO save location": "",
   "ISO upload location": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -2097,7 +2097,6 @@
   "IPv6 Address": "IPv6 地址",
   "IPv6 Default Gateway": "IPv6默认网关",
   "IPv6 Prefix Length": "IPv6前缀长度",
-  "IPv6 addresses are not allowed for HA.": "HA不允许使用IPv6地址。",
   "ISNS Servers": "ISNS服务器",
   "ISO save location": "ISO保存位置",
   "ISO upload location": "ISO上传位置",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1262,7 +1262,6 @@
   "IPv4": "",
   "IPv6": "",
   "IPv6 Prefix Length": "",
-  "IPv6 addresses are not allowed for HA.": "",
   "ISO save location": "",
   "ISO upload location": "",
   "Icon URL": "",


### PR DESCRIPTION
Testing: The UI is hidden behind a license check. I commented out the check in the code, and fixed it. But for someone to be able to test my PR, they need an Enterprise license.