### PR TITLE
NAS-115254 / 22.12 / NAS-115254: In UI preserve protocol/port when opening up display of vm devices

### DIFF
--- a/src/app/interfaces/virtual-machine.interface.ts
+++ b/src/app/interfaces/virtual-machine.interface.ts
@@ -42,9 +42,9 @@ export type VmStopParams = [
 export type VmDisplayWebUriParams = [
   id: number,
   domain: string,
-  protocol?: string,
   options?: {
-    devices_passwords: [
+    protocol?: string;
+    devices_passwords?: [
       {
         device_id: number;
         password: string;

--- a/src/app/interfaces/virtual-machine.interface.ts
+++ b/src/app/interfaces/virtual-machine.interface.ts
@@ -50,6 +50,7 @@ export type VmDisplayWebUriParams = [
       },
     ];
   },
+  protocol?: string,
 ];
 
 export interface VmPortWizardResult {

--- a/src/app/interfaces/virtual-machine.interface.ts
+++ b/src/app/interfaces/virtual-machine.interface.ts
@@ -42,6 +42,7 @@ export type VmStopParams = [
 export type VmDisplayWebUriParams = [
   id: number,
   domain: string,
+  protocol?: string,
   options?: {
     devices_passwords: [
       {
@@ -50,7 +51,6 @@ export type VmDisplayWebUriParams = [
       },
     ];
   },
-  protocol?: string,
 ];
 
 export interface VmPortWizardResult {

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -494,7 +494,7 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
                 [
                   vm.id,
                   window.location.host,
-                  window.location.protocol.replace(':', ''),
+                  { protocol: window.location.protocol.replace(':', '').toUpperCase() },
                 ],
               ).pipe(untilDestroyed(this)).subscribe((webUris) => {
                 this.loader.close();
@@ -534,7 +534,7 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
                     [
                       vm.id,
                       window.location.host,
-                      window.location.protocol.replace(':', ''),
+                      { protocol: window.location.protocol.replace(':', '').toUpperCase() },
                     ],
                   ).pipe(untilDestroyed(this)).subscribe((webUris) => {
                     this.loader.close();
@@ -612,8 +612,8 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
           [
             vm.id,
             window.location.host,
-            window.location.protocol.replace(':', ''),
             {
+              protocol: window.location.protocol.replace(':', '').toUpperCase(),
               devices_passwords: [
                 {
                   device_id: displayDevice.id,

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -278,19 +278,6 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
     });
   }
 
-  extractHostname(url: string): string {
-    let hostname: string;
-    if (url.includes('//')) {
-      hostname = url.split('/')[2];
-    } else {
-      hostname = url.split('/')[0];
-    }
-    hostname = hostname.split(':')[0];
-    hostname = hostname.split('?')[0];
-
-    return hostname;
-  }
-
   doRowAction(row: VirtualMachineRow, method: ApiMethod, params: unknown[] = [row.id], updateTable = false): void {
     if (method === this.wsMethods.stop) {
       this.dialogRef = this.dialog.open(EntityJobComponent,
@@ -506,7 +493,9 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
                 'vm.get_display_web_uri',
                 [
                   vm.id,
-                  this.extractHostname(window.origin),
+                  window.location.host,
+                  undefined,
+                  window.location.protocol.replace(':', ''),
                 ],
               ).pipe(untilDestroyed(this)).subscribe((webUris) => {
                 this.loader.close();
@@ -545,7 +534,9 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
                     'vm.get_display_web_uri',
                     [
                       vm.id,
-                      this.extractHostname(window.origin),
+                      window.location.host,
+                      undefined,
+                      window.location.protocol.replace(':', ''),
                     ],
                   ).pipe(untilDestroyed(this)).subscribe((webUris) => {
                     this.loader.close();
@@ -622,7 +613,7 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
           'vm.get_display_web_uri',
           [
             vm.id,
-            this.extractHostname(window.origin),
+            window.location.host,
             {
               devices_passwords: [
                 {

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -494,7 +494,6 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
                 [
                   vm.id,
                   window.location.host,
-                  undefined,
                   window.location.protocol.replace(':', ''),
                 ],
               ).pipe(untilDestroyed(this)).subscribe((webUris) => {
@@ -535,7 +534,6 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
                     [
                       vm.id,
                       window.location.host,
-                      undefined,
                       window.location.protocol.replace(':', ''),
                     ],
                   ).pipe(untilDestroyed(this)).subscribe((webUris) => {
@@ -614,6 +612,7 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
           [
             vm.id,
             window.location.host,
+            window.location.protocol.replace(':', ''),
             {
               devices_passwords: [
                 {


### PR DESCRIPTION
Summary: 

Adapted to back-end changes made to WS call **web_uri** [here](https://github.com/truenas/middleware/pull/8528)

- new parameter `protocol`, example: `protocol: 'https'`
- parameter `host` now accepts host & port. example: `host: 'localhost:4200'`

Testing: 

1. (Optional) Download middleware update from latest night build ("-manual-update-unsigned.tar" file should work)

2. Virtualization -> (Expand "vm" row) -> "Display" button (you may mock the data to actually make it visible)

3. WS call **web_uri** should be made with correct parameters, taken from your browser's address bar.
   Example:
   - User visits Angular app via **http**://localhost:4200 -> **Display** button opens **http**://localhost:5800/vnc.html?autoconnect=1 **CORRECT**
   - User visits Angular app via http://localhost:**4200** -> **Display** button sends  `host: "localhost:4200"` **CORRECT**