### PR TITLE
Nas-114918

### DIFF
--- a/src/app/helptext/system/certificates.ts
+++ b/src/app/helptext/system/certificates.ts
@@ -208,7 +208,7 @@ matches your certificate usage scenario.'),
       config: {
         placeholder: T('Basic Constraints Config'),
         tooltip: T('Specify whether the certificate may be used for a Certificate Authority,\
-          and whether this extension is critical\
+          and whether this extension is critical. Critical extensions must be recognized by the client or be rejected.\
           Basic web certificates typically require CA disabled, and critical marked.'),
       },
       ca: {
@@ -222,8 +222,7 @@ matches your certificate usage scenario.'),
  subject of the certificate is a CA, and the maximum depth of valid \
  certification paths that include this certificate. <br> \
  See <a href="https://www.ietf.org/rfc/rfc3280.txt">RFC 3280, section 4.2.1.10</a> \
- for more information.'
-          '),
+ for more information.'),
       },
       path_length: {
         placeholder: T('Path Length'),
@@ -243,15 +242,8 @@ certificate still approved.'),
     authority_key_identifier: {
       config: {
         placeholder: T('Authority Key Config'),
-        tooltip: T('The authority key identifier extension provides a means of \
- identifying the public key corresponding to the private key used to \
- sign a certificate. This extension is used where an issuer has \
- multiple signing keys (either due to multiple concurrent key pairs or \
- due to changeover). The identification MAY be based on either the \
- key identifier (the subject key identifier in the issuer\'s \
- certificate) or on the issuer name and serial number.<br> \
- See <a href="https://www.ietf.org/rfc/rfc3280.txt">RFC 3280, section 4.2.1.1</a> \
- for more information.'),
+        tooltip: T('Specify whether the issued certificate should include Authority Key Identifier information,\
+          and whether the extension is critical. Critical extensions must be recognized by the client or be rejected.'),
       },
       authority_cert_issuer: {
         placeholder: T('Authority Cert Issuer'),
@@ -260,7 +252,16 @@ key used to sign this certificate.'),
       },
       enabled: {
         placeholder: T('Authority Key Identifier'),
-        tooltip: T('Activate this certificate extension.'),
+        tooltip: T('Activate this extension.\
+ The authority key identifier extension provides a means of \
+ identifying the public key corresponding to the private key used to \
+ sign a certificate. This extension is used where an issuer has \
+ multiple signing keys (either due to multiple concurrent key pairs or \
+ due to changeover). The identification MAY be based on either the \
+ key identifier (the subject key identifier in the issuer\'s \
+ certificate) or on the issuer name and serial number.<br> \
+ See <a href="https://www.ietf.org/rfc/rfc3280.txt">RFC 3280, section 4.2.1.1</a> \
+ for more information.'),
       },
       extension_critical: {
         placeholder: T('Critical Extension'),

--- a/src/app/helptext/system/certificates.ts
+++ b/src/app/helptext/system/certificates.ts
@@ -207,11 +207,9 @@ matches your certificate usage scenario.'),
     basic_constraints: {
       config: {
         placeholder: T('Basic Constraints Config'),
-        tooltip: T('The basic constraints extension identifies whether the \
- subject of the certificate is a CA and the maximum depth of valid \
- certification paths that include this certificate. <br> \
- See <a href="https://www.ietf.org/rfc/rfc3280.txt">RFC 3280, section 4.2.1.10</a> \
- for more information.'),
+        tooltip: T('Specify whether the certificate may be used for a Certificate Authority,\
+          and whether this extension is critical\
+          Basic web certificates typically require CA disabled, and critical marked.'),
       },
       ca: {
         placeholder: T('CA'),
@@ -219,7 +217,13 @@ matches your certificate usage scenario.'),
       },
       enabled: {
         placeholder: T('Basic Constraints'),
-        tooltip: T('Activate this certificate extension.'),
+        tooltip: T('Activate the basic contstraints extension.\
+ This extension identifies whether the \
+ subject of the certificate is a CA, and the maximum depth of valid \
+ certification paths that include this certificate. <br> \
+ See <a href="https://www.ietf.org/rfc/rfc3280.txt">RFC 3280, section 4.2.1.10</a> \
+ for more information.'
+          '),
       },
       path_length: {
         placeholder: T('Path Length'),

--- a/src/app/helptext/system/certificates.ts
+++ b/src/app/helptext/system/certificates.ts
@@ -24,8 +24,8 @@ export const helptextSystemCertificates = {
 
     cert_create_type: {
       placeholder: T('Type'),
-      tooltip: T('<i>Internal Certificate</i> is used for internal or local \
- systems. <i>Import Certificate</i> allows an existing certificate to be imported onto \
+      tooltip: T('<i>Internal Certificate</i> uses a system-managed CA for certificate issuance. \
+ <i>Import Certificate</i> allows an existing certificate to be imported onto \
  the system.'),
       options: [
         { label: T('Internal Certificate'), value: 'CERTIFICATE_CREATE_INTERNAL' },
@@ -36,9 +36,10 @@ export const helptextSystemCertificates = {
 
     csr_create_type: {
       placeholder: T('Type'),
-      tooltip: T('<i>Certificate Signing Request</i> is used to get a CA signature. \
+      tooltip: T('<i>Certificate Signing Request</i>: when an external CA will issue (sign) the certificate. \
+        Typically used with ACME, or when default browser trust is needed.\
  <i>Import Certificate Signing Request</i> allows an existing CSR \
- to be imported onto the system.'),
+ to be imported onto the system, typically for use with ACME or an internal CA.'),
       options: [
         { label: T('Certificate Signing Request'), value: 'CERTIFICATE_CREATE_CSR' },
         { label: T('Import Certificate Signing Request'), value: 'CERTIFICATE_CREATE_IMPORTED_CSR' },

--- a/src/app/helptext/system/certificates.ts
+++ b/src/app/helptext/system/certificates.ts
@@ -285,7 +285,10 @@ for more details.'),
       },
       enabled: {
         placeholder: T('Extended Key Usage'),
-        tooltip: T('Activate this certificate extension.'),
+        tooltip: T('Activate this certificate extension.\
+The Extended Key Usage extension identifies and limits valid uses for this certificate, such as client authentication or server authentication.\
+See <a href="https://www.ietf.org/rfc/rfc3280.txt" target="_blank">RFC 3280, section 4.2.1.13</a> \
+for more details.'),'),
       },
       extension_critical: {
         placeholder: T('Critical Extension'),

--- a/src/app/helptext/system/certificates.ts
+++ b/src/app/helptext/system/certificates.ts
@@ -302,7 +302,14 @@ certificate still approved.'),
     key_usage: {
       config: {
         placeholder: T('Key Usage Config'),
-        tooltip: T('The key usage extension defines the purpose \
+        tooltip: T('Specify the valid key usages for this certificate.\
+Web certificates will typically need at least Digital Signature and possibly Key Encipherment or Key Agreement,\
+while other applications may need additional key usages.'),
+      },
+      enabled: {
+        placeholder: T('Key Usage'),
+        tooltip: T('Activate this certificate extension.\
+  The key usage extension defines the purpose \
  (e.g., encipherment, signature, certificate signing) of the key contained in \
  the certificate. The usage restriction might be employed when a key that \
  could be used for more than one operation is to be restricted. For \
@@ -312,10 +319,6 @@ certificate still approved.'),
  management, the <i>Key Encipherment</i> bit would be asserted. <br> \
  See <a href="https://www.ietf.org/rfc/rfc3280.txt">RFC 3280, section 4.2.1.3</a> \
  for more information.'),
-      },
-      enabled: {
-        placeholder: T('Key Usage'),
-        tooltip: T('Activate this certificate extension.'),
       },
       digital_signature: {
         placeholder: T('Digital Signature'),


### PR DESCRIPTION
Many of the tooltips for the Certificate dialog are either overly terse, or are hidden. As an example, the Basic Constraints "enable" tooltip is the only help text initially available, and only states "activate this extension" without explaining what that does.

For many of the extensions there is already very helpful text attached to the "config" dropdown. This pull request does three things:
 1. Tidy up the language around CSRs and internal certs, and when you might use them
 2. move the bulk of explanatory text for the extensions from "config" up to the "enable" tooltip where they will be most useful
 3. Replace  the "config" tooltips with brief overviews of the options
