### PR TITLE
NAS-114089 / 22.12 / NAS-114089: Fixed overlap and scroll issue

### DIFF
--- a/src/app/modules/entity/entity-table/entity-table-row-details/entity-table-row-details.component.html
+++ b/src/app/modules/entity/entity-table/entity-table-row-details/entity-table-row-details.component.html
@@ -45,25 +45,27 @@
   class="wrapper__action-buttons"
   *ngIf="parent.hasActions"
 >
-  <ng-container *ngFor="let action of actions">
-    <button
-      *ngIf="!parent.conf.isActionVisible || parent.conf.isActionVisible.bind(parent.conf)(action.id, this.config)"
-      mat-button
-      [disabled]="action.disabled"
-      id="action_button_{{ action?.name }}__{{action.id}}"
-      [ix-auto]="config.name"
-      ix-auto-type="button"
-      ix-auto-identifier="{{ action?.name | uppercase }}_{{action.id}}"
-      (click)="action.onClick(this.config)"
-    >
-      <div fxLayoutAlign="center center" fxLayoutGap="8px">
-        <mat-icon>{{ action.icon }}</mat-icon>
-        <p
-          [matTooltip]="action.matTooltip"
-          [matTooltipDisabled]="!action.disabled"
-          [matTooltipPosition]="action.ttposition ? action.ttposition : 'below'"
-        >{{ action.label | translate}}</p>
-      </div>
-    </button>
-  </ng-container>
+  <div class="wrap-buttons-container">
+    <ng-container *ngFor="let action of actions">
+      <button
+        *ngIf="!parent.conf.isActionVisible || parent.conf.isActionVisible.bind(parent.conf)(action.id, this.config)"
+        mat-button
+        [disabled]="action.disabled"
+        id="action_button_{{ action?.name }}__{{action.id}}"
+        [ix-auto]="config.name"
+        ix-auto-type="button"
+        ix-auto-identifier="{{ action?.name | uppercase }}_{{action.id}}"
+        (click)="action.onClick(this.config)"
+      >
+        <div fxLayoutAlign="center center" fxLayoutGap="8px">
+          <mat-icon>{{ action.icon }}</mat-icon>
+          <p
+            [matTooltip]="action.matTooltip"
+            [matTooltipDisabled]="!action.disabled"
+            [matTooltipPosition]="action.ttposition ? action.ttposition : 'below'"
+          >{{ action.label | translate}}</p>
+        </div>
+      </button>
+    </ng-container>
+  </div>
 </div>

--- a/src/app/modules/entity/entity-table/entity-table-row-details/entity-table-row-details.component.scss
+++ b/src/app/modules/entity/entity-table/entity-table-row-details/entity-table-row-details.component.scss
@@ -34,3 +34,10 @@
     background-color: rgba(0, 0, 0, 0.1);
   }
 }
+
+.wrap-buttons-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 2px;
+}

--- a/src/app/modules/entity/entity-table/entity-table.component.html
+++ b/src/app/modules/entity/entity-table/entity-table.component.html
@@ -64,8 +64,25 @@
             [sticky]="isLeftStickyColumnNo(i)"
             matColumnDef="{{column}}"
           >
-            <th [ngClass]="{'sticky-left-offset': shouldApplyStickyOffset(i), 'sticky-border-right': isLeftStickyColumnNo(i) && isTableOverflow()}" class="data-column" mat-header-cell *matHeaderCellDef>{{ currentColumns[i].name | translate }}</th>
-            <td [ngClass]="{'sticky-left-offset': shouldApplyStickyOffset(i), 'sticky-border-right': isLeftStickyColumnNo(i) && isTableOverflow()}" [ngStyle]="{'cursor': (checkLength() && !conf.onRowClick) ? 'auto' : 'pointer'}" class="data-column" (mouseover)="onHover($event, true)" (mouseout)="onHover($event, false)" mat-cell *matCellDef="let element">
+            <th
+              [class.sticky-left-offset]="shouldApplyStickyOffset(i)"
+              [class.sticky-border-right]="isLeftStickyColumnNo(i) && isTableOverflow()"
+              [class.padded-away]="!shouldApplyStickyOffset(i) && !(isLeftStickyColumnNo(i) && isTableOverflow())"
+              class="data-column" 
+              mat-header-cell 
+              *matHeaderCellDef
+            >{{ currentColumns[i].name | translate }}</th>
+            <td
+              [class.sticky-left-offset]="shouldApplyStickyOffset(i)"
+              [class.sticky-border-right]="isLeftStickyColumnNo(i) && isTableOverflow()"
+              [ngStyle]="{ 'cursor': (checkLength() && !conf.onRowClick) ? 'auto' : 'pointer' }" 
+              [class.padded-away]="!shouldApplyStickyOffset(i) && !(isLeftStickyColumnNo(i) && isTableOverflow())"
+              class="data-column" 
+              (mouseover)="onHover($event, true)" 
+              (mouseout)="onHover($event, false)" 
+              mat-cell 
+              *matCellDef="let element"
+            >
               <div class="text-overflow-ellipsis" [matTooltip]="currentColumns[i].enableMatTooltip ? element[column] : null">{{element[column]}}</div>
             </td>
           </ng-container>
