### PR TITLE
NAS-112307 / 22.02 / NAS-112307: Fix CPU Reports in Dashboard broken, when using a proxy host

### DIFF
--- a/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
+++ b/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
@@ -316,7 +316,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements AfterView
   }
 
   async fetchReportData(): Promise<void> {
-    const endDate = await this.reportsService.getServerTime();
+    const endDate = await this.reportsService.getServerTime().pipe(untilDestroyed(this)).toPromise();
     const subOptions: Duration = {};
     subOptions['hours'] = 1;
     const startDate = sub(endDate, subOptions);

--- a/src/app/pages/reports-dashboard/components/report/report.component.ts
+++ b/src/app/pages/reports-dashboard/components/report/report.component.ts
@@ -272,7 +272,7 @@ export class ReportComponent extends WidgetComponent implements AfterViewInit, O
     let durationUnit: keyof Duration;
     let value: number;
 
-    const now = await this.reportsService.getServerTime();
+    const now = await this.reportsService.getServerTime().pipe(untilDestroyed(this)).toPromise();
 
     let startDate: Date;
     let endDate: Date;

--- a/src/app/pages/reports-dashboard/reports.service.ts
+++ b/src/app/pages/reports-dashboard/reports.service.ts
@@ -1,5 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, OnDestroy } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { CoreService } from 'app/core/services/core-service/core.service';
 import { CoreEvent } from 'app/interfaces/events';
 import { WebsocketError } from 'app/interfaces/websocket-error.interface';
@@ -123,20 +125,11 @@ export class ReportsService implements OnDestroy {
     return data;
   }
 
-  async getServerTime(): Promise<Date> {
-    let date;
-    const options = {
-      observe: 'response' as const,
-      responseType: 'text' as const,
-    };
-    await this.http.get(window.location.origin.toString(), options).toPromise().then((resp) => {
-      const serverTime = resp.headers.get('Date');
-      const seconds = new Date(serverTime).getTime();
-      const secondsToTrim = 60;
-      const trimmed = new Date(seconds - (secondsToTrim * 1000));
-      date = trimmed;
-    });
-
-    return date;
+  getServerTime(): Observable<Date> {
+    return this.ws.call('system.info')
+      .pipe(map((systemInfo) => {
+        const msToTrim = 60_000;
+        return new Date(systemInfo.datetime.$date - msToTrim);
+      }));
   }
 }


### PR DESCRIPTION
Replacement for `getServerTime`.
Old `getServerTime` implementation was relying on XMLHttpRequest and thus was sensitive to how the user opens the WebUI - through a proxy or not, through https or http, and so on.
New implementation relies on existing WS which is more stable. I've used existing message `systeminfo`, which provides exact same value.

Testing: make sure charts work. I wasn't able to replicate the behavior which user were observing. I believe user had some networking issue, which should be worked around by getting rid of XMLHttpRequest.