### PR TITLE
NAS-114530 / 22.02 / NAS-114530: Added filter for ix-chart

### DIFF
--- a/src/app/pages/applications/catalog/catalog.component.ts
+++ b/src/app/pages/applications/catalog/catalog.component.ts
@@ -376,7 +376,7 @@ export class CatalogComponent implements OnInit {
        * Below is a special check to remove 'ix-chart' from the list of apps shown. 'ix-chart' is the same thing
        * as the button 'Launch Docker Image' in UI. Middleware advised UI to hide this option
        */
-      if (app.name === 'ix-chart') {
+      if (app.name === ixChartApp) {
         return false;
       }
 

--- a/src/app/pages/applications/catalog/catalog.component.ts
+++ b/src/app/pages/applications/catalog/catalog.component.ts
@@ -372,6 +372,14 @@ export class CatalogComponent implements OnInit {
         return false;
       }
 
+      /**
+       * Below is a special check to remove 'ix-chart' from the list of apps shown. 'ix-chart' is the same thing
+       * as the button 'Launch Docker Image' in UI. Middleware advised UI to hide this option
+       */
+      if (app.name === 'ix-chart') {
+        return false;
+      }
+
       return this.filteredCatalogNames.includes(app.catalog.label);
     });
 


### PR DESCRIPTION
Go to the apps page and go to the `Available Applications` tab. You shouldn't see the `ix-chart` app as mentioned in the ticket.