### PR TITLE
NAS-114146 / 13.0 / Add support for "duplicate_serial" field (by denysbutenko)

### DIFF
--- a/src/app/enums/disk-bus.enum.ts
+++ b/src/app/enums/disk-bus.enum.ts
@@ -1,0 +1,4 @@
+export enum DiskBus {
+  Spi = 'SPI',
+  Usb = 'USB',
+}

--- a/src/app/pages/storage/volumes/manager/manager.component.css
+++ b/src/app/pages/storage/volumes/manager/manager.component.css
@@ -1,7 +1,7 @@
 .custom_cell_styling {
-	overflow: hidden; 
-	height: 20px; 
-	width: 100%; 
+	overflow: hidden;
+	height: 20px;
+	width: 100%;
 	padding-left: 5px;
 }
 
@@ -16,7 +16,7 @@
 	/* flex-basis: auto;
 	-webkit-box-flex: 1;
 	flex-grow: 1; */
-	width: 510px; 
+	width: 510px;
 	/* max-width: 400px; */
 }
 
@@ -95,7 +95,7 @@ h4 {
 #pool-manager__encryption-checkbox {
 	margin-left: 10px;
 }
-  
+
 #pool-manager__reset-layout-button:disabled,
 #pool-manager__suggest-layout-button:disabled {
 	color: var(--fg2);
