### PR TITLE
NAS-114718 / 13.0 / NAS-114718: Fix for Pool Status -> Edit

### DIFF
--- a/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
+++ b/src/app/pages/storage/volumes/volume-status/volume-status.component.ts
@@ -524,7 +524,7 @@ export class VolumeStatusComponent implements OnInit {
       stats = data.stats;
     }
     if (data.type && data.type != 'DISK') {
-      data.name = data.type;
+      data.disk = data.type;
     }
     // use path as the device name if the device name is null
     if (!data.device || data.device == null) {
@@ -532,7 +532,7 @@ export class VolumeStatusComponent implements OnInit {
     }
 
     const item: poolDiskInfo = {
-      name: data.name ? data.name : data.device,
+      name: data.disk ? data.disk : data.device,
       read: stats.read_errors ? stats.read_errors : 0,
       write: stats.write_errors ? stats.write_errors : 0,
       checksum: stats.checksum_errors ? stats.checksum_errors : 0,
@@ -563,7 +563,7 @@ export class VolumeStatusComponent implements OnInit {
         const extend_action = this.extendAction(data);
         node.data.actions.push(extend_action[0]);
       }
-      vdev_type = data.name;
+      vdev_type = data.disk;
       for (let i = 0; i < data.children.length; i++) {
         node.children.push(this.parseTopolgy(data.children[i], category, vdev_type));
       }


### PR DESCRIPTION
## Testing

To see **Pool Status** page,

1. Storage -> Pools

2. Click ![image](https://user-images.githubusercontent.com/20611516/154975443-28293f5c-353c-45fc-b62f-f3398ddf636e.png) next to the pool's name, and choose **Status** from the menu

![image](https://user-images.githubusercontent.com/20611516/154975503-36ce42d9-d7e4-4bb9-9032-7e94cf23d7f8.png)

3. When **(Context menu next to one of the disks) -> Edit** is clicked,

**Expected result**: editing form is opened.

**Actual result**: error in console. form won't open,

```
[Error] ERROR
TypeError: undefined is not an object (evaluating 'e[0].identifier')
```

## Summary of changes

Error was caused by incorrect query sent over WS, which resulted in an empty result:

```
"disk.query"
      [
        "devname",
        "=",
        "sdc2"    <--- incorrect. should be "sdc"
      ]
```

After looking into the code, I've found out that in 13 data bindings for device names were incorrectly calculated on UI side.
I've confirmed this by comparing with 22, where **Edit** action worked correctly. Example: 
   - in 13 name of one of my disks was "sdc2" , which is incorrect device name
      ![image](https://user-images.githubusercontent.com/20611516/154976246-8fdf290a-3048-4ade-9a42-e95f2d6b2874.png)

   - in 22 the same disk had a correct device name "sdc"
     ![image](https://user-images.githubusercontent.com/20611516/154976234-6474769e-c5b5-4b31-ad4b-05fbba147294.png)

So, in this PR I've synced data displaying logic from 22 to 13.