### PR TITLE
NAS-114028 / 22.02 / Added the new field

### DIFF
--- a/src/app/interfaces/s3-config.interface.ts
+++ b/src/app/interfaces/s3-config.interface.ts
@@ -7,6 +7,7 @@ export interface S3Config {
   id: number;
   secret_key: string;
   storage_path: string;
+  tls_server_uri: string;
 }
 
 export type S3ConfigUpdate = Omit<S3Config, 'id'>;

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -49,6 +49,7 @@
           *ngIf="form.controls['certificate'].value !== null"
           formControlName="tls_server_uri"
           [label]="'TLS Server Uri' | translate"
+          [required]="true"
         >
         </ix-input>
       </ix-fieldset>

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -45,6 +45,13 @@
           [tooltip]="tooltips.certificate | translate"
           [options]="certificateOptions$"
         ></ix-select>
+        <ix-input
+          formControlName="tls_server_uri"
+          [label]="'TLS Server Uri' | translate"
+          [required]="true"
+          *ngIf="form.controls['certificate'].value !== null"
+        >
+        </ix-input>
       </ix-fieldset>
 
       <div class="form-actions">

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -46,10 +46,9 @@
           [options]="certificateOptions$"
         ></ix-select>
         <ix-input
+          *ngIf="form.controls['certificate'].value !== null"
           formControlName="tls_server_uri"
           [label]="'TLS Server Uri' | translate"
-          [required]="true"
-          *ngIf="form.controls['certificate'].value !== null"
         >
         </ix-input>
       </ix-fieldset>

--- a/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
@@ -37,6 +37,7 @@ describe('ServiceS3Component', () => {
           storage_path: '/mnt/s3/',
           browser: true,
           certificate: 2,
+          tls_server_uri: 'test',
         } as S3Config),
         mockCall('s3.bindip_choices', {
           '0.0.0.0': '0.0.0.0',
@@ -83,6 +84,7 @@ describe('ServiceS3Component', () => {
       Disk: '/mnt/s3/',
       'Secret Key': '12345678',
       Certificate: 'Very Secure',
+      'TLS Server Uri': 'test',
     });
   });
 
@@ -110,6 +112,7 @@ describe('ServiceS3Component', () => {
       Disk: '/mnt/new',
       'Enable Browser': false,
       Certificate: 'Default',
+      'TLS Server Uri': 'test',
     });
 
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -123,6 +126,7 @@ describe('ServiceS3Component', () => {
       certificate: 1,
       secret_key: '12345678',
       storage_path: '/mnt/new',
+      tls_server_uri: 'test',
     }]);
   });
 });

--- a/src/app/pages/services/components/service-s3/service-s3.component.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.ts
@@ -40,6 +40,7 @@ export class ServiceS3Component implements OnInit {
     storage_path: ['', Validators.required],
     browser: [false],
     certificate: [null as number],
+    tls_server_uri: ['', Validators.required],
   });
 
   readonly tooltips = {
@@ -121,6 +122,10 @@ export class ServiceS3Component implements OnInit {
       ...this.form.value,
       bindport: Number(this.form.value.bindport),
     };
+
+    if (values.certificate === null) {
+      delete values.tls_server_uri;
+    }
 
     this.isFormLoading = true;
     this.ws.call('s3.update', [values])

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2882,6 +2882,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1971,6 +1971,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -824,6 +824,7 @@
   "TFTP": "",
   "TLS": "",
   "TLS (STARTTLS)": "",
+  "TLS Server Uri": "",
   "Tag to use for the specified image": "",
   "Tags": "",
   "Tail Lines": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3146,6 +3146,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -736,6 +736,7 @@
   "TLS": "",
   "TLS (STARTTLS)": "",
   "TLS Crypt Auth": "",
+  "TLS Server Uri": "",
   "Tags": "",
   "Target Dataset": "",
   "Temperature data missing.": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3128,6 +3128,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2881,6 +2881,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3409,6 +3409,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3284,6 +3284,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3321,6 +3321,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3202,6 +3202,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1194,6 +1194,7 @@
   "TLS Allow Per User": "",
   "TLS Crypt Auth": "",
   "TLS Crypt Auth Enabled": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3425,6 +3425,7 @@
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
   "TLS Policy": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -3,6 +3,7 @@
   "Browse to the path to be copied. Linux file path limits apply. Other operating systems can have different limits which might affect how they can be used as sources or destinations.": "",
   "Enter the device name of the interface. This cannot be changed after the interface is created.": "",
   "Select Disks": "",
+  "TLS Server Uri": "",
   " Check Notifications for more details.": " 检查通知以获取更多详细信息。",
   " Download Updates": " 下载更新",
   " KiB.": " KiB。",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2509,6 +2509,7 @@
   "TLS No Certificate Request": "",
   "TLS No Empty Fragments": "",
   "TLS No Session Reuse Required": "",
+  "TLS Server Uri": "",
   "Tag": "",
   "Tag to use for the specified image": "",
   "Tags": "",


### PR DESCRIPTION
To test, go to the page Services -> S3 (Config/Edit icon click)
There, if you change the `Certificate` field to something other than empty/null, the new field should show up. It should be required only in this case and not required otherwise.