### PR TITLE
NAS-114222 / 22.02 / default to sh for container shell

### DIFF
--- a/src/app/pages/applications/chart-releases/chart-releases.component.ts
+++ b/src/app/pages/applications/chart-releases/chart-releases.component.ts
@@ -109,7 +109,7 @@ export class ChartReleasesComponent implements OnInit {
       type: 'input',
       name: 'command',
       placeholder: helptext.podConsole.chooseCommand.placeholder,
-      value: '/bin/bash',
+      value: '/bin/sh',
     }],
     saveButtonText: helptext.podConsole.choosePod.action,
     customSubmit: (entityDialog) => this.doPodSelect(entityDialog),


### PR DESCRIPTION
This moves the default container shell from /bin/bash to /bin/sh.
Generally speaking all containers have sh, but lightweight containers do not always contain bash.

This has lead to multiple instances of people getting confused and filing bugreports on either the forum, discord or TrueCharts-support