### PR TITLE
NAS-114383 / 13.0 / NAS-114383: Fixing logic of joining disks and enclosures

### DIFF
--- a/src/app/core/services/api.service.ts
+++ b/src/app/core/services/api.service.ts
@@ -85,6 +85,15 @@ export class ApiService {
         responseEvent: 'DisksData',
       },
     },
+    DisksRequestExtra: {
+      apiCall: {
+        protocol: 'websocket',
+        version: '2.0',
+        args: [[], { extra: { pools: true } }],
+        namespace: 'disk.query',
+        responseEvent: 'DisksData',
+      },
+    },
     MultipathRequest: {
       apiCall: {
         protocol: 'websocket',

--- a/src/app/pages/system/viewenclosure/enclosure-disks/components/tab-content/tab-content.component.html
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/components/tab-content/tab-content.component.html
@@ -1,11 +1,10 @@
 <table id="tab-data" mat-table [dataSource]="data.elements">
   <!-- Column -->
-  <ng-container *ngFor="let header of data.header; let i = index" [matColumnDef]="data.header[i]">
+  <ng-container *ngFor="let header of headers; let i = index" [matColumnDef]="headers[i]">
     <th mat-header-cell *matHeaderCellDef> {{header}} </th>
-    <td mat-cell *matCellDef="let element"> {{element.data[header]}} </td>
+    <td mat-cell *matCellDef="let element"> {{element[header]}} </td>
   </ng-container>
 
-  <tr mat-header-row *matHeaderRowDef="data.header"></tr>
-  <tr mat-row *matRowDef="let row; columns: data.header;"></tr>
+  <tr mat-header-row *matHeaderRowDef="headers"></tr>
+  <tr mat-row *matRowDef="let row; columns: headers;"></tr>
 </table>
-

--- a/src/app/pages/system/viewenclosure/enclosure-disks/components/tab-content/tab-content.component.ts
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/components/tab-content/tab-content.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, OnInit, AfterViewInit, Input, ElementRef, NgZone, OnDestroy,
+  Component, OnInit, AfterViewInit, Input, ElementRef, NgZone, OnDestroy, OnChanges,
 } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MaterialModule } from 'app/appMaterial.module';
@@ -10,10 +10,20 @@ import { MaterialModule } from 'app/appMaterial.module';
   styleUrls: ['./tab-content.component.css'],
 })
 
