### PR TITLE
NAS-115137 / 22.12 / New method "webdav.cert_choices". Get valid certs for webdav service

### DIFF
--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -972,6 +972,7 @@ export type ApiDirectory = {
   // WEBDAV
   'webdav.config': { params: void; response: WebdavConfig };
   'webdav.update': { params: [WebdavConfigUpdate]; response: WebdavConfig };
+  'webdav.cert_choices': { params: void; response: Choices };
 
   // InitShutdownScript
   'initshutdownscript.query': { params: QueryParams<InitShutdownScript>; response: InitShutdownScript[] };

--- a/src/app/pages/services/components/service-webdav/service-webdav.component.ts
+++ b/src/app/pages/services/components/service-webdav/service-webdav.component.ts
@@ -71,7 +71,7 @@ export class ServiceWebdavComponent implements OnInit {
         const certKeys = Object.keys(certificates);
         const options = certKeys.map((key) => ({
           label: certificates[key],
-          value: key,
+          value: Number(key),
         }));
 
         return [

--- a/src/app/pages/services/components/service-webdav/service-webdav.component.ts
+++ b/src/app/pages/services/components/service-webdav/service-webdav.component.ts
@@ -66,11 +66,12 @@ export class ServiceWebdavComponent implements OnInit {
     fcName: 'certssl',
     label: helptext.certssl_placeholder,
     tooltip: helptext.certssl_tooltip,
-    options: this.systemGeneralService.getCertificates().pipe(
+    options: this.ws.call('webdav.cert_choices').pipe(
       map((certificates) => {
-        const options = certificates.map((certificate) => ({
-          label: certificate.name,
-          value: certificate.id,
+        const certKeys = Object.keys(certificates);
+        const options = certKeys.map((key) => ({
+          label: certificates[key],
+          value: key,
         }));
 
         return [


### PR DESCRIPTION
Replaced 'certificate.query' API endpoint with "webdav.cert_choices" in Services -> WebDAV form
Getting, updating and saving of certificates in the form.