### PR TITLE
NAS-114141 / None / NAS-114141: fixed scrollbar display in pool widget

### DIFF
--- a/src/app/pages/dashboard/components/widget-pool/widget-pool.component.scss
+++ b/src/app/pages/dashboard/components/widget-pool/widget-pool.component.scss
@@ -273,7 +273,7 @@ span.capitalize {
 }
 
 .list-subheader:first-child {
-  padding: 8px 8px 0 16px;
+  padding: 2px 8px 0 16px;
 }
 
 .detail-key {


### PR DESCRIPTION
Check widgets. The scrollbar should only appear if the content block is overflow.
![pastedImage](https://user-images.githubusercontent.com/22006748/153843109-f2920338-eb4d-4906-9bb1-efb71f39edc1.png)

