### PR TITLE
NAS-114045 / 22.02 / NAS-114045: Fix Truenas Scale PCIe Passthru issue - Raid card not visible

### DIFF
--- a/src/app/pages/vm/devices/device-add/device-add.component.html
+++ b/src/app/pages/vm/devices/device-add/device-add.component.html
@@ -30,9 +30,14 @@
               </div>
             </div>
             <div *ngSwitchCase="VmDeviceType.Pci" fxFlex="100%" fxFlex.gt-xs="calc(100% - 16px)" class="form-line">
-              <div *ngFor="let pciField of fieldSet.pciFieldConfig;">
-                <div dynamicField [config]="pciField" [group]="pciFormGroup"></div>
+              <div class="spinner-wrapper" *ngIf="isLoadingPci && fieldSet.pciFieldConfig?.length">
+                <mat-spinner [diameter]="40" id="dir-service-monitor-spinner"></mat-spinner>
               </div>
+              <ng-container *ngIf="!isLoadingPci">
+                <div *ngFor="let pciField of fieldSet.pciFieldConfig;">
+                  <div dynamicField [config]="pciField" [group]="pciFormGroup"></div>
+                </div>
+              </ng-container>
             </div>
             <div  *ngSwitchCase="VmDeviceType.Display" fxFlex="100%" fxFlex.gt-xs="calc(100% - 16px)" class="form-line">
               <div *ngFor="let displayField of fieldSet.displayFieldConfig;">

--- a/src/app/pages/vm/devices/device-add/device-add.component.ts
+++ b/src/app/pages/vm/devices/device-add/device-add.component.ts
@@ -333,6 +333,8 @@ export class DeviceAddComponent implements OnInit, OnDestroy {
 
   protected ipAddress: FormSelectConfig;
 
+  isLoadingPci = false;
+
   constructor(
     protected router: Router,
     protected core: CoreService,
@@ -402,11 +404,16 @@ export class DeviceAddComponent implements OnInit, OnDestroy {
 
     // pci
     this.ws.call('vm.device.passthrough_device_choices').pipe(untilDestroyed(this)).subscribe((res) => {
+      this.isLoadingPci = true;
       this.pptdev = _.find(this.pciFieldConfig, { name: 'pptdev' }) as FormSelectConfig;
       this.pptdev.options = Object.keys(res || {}).map((pptdevId) => ({
         label: pptdevId,
         value: pptdevId,
       }));
+      this.isLoadingPci = false;
+    },
+    () => {
+      this.isLoadingPci = false;
     });
   }
 

--- a/src/app/pages/vm/devices/device-add/device-add.component.ts
+++ b/src/app/pages/vm/devices/device-add/device-add.component.ts
@@ -403,17 +403,17 @@ export class DeviceAddComponent implements OnInit, OnDestroy {
     });
 
     // pci
+    this.isLoadingPci = true;
     this.ws.call('vm.device.passthrough_device_choices').pipe(untilDestroyed(this)).subscribe((res) => {
-      this.isLoadingPci = true;
       this.pptdev = _.find(this.pciFieldConfig, { name: 'pptdev' }) as FormSelectConfig;
       this.pptdev.options = Object.keys(res || {}).map((pptdevId) => ({
         label: pptdevId,
         value: pptdevId,
       }));
       this.isLoadingPci = false;
-    },
-    () => {
+    }, (err) => {
       this.isLoadingPci = false;
+      new EntityUtils().handleWsError(this, err, this.dialogService);
     });
   }
 


### PR DESCRIPTION
After check the video attachment, I made a suggestion that `vm.device.passthrough_device_choices` has slow response. Assuming it may take ~15 seconds to retrieve such a long device list, it's possible to see the behavior depicted on the video.

The spinner I've added should help the user to know that he needs to wait until PCI devices will be loaded.

Testing: create a VM, and go to Devices -> Add. As a shortcut, I've adjusted response of `vm.device.passthrough_device_choices` query by hard-coding the JSON from the debugging logs which the user has uploaded.