### PR TITLE
NAS-115466 / 22.12 / "Select All" checkbox stays checked after completing operation

### DIFF
--- a/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
@@ -277,6 +277,7 @@ export class SnapshotListComponent implements OnInit {
   doBatchDelete(snapshots: ZfsSnapshot[]): void {
     this.matDialog.open(SnapshotBatchDeleteDialogComponent, {
       data: snapshots,
+      disableClose: true,
     }).afterClosed().pipe(
       filter(Boolean),
       untilDestroyed(this),


### PR DESCRIPTION
There was already the feature of clearing selection after closed dialog.
Disabled close dialog by clicking backdrop.