### PR TITLE
NAS-114782 / 22.02 / NAS-114782: Removing race conditions in disk lists

### DIFF
--- a/src/app/pages/storage/disks/disk-list/disk-list.component.ts
+++ b/src/app/pages/storage/disks/disk-list/disk-list.component.ts
@@ -284,7 +284,7 @@ export class DiskListComponent implements EntityTableConfig<Disk> {
       }),
       catchError((error) => {
         new EntityUtils().handleWsError(this, error);
-        return of(true);
+        return of(false);
       }),
       untilDestroyed(this),
     ).toPromise();

--- a/src/app/pages/storage/disks/disk-list/disk-list.component.ts
+++ b/src/app/pages/storage/disks/disk-list/disk-list.component.ts
@@ -5,7 +5,8 @@ import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import * as filesize from 'filesize';
-import { filter } from 'rxjs/operators';
+import { forkJoin, of } from 'rxjs';
+import { catchError, filter, map } from 'rxjs/operators';
 import { CoreService } from 'app/core/services/core-service/core.service';
 import { DiskPowerLevel } from 'app/enums/disk-power-level.enum';
 import { DiskStandby } from 'app/enums/disk-standby.enum';
@@ -271,6 +272,24 @@ export class DiskListComponent implements EntityTableConfig<Disk> {
     }
   }
 
+  prerequisite(): Promise<boolean> {
+    return forkJoin([
+      this.ws.call('disk.get_unused'),
+      this.ws.call('smart.test.disk_choices'),
+    ]).pipe(
+      map(([unusedDisks, disksThatSupportSmart]) => {
+        this.unused = unusedDisks;
+        this.SMARTdiskChoices = disksThatSupportSmart;
+        return true;
+      }),
+      catchError((error) => {
+        new EntityUtils().handleWsError(this, error);
+        return of(true);
+      }),
+      untilDestroyed(this),
+    ).toPromise();
+  }
+
   afterInit(entityList: EntityTableComponent): void {
     this.core.register({
       observerClass: this,
@@ -280,24 +299,13 @@ export class DiskListComponent implements EntityTableConfig<Disk> {
         entityList.getData();
       }
     });
-
-    this.ws.call('disk.get_unused', []).pipe(untilDestroyed(this)).subscribe((unused) => {
-      this.unused = unused;
-      entityList.getData();
-    }, (err) => new EntityUtils().handleWsError(this, err));
-
-    this.ws.call('smart.test.disk_choices').pipe(untilDestroyed(this)).subscribe(
-      (res) => {
-        this.SMARTdiskChoices = res;
-        entityList.getData();
-      },
-      (err) => new EntityUtils().handleWsError(this, err),
-    );
   }
 
-  resourceTransformIncomingRestData(data: Disk[]): Disk[] {
-    data.forEach((i) => i.pool = i.pool ? i.pool : 'N/A');
-    return data;
+  resourceTransformIncomingRestData(disks: Disk[]): Disk[] {
+    return disks.map((disk) => ({
+      ...disk,
+      pool: disk.pool || this.translate.instant('N/A'),
+    }));
   }
 
   manualTest(selected: Disk | Disk[]): void {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1796,6 +1796,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1253,6 +1253,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -514,6 +514,7 @@
   "More info...": "",
   "Mount Path": "",
   "Must be part of a pool to check errors": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1943,6 +1943,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -403,6 +403,7 @@
   "More info...": "",
   "Mount Path": "",
   "Must be part of a pool to check errors": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1860,6 +1860,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1750,6 +1750,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2141,6 +2141,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2059,6 +2059,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2054,6 +2054,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2007,6 +2007,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -641,6 +641,7 @@
   "Multicast DNS. Uses the system <i>Hostname</i> to  advertise enabled and running services. For example, this controls if  the server appears under <i>Network</i> on MacOS clients.": "",
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2157,6 +2157,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -29,6 +29,7 @@
   "Enter accounts that have administrative access. See <a href=\"https://linux.die.net/man/5/upsd.users\" target=\"_blank\">upsd.users(5)</a> for examples.": "",
   "Enter the device name of the interface. This cannot be changed after the interface is created.": "",
   "Maximum number of replication tasks being executed simultaneously.": "",
+  "N/A": "",
   "Off by default. When set, <a href=\"https://www.samba.org/samba/docs/current/man-html/smbd.8.html\" target=\"_blank\">smbd(8)</a> attempts to authenticate users with the insecure and vulnerable NTLMv1 encryption. This setting allows backward compatibility with older versions of Windows, but is not recommended and should not be used on untrusted networks.": "",
   "Parent dataset path (read-only).": "",
   "Parent path": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1540,6 +1540,7 @@
   "Must be part of a pool to check errors": "",
   "Must match Windows workgroup name.  When this is unconfigured and Active Directory or LDAP are active,  TrueNAS will detect and set the correct workgroup from these services.": "",
   "Mutual secret password. Required when Peer User is set. Must be different than the <i>Secret</i>.": "",
+  "N/A": "",
   "NAA": "",
   "NETBIOS-NS": "",
   "NFS": "",


### PR DESCRIPTION
Presumably fixes issues in RE tests.

Testing:
Connect to a machine here: https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20-%20Releng/job/TrueNAS%20Scale%20Releng%20UI%20Tests/
go to Storage -> Disks and check that Wipe button appears correctly (should appear next to a disk unused in any pools).