### PR TITLE
NAS-114338 / 22.02 / NAS-114338: Warning not showing up for isolating Passthrough devices

### DIFF
--- a/src/app/pages/common/ix-forms/components/ix-errors/ix-errors.component.html
+++ b/src/app/pages/common/ix-forms/components/ix-errors/ix-errors.component.html
@@ -1,5 +1,5 @@
 <div class="form-error" *ngIf="control.touched || control.dirty">
   <mat-error *ngFor="let message of messages">
-    {{ message }}
+    <span [innerHTML]="message"></span>
   </mat-error>
 </div>

--- a/src/app/pages/system/advanced/isolated-gpu-pcis/isolated-gpu-pcis-form.component.ts
+++ b/src/app/pages/system/advanced/isolated-gpu-pcis/isolated-gpu-pcis-form.component.ts
@@ -58,24 +58,23 @@ export class IsolatedGpuPcisFormComponent implements OnInit {
       if (selectedGpus.length >= this.availableGpus?.length) {
         const prevSelectedGpus = [];
         for (const gpu of this.availableGpus) {
-          if (this.isolatedGpuPciIds.findIndex((igpi) => igpi === gpu.addr.pci_slot) >= 0) {
+          if (this.isolatedGpuPciIds.find((igpi) => igpi === gpu.addr.pci_slot)) {
             prevSelectedGpus.push(gpu);
           }
         }
-        let manualValidateErrorMsg = '';
+        let message = '';
         const atLeastOneGpu = this.translate.instant('At least 1 GPU is required by the host for it’s functions.');
         const noGpuAvailable = this.translate.instant('With your selection, no GPU is available for the host to consume.');
         if (prevSelectedGpus.length > 0) {
-          const gpus = '<li>' + prevSelectedGpus.map((gpu, index) => (index + 1) + '. ' + gpu.description).join('</li><li>') + '</li>';
+          const gpus = '<li>' + prevSelectedGpus.map((gpu) => gpu.description).join('</li><li>') + '</li>';
 
           const selectedGpu = this.translate.instant('<p>Currently following GPU(s) have been isolated:<ol>{gpus}</ol></p>', { gpus });
-          manualValidateErrorMsg = `${atLeastOneGpu} ${selectedGpu} ${noGpuAvailable}`;
+          message = `${atLeastOneGpu} ${selectedGpu} ${noGpuAvailable}`;
         } else {
-          manualValidateErrorMsg = `${atLeastOneGpu} ${noGpuAvailable}`;
+          message = `${atLeastOneGpu} ${noGpuAvailable}`;
         }
         gpusFormControl.setErrors({
-          manualValidateError: true,
-          manualValidateErrorMsg,
+          manualValidateError: { message },
         });
       } else {
         gpusFormControl.setErrors(null);

--- a/src/app/pages/vm/vm-form/vm-form.component.ts
+++ b/src/app/pages/vm/vm-form/vm-form.component.ts
@@ -305,7 +305,14 @@ export class VmFormComponent implements FormConfiguration {
           }
         }
         const listItems = '<li>' + prevSelectedGpus.map((gpu, index) => (index + 1) + '. ' + gpu.description).join('</li><li>') + '</li>';
-        gpusConf.warnings = 'At least 1 GPU is required by the host for it’s functions.<p>Currently following GPU(s) have been isolated:<ol>' + listItems + '</ol></p><p>With your selection, no GPU is available for the host to consume.</p>';
+        gpusConf.warnings = this.translate.instant('At least 1 GPU is required by the host for it’s functions.')
+          + (prevSelectedGpus.length
+            ? this.translate.instant(
+              '<p>Currently following GPU(s) have been isolated:<ol>{gpus}</ol></p>',
+              { gpus: listItems },
+            )
+            : '')
+          + `<p>${this.translate.instant('With your selection, no GPU is available for the host to consume.')}</p>`;
         gpusFormControl.setErrors({ maxPCIIds: true });
       } else {
         gpusConf.warnings = null;

--- a/src/app/pages/vm/vm-form/vm-form.component.ts
+++ b/src/app/pages/vm/vm-form/vm-form.component.ts
@@ -300,19 +300,19 @@ export class VmFormComponent implements FormConfiguration {
       if (finalIsolatedPciIds.length && finalIsolatedPciIds.length >= gpusConf.options.length) {
         const prevSelectedGpus = [];
         for (const gpu of this.gpus) {
-          if (this.isolatedGpuPciIds.findIndex((igpi) => igpi === gpu.addr.pci_slot) >= 0) {
+          if (this.isolatedGpuPciIds.find((igpi) => igpi === gpu.addr.pci_slot)) {
             prevSelectedGpus.push(gpu);
           }
         }
         const listItems = '<li>' + prevSelectedGpus.map((gpu, index) => (index + 1) + '. ' + gpu.description).join('</li><li>') + '</li>';
-        gpusConf.warnings = this.translate.instant('At least 1 GPU is required by the host for it’s functions.')
-          + (prevSelectedGpus.length
-            ? this.translate.instant(
-              '<p>Currently following GPU(s) have been isolated:<ol>{gpus}</ol></p>',
-              { gpus: listItems },
-            )
-            : '')
-          + `<p>${this.translate.instant('With your selection, no GPU is available for the host to consume.')}</p>`;
+        gpusConf.warnings = this.translate.instant('At least 1 GPU is required by the host for it’s functions.');
+        if (prevSelectedGpus.length) {
+          gpusConf.warnings += this.translate.instant(
+            '<p>Currently following GPU(s) have been isolated:<ol>{gpus}</ol></p>',
+            { gpus: listItems },
+          );
+        }
+        gpusConf.warnings += `<p>${this.translate.instant('With your selection, no GPU is available for the host to consume.')}</p>`;
         gpusFormControl.setErrors({ maxPCIIds: true });
       } else {
         gpusConf.warnings = null;

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -698,19 +698,19 @@ export class VMWizardComponent implements WizardConfiguration {
         if (finalIsolatedPciIds.length && finalIsolatedPciIds.length >= gpusConf.options.length) {
           const prevSelectedGpus = [];
           for (const gpu of this.gpus) {
-            if (this.isolatedGpuPciIds.findIndex((igpi) => igpi === gpu.addr.pci_slot) >= 0) {
+            if (this.isolatedGpuPciIds.find((igpi) => igpi === gpu.addr.pci_slot)) {
               prevSelectedGpus.push(gpu);
             }
           }
           const listItems = '<li>' + prevSelectedGpus.map((gpu, index) => (index + 1) + '. ' + gpu.description).join('</li><li>') + '</li>';
-          gpusConf.warnings = this.translate.instant('At least 1 GPU is required by the host for it’s functions.')
-            + (prevSelectedGpus.length
-              ? this.translate.instant(
-                '<p>Currently following GPU(s) have been isolated:<ol>{gpus}</ol></p>',
-                { gpus: listItems },
-              )
-              : '')
-            + `<p>${this.translate.instant('With your selection, no GPU is available for the host to consume.')}</p>`;
+          gpusConf.warnings = this.translate.instant('At least 1 GPU is required by the host for it’s functions.');
+          if (prevSelectedGpus.length) {
+            gpusConf.warnings += this.translate.instant(
+              '<p>Currently following GPU(s) have been isolated:<ol>{gpus}</ol></p>',
+              { gpus: listItems },
+            );
+          }
+          gpusConf.warnings += `<p>${this.translate.instant('With your selection, no GPU is available for the host to consume.')}</p>`;
           gpusFormControl.setErrors({ maxPCIIds: true });
         } else {
           gpusConf.warnings = null;

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -703,7 +703,14 @@ export class VMWizardComponent implements WizardConfiguration {
             }
           }
           const listItems = '<li>' + prevSelectedGpus.map((gpu, index) => (index + 1) + '. ' + gpu.description).join('</li><li>') + '</li>';
-          gpusConf.warnings = 'At least 1 GPU is required by the host for it’s functions.<p>Currently following GPU(s) have been isolated:<ol>' + listItems + '</ol></p><p>With your selection, no GPU is available for the host to consume.</p>';
+          gpusConf.warnings = this.translate.instant('At least 1 GPU is required by the host for it’s functions.')
+            + (prevSelectedGpus.length
+              ? this.translate.instant(
+                '<p>Currently following GPU(s) have been isolated:<ol>{gpus}</ol></p>',
+                { gpus: listItems },
+              )
+              : '')
+            + `<p>${this.translate.instant('With your selection, no GPU is available for the host to consume.')}</p>`;
           gpusFormControl.setErrors({ maxPCIIds: true });
         } else {
           gpusConf.warnings = null;


### PR DESCRIPTION
Testing in 3 places:
1. Settings -> Advanced -> Isolated GPUs: logic of validation
2. Virtualization -> Create new VM: translation of error message
3. Edit VM: translation of error message

I've tested 2 GPU setup by mocking the response of `'device.get_info', [DeviceType.Gpu]` . Also need to mockup response of `system.advanced.config  -> isolated_gpu_pci_ids` to emulate GPUs which are already chosen to isolate.