### PR TITLE
NAS-115262 / 22.12 / Added certificates links under certificate inputs

### DIFF
--- a/src/app/modules/entity/entity-form/components/form-select/form-select.component.html
+++ b/src/app/modules/entity/entity-form/components/form-select/form-select.component.html
@@ -115,6 +115,11 @@
       </ng-container>
     </mat-select>
   </mat-form-field>
+
+  <div *ngIf="config.linkText">
+    <a (click)="linkClicked()" class="link">{{ config.linkText | translate }}<mat-icon style="font-size: x-small;">open_in_new</mat-icon></a>
+  </div>
+
   <div class="margin-for-error">
     <form-errors [control]="group.controls[config.name]" [config]="config"></form-errors>
     <mat-error *ngIf="config['hasErrors']"><div [innerHTML]="config['errors']"></div></mat-error>

--- a/src/app/modules/entity/entity-form/components/form-select/form-select.component.scss
+++ b/src/app/modules/entity/entity-form/components/form-select/form-select.component.scss
@@ -19,6 +19,12 @@
   padding: 8px;
 }
 
+.link {
+  color: var(--primary);
+  cursor: pointer;
+  font-size: x-small;
+}
+
 :host-context(app-system-alert) {
   .inline-label label.label.input-select {
     padding: 8px !important;

--- a/src/app/modules/entity/entity-form/components/form-select/form-select.component.ts
+++ b/src/app/modules/entity/entity-form/components/form-select/form-select.component.ts
@@ -114,6 +114,12 @@ export class FormSelectComponent implements Field, AfterViewInit, AfterViewCheck
     });
   }
 
