### PR TITLE
Fix the tooltip text for path field configuring a ddns service

### DIFF
--- a/src/app/pages/services/components/service-dynamic-dns/service-dynamic-dns.component.ts
+++ b/src/app/pages/services/components/service-dynamic-dns/service-dynamic-dns.component.ts
@@ -48,7 +48,7 @@ export class ServiceDynamicDnsComponent implements OnInit {
     checkip_path: helptext.checkip_path_tooltip,
     ssl: helptext.ssl_tooltip,
     custom_ddns_server: helptext.custom_ddns_server_tooltip,
-    custom_ddns_path: helptext.custom_ddns_server_tooltip,
+    custom_ddns_path: helptext.custom_ddns_path_tooltip,
     domain: helptext.domain_tooltip,
     period: helptext.period_tooltip,
     username: helptext.username_tooltip,


### PR DESCRIPTION
Just fix the text used for tooltips, now is showing the same text as in `server`