### PR TITLE
NAS-114032 / None / NAS-114032: backport changes to bluefin

### DIFF
--- a/src/app/modules/entity/entity-table/entity-table.component.html
+++ b/src/app/modules/entity/entity-table/entity-table.component.html
@@ -242,6 +242,8 @@
     </mat-card-footer>
   </ng-container>
   <ng-container *ngIf="isTableEmpty">
-    <entity-empty [conf]="emptyTableConf"></entity-empty>
+    <div class="entity-empty-wrapper" fxFlex="100%" fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="32px">
+      <entity-empty [conf]="emptyTableConf"></entity-empty>
+    </div>
   </ng-container>
 </div>

--- a/src/app/modules/entity/entity-table/entity-table.component.scss
+++ b/src/app/modules/entity/entity-table/entity-table.component.scss
@@ -345,3 +345,7 @@ button div.label-warning-icon .mat-icon {
     }
   }
 }
+
+.entity-empty-wrapper entity-empty {
+  margin: 32px 0;
+}

--- a/src/app/pages/directory-service/directory-services.component.html
+++ b/src/app/pages/directory-service/directory-services.component.html
@@ -1,5 +1,5 @@
 <ng-container [ngSwitch]="true">
-  <div *ngSwitchCase="!isActiveDirectoryEnabled && !isLdapEnabled" class="everything-disabled">
+  <div fxLayout="column" fxLayoutAlign="center center"*ngSwitchCase="!isActiveDirectoryEnabled && !isLdapEnabled" class="everything-disabled">
     <entity-empty [conf]="noDirectoryServicesConfig"></entity-empty>
     <div class="actions">
       <button mat-button (click)="onCardButtonPressed(DirectoryServicesCardId.ActiveDirectory)">

--- a/src/app/pages/directory-service/directory-services.component.scss
+++ b/src/app/pages/directory-service/directory-services.component.scss
@@ -1,8 +1,6 @@
 @import 'cssvars';
 
 .everything-disabled {
-  text-align: center;
-
   button {
     margin-right: 10px;
 


### PR DESCRIPTION
Same as https://github.com/truenas/webui/pull/6248

To test:

Go to a page that uses entity-table and doesn't have content.
Make sure entity-empty is centered