### PR TITLE
NAS-114428 / 22.02 / NAS-114428: Validation Error Traceback from unsetting Include Dataset Properties

### DIFF
--- a/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
+++ b/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
@@ -1427,15 +1427,14 @@ export class ReplicationFormComponent implements FormConfiguration {
       data['properties'] = true;
       data['exclude'] = [];
     }
+    const propertiesExcludeObj: any = {};
     if (data['properties_override']) {
-      const propertiesExcludeObj: any = {};
       for (let item of data['properties_override']) {
         item = item.split('=');
         propertiesExcludeObj[item[0]] = item[1];
       }
-      data['properties_override'] = propertiesExcludeObj;
     }
-
+    data['properties_override'] = propertiesExcludeObj;
     if (data['speed_limit'] !== undefined && data['speed_limit'] !== null) {
       data['speed_limit'] = this.storageService.convertHumanStringToNum(data['speed_limit']);
     }


### PR DESCRIPTION

**Testing:**

1. Data Protection -> Replication Tasks -> Add one (use Wizard for simplicity)
2. Click on your replication task to Edit
3. Uncheck **Include Dataset Properties** and click **Save**

**Summary:**

When saving changes with **Include Dataset Properties** unticked, payload for `replication.update` was:

BEFORE:
```
      "name":"My Pool/My Dataset - My Pool/My Dataset 2",
      "properties":false,      <--- FALSE reflects unchecked state of "Include Dataset Properties"
      "properties_override":null, <--- NULL causes "null not allowed"
      "properties_exclude":[],
```

AFTER:
```
      "name":"My Pool/My Dataset - My Pool/My Dataset 2",
      "properties":false,
      "properties_override":{}, <--- dummy object
      "properties_exclude":[],
```

