### PR TITLE
NAS-114383 / 13.0 / NAS-114383: enclosure plugin rewritten on 13 needs webUI changes

### DIFF
--- a/src/app/pages/system/viewenclosure/view-enclosure.component.ts
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.ts
@@ -116,6 +116,8 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
     });
 
     core.register({ observerClass: this, eventName: 'EnclosureData' }).subscribe((evt: CoreEvent) => {
+      evt.data = this._parseEnclosureData(evt.data);
+
       this.system = new SystemProfiler(this.system_product, evt.data);
       this.selectedEnclosure = this.system.profile[this.system.headIndex];
       core.emit({ name: 'DisksRequest', sender: this });
@@ -269,5 +271,32 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
     } else {
       this.currentView = disks;
     }
+  }
+
+  private _parseEnclosureData(enclosure) {
+    const parsedEnclosure = [];
+
+    enclosure.forEach((e, idx) => {
+      parsedEnclosure.push({
+        id: e.id,
+        number: e.number,
+        name: e.name,
+        model: e.model,
+        controller: e.controller,
+        label: e.label,
+        elements: [],
+      });
+      for (const [keyElem, valElem] of Object.entries(e.elements)) {
+        const newElem = {
+          name: keyElem,
+          elements: [],
+        };
+        for (const [keySlot, valSlot] of Object.entries(valElem)) {
+          newElem.elements.push(Object.assign(valSlot, { slot: parseInt(keySlot) }));
+        }
+        parsedEnclosure[idx].elements.push(newElem);
+      }
+    });
+    return parsedEnclosure;
   }
 }

--- a/src/app/pages/system/viewenclosure/view-enclosure.component.ts
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.ts
@@ -20,6 +20,16 @@ interface ViewConfig {
   showInNavbar: boolean;
 }
 
+interface EnclosureResponse {
+  id: string;
+  number: string;
+  name: string;
+  model: string;
+  controller: string;
+  label: string;
+  elements: unknown[];
+}
+
 @Component({
   selector: 'view-enclosure',
   templateUrl: './view-enclosure.component.html',
@@ -116,7 +126,7 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
     });
 
     core.register({ observerClass: this, eventName: 'EnclosureData' }).subscribe((evt: CoreEvent) => {
-      evt.data = this._parseEnclosureData(evt.data);
+      evt.data = this.parseEnclosureData(evt.data);
 
       this.system = new SystemProfiler(this.system_product, evt.data);
       this.selectedEnclosure = this.system.profile[this.system.headIndex];
@@ -273,20 +283,20 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
     }
   }
 
-  private _parseEnclosureData(enclosure) {
-    const parsedEnclosure = [];
+  private parseEnclosureData(enclosures: EnclosureResponse[]): EnclosureResponse[] {
+    const parsedEnclosure: EnclosureResponse[] = [];
 
-    enclosure.forEach((e, idx) => {
+    enclosures.forEach((enclosure, idx) => {
       parsedEnclosure.push({
-        id: e.id,
-        number: e.number,
-        name: e.name,
-        model: e.model,
-        controller: e.controller,
-        label: e.label,
+        id: enclosure.id,
+        number: enclosure.number,
+        name: enclosure.name,
+        model: enclosure.model,
+        controller: enclosure.controller,
+        label: enclosure.label,
         elements: [],
       });
-      for (const [keyElem, valElem] of Object.entries(e.elements)) {
+      for (const [keyElem, valElem] of Object.entries(enclosure.elements)) {
         const newElem = {
           name: keyElem,
           elements: [],


### PR DESCRIPTION
Summary: adapted response of `EnclosureData` to existing UI logic.

Testing:

To see **System -> View Enclosures**:
1. edit src/app/services/navigation/navigation.service.ts
   ![image](https://user-images.githubusercontent.com/20611516/154661347-c34db97d-d6a7-469b-a56a-6d557ebf83a6.png)

2. edit src/app/pages/system/viewenclosure/view-enclosure.component.ts:
   ![image](https://user-images.githubusercontent.com/20611516/154661525-5d7f1de4-f544-4530-a584-e5085a8b585b.png)

3. remove condition at src\\app\\pages\\system\\viewenclosure\\view-enclosure.component.html:2
   ![image](https://user-images.githubusercontent.com/20611516/154661601-26e4ac92-326c-41da-94eb-3b861fb05a1f.png)

   
To see contents of **View Enclosures**:
1. Download new JSON response for  `EnclosureData` query from attachments of the ticket https://jira.ixsystems.com/browse/NAS-114383
2. Extract responses  `PoolData`, `SensorData` and `DisksData` queres from the machine mentioned in the ticket https://jira.ixsystems.com/browse/NAS-114383
3. Paste JSON to src/app/pages/system/viewenclosure/view-enclosure.component.ts  
   ![image](https://user-images.githubusercontent.com/20611516/154662705-792a314f-e8b4-4fc0-8065-4036f1ab1ea0.png)