+  linkClicked(): void {
+    if (this.config.linkClicked) {
+      this.config.linkClicked();
+    }
+  }
+
   ngAfterViewChecked(): void {
     if (!this.formReady && typeof this.config.options !== 'undefined' && this.config.options && this.config.options.length > 0) {
       const newStates = this.config.options.map((item) => item && this.selectedValues.includes(item.value));

--- a/src/app/modules/entity/entity-form/models/field-config.interface.ts
+++ b/src/app/modules/entity/entity-form/models/field-config.interface.ts
@@ -211,6 +211,8 @@ export interface FormSelectConfig<P = unknown> extends BaseFieldConfig<P> {
   enableTextWrapForOptions?: boolean;
   fileLocation?: string;
   inlineLabel?: string;
+  linkText?: string;
+  linkClicked?(): void;
   isLoading?: boolean;
   multiple?: boolean;
   onChangeOption?(data: { event: MatSelectChange }): void;

--- a/src/app/modules/ix-forms/components/ix-input/ix-input.component.html
+++ b/src/app/modules/ix-forms/components/ix-input/ix-input.component.html
@@ -39,11 +39,17 @@
     <i class="material-icons" matTooltip="Show" *ngIf="!showPassword">visibility_off</i>
   </button>
 </div>
+
+<div *ngIf="linkText">
+  <a (click)="linkClicked.emit()" class="link">{{ linkText | translate }}<mat-icon style="font-size: x-small;">open_in_new</mat-icon></a>
+</div>
+
 <div *ngIf="invalid">
   <mat-error>
     <div [innerHTML]="invalidMessage()"></div>
   </mat-error>
 </div>
+
 <ix-errors [control]="controlDirective.control" [label]="label"></ix-errors>
 
 <mat-hint *ngIf="hint">{{hint}}</mat-hint>

--- a/src/app/modules/ix-forms/components/ix-input/ix-input.component.scss
+++ b/src/app/modules/ix-forms/components/ix-input/ix-input.component.scss
@@ -46,6 +46,12 @@
   }
 }
 
+.link {
+  color: var(--primary);
+  cursor: pointer;
+  font-size: x-small;
+}
+
 .label-container {
   margin-bottom: 1px;
   margin-left: 1px;

--- a/src/app/modules/ix-forms/components/ix-input/ix-input.component.ts
+++ b/src/app/modules/ix-forms/components/ix-input/ix-input.component.ts
@@ -1,5 +1,5 @@
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Input,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output,
 } from '@angular/core';
 import { ControlValueAccessor, FormControl, NgControl } from '@angular/forms';
 import { UntilDestroy } from '@ngneat/until-destroy';
@@ -22,6 +22,8 @@ export class IxInputComponent implements ControlValueAccessor {
   @Input() readonly: boolean;
   @Input() type: string;
   @Input() autocomplete = 'off';
+  @Output() linkClicked: EventEmitter<void> = new EventEmitter();
+  @Input() linkText: string = null;
 
   /** If formatted value returned by parseAndFormatInput has non-numeric letters
    * and input 'type' is a number, the input will stay empty on the form */

--- a/src/app/modules/ix-forms/components/ix-select/ix-select.component.html
+++ b/src/app/modules/ix-forms/components/ix-select/ix-select.component.html
@@ -27,6 +27,11 @@
       </ng-template>
     </mat-select>
   </div>
+
+
+  <div *ngIf="linkText">
+    <a (click)="linkClicked.emit()" class="link">{{ linkText | translate }}<mat-icon style="font-size: x-small;">open_in_new</mat-icon></a>
+  </div>
   <ix-errors [control]="controlDirective.control" [label]="label"></ix-errors>
 
   <mat-hint *ngIf="hint">{{ hint }}</mat-hint>

--- a/src/app/modules/ix-forms/components/ix-select/ix-select.component.scss
+++ b/src/app/modules/ix-forms/components/ix-select/ix-select.component.scss
@@ -19,6 +19,12 @@
   margin-left: 8px;
 }
 
+.link {
+  color: var(--primary);
+  cursor: pointer;
+  font-size: x-small;
+}
+
 .input-container {
   background: var(--bg1);
   border: solid 1px var(--lines);

--- a/src/app/modules/ix-forms/components/ix-select/ix-select.component.ts
+++ b/src/app/modules/ix-forms/components/ix-select/ix-select.component.ts
@@ -1,6 +1,6 @@
 import {
   ChangeDetectionStrategy, ChangeDetectorRef,
-  Component, Input, OnChanges,
+  Component, EventEmitter, Input, OnChanges, Output,
 } from '@angular/core';
 import {
   ControlValueAccessor, FormControl, NgControl,
@@ -27,6 +27,8 @@ export class IxSelectComponent implements ControlValueAccessor, OnChanges {
   @Input() required: boolean;
   @Input() tooltip: string;
   @Input() multiple: boolean;
+  @Output() linkClicked: EventEmitter<void> = new EventEmitter();
+  @Input() linkText: string = null;
 
   constructor(
     public controlDirective: NgControl,

--- a/src/app/pages/directory-service/components/idmap/idmap-form.component.ts
+++ b/src/app/pages/directory-service/components/idmap/idmap-form.component.ts
@@ -122,7 +122,7 @@ export class IdmapFormComponent implements FormConfiguration {
         {
           type: 'select',
           name: 'certificate',
-          placeholder: 'Rehan Cert', // helptext.idmap.certificate_id.placeholder,
+          placeholder: helptext.idmap.certificate_id.placeholder,
           tooltip: helptext.idmap.certificate_id.tooltip,
           options: [],
           linkText: this.translate.instant('Certificates'),

--- a/src/app/pages/directory-service/components/idmap/idmap-form.component.ts
+++ b/src/app/pages/directory-service/components/idmap/idmap-form.component.ts
@@ -3,6 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatDialogRef } from '@angular/material/dialog/dialog-ref';
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { TranslateService } from '@ngx-translate/core';
 import * as _ from 'lodash';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -124,7 +125,7 @@ export class IdmapFormComponent implements FormConfiguration {
           placeholder: 'Rehan Cert', // helptext.idmap.certificate_id.placeholder,
           tooltip: helptext.idmap.certificate_id.tooltip,
           options: [],
-          linkText: 'Certificates',
+          linkText: this.translate.instant('Certificates'),
           linkClicked: () => {
             this.modalService.closeSlideIn().then(() => {
               this.router.navigate(['/', 'credentials', 'certificates']);
@@ -295,7 +296,7 @@ export class IdmapFormComponent implements FormConfiguration {
   ];
 
   constructor(protected idmapService: IdmapService, protected validationService: ValidationService,
-    private modalService: ModalService, private router: Router,
+    private modalService: ModalService, private router: Router, private translate: TranslateService,
     protected dialogService: DialogService, protected dialog: MatDialog) {
     this.getRow = this.modalService.getRow$.pipe(untilDestroyed(this)).subscribe((rowId: number) => {
       this.pk = rowId;

--- a/src/app/pages/directory-service/components/idmap/idmap-form.component.ts
+++ b/src/app/pages/directory-service/components/idmap/idmap-form.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatDialogRef } from '@angular/material/dialog/dialog-ref';
+import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import * as _ from 'lodash';
 import { Subscription } from 'rxjs';
@@ -120,12 +121,17 @@ export class IdmapFormComponent implements FormConfiguration {
         {
           type: 'select',
           name: 'certificate',
-          placeholder: helptext.idmap.certificate_id.placeholder,
+          placeholder: 'Rehan Cert', // helptext.idmap.certificate_id.placeholder,
           tooltip: helptext.idmap.certificate_id.tooltip,
           options: [],
+          linkText: 'Certificates',
+          linkClicked: () => {
+            this.modalService.closeSlideIn().then(() => {
+              this.router.navigate(['/', 'credentials', 'certificates']);
+            });
+          },
           isHidden: true,
         },
-
       ],
     },
     {
@@ -289,7 +295,7 @@ export class IdmapFormComponent implements FormConfiguration {
   ];
 
   constructor(protected idmapService: IdmapService, protected validationService: ValidationService,
-    private modalService: ModalService,
+    private modalService: ModalService, private router: Router,
     protected dialogService: DialogService, protected dialog: MatDialog) {
     this.getRow = this.modalService.getRow$.pipe(untilDestroyed(this)).subscribe((rowId: number) => {
       this.pk = rowId;

--- a/src/app/pages/directory-service/components/ldap/ldap.component.ts
+++ b/src/app/pages/directory-service/components/ldap/ldap.component.ts
@@ -137,7 +137,7 @@ export class LdapComponent implements FormConfiguration {
           placeholder: helptext.ldap_certificate_placeholder,
           tooltip: helptext.ldap_certificate_tooltip,
           options: [{ label: '---', value: null }],
-          linkText: 'Certificates',
+          linkText: this.translate.instant('Certificates'),
           linkClicked: () => {
             this.modalService.closeSlideIn().then(() => {
               this.router.navigate(['/', 'credentials', 'certificates']);

--- a/src/app/pages/directory-service/components/ldap/ldap.component.ts
+++ b/src/app/pages/directory-service/components/ldap/ldap.component.ts
@@ -22,6 +22,7 @@ import {
   SystemGeneralService,
   WebSocketService,
   DialogService,
+  AppLoaderService,
 } from 'app/services';
 import { ModalService } from 'app/services/modal.service';
 
@@ -136,6 +137,12 @@ export class LdapComponent implements FormConfiguration {
           placeholder: helptext.ldap_certificate_placeholder,
           tooltip: helptext.ldap_certificate_tooltip,
           options: [{ label: '---', value: null }],
+          linkText: 'Certificates',
+          linkClicked: () => {
+            this.modalService.closeSlideIn().then(() => {
+              this.router.navigate(['/', 'credentials', 'certificates']);
+            });
+          },
         },
         {
           type: 'checkbox',
@@ -225,6 +232,7 @@ export class LdapComponent implements FormConfiguration {
     private modalService: ModalService,
     private dialogService: DialogService,
     private matDialog: MatDialog,
+    private loader: AppLoaderService,
     private systemGeneralService: SystemGeneralService,
     private translate: TranslateService,
   ) { }

--- a/src/app/pages/directory-service/directory-services.component.ts
+++ b/src/app/pages/directory-service/directory-services.component.ts
@@ -186,8 +186,7 @@ export class DirectoryServicesComponent implements OnInit {
   ngOnInit(): void {
     this.refreshCards();
     merge(
-      this.modalService.onClose$,
-      this.slideInService.onClose$,
+      this.slideInService.onClose$.pipe(filter((res) => !!res)),
       this.modalService.refreshTable$,
     )
       .pipe(untilDestroyed(this))

--- a/src/app/pages/network/components/download-client-config-modal/download-client-config-modal.component.html
+++ b/src/app/pages/network/components/download-client-config-modal/download-client-config-modal.component.html
@@ -5,6 +5,8 @@
     [label]="'Client Certificate' | translate"
     [options]="serverCertificates$"
     [required]="true"
+    [linkText]="'Certificates'"
+    (linkClicked)="certificatesLinkClicked()"
   ></ix-select>
 </div>
 <div mat-dialog-actions class="buttons">

--- a/src/app/pages/network/components/download-client-config-modal/download-client-config-modal.component.html
+++ b/src/app/pages/network/components/download-client-config-modal/download-client-config-modal.component.html
@@ -5,7 +5,7 @@
     [label]="'Client Certificate' | translate"
     [options]="serverCertificates$"
     [required]="true"
-    [linkText]="'Certificates'"
+    [linkText]="'Certificates' | translate"
     (linkClicked)="certificatesLinkClicked()"
   ></ix-select>
 </div>

--- a/src/app/pages/network/components/download-client-config-modal/download-client-config-modal.component.ts
+++ b/src/app/pages/network/components/download-client-config-modal/download-client-config-modal.component.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
+import { Router } from '@angular/router';
 import { FormControl } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { switchMap } from 'rxjs/operators';
@@ -11,6 +12,7 @@ import { EntityUtils } from 'app/modules/entity/utils';
 import {
   AppLoaderService, DialogService, ServicesService, StorageService, WebSocketService,
 } from 'app/services';
+import { IxSlideInService } from 'app/services/ix-slide-in.service';
 
 @UntilDestroy()
 @Component({
@@ -28,6 +30,8 @@ export class DownloadClientConfigModalComponent {
     private dialogService: DialogService,
     private dialogRef: MatDialogRef<DownloadClientConfigModalComponent>,
     private services: ServicesService,
+    private router: Router,
+    private slideInService: IxSlideInService,
     private storageService: StorageService,
   ) {}
 
@@ -53,5 +57,11 @@ export class DownloadClientConfigModalComponent {
           new EntityUtils().handleWsError(this, error, this.dialogService);
         },
       );
+  }
+
+  certificatesLinkClicked(): void {
+    this.dialogRef.close();
+    this.slideInService.close();
+    this.router.navigate(['/', 'credentials', 'certificates']);
   }
 }

--- a/src/app/pages/network/components/forms/service-openvpn-client.component.ts
+++ b/src/app/pages/network/components/forms/service-openvpn-client.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import * as _ from 'lodash';
@@ -8,7 +9,7 @@ import { OpenvpnClientConfigUpdate } from 'app/interfaces/openvpn-client-config.
 import { EntityFormComponent } from 'app/modules/entity/entity-form/entity-form.component';
 import { FieldConfig, FormSelectConfig } from 'app/modules/entity/entity-form/models/field-config.interface';
 import { FieldSet } from 'app/modules/entity/entity-form/models/fieldset.interface';
-import { ServicesService } from 'app/services';
+import { ModalService, ServicesService } from 'app/services';
 
 @UntilDestroy()
 @Component({
@@ -31,6 +32,12 @@ export class OpenvpnClientComponent implements FormConfiguration {
           placeholder: helptext.certificate.client_placeholder,
           tooltip: helptext.certificate.tooltip,
           options: [],
+          linkText: 'Certificates',
+          linkClicked: () => {
+            this.modalService.closeSlideIn().then(() => {
+              this.router.navigate(['/', 'credentials', 'certificates']);
+            });
+          },
         },
         {
           type: 'select',
@@ -38,6 +45,12 @@ export class OpenvpnClientComponent implements FormConfiguration {
           placeholder: helptext.root_ca.placeholder,
           tooltip: helptext.root_ca.tooltip,
           options: [],
+          linkText: 'Certificate Authorities',
+          linkClicked: () => {
+            this.modalService.closeSlideIn().then(() => {
+              this.router.navigate(['/', 'credentials', 'certificates']);
+            });
+          },
         },
         {
           type: 'input',
@@ -127,6 +140,7 @@ export class OpenvpnClientComponent implements FormConfiguration {
   constructor(
     protected services: ServicesService,
     protected translate: TranslateService,
+    private router: Router, private modalService: ModalService,
   ) { }
 
   afterInit(entityEdit: EntityFormComponent): void {

--- a/src/app/pages/network/components/forms/service-openvpn-client.component.ts
+++ b/src/app/pages/network/components/forms/service-openvpn-client.component.ts
@@ -32,7 +32,7 @@ export class OpenvpnClientComponent implements FormConfiguration {
           placeholder: helptext.certificate.client_placeholder,
           tooltip: helptext.certificate.tooltip,
           options: [],
-          linkText: 'Certificates',
+          linkText: this.translate.instant('Certificates'),
           linkClicked: () => {
             this.modalService.closeSlideIn().then(() => {
               this.router.navigate(['/', 'credentials', 'certificates']);
@@ -45,7 +45,7 @@ export class OpenvpnClientComponent implements FormConfiguration {
           placeholder: helptext.root_ca.placeholder,
           tooltip: helptext.root_ca.tooltip,
           options: [],
-          linkText: 'Certificate Authorities',
+          linkText: this.translate.instant('Certificate Authorities'),
           linkClicked: () => {
             this.modalService.closeSlideIn().then(() => {
               this.router.navigate(['/', 'credentials', 'certificates']);

--- a/src/app/pages/network/components/open-vpn-server-config/open-vpn-server-config.component.html
+++ b/src/app/pages/network/components/open-vpn-server-config/open-vpn-server-config.component.html
@@ -11,7 +11,7 @@
               [required]="true"
               [options]="serverCertificates$"
               (linkClicked)="certificatesLinkClicked()"
-              [linkText]="'Certificates'"
+              [linkText]="'Certificates' | translate"
               [tooltip]="tooltips.server_certificate | translate"
             ></ix-select>
             <ix-select
@@ -20,7 +20,7 @@
               [required]="true"
               [options]="rootAuthorities$"
               [tooltip]="tooltips.root_ca | translate"
-              [linkText]="'Certificate Authorities'"
+              [linkText]="'Certificate Authorities' | translate"
               [tooltip]="tooltips.server_certificate | translate"
             ></ix-select>
             <ix-ip-input-with-netmask

--- a/src/app/pages/network/components/open-vpn-server-config/open-vpn-server-config.component.html
+++ b/src/app/pages/network/components/open-vpn-server-config/open-vpn-server-config.component.html
@@ -10,6 +10,8 @@
               [label]="'Server Certificate' | translate"
               [required]="true"
               [options]="serverCertificates$"
+              (linkClicked)="certificatesLinkClicked()"
+              [linkText]="'Certificates'"
               [tooltip]="tooltips.server_certificate | translate"
             ></ix-select>
             <ix-select
@@ -18,6 +20,8 @@
               [required]="true"
               [options]="rootAuthorities$"
               [tooltip]="tooltips.root_ca | translate"
+              [linkText]="'Certificate Authorities'"
+              [tooltip]="tooltips.server_certificate | translate"
             ></ix-select>
             <ix-ip-input-with-netmask
               formControlName="server"

--- a/src/app/pages/network/components/open-vpn-server-config/open-vpn-server-config.component.ts
+++ b/src/app/pages/network/components/open-vpn-server-config/open-vpn-server-config.component.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
+import { Router } from '@angular/router';
 import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { of, Subscription } from 'rxjs';
@@ -87,6 +88,7 @@ export class OpenVpnServerConfigComponent implements OnInit {
     private services: ServicesService,
     private loader: AppLoaderService,
     private cdr: ChangeDetectorRef,
+    private router: Router,
     private slideInService: IxSlideInService,
     private dialogService: DialogService,
     private storageService: StorageService,
@@ -120,6 +122,11 @@ export class OpenVpnServerConfigComponent implements OnInit {
           this.cdr.markForCheck();
         },
       );
+  }
+
+  certificatesLinkClicked(): void {
+    this.router.navigate(['/', 'credentials', 'certificates']);
+    this.slideInService.close(null, false);
   }
 
   onRenewStaticKey(): void {

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.ts
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.ts
@@ -101,7 +101,7 @@ export class ServiceFtpComponent implements FormConfiguration, OnInit {
           placeholder: helptext.ssltls_certificate_placeholder,
           tooltip: helptext.ssltls_certificate_tooltip,
           options: [{ label: '-', value: null }],
-          linkText: 'Certificates',
+          linkText: this.translate.instant('Certificates'),
           linkClicked: () => {
             this.router.navigate(['/', 'credentials', 'certificates']);
           },

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.ts
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.ts
@@ -101,6 +101,10 @@ export class ServiceFtpComponent implements FormConfiguration, OnInit {
           placeholder: helptext.ssltls_certificate_placeholder,
           tooltip: helptext.ssltls_certificate_tooltip,
           options: [{ label: '-', value: null }],
+          linkText: 'Certificates',
+          linkClicked: () => {
+            this.router.navigate(['/', 'credentials', 'certificates']);
+          },
         },
       ],
     },

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -51,7 +51,7 @@
           [tooltip]="tooltips.certificate | translate"
           [options]="certificateOptions$"
           (linkClicked)="certificatesLinkClicked()"
-          [linkText]="'Certificates'"
+          [linkText]="'Certificates' | translate"
         ></ix-select>
         <ix-input
           *ngIf="form.controls['certificate'].value !== null"

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -50,6 +50,8 @@
           [label]="'Certificate' | translate"
           [tooltip]="tooltips.certificate | translate"
           [options]="certificateOptions$"
+          (linkClicked)="certificatesLinkClicked()"
+          [linkText]="'Certificates'"
         ></ix-select>
         <ix-input
           *ngIf="form.controls['certificate'].value !== null"

--- a/src/app/pages/services/components/service-s3/service-s3.component.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.ts
@@ -149,6 +149,10 @@ export class ServiceS3Component implements OnInit {
     });
   }
 
+  certificatesLinkClicked(): void {
+    this.router.navigate(['/', 'credentials', 'certificates']);
+  }
+
   onSubmit(): void {
     const values = {
       ...this.form.value,

--- a/src/app/pages/services/components/service-webdav/service-webdav.component.html
+++ b/src/app/pages/services/components/service-webdav/service-webdav.component.html
@@ -28,7 +28,7 @@
           [tooltip]="certssl.tooltip"
           [options]="certssl.options"
           (linkClicked)="certificatesLinkClicked()"
-          [linkText]="'Certificates'"
+          [linkText]="'Certificates' | translate"
         ></ix-select>
         <ix-select
           [formControlName]="htauth.fcName"

--- a/src/app/pages/services/components/service-webdav/service-webdav.component.html
+++ b/src/app/pages/services/components/service-webdav/service-webdav.component.html
@@ -27,6 +27,8 @@
           [label]="certssl.label"
           [tooltip]="certssl.tooltip"
           [options]="certssl.options"
+          (linkClicked)="certificatesLinkClicked()"
+          [linkText]="'Certificates'"
         ></ix-select>
         <ix-select
           [formControlName]="htauth.fcName"

--- a/src/app/pages/services/components/service-webdav/service-webdav.component.ts
+++ b/src/app/pages/services/components/service-webdav/service-webdav.component.ts
@@ -165,6 +165,10 @@ export class ServiceWebdavComponent implements OnInit {
     );
   }
 
+  certificatesLinkClicked(): void {
+    this.router.navigate(['/', 'credentials', 'certificates']);
+  }
+
   onSubmit(): void {
     this.isFormLoading = true;
 

--- a/src/app/pages/system/general-settings/gui-form/gui-form.component.html
+++ b/src/app/pages/system/general-settings/gui-form/gui-form.component.html
@@ -17,7 +17,7 @@
           [options]="options.ui_certificate"
           [required]="true"
           (linkClicked)="certificatesLinkClicked()"
-          [linkText]="'Certificates'"
+          [linkText]="'Certificates' | translate"
         ></ix-select>
 
         <ix-select

--- a/src/app/pages/system/general-settings/gui-form/gui-form.component.html
+++ b/src/app/pages/system/general-settings/gui-form/gui-form.component.html
@@ -16,6 +16,8 @@
           [tooltip]="helptext.ui_certificate.tooltip | translate"
           [options]="options.ui_certificate"
           [required]="true"
+          (linkClicked)="certificatesLinkClicked()"
+          [linkText]="'Certificates'"
         ></ix-select>
 
         <ix-select

--- a/src/app/pages/system/general-settings/gui-form/gui-form.component.ts
+++ b/src/app/pages/system/general-settings/gui-form/gui-form.component.ts
@@ -5,6 +5,7 @@ import {
 import {
   Validators,
 } from '@angular/forms';
+import { Router } from '@angular/router';
 import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
@@ -73,6 +74,7 @@ export class GuiFormComponent {
     private ws: WebSocketService,
     private dialog: DialogService,
     private loader: AppLoaderService,
+    private router: Router,
     private translate: TranslateService,
     private errorHandler: FormErrorHandlerService,
     private store$: Store<AppState>,
@@ -121,6 +123,11 @@ export class GuiFormComponent {
       this.errorHandler.handleWsFormError(error, this.formGroup);
       this.cdr.markForCheck();
     });
+  }
+
+  certificatesLinkClicked(): void {
+    this.router.navigate(['/', 'credentials', 'certificates']);
+    this.slideInService.close(null, false);
   }
 
   getIsServiceRestartRequired(current: SystemGeneralConfig, next: SystemGeneralConfigUpdate): boolean {

--- a/src/app/pages/system/kmip/kmip.component.ts
+++ b/src/app/pages/system/kmip/kmip.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import * as _ from 'lodash';
 import { helptextSystemKmip } from 'app/helptext/system/kmip';
@@ -68,6 +69,10 @@ export class KmipComponent implements FormConfiguration {
           ],
           class: 'inline',
           width: '50%',
+          linkText: 'Certificates',
+          linkClicked: () => {
+            this.router.navigate(['/', 'credentials', 'certificates']);
+          },
         },
         {
           type: 'select',
@@ -79,6 +84,10 @@ export class KmipComponent implements FormConfiguration {
           ],
           class: 'inline',
           width: '50%',
+          linkText: 'Certificate Authorities',
+          linkClicked: () => {
+            this.router.navigate(['/', 'credentials', 'certificates']);
+          },
         },
       ],
     },
@@ -135,7 +144,7 @@ export class KmipComponent implements FormConfiguration {
   constructor(
     private systemGeneralService: SystemGeneralService,
     private dialogService: DialogService,
-    private dialog: MatDialog,
+    private dialog: MatDialog, private router: Router,
     private ws: WebSocketService,
   ) {
     this.ws.call(this.queryCall).pipe(untilDestroyed(this)).subscribe(

--- a/src/app/pages/system/kmip/kmip.component.ts
+++ b/src/app/pages/system/kmip/kmip.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { TranslateService } from '@ngx-translate/core';
 import * as _ from 'lodash';
 import { helptextSystemKmip } from 'app/helptext/system/kmip';
 import { FormConfiguration } from 'app/interfaces/entity-form.interface';
@@ -84,7 +85,7 @@ export class KmipComponent implements FormConfiguration {
           ],
           class: 'inline',
           width: '50%',
-          linkText: 'Certificate Authorities',
+          linkText: this.translate.instant('Certificate Authorities'),
           linkClicked: () => {
             this.router.navigate(['/', 'credentials', 'certificates']);
           },
@@ -145,7 +146,7 @@ export class KmipComponent implements FormConfiguration {
     private systemGeneralService: SystemGeneralService,
     private dialogService: DialogService,
     private dialog: MatDialog, private router: Router,
-    private ws: WebSocketService,
+    private ws: WebSocketService, private translate: TranslateService,
   ) {
     this.ws.call(this.queryCall).pipe(untilDestroyed(this)).subscribe(
       (res) => {

--- a/src/app/services/ix-slide-in.service.ts
+++ b/src/app/services/ix-slide-in.service.ts
@@ -21,7 +21,7 @@ export class IxSlideInService {
     if (error) {
       this.slideInClosed$.error(error);
     }
-    this.slideInClosed$.next(response || {});
+    this.slideInClosed$.next(response === undefined ? {} : response);
     this.slideInComponent.closeSlideIn();
   }
 


### PR DESCRIPTION
To test,
check that inputs for certificates or certificate authorities have links under them. Also check that on the directory services page, when you come back from a form, the tables update. The changes to the modal close methods are to ensure that tables are refreshed only when we want them to and not when modal is closed for any reason at all.

Let me know if further clarification is needed.