### PR TITLE
NAS-114069 / 22.12 / NAS-114069: "hidden" class removed

### DIFF
--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.html
@@ -37,7 +37,7 @@
           </span>
         </mat-panel-description>
 
-        <div fxLayoutAlign="end start" class="icon-row hidden">
+        <div fxLayoutAlign="end start" class="icon-row">
           <div class="global_volume_based_action_menu pool-icon" title="Pool Operations" >
             <app-entity-table-actions
               icon_name="mdi-database-cog"


### PR DESCRIPTION
Removed class 'hidden' which had no effect.
Check rendering and efficiency "pool operations" button


![image](https://user-images.githubusercontent.com/22006748/159459950-e5d69a98-7a0e-4e3e-9fbe-6c49d7317bf9.png)
