### PR TITLE
NAS-115186 / 22.12 / NAS-115186: Added missing module

### DIFF
--- a/src/app/modules/tooltip/tooltip.module.ts
+++ b/src/app/modules/tooltip/tooltip.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxPopperjsModule } from 'ngx-popperjs';
 import { CommonDirectivesModule } from 'app/directives/common/common-directives.module';
@@ -14,6 +15,7 @@ import { TooltipComponent } from 'app/modules/tooltip/tooltip.component';
     TranslateModule,
     CommonDirectivesModule,
     CastModule,
+    MatIconModule,
   ],
   declarations: [
     TooltipComponent,


### PR DESCRIPTION
The close icon on tooltips wasn't showing due to the missing module. That should be fixed now.
