### PR TITLE
NAS-110571 / None / Confusing order of group fields when creating a user

### DIFF
--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -150,15 +150,6 @@ export class UserFormComponent implements FormConfiguration {
           required: true,
           validation: helptext.user_form_uid_validation,
         },
-        {
-          type: 'checkbox',
-          name: helptext.user_form_group_create_name,
-          placeholder: helptext.user_form_group_create_placeholder,
-          tooltip: helptext.user_form_group_create_tooltip,
-          value: true,
-          isHidden: false,
-          expandedHeight: true,
-        },
       ],
     },
     {
@@ -168,6 +159,15 @@ export class UserFormComponent implements FormConfiguration {
       width: '50%',
       config: [
         {
+          type: 'checkbox',
+          name: helptext.user_form_group_create_name,
+          placeholder: helptext.user_form_group_create_placeholder,
+          tooltip: helptext.user_form_group_create_tooltip,
+          value: true,
+          isHidden: false,
+          expandedHeight: true,
+        },
+        {
           type: 'select',
           name: helptext.user_form_primary_group_name,
           placeholder: helptext.user_form_primary_group_placeholder,
@@ -175,7 +175,7 @@ export class UserFormComponent implements FormConfiguration {
           options: [],
           relation: [
             {
-              action: RelationAction.Disable,
+              action: RelationAction.Hide,
               when: [{
                 name: 'group_create',
                 value: true,


### PR DESCRIPTION
To test:
Go to Credentials -> Users
Hidden `Primary Group` select when `New Primary Group` checked.

![Screenshot_13](https://user-images.githubusercontent.com/22980553/150170738-81222138-5085-453d-aa0b-42c5dd7cbd77.png)
