### PR TITLE
NAS-113560 / 22.02 / NAS-113560: Added check for a not auth message

### DIFF
--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -114,6 +114,10 @@ export class WebSocketService {
       return;
     }
 
+    if (data.error && data.error == 13 /** Not Authenticated */) {
+      return this.socket.close(); // will trigger onClose which handles redirection
+    }
+
     if (data.msg == ApiEventMessage.Result) {
       const call = this.pendingCalls.get(data.id);
 


### PR DESCRIPTION
This is a preventative measure for getting `Not Authenticated` errors. Not sure how to reproduce the scenario where this code would be reached but as described by the ticket description, this case is reached somehow. Another ticket will be created to refactor the authentication process. That's expected to improve the process overall.