@@ -186,4 +186,14 @@ button.vdev-option p{
 
 .encryption-select.inline {
 	width: 200px;
+}
+
+.non-unique-serial-disks-checkbox {
+  padding-left: 0.6rem;
+}
+
+.non-unique-serial-disks-warning {
+  color: var(--orange);
+  margin: 0;
+  padding: 1.2rem 1.2rem 0;
 }

--- a/src/app/pages/storage/volumes/manager/manager.component.html
+++ b/src/app/pages/storage/volumes/manager/manager.component.html
@@ -300,6 +300,30 @@
                     </a>
                   </ng-template>
                 </ngx-datatable-column>
+
+                <ngx-datatable-footer>
+                  <ng-template
+                    ngx-datatable-footer-template
+                    let-selectedCount="selectedCount"
+                    let-rowCount="rowCount"
+                  >
+                    <div>
+                      <p *ngIf="availableNonUniqueSerialDisksCount" class="non-unique-serial-disks-warning">{{ nonUniqueSerialDisksWarning }}</p>
+
+                      <mat-checkbox
+                        *ngIf="availableNonUniqueSerialDisksCount"
+                        color="primary"
+                        class="non-unique-serial-disks-checkbox"
+                        [checked]="includeNonUniqueSerialDisks"
+                        (change)="toggleNonUniqueSerialDisks()"
+                      >{{ 'Show disks with non-unique serial numbers' | translate }}</mat-checkbox>
+
+                      <div class="page-count">
+                        <div>{{ selectedCount }} {{ 'selected' | translate }} / {{ rowCount }} {{ 'total' | translate }}</div>
+                      </div>
+                    </div>
+                  </ng-template>
+                </ngx-datatable-footer>
               </ngx-datatable>
               <div id="filter-wrapper">
                 <mat-form-field fxFlex="1 1 40%">

--- a/src/app/pages/storage/volumes/manager/manager.component.ts
+++ b/src/app/pages/storage/volumes/manager/manager.component.ts
@@ -19,6 +19,7 @@ import { DialogFormConfiguration } from '../../../common/entity/entity-dialog/di
 import { EntityUtils } from '../../../common/entity/utils';
 import { DiskComponent } from './disk';
 import { VdevComponent } from './vdev';
+import { DiskBus } from 'app/enums/disk-bus.enum';
 
 @Component({
   selector: 'app-manager',
@@ -36,8 +37,8 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
     data: [{}], cache: [], spares: [], log: [], special: [], dedup: [],
   };
   original_vdevs: any = {};
-  original_disks: any[];
-  orig_suggestable_disks: any[];
+  original_disks: any[] = [];
+  orig_suggestable_disks: any[] = [];
   error: string;
   @ViewChild('disksdnd', { static: true }) disksdnd;
   @ViewChildren(VdevComponent) vdevComponents: QueryList < VdevComponent > ;
@@ -134,6 +135,26 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
   protected mindisks = {
     stripe: 1, mirror: 2, raidz: 3, raidz2: 4, raidz3: 5,
   };
+
+  includeNonUniqueSerialDisks = false;
+  nonUniqueSerialDisks: any[] = [];
+  get availableNonUniqueSerialDisksCount(): number {
+    if (this.original_disks.length === this.temp.length) {
+      return this.nonUniqueSerialDisks.length;
+    }
+    return this.temp.filter((disk) => this.nonUniqueSerialDisks.includes(disk)).length;
+  }
+  get nonUniqueSerialDisksWarning(): string {
+    if (!this.nonUniqueSerialDisks.length) {
+      return null;
+    }
+
+    if (this.nonUniqueSerialDisks.every((disk) => disk.bus === DiskBus.Usb)) {
+      return this.translate.instant('Warning: There are {n} USB disks available that have non-unique serial numbers. USB controllers may report disk serial incorrectly, making such disks indistinguishable from each other. Adding such disks to a pool can result in lost data.', { n: this.availableNonUniqueSerialDisksCount });
+    }
+
+    return this.translate.instant('Warning: There are {n} disks available that have non-unique serial numbers. Non-unique serial numbers can be caused by a cabling issue and adding such disks to a pool can result in lost data.', { n: this.availableNonUniqueSerialDisksCount });
+  }
 
   constructor(
     private ws: WebSocketService,
@@ -375,6 +396,8 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
       this.can_suggest = this.suggestable_disks.length < 11;
 
       this.temp = [...this.disks];
+      this.nonUniqueSerialDisks = this.disks.filter((disk) => disk.duplicate_serial.length);
+      this.disks = this.disks.filter((disk) => !disk.duplicate_serial.length);
       this.getDuplicableDisks();
     }, (err) => {
       this.loader.close();
@@ -581,6 +604,7 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
   doSubmit() {
     let confirmButton = T('Create Pool');
     let diskWarning = this.diskAddWarning;
+    let allowDuplicateSerials = false;
     if (!this.isNew) {
       confirmButton = T('Add Vdevs');
       diskWarning = this.diskExtendWarning;
@@ -594,6 +618,9 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
         this.vdevComponents.forEach((vdev) => {
           const disks = [];
           vdev.getDisks().forEach((disk) => {
+            if (disk.duplicate_serial.length) {
+              allowDuplicateSerials = true;
+            }
             disks.push(disk.devname);
           });
           if (disks.length > 0) {
@@ -619,6 +646,10 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
           }
         } else {
           body = { topology: layout };
+        }
+
+        if (allowDuplicateSerials) {
+          body['allow_duplicate_serials'] = true;
         }
 
         const dialogRef = this.mdDialog.open(EntityJobComponent, {
@@ -808,5 +839,14 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
       const heightStr = `height: ${newHeight}px`;
       document.getElementsByClassName('ngx-datatable')[0].setAttribute('style', heightStr);
     }, 100);
+  }
+
+  toggleNonUniqueSerialDisks(): void {
+    this.includeNonUniqueSerialDisks = !this.includeNonUniqueSerialDisks;
+    if (this.includeNonUniqueSerialDisks) {
+      this.disks = this.original_disks.filter((disk) => this.temp.includes(disk));
+    } else {
+      this.disks = this.disks.filter((disk) => !this.nonUniqueSerialDisks.includes(disk));
+    }
   }
 }

--- a/src/app/pages/storage/volumes/manager/manager.component.ts
+++ b/src/app/pages/storage/volumes/manager/manager.component.ts
@@ -150,10 +150,10 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     if (this.nonUniqueSerialDisks.every((disk) => disk.bus === DiskBus.Usb)) {
-      return this.translate.instant('Warning: There are {n} USB disks available that have non-unique serial numbers. USB controllers may report disk serial incorrectly, making such disks indistinguishable from each other. Adding such disks to a pool can result in lost data.', { n: this.availableNonUniqueSerialDisksCount });
+      return this.translate.instant('Warning: There are ') + this.availableNonUniqueSerialDisksCount + this.translate.instant(' USB disks available that have non-unique serial numbers. USB controllers may report disk serial incorrectly, making such disks indistinguishable from each other. Adding such disks to a pool can result in lost data.');
     }
 
-    return this.translate.instant('Warning: There are {n} disks available that have non-unique serial numbers. Non-unique serial numbers can be caused by a cabling issue and adding such disks to a pool can result in lost data.', { n: this.availableNonUniqueSerialDisksCount });
+    return this.translate.instant('Warning: There are ') + this.availableNonUniqueSerialDisksCount + this.translate.instant(' disks available that have non-unique serial numbers. Non-unique serial numbers can be caused by a cabling issue and adding such disks to a pool can result in lost data.');
   }
 
   constructor(
@@ -396,8 +396,10 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
       this.can_suggest = this.suggestable_disks.length < 11;
 
       this.temp = [...this.disks];
-      this.nonUniqueSerialDisks = this.disks.filter((disk) => disk.duplicate_serial.length);
-      this.disks = this.disks.filter((disk) => !disk.duplicate_serial.length);
+      if (this.disks.some((disk) => disk.duplicate_serial)) {
+        this.nonUniqueSerialDisks = this.disks.filter((disk) => disk.duplicate_serial.length);
+        this.disks = this.disks.filter((disk) => !disk.duplicate_serial.length);
+      }
       this.getDuplicableDisks();
     }, (err) => {
       this.loader.close();
@@ -618,7 +620,7 @@ export class ManagerComponent implements OnInit, OnDestroy, AfterViewInit {
         this.vdevComponents.forEach((vdev) => {
           const disks = [];
           vdev.getDisks().forEach((disk) => {
-            if (disk.duplicate_serial.length) {
+            if (disk.duplicate_serial && disk.duplicate_serial.length) {
               allowDuplicateSerials = true;
             }
             disks.push(disk.devname);

--- a/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
+++ b/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
@@ -205,7 +205,9 @@ export class VolumeStatusComponent implements OnInit {
       }
       _.find(this.replaceDiskFormFields, { name: 'disk' }).options = availableDisks;
       _.find(this.extendVdevFormFields, { name: 'new_disk' }).options = availableDisksForExtend;
-      this.duplicateSerialDisks = res.filter((disk) => disk.duplicate_serial.length);
+      if (res.some((disk) => disk.duplicate_serial)) {
+        this.duplicateSerialDisks = res.filter((disk) => disk.duplicate_serial.length);
+      }
     });
   }
   ngOnInit() {

--- a/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
+++ b/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
@@ -128,6 +128,7 @@ export class VolumeStatusComponent implements OnInit {
   }];
 
   protected pool: any;
+  private duplicateSerialDisks: any[] = [];
 
   constructor(protected aroute: ActivatedRoute,
     protected ws: WebSocketService,
@@ -204,6 +205,7 @@ export class VolumeStatusComponent implements OnInit {
       }
       _.find(this.replaceDiskFormFields, { name: 'disk' }).options = availableDisks;
       _.find(this.extendVdevFormFields, { name: 'new_disk' }).options = availableDisksForExtend;
+      this.duplicateSerialDisks = res.filter((disk) => disk.duplicate_serial.length);
     });
   }
   ngOnInit() {
@@ -319,11 +321,15 @@ export class VolumeStatusComponent implements OnInit {
           saveButtonText: helptext.replace_disk.saveButtonText,
           parent: this,
           customSubmit(entityDialog: any) {
-            delete entityDialog.formValue['passphrase2'];
+            const body = { ...entityDialog.formValue };
+            delete body['passphrase2'];
+            if (this.duplicateSerialDisks.find((disk) => disk.name === entityDialog.formValue.new_disk)) {
+              body['allow_duplicate_serials'] = true;
+            }
 
             const dialogRef = entityDialog.parent.matDialog.open(EntityJobComponent, { data: { title: helptext.replace_disk.title }, disableClose: true });
             dialogRef.componentInstance.setDescription(helptext.replace_disk.description);
-            dialogRef.componentInstance.setCall('pool.replace', [pk, entityDialog.formValue]);
+            dialogRef.componentInstance.setCall('pool.replace', [pk, body]);
             dialogRef.componentInstance.submit();
             dialogRef.componentInstance.success.subscribe((res) => {
               dialogRef.close(true);


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 16ee21b00d1f90db64054c8c03996ee4b80d279e
    git cherry-pick -x 6ae1887ccd4c93ee1bf8e4da38c03e32c533bfe5
    git cherry-pick -x a4cc4d428e08443f30d87c9d4f5c8246ee132ad6
    git cherry-pick -x 388d4d45b1dcb16970e647f96affe67d8ee7206c
    git cherry-pick -x 11ff5b744e4b7b3779117151ccc051d464ba9fbd
    git cherry-pick -x f5cbe527ad2e50967cde5fe1125bed0b292fefb3
    git cherry-pick -x d0a6c043b524bb43ae0b275fb030de86ebd2b44d
    git cherry-pick -x 8a49236f5e0eb34f5d93de3acb235e09d41172dd

Display warning if available disks have items in `duplicate_serial`

Testing:
- Use the latest nightly on a VM
- Mock response or create new disks
- Go to `Storage - Create Pool`
- Check the warning message
- Toggle Show/Hide all disks
- Add disk with non-unique serial to vdev
- Try to break form submission

Also check ticket details for additional info

Original PR: https://github.com/truenas/webui/pull/6264
Jira URL: https://jira.ixsystems.com/browse/NAS-114146