### PR TITLE
changed string from 'TLS Server URI' to 'TLS Server Hostname'

### DIFF
--- a/src/app/helptext/services/components/service-s3.ts
+++ b/src/app/helptext/services/components/service-s3.ts
@@ -49,7 +49,7 @@ export default {
     { label: 'local' },
   ],
 
-  tls_server_uri_placeholder: T('TLS Server URI'),
+  tls_server_uri_placeholder: T('TLS Server Hostname'),
   certificate_placeholder: T('Certificate'),
   certificate_tooltip: T('Use an SSL certificate that was created or imported in \
  <b>System > Certificates</b> for secure S3 connections.'),


### PR DESCRIPTION
The field name "TLS Server URI" has been changed to "TLS Server Hostname" for S3 Service. Check this label and field.
Services -> S3 ->Certificate (choose freenas_default)