### PR TITLE
NAS-113953 / 22.02 / NAS-113953: When locale is not "English (en)", reports other than CPU cannot be accessed, as they redirect to the dashboard

### DIFF
--- a/src/app/enums/report-tab.enum.ts
+++ b/src/app/enums/report-tab.enum.ts
@@ -1,0 +1,12 @@
+export enum ReportTab {
+  Cpu = 'cpu',
+  Disk = 'disk',
+  Memory = 'memory',
+  Network = 'network',
+  Nfs = 'nfs',
+  Partition = 'partition',
+  System = 'system',
+  Ups = 'ups',
+  Target = 'target',
+  Zfs = 'zfs',
+}

--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.html
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="config" class="reports-toolbar">
   <div class="reports-dash-global-controls" fxLayout="row" fxLayoutAlign="center end">
-    <ng-container *ngIf="config.activeTab == 'Disk'">
+    <ng-container *ngIf="config.activeTab?.value === ReportTab.Disk">
       <entity-toolbar fxFlex [conf]="config.toolbarConfig"></entity-toolbar>
     </ng-container>
 
@@ -14,7 +14,7 @@
         ix-auto-type="button"
         ix-auto-identifier="tab-selector"
       >
-        {{ config.activeTabVerified ? config.activeTab : ('Loading...' | translate) }}
+        {{ config.activeTabVerified ? config.activeTab?.label : ('Loading...' | translate) }}
         <mat-icon class="menu-caret">arrow_drop_down</mat-icon>
       </button>
 
@@ -23,7 +23,7 @@
           <button
             mat-menu-item
             *ngFor="let tab of config.allTabs"
-            (click)="config.navigateToTab(tab.value)"
+            (click)="config.navigateToTab(tab)"
             ix-auto
             ix-auto-type="option"
             ix-auto-identifier="{{ tab.label }}"

--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
 } from '@angular/core';
+import { ReportTab } from 'app/enums/report-tab.enum';
 import { GlobalAction } from 'app/interfaces/global-action.interface';
 import { ReportsDashboardComponent } from 'app/pages/reports-dashboard/reports-dashboard.component';
 
