### PR TITLE
NAS-114215 / 22.02 / NAS-114215: Fix Disk Report not showing the correct drives in a pool

### DIFF
--- a/src/app/pages/common/entity/entity-toolbar/components/toolbar-multiselect/toolbar-multiselect.component.ts
+++ b/src/app/pages/common/entity/entity-toolbar/components/toolbar-multiselect/toolbar-multiselect.component.ts
@@ -30,9 +30,9 @@ export class ToolbarMultiSelectComponent extends IxAbstractObject implements Aft
 
   ngAfterViewInit(): void {
     this.deselectAll();
-    if (this.config.value && this.config.value.length) {
+    if (this.config.value?.length) {
       this.config.value
-        .map(() => this.config.options.findIndex((x) => x.value))
+        .map((option: Option) => this.config.options.findIndex((x) => x.value == option.value))
         .filter((index: number) => index !== -1)
         .forEach((index: number) => this.selectOption(index));
     } else {


### PR DESCRIPTION
Testing: 
1. create a pool
2. go to dashboard, show "pool" widget 
3. click "disk reports" icon in the top right corner 