-export class TabContentComponent implements AfterViewInit, OnDestroy {
+export class TabContentComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() data: any;
 
+  headers = ['descriptor', 'status', 'value', 'slot'];
+
   constructor(public el: ElementRef/* , private ngZone: NgZone */) {
+  }
+
+  ngOnChanges() {
+    if (this.data.header) {
+      this.headers = this.data.header;
+    } else {
+      this.headers = ['descriptor', 'status', 'value', 'slot'];
+    }
   }
 
   ngAfterViewInit() {

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
@@ -10,8 +10,7 @@
 
   <mat-toolbar id="Disks-toolbar">
     <div *ngIf="selectedEnclosure" class="mat-card-title-text">
-      {{currentTab.alias}} on 
-      {{selectedEnclosure.label ? selectedEnclosure.label : selectedEnclosure.model}}
+      {{currentTab.alias}} on {{enclosureLabel}}
       <!-- {{selectedEnclosure.label == selectedEnclosure.name ? selectedEnclosure.model : selectedEnclosure.label}}  -->
       ({{selectedEnclosure.enclosureKey}})
     </div>

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
@@ -11,7 +11,8 @@
   <mat-toolbar id="Disks-toolbar">
     <div *ngIf="selectedEnclosure" class="mat-card-title-text">
       {{currentTab.alias}} on 
-      {{selectedEnclosure.label == selectedEnclosure.name ? selectedEnclosure.model : selectedEnclosure.label}} 
+      {{selectedEnclosure.label ? selectedEnclosure.label : selectedEnclosure.model}}
+      <!-- {{selectedEnclosure.label == selectedEnclosure.name ? selectedEnclosure.model : selectedEnclosure.label}}  -->
       ({{selectedEnclosure.enclosureKey}})
     </div>
 

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
@@ -99,7 +99,7 @@
         <!-- DETAILS OVERLAY -->
           <div *ngIf="currentView == 'details' || exitingView == 'details'" class="details stage-left dom-overlay">
             <div class="content">
-              <h1 class="disk-name {{selectedDisk.name}}">{{selectedDisk.name}}</h1>
+              <h1 class="disk-name {{selectedDisk?.name}}">{{selectedDisk?.name}}</h1>
               <div class="title">
                 <span class="semibold">vdev: </span> 
                 <span *ngIf="selectedVdev.type == 'DISK'"> NONE </span>
@@ -118,7 +118,7 @@
               </div>
               <div class="title">
                 <span class="semibold">Slot: </span> 
-                <span>{{selectedDisk.enclosure.slot}}</span> 
+                <span>{{selectedDisk?.enclosure.slot}}</span> 
               </div>
             </div>
           </div>
@@ -127,7 +127,7 @@
             <div class="content" (mouseenter)="toggleHighlightMode('on')" (mouseleave)="toggleHighlightMode('off')">
 
               <div *ngIf="selectedVdevDisks; else noVdevDisks;" class="legend">
-                <div *ngFor="let disk of selectedVdevDisks; let i = index" class="vdev-disk {{disk}}"(mouseenter)="highlightPath(disk)" (mouseleave)="unhighlightPath(disk)"><div class="swatch" [style.background]="selectedDisk.devname == disk ? theme.yellow : theme.cyan"></div>{{disk}} <span> {{ selectedEnclosure.disks[disk] }}</span>
+                <div *ngFor="let disk of selectedVdevDisks; let i = index" class="vdev-disk {{disk}}"(mouseenter)="highlightPath(disk)" (mouseleave)="unhighlightPath(disk)"><div class="swatch" [style.background]="selectedDisk?.devname == disk ? theme.yellow : theme.cyan"></div>{{disk}} <span> {{ selectedEnclosure.disks[disk] }}</span>
                   <span *ngIf="!selectedVdev.slots[disk]">({{ selectedVdev.diskEnclosures[disk] == system.rearIndex ? 'Rear' : selectedVdev.diskEnclosures[disk] }})</span>
                 </div>
               </div>

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.html
@@ -11,7 +11,7 @@
   <mat-toolbar id="Disks-toolbar">
     <div *ngIf="selectedEnclosure" class="mat-card-title-text">
       {{currentTab.alias}} on 
-      {{system.enclosures[selectedEnclosure.enclosureKey].label == system.enclosures[selectedEnclosure.enclosureKey].name ? selectedEnclosure.model : system.enclosures[selectedEnclosure.enclosureKey].label}} 
+      {{selectedEnclosure.label == selectedEnclosure.name ? selectedEnclosure.model : selectedEnclosure.label}} 
       ({{selectedEnclosure.enclosureKey}})
     </div>
 
@@ -29,7 +29,7 @@
   </mat-toolbar>
 
   <!-- Tabs other than Disks -->
-  <tab-content class="other-tab" *ngIf="currentTab.alias !== 'Disks'" [data]="system.enclosures[selectedEnclosure.enclosureKey].elements[currentTab.elementIndex]" ></tab-content>
+  <tab-content class="other-tab" *ngIf="currentTab.alias !== 'Disks'" [data]="selectedEnclosure.enclosure.elements[currentTab.elementIndex]" ></tab-content>
   
   <mat-card-content id="Disks-content" [class]="currentTab.alias">
 

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
@@ -157,6 +157,11 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
     return scale > 1 ? 1 : scale;
   }
 
+  get enclosureLabel() {
+    const obj = this.system.enclosures[this.selectedEnclosure.enclosureKey];
+    return obj.label ? obj.label : this.selectedEnclosure.model;
+  }
+
   scaleArgs: string;
 
   constructor(

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
@@ -1079,7 +1079,8 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
     const self = this;
 
     const obj = self.system.enclosures[self.selectedEnclosure.enclosureKey];
-    const currentLabel = obj.label !== obj.name ? obj.label : self.selectedEnclosure.model;
+    // const currentLabel = obj.label !== obj.name ? obj.label : self.selectedEnclosure.model;
+    const currentLabel = obj.label ? obj.label : self.selectedEnclosure.model;
     const conf = {
       title: T('Change Enclosure Label'),
       fieldConfig: [

--- a/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/viewenclosure/enclosure-disks/enclosure-disks.component.ts
@@ -1060,7 +1060,7 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
   enclosureOverride(view: string) {
     if (view !== this.view) {
       this.selectedDisk = null;
-      this.clearDisk();
+      // this.clearDisk();
       this.loadEnclosure(this.selectedEnclosure, view, true);
     }
   }

--- a/src/app/pages/system/viewenclosure/view-enclosure.component.html
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.html
@@ -45,10 +45,10 @@
   
   <!-- Enclosure Selector -->
   <div fxFlex="240px" fxFlex.lt-lg="180px" #navigation  *ngIf="showEnclosureSelector" class="enclosure-selector" [ngClass.lt-lg]="'lt-lg'">
-    <ng-container *ngFor="let enclosure of system.profile; let i = index">
-      <div *ngIf="enclosure.enclosureKey != system.rearIndex" (click)="selectEnclosure(i)" class="enclosure enclosure-{{i}} {{selectedEnclosure.enclosureKey == i ? 'active' : '' }} ">
-        <div *ngIf="system.enclosures[enclosure.enclosureKey].label == system.enclosures[enclosure.enclosureKey].name">{{enclosure.model}} ({{i}})</div>
-        <div *ngIf="system.enclosures[enclosure.enclosureKey].label !== system.enclosures[enclosure.enclosureKey].name">{{system.enclosures[enclosure.enclosureKey].label}} ({{i}})</div>
+    <ng-container *ngFor="let profile of system.profile; let i = index">
+      <div *ngIf="profile.enclosureKey != system.rearIndex" (click)="selectEnclosure(i)" class="enclosure enclosure-{{i}} {{selectedEnclosure.enclosureKey == i ? 'active' : '' }} ">
+        <div *ngIf="profile.label == profile.name">{{profile.model}} ({{i}})</div>
+        <div *ngIf="profile.label !== profile.name">{{profile.label}} ({{i}})</div>
       </div>
     </ng-container>
   </div>

--- a/src/app/pages/system/viewenclosure/view-enclosure.component.ts
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.ts
@@ -245,7 +245,7 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
           view.icon = 'fan';
           views.push(view);
           break;
-        case 'Temperature Sensor':
+        case 'Temperature Sensors':
           view.alias = 'Temperature';
           view.icon = 'fan';
           views.push(view);
@@ -260,12 +260,12 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
           view.icon = 'flash';
           views.push(view);
           break;
-        case 'SAS Connector':
+        case 'SAS Expander':
           view.alias = 'SAS';
           view.icon = 'flash';
           views.push(view);
           break;
-        case 'Enclosure Services Controller Electronics':
+        case 'Enclosure':
           view.alias = 'Services';
           view.icon = 'flash';
           views.push(view);

--- a/src/app/pages/system/viewenclosure/view-enclosure.component.ts
+++ b/src/app/pages/system/viewenclosure/view-enclosure.component.ts
@@ -25,7 +25,7 @@ interface EnclosureResponse {
   number: string;
   name: string;
   model: string;
-  controller: string;
+  controller: boolean;
   label: string;
   elements: unknown[];
 }
@@ -126,11 +126,12 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
     });
 
     core.register({ observerClass: this, eventName: 'EnclosureData' }).subscribe((evt: CoreEvent) => {
-      evt.data = this.parseEnclosureData(evt.data);
+      evt.data = this.parseEnclosures(evt.data);
+      evt.data = this.sortEnclosures(evt.data);
 
       this.system = new SystemProfiler(this.system_product, evt.data);
       this.selectedEnclosure = this.system.profile[this.system.headIndex];
-      core.emit({ name: 'DisksRequest', sender: this });
+      core.emit({ name: 'DisksRequestExtra', sender: this });
       core.emit({ name: 'SensorDataRequest', sender: this });
     });
 
@@ -185,7 +186,7 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
 
   fetchData() {
     console.warn('Fetching Data...');
-    this.core.emit({ name: 'DisksRequest', sender: this });
+    this.core.emit({ name: 'DisksRequestExtra', sender: this });
   }
 
   ngAfterContentInit() {
@@ -228,7 +229,7 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
     views.unshift(disks);
     let matchIndex;
 
-    this.system.enclosures[this.selectedEnclosure.enclosureKey].elements.forEach((element, index) => {
+    this.selectedEnclosure.enclosure.elements.forEach((element, index) => {
       const view = {
         name: element.name,
         alias: '',
@@ -283,30 +284,59 @@ export class ViewEnclosureComponent implements AfterContentInit, OnChanges, OnDe
     }
   }
 
-  private parseEnclosureData(enclosures: EnclosureResponse[]): EnclosureResponse[] {
-    const parsedEnclosure: EnclosureResponse[] = [];
-
-    enclosures.forEach((enclosure, idx) => {
-      parsedEnclosure.push({
-        id: enclosure.id,
-        number: enclosure.number,
-        name: enclosure.name,
-        model: enclosure.model,
-        controller: enclosure.controller,
-        label: enclosure.label,
-        elements: [],
-      });
-      for (const [keyElem, valElem] of Object.entries(enclosure.elements)) {
-        const newElem = {
-          name: keyElem,
-          elements: [],
-        };
-        for (const [keySlot, valSlot] of Object.entries(valElem)) {
-          newElem.elements.push(Object.assign(valSlot, { slot: parseInt(keySlot) }));
-        }
-        parsedEnclosure[idx].elements.push(newElem);
+  private sortEnclosures(enclosures: EnclosureResponse[]): EnclosureResponse[] {
+    const sortedEnclosures: EnclosureResponse[] = [];
+    for (const enclosure of enclosures) {
+      if (!enclosure.id.includes('plx_enclosure') && enclosure.controller == true) {
+        sortedEnclosures.unshift(enclosure);
+      } else {
+        sortedEnclosures.push(enclosure);
       }
+    }
+    return sortedEnclosures;
+  }
+
+  private parseEnclosures(enclosures: EnclosureResponse[]): EnclosureResponse[] {
+    return enclosures.map((enclosure) => ({
+      id: enclosure.id,
+      number: enclosure.number,
+      name: enclosure.name,
+      model: enclosure.model,
+      controller: enclosure.controller,
+      label: enclosure.label,
+      elements: this.parseEnclosure(enclosure.elements),
+    } as EnclosureResponse));
+  }
+
+  private parseEnclosure(elements: Object): Object[] {
+    return Object.entries(elements).map(([keyElem, valElem]) => {
+      if (keyElem === 'Array Device Slot') {
+        return this.parseEnclosureSlotElements(keyElem, valElem);
+      }
+
+      return this.parseEnclosureOtherElements(keyElem, valElem);
     });
-    return parsedEnclosure;
+  }
+
+  private parseEnclosureSlotElements(name: string, elements: Object): Object {
+    return {
+      name,
+      elements: this.parseEnclosureElements(elements),
+      has_slot_status: true,
+    };
+  }
+
+  private parseEnclosureOtherElements(name: string, elements: Object): Object {
+    return {
+      name,
+      elements: this.parseEnclosureElements(elements),
+      has_slot_status: false,
+    };
+  }
+
+  private parseEnclosureElements(elements: Object): Object[] {
+    return Object.entries(elements)
+      .slice(1) // skip 1st key
+      .map(([keySlot, valSlot]) => Object.assign(valSlot, { slot: parseInt(keySlot) }));
   }
 }


### PR DESCRIPTION
Summary:
- adapted the UI code to a new response of `enclosure.query` (use new parameters `{ extra: { pools: true } }`)
- changed order so that controller module are always displayed at the top 

Testing:
1. connect your setup to testing machine `m60-100.dc1.ixsystems.net` 
2. System -> View Enclosure


https://user-images.githubusercontent.com/20611516/156405176-31fad5e9-987e-4df6-891e-77b3a18c1344.mp4
- "m60" module should be on the top
- check that disks are displayed at proper slots in each enclosure (
   - first ~24 front
   - others ~100 disks each
- check that table rows contain proper sensor data on each tab for each enclosure


https://user-images.githubusercontent.com/20611516/156405198-115d0653-34fa-4239-be93-1c72306ca405.mp4
- check Front - should contain ~23 disks
- check Rear - should contain 4 disks




