### PR TITLE
NAS-115077 / 22.02.1 / NAS-115077: Show close button after abort

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -446,6 +446,9 @@ export class CloudsyncFormComponent implements FormConfiguration {
         dialogRef.componentInstance.showRealtimeLogs = true;
         dialogRef.componentInstance.hideProgressValue = true;
         dialogRef.componentInstance.submit();
+        dialogRef.componentInstance.aborted.pipe(untilDestroyed(this)).subscribe(() => {
+          dialogRef.componentInstance.showCloseButton = true;
+        });
         dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
           dialogRef.componentInstance.showCloseButton = true;
           // this.matDialog.closeAll();


### PR DESCRIPTION
Go to the Add new cloud sync task form and after entering the values (Google Photos preferably), do a dry run. You should see the abort button and after abort, the dialog should be closable.