### PR TITLE
NAS-114394 / 22.02 / NAS-114394: Making sure the service restarts

### DIFF
--- a/src/app/components/common/modal/modal.component.ts
+++ b/src/app/components/common/modal/modal.component.ts
@@ -95,10 +95,19 @@ export class ModalComponent implements OnInit, OnDestroy {
   // close modal
   close(): Promise<boolean> {
     return new Promise((resolve) => {
-      this.modal.classList.remove('open');
-      this.background.classList.remove('open');
+      this.modal = document.querySelector(`.${this.id}`);
+      if (this.modal) {
+        this.modal.classList.remove('open');
+      }
+      this.background = document.querySelector(`.${this.id}-background`);
+      if (this.background) {
+        this.background.classList.remove('open');
+      }
       document.body.classList.remove('jw-modal-open');
-      this.slideIn.classList.remove('wide');
+      this.slideIn = document.querySelector('.slide-in-form');
+      if (this.slideIn) {
+        this.slideIn.classList.remove('wide');
+      }
       this.formOpen = false;
       this.modalService.refreshForm();
       this.wizard = false;

--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -786,6 +786,7 @@ export type ApiDirectory = {
   'system.general.ui_v6address_choices': { params: void; response: Choices };
   'system.general.ui_certificate_choices': { params: void; response: Record<number, string> };
   'system.general.ui_httpsprotocols_choices': { params: void; response: Choices };
+  'system.general.ui_restart': { params: void; response: void };
   'system.build_time': { params: void; response: ApiTimestamp };
   'system.product_type': { params: void; response: ProductType };
   'system.advanced.syslog_certificate_choices': { params: void; response: Choices };

--- a/src/app/pages/system/general-settings/gui-form/gui-form.component.spec.ts
+++ b/src/app/pages/system/general-settings/gui-form/gui-form.component.spec.ts
@@ -54,7 +54,7 @@ describe('GuiFormComponent', () => {
       DialogService,
       mockWebsocket([
         mockCall('system.general.update', mockSystemGeneralConfig),
-        mockCall('service.restart'),
+        mockCall('system.general.ui_restart'),
       ]),
       mockProvider(IxSlideInService),
       mockProvider(SystemGeneralService, {

--- a/src/app/pages/system/general-settings/gui-form/gui-form.component.ts
+++ b/src/app/pages/system/general-settings/gui-form/gui-form.component.ts
@@ -8,9 +8,7 @@ import {
 import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
-import { combineLatest } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
-import { ServiceName } from 'app/enums/service-name.enum';
 import { choicesToOptions } from 'app/helpers/options.helper';
 import { helptextSystemGeneral as helptext } from 'app/helptext/system/general';
 import { SystemGeneralConfig, SystemGeneralConfigUpdate } from 'app/interfaces/system-config.interface';
@@ -152,7 +150,6 @@ export class GuiFormComponent {
     const current: SystemGeneralConfig = { ...this.configData };
     const httpPortChanged = current.ui_port !== changed.ui_port;
     const httpsPortChanged = current.ui_httpsport !== changed.ui_httpsport;
-    const uiCertificateChanged = current.ui_certificate?.id !== changed.ui_certificate;
     const isServiceRestartRequired = this.getIsServiceRestartRequired(current, changed);
 
     this.sysGeneralService.refreshSysGeneral();
@@ -181,11 +178,7 @@ export class GuiFormComponent {
 
         this.loader.open();
         this.ws.shuttingdown = true; // not really shutting down, just stop websocket detection temporarily
-        const obs = [this.ws.call('service.restart', [ServiceName.Http])];
-        if (uiCertificateChanged) {
-          obs.push(this.ws.call('system.general.ui_restart'));
-        }
-        combineLatest(obs).pipe(
+        this.ws.call('system.general.ui_restart').pipe(
           untilDestroyed(this),
         ).subscribe(
           () => {

--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -83,10 +83,16 @@ export class WebSocketService {
 
   onconnect(): void {
     this.shuttingdown = false;
-    while (this.pendingMessages.length > 0) {
-      const payload = this.pendingMessages.pop();
-      this.send(payload);
-    }
+    this.loginToken(this.token).subscribe((result) => {
+      if (!result) {
+        this.router.navigate(['/sessions/signin']);
+      } else {
+        while (this.pendingMessages.length > 0) {
+          const payload = this.pendingMessages.pop();
+          this.send(payload);
+        }
+      }
+    });
   }
 
   onclose(): void {


### PR DESCRIPTION
Go to the GUI settings under System -> General. Change the certificate and save. You should be prompted to restart the service. If you restart the service, the websocket will disconnect and connect again. Make sure that login on reconnect is working and you are still able to use the UI or redirected to the signin page if sign in is not possible.

Save anything other setting other than certificate (like one of the ports) and check that service restart happens (`service.restart` http is called) without calling `system.general.ui_restart` being called. And again that upon reconnection, login works and UI is usable.

You can test this on the Scale VM available to the team.