@@ -10,6 +11,8 @@ import { ReportsDashboardComponent } from 'app/pages/reports-dashboard/reports-d
   styleUrls: ['./reports-global-controls.component.scss'],
 })
 export class ReportsGlobalControlsComponent implements GlobalAction {
+  readonly ReportTab = ReportTab;
+
   config: ReportsDashboardComponent; // Reports page
 
   applyConfig(conf: ReportsDashboardComponent): void {

--- a/src/app/pages/reports-dashboard/reports-dashboard.component.ts
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.ts
@@ -9,6 +9,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { Subject, BehaviorSubject } from 'rxjs';
 import { CoreService } from 'app/core/services/core-service/core.service';
+import { ReportTab } from 'app/enums/report-tab.enum';
 import { CoreEvent } from 'app/interfaces/events';
 import { ReportingGraphsEvent } from 'app/interfaces/events/reporting-graphs-event.interface';
 import {
@@ -32,7 +33,7 @@ import { ReportsGlobalControlsComponent } from './components/reports-global-cont
 
 interface Tab {
   label: string;
-  value: string;
+  value: ReportTab;
 }
 
 @UntilDestroy()
@@ -54,7 +55,7 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, /* HandleCh
   otherReports: Report[];
   activeReports: Report[] = [];
 
-  activeTab = 'CPU'; // Tabs (lower case only): CPU, Disk, Memory, Network, NFS, Partition?, System, Target, UPS, ZFS
+  activeTab = { label: this.translate.instant('CPU'), value: ReportTab.Cpu } as Tab;
   activeTabVerified = false;
   allTabs: Tab[] = [];
   loadingReports = false;
@@ -127,7 +128,7 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, /* HandleCh
 
         this.otherReports = allReports.filter((report) => !report.name.startsWith('disk'));
 
-        this.generateTabs();
+        this.allTabs = this.getAllTabs();
 
         this.activateTabFromUrl();
       }
@@ -170,43 +171,26 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, /* HandleCh
     this.scrolledIndex = evt;
   }
 
-  generateTabs(): void {
-    const labels: string[] = [
-      this.translate.instant('CPU'),
-      this.translate.instant('Disk'),
-      this.translate.instant('Memory'),
-      this.translate.instant('Network'),
-      this.translate.instant('NFS'),
-      this.translate.instant('Partition'),
-      this.translate.instant('System'),
-      this.translate.instant('Target'),
-      this.translate.instant('ZFS'),
-    ];
-    const ups = this.otherReports.find((report) => report.title.startsWith('UPS'));
-
-    if (ups) {
-      labels.splice(8, 0, 'UPS');
-    }
-
-    labels.forEach((item) => {
-      this.allTabs.push({ label: item, value: item.toLowerCase() });
-    });
+  getAllTabs(): Tab[] {
+    const hasUps = this.otherReports.find((report) => report.title.startsWith('UPS'));
+    return [
+      { label: this.translate.instant('CPU'), value: ReportTab.Cpu },
+      { label: this.translate.instant('Disk'), value: ReportTab.Disk },
+      { label: this.translate.instant('Memory'), value: ReportTab.Memory },
+      { label: this.translate.instant('Network'), value: ReportTab.Network },
+      { label: this.translate.instant('NFS'), value: ReportTab.Nfs },
+      { label: this.translate.instant('Partition'), value: ReportTab.Partition },
+      { label: this.translate.instant('System'), value: ReportTab.System },
+      ...(hasUps ? [{ label: this.translate.instant('UPS'), value: ReportTab.Ups }] : []),
+      { label: this.translate.instant('Target'), value: ReportTab.Target },
+      { label: this.translate.instant('ZFS'), value: ReportTab.Zfs },
+    ] as Tab[];
   }
 
   activateTabFromUrl(): void {
     const subpath = this.route.snapshot.url[0] && this.route.snapshot.url[0].path;
     const tabFound = this.allTabs.find((tab) => tab.value === subpath);
     this.updateActiveTab(tabFound || this.allTabs[0]);
-  }
-
-  isActiveTab(str: string): boolean {
-    let test: boolean;
-    if (!this.activeTab) {
-      test = ('/reportsdashboard/' + str.toLowerCase()) == this.router.url;
-    } else {
-      test = (this.activeTab == str.toLowerCase());
-    }
-    return test;
   }
 
   updateActiveTab(tab: Tab): void {
@@ -231,64 +215,65 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, /* HandleCh
 
     this.core.emit({ name: 'PseudoRouteChange', data: pseudoRouteEvent });
 
-    this.activateTab(tab.label);
+    this.activateTab(tab);
 
-    if (tab.label == 'Disk') {
+    if (tab.value === ReportTab.Disk) {
       const selectedDisks = this.route.snapshot.queryParams.disks;
       this.diskReportBuilderSetup(selectedDisks);
     }
   }
 
-  navigateToTab(tabName: string): void {
-    const link = '/reportsdashboard/' + tabName.toLowerCase();
+  navigateToTab(tab: Tab): void {
+    const link = '/reportsdashboard/' + tab.value;
     this.router.navigate([link]);
   }
 
-  activateTab(name: string): void {
-    this.activeTab = name;
+  activateTab(activeTab: Tab): void {
+    this.activeTab = activeTab;
     this.activeTabVerified = true;
 
-    const reportCategories = name == 'Disk' ? this.diskReports : this.otherReports.filter((report) => {
-      // Tabs: CPU, Disk, Memory, Network, NFS, Partition, System, Target, UPS, ZFS
-      let condition;
-      switch (name) {
-        case 'CPU':
-          condition = (report.name == 'cpu' || report.name == 'load' || report.name == 'cputemp');
-          break;
-        case 'Memory':
-          condition = (report.name == 'memory' || report.name == 'swap');
-          break;
-        case 'Network':
-          condition = (report.name == 'interface');
-          break;
-        case 'NFS':
-          condition = (report.name == 'nfsstat' || report.name == 'nfsstatbytes');
-          break;
-        case 'Partition':
-          condition = (report.name == 'df');
-          break;
-        case 'System':
-          condition = (report.name == 'processes' || report.name == 'uptime');
-          break;
-        case 'Target':
-          condition = (report.name == 'ctl');
-          break;
-        case 'UPS':
-          condition = report.name.startsWith('ups');
-          break;
-        case 'ZFS':
-          condition = report.name.startsWith('arc');
-          break;
-        default:
-          condition = true;
-      }
+    const reportCategories = activeTab.value === ReportTab.Disk ? this.diskReports : this.otherReports.filter(
+      (report) => {
+        let condition;
+        switch (activeTab.value) {
+          case ReportTab.Cpu:
+            condition = (report.name == 'cpu' || report.name == 'load' || report.name == 'cputemp');
+            break;
+          case ReportTab.Memory:
+            condition = (report.name == 'memory' || report.name == 'swap');
+            break;
+          case ReportTab.Network:
+            condition = (report.name == 'interface');
+            break;
+          case ReportTab.Nfs:
+            condition = (report.name == 'nfsstat' || report.name == 'nfsstatbytes');
+            break;
+          case ReportTab.Partition:
+            condition = (report.name == 'df');
+            break;
+          case ReportTab.System:
+            condition = (report.name == 'processes' || report.name == 'uptime');
+            break;
+          case ReportTab.Target:
+            condition = (report.name == 'ctl');
+            break;
+          case ReportTab.Ups:
+            condition = report.name.startsWith('ups');
+            break;
+          case ReportTab.Zfs:
+            condition = report.name.startsWith('arc');
+            break;
+          default:
+            condition = true;
+        }
 
-      return condition;
-    });
+        return condition;
+      },
+    );
 
     this.activeReports = this.flattenReports(reportCategories);
 
-    if (name !== 'Disk') {
+    if (activeTab.value !== ReportTab.Disk) {
       const keys = Object.keys(this.activeReports);
       this.visibleReports = keys.map((v) => parseInt(v));
     }


### PR DESCRIPTION
Testing: switch between different reports and keep an eye on URL - the URL should not contain any invalid routes, such as "процессор" or "Datenträger" 