### PR TITLE
NAS-113490 / 22.02 / NAS-113490: Dinstinguish csr from cert + Fix file extension when downloading csr

### DIFF
--- a/src/app/pages/credentials/certificates-dash/certificates-dash.component.ts
+++ b/src/app/pages/credentials/certificates-dash/certificates-dash.component.ts
@@ -255,8 +255,9 @@ export class CertificatesDashComponent implements OnInit {
         matTooltip: this.translate.instant('Download'),
         name: 'download',
         onClick: (rowinner: Certificate) => {
-          const path = rowinner.CSR ? rowinner.csr_path : rowinner.certificate_path;
-          const fileName = rowinner.name + '.crt'; // what about for a csr?
+          const isCsr = rowinner.cert_type_CSR;
+          const path = isCsr ? rowinner.csr_path : rowinner.certificate_path;
+          const fileName = `${rowinner.name}.${isCsr ? 'csr' : 'crt'}`;
           this.ws.call('core.download', ['filesystem.get', [path], fileName]).pipe(untilDestroyed(this)).subscribe(
             (res) => {
               const url = res[1];


### PR DESCRIPTION
What caused the issue:
https://jira.ixsystems.com/browse/NAS-113490?focusedCommentId=144630&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-144630

Testing:  

a. download dump from the ticket, find "CSR" and "cert_type_CSR", hard-code faulty values into WS response for `certificate.query`

b. alternatively, there's a possibility to test end-to-end: create authenticator (you'll need a domain name and it's Cloudflare or AWS Route53 credentials), then create CSR, then click CSR and choose your authenticator, and then download the resulting certificate

   - AR: .crt file with size equal to 0 bytes, and error message in task manager
   - ER: .csr file with size matching the size from `ls -l` command in shell