### PR TITLE
NAS-114563 / 22.02 / NAS-114563: Reverting reconnection logic change

### DIFF
--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -83,16 +83,10 @@ export class WebSocketService {
 
   onconnect(): void {
     this.shuttingdown = false;
-    this.loginToken(this.token).subscribe((result) => {
-      if (!result) {
-        this.router.navigate(['/sessions/signin']);
-      } else {
-        while (this.pendingMessages.length > 0) {
-          const payload = this.pendingMessages.pop();
-          this.send(payload);
-        }
-      }
-    });
+    while (this.pendingMessages.length > 0) {
+      const payload = this.pendingMessages.pop();
+      this.send(payload);
+    }
   }
 
   onclose(): void {


### PR DESCRIPTION
The ticket has a gif attached of the issue
On master, if you stay on the dashboard and refresh the page a few times. The UI will break eventually. This PR fixes that.
We're reverting the re-connection logic to how it was before. The login addition was an attempt at improving the connection/disconnection of websocket but that can be addressed in a separate ticket.
Refreshing the UI on dashboard on this PR shouldn't cause the UI to break as many times as needed.
Note: This doesn't fix the issue of misplaced UI dashboard widgets. That is addressed by a different ticket.