### PR TITLE
NAS-114088 / 22.02 / NAS-114088: Cloud Sync Tasks - prevent page from crashing (fix job schedule parsing)

### DIFF
--- a/src/app/pages/common/entity/entity-table/entity-table-row-details/entity-table-row-details.component.html
+++ b/src/app/pages/common/entity/entity-table/entity-table-row-details/entity-table-row-details.component.html
@@ -28,7 +28,7 @@
             ></app-task-schedule-list>
           </ng-container>
         </mat-menu>
-        <p>{{ getPropValue(column.prop, true) }}</p>
+        <p>{{ config.enabled ? getPropValue(column.prop, true) : getPropValue(column.prop) }}</p>
       </ng-container>
       <ng-template #notScheduleList>
         <p>{{ getPropValue(column.prop) }}</p>


### PR DESCRIPTION
Made a lot of attempts to replicate issue which user was facing, and finally discovered the following bug:
Parse logic was based on a hard-coded string "Disabled" and thus was tightly coupled with English localization

Testing:
1. Switch language to non English (German, Russian)
2. Credentials -> Cloud Storage -> Dropbox (fill in your dropbox creds, or any other cloud creds you have)
3. Go to Data Protection -> Add Cloud Sync task -> Create 2 tasks
4. Edit both tasks marking each as "Disabled"
5. Go to Data Protection -> click "Flyout" icon next to Cloud Sync Tasks 
Expected result:
![image](https://user-images.githubusercontent.com/20611516/148945041-5ca45963-0fa9-41fa-b095-cae14af11b93.png)