@@ -142,8 +159,20 @@
 
           <!-- Interactive Toggle Column -->
           <ng-container *ngIf="column == 'state' && isInteractive(column)" matColumnDef="{{column}}">
-            <th class="toggle-column" mat-header-cell *matHeaderCellDef>{{ currentColumns[i].name | translate }}</th>
-            <td class="toggle-column" mat-cell *matCellDef="let element" (mouseover)="onHover($event, true)" (mouseout)="onHover($event, false)">
+            <th 
+              [class.padded-away]="!shouldApplyStickyOffset(i) && !(isLeftStickyColumnNo(i) && isTableOverflow())"
+              class="toggle-column" 
+              mat-header-cell 
+              *matHeaderCellDef
+            >{{ currentColumns[i].name | translate }}</th>
+            <td 
+              class="toggle-column" 
+              [class.padded-away]="!shouldApplyStickyOffset(i) && !(isLeftStickyColumnNo(i) && isTableOverflow())"
+              mat-cell 
+              *matCellDef="let element" 
+              (mouseover)="onHover($event, true)" 
+              (mouseout)="onHover($event, false)"
+            >
               <mat-spinner [diameter]='40' *ngIf="element['onChanging']; else actionButtons"></mat-spinner>
               <ng-template #actionButtons>
                 <!-- Toggle -->
@@ -177,16 +206,29 @@
 
           <!-- Interactive Checkbox Column -->
           <ng-container *ngIf="['enabled', 'enable', 'autostart'].includes(column) && isInteractive(column)" matColumnDef="{{column}}">
-            <th class="toggle-column" mat-header-cell *matHeaderCellDef>{{ currentColumns[i].name | translate }}</th>
-            <td class="toggle-column" mat-cell *matCellDef="let element" (mouseover)="onHover($event, true)" (mouseout)="onHover($event, false)">
+            <th 
+              [class.padded-away]="!shouldApplyStickyOffset(i) && !(isLeftStickyColumnNo(i) && isTableOverflow())"
+              class="toggle-column" 
+              mat-header-cell 
+              *matHeaderCellDef
+            >{{ currentColumns[i].name | translate }}</th>
+            <td 
+              class="toggle-column" 
+              mat-cell 
+              *matCellDef="let element" 
+              [class.padded-away]="!shouldApplyStickyOffset(i) && !(isLeftStickyColumnNo(i) && isTableOverflow())"
+              (mouseover)="onHover($event, true)" 
+              (mouseout)="onHover($event, false)"
+            >
               <mat-checkbox
-              color="primary"
-              id="checkbox__{{element.name}}"
-              class="checkbox"
-              [(ngModel)]="element[column]"
-              (change)="this.conf.onCheckboxChange(element)"
-              (click)="$event.stopPropagation()"
-              ix-auto ix-auto-type="checkbox" ix-auto-identifier="{{ column }}__{{ element.name}}"></mat-checkbox>
+                color="primary"
+                id="checkbox__{{element.name}}"
+                class="checkbox"
+                [(ngModel)]="element[column]"
+                (change)="this.conf.onCheckboxChange(element)"
+                (click)="$event.stopPropagation()"
+                ix-auto ix-auto-type="checkbox" ix-auto-identifier="{{ column }}__{{ element.name}}"
+              ></mat-checkbox>
             </td>
           </ng-container>
 

--- a/src/app/modules/entity/entity-table/entity-table.component.scss
+++ b/src/app/modules/entity/entity-table/entity-table.component.scss
@@ -301,6 +301,7 @@ div#cardHeaderContainer {
 
 .sticky-border-right {
   border-right: 1px solid var(--lines);
+  padding-right: 5px;
 }
 
 button div.label-warning-icon {
@@ -361,4 +362,12 @@ div.mat-card-table {
   box-shadow: none;
   color: inherit;
   cursor: pointer;
+}
+
+.mat-table-sticky {
+  z-index: 2 !important;
+}
+
+.padded-away {
+  padding-left: 10px;
 }

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -57,7 +57,9 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
     {
       name: this.translate.instant('State') as string, prop: 'state', always_display: true, toggle: true,
     },
-    { name: this.translate.instant('Autostart') as string, prop: 'autostart', checkbox: true },
+    {
+      name: this.translate.instant('Autostart') as string, prop: 'autostart', checkbox: true, always_display: true,
+    },
     { name: this.translate.instant('Virtual CPUs') as string, prop: 'vcpus', hidden: true },
     { name: this.translate.instant('Cores') as string, prop: 'cores', hidden: true },
     { name: this.translate.instant('Threads') as string, prop: 'threads', hidden: true },


### PR DESCRIPTION
The virtualization table had issues of overlap columns by first and last columns due to them being `sticky`. Check responsive of the table with different column configurations and responsiveness on different screen sizes. Also, the border on the left column for scroll shouldn't touch the next column (usually the toggle) as complained about in the ticket comments.