### PR TITLE
NAS-115224 / 22.12 / NAS-115224: Fixed drag

### DIFF
--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.html
@@ -47,7 +47,7 @@
               *ngSwitchCase="'help'"
               ixDrag
               [showReorderHandle]="reorderMode"
-            ></widget-help>
+            ><span ixDragHandle></span></widget-help>
 
             <widget-cpu *ngSwitchCase="'cpu'"
               fxFlex="{{widgetWidth}}px"


### PR DESCRIPTION
The help widget is draggable all the time. Even when the dashboard is not being re-ordered. You can click on it and drag it around. This PR fixes that.