### PR TITLE
NAS-115110 / 12.0 / Added option to remove invalid user quotas (by RehanY147)

### DIFF
--- a/src/app/interfaces/dataset-quotas.interface.ts
+++ b/src/app/interfaces/dataset-quotas.interface.ts
@@ -1,0 +1,25 @@
+export interface DatasetQuota {
+  id: number;
+  name: string;
+  obj_quota: number;
+  obj_used: number;
+  obj_used_percent: number;
+  quota: number;
+  quota_type: DatasetQuotaType;
+  used_bytes: number;
+  used_percent: number;
+}
+
+export interface SetDatasetQuota {
+  quota_type: DatasetQuotaType;
+  id: string;
+  quota_value: number;
+}
+
+export enum DatasetQuotaType {
+  Dataset = 'DATASET',
+  User = 'USER',
+  Group = 'GROUP',
+  UserObj = 'USEROBJ',
+  GroupObj = 'GROUPOBJ',
+}

--- a/src/app/pages/common/entity/entity-table/entity-table-add-actions.component.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table-add-actions.component.ts
@@ -6,6 +6,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { RestService } from '../../../../services/rest.service';
 
 import { EntityTableComponent } from './entity-table.component';
+import { EntityTableService } from 'app/pages/common/entity/entity-table/entity-table.service';
 
 @Component({
   selector: 'app-entity-table-add-actions',
@@ -25,9 +26,13 @@ export class EntityTableAddActionsComponent implements OnInit {
     return this.actions.length + addAction;
   }
 
-  constructor(protected translate: TranslateService) { }
+  constructor(protected translate: TranslateService, private entityTableService: EntityTableService) { }
 
   ngOnInit() {
     this.actions = this.entity.getAddActions();
+
+    this.entityTableService.addActionsUpdater$.subscribe((actions: any) => {
+      this.actions = actions;
+    });
   }
 }

--- a/src/app/pages/common/entity/entity-table/entity-table.service.ts
+++ b/src/app/pages/common/entity/entity-table/entity-table.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable()
+export class EntityTableService {
+  private addActionsUpdaterSubject$: Subject<unknown> = new Subject();
+
+  get addActionsUpdater$(): Subject<unknown> {
+    return this.addActionsUpdaterSubject$;
+  }
+}

--- a/src/app/pages/common/entity/entity.module.ts
+++ b/src/app/pages/common/entity/entity.module.ts
@@ -79,6 +79,7 @@ import { ToolbarMultimenuComponent } from './entity-toolbar/components/toolbar-m
 import { EntityRowDetailsComponent } from './entity-table/entity-row-details.component';
 import { TaskScheduleListComponent } from 'app/pages/task-calendar/components/task-schedule-list/task-schedule-list.component';
 import { FormStatusComponent } from './entity-form/components/form-status/form-status.component';
+import { EntityTableService } from './entity-table/entity-table.service';
 
 @NgModule({
   imports: [
@@ -204,6 +205,7 @@ import { FormStatusComponent } from './entity-form/components/form-status/form-s
     AppLoaderService,
     DocsService,
     JobService,
+    EntityTableService,
   ],
 })
 export class EntityModule {}

--- a/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-grouplist/dataset-quotas-grouplist.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-grouplist/dataset-quotas-grouplist.component.ts
@@ -176,7 +176,7 @@ export class DatasetQuotasGrouplistComponent implements OnDestroy {
                 quota_value: self.storageService.convertHumanStringToNum(entryData.data_quota),
               },
               {
-                quota_type: 'GROUPOBJ',
+                quota_type: DatasetQuotaType.GroupObj,
                 id: res[0].id,
                 quota_value: entryData.obj_quota,
               });

--- a/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-grouplist/dataset-quotas-grouplist.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-grouplist/dataset-quotas-grouplist.component.ts
@@ -47,7 +47,7 @@ export class DatasetQuotasGrouplistComponent implements OnDestroy {
     },
   };
 
-  invalidQuotas: DatasetQuota[] = null;
+  invalidQuotas: DatasetQuota[] = [];
 
   constructor(protected ws: WebSocketService, protected storageService: StorageService,
     protected dialogService: DialogService, protected loader: AppLoaderService,
@@ -90,9 +90,10 @@ export class DatasetQuotasGrouplistComponent implements OnDestroy {
               });
             }
             this.loader.open();
-            this.ws.call('pool.dataset.set_quota', [this.pk, payload]).subscribe((res) => {
+            this.ws.call('pool.dataset.set_quota', [this.pk, payload]).subscribe(() => {
               this.loader.close();
               this.entityList.getData();
+              this.getInvalidQuotas();
             }, (err) => {
               this.loader.close();
               this.dialogService.errorReport('Error', err.reason, err.trace.formatted);
@@ -205,6 +206,10 @@ export class DatasetQuotasGrouplistComponent implements OnDestroy {
     const paramMap: any = (<any> this.aroute.params).getValue();
     this.pk = paramMap.pk;
     this.useFullFilter = window.localStorage.getItem('useFullFilter') !== 'false';
+    this.getInvalidQuotas();
+  }
+
+  getInvalidQuotas(): void {
     this.ws.call(
       'pool.dataset.get_quota',
       [this.pk, DatasetQuotaType.Group, [['name', '=', null]]],

--- a/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-userlist/dataset-quotas-userlist.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-userlist/dataset-quotas-userlist.component.ts
@@ -175,7 +175,7 @@ export class DatasetQuotasUserlistComponent implements OnDestroy {
                 quota_value: self.storageService.convertHumanStringToNum(entryData.data_quota),
               },
               {
-                quota_type: 'USEROBJ',
+                quota_type: DatasetQuotaType.UserObj,
                 id: res[0].id,
                 quota_value: entryData.obj_quota,
               });

--- a/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-userlist/dataset-quotas-userlist.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-userlist/dataset-quotas-userlist.component.ts
@@ -11,6 +11,7 @@ import globalHelptext from 'app/helptext/global-helptext';
 import { DatasetQuota, DatasetQuotaType, SetDatasetQuota } from 'app/interfaces/dataset-quotas.interface';
 import helptext from 'app/helptext/storage/volumes/datasets/dataset-quotas';
 import { filter } from 'rxjs/operators';
+import { EntityTableService } from 'app/pages/common/entity/entity-table/entity-table.service';
 
 @Component({
   selector: 'app-dataset-quotas-userlist',
@@ -25,7 +26,6 @@ export class DatasetQuotasUserlistComponent implements OnDestroy {
   protected emptyFilter = [];
   protected useFullFilter = true;
 
-  invalidQuotas: DatasetQuota[] = [];
   columns: any[] = [
     {
       name: T('Name'), prop: 'name', always_display: true, minWidth: 150,
@@ -48,59 +48,64 @@ export class DatasetQuotasUserlistComponent implements OnDestroy {
     },
   };
 
+  readonly addActions = [
+    {
+      label: T('Toggle Display'),
+      onClick: () => {
+        this.toggleDisplay();
+      },
+    },
+    {
+      label: T('Set Quotas (Bulk)'),
+      onClick: () => {
+        this.router.navigate(['storage', 'pools', 'user-quotas-form', this.pk]);
+      },
+    },
+  ];
+
+  getRemoveInvalidQuotasAction(invalidQuotas: DatasetQuota[]) {
+    return {
+      label: T('Remove quotas for invalid users'),
+      onClick: () => {
+        this.dialogService.confirm({
+          title: T('Remove invalid quotas'),
+          message: T('This action will set all dataset quotas for the removed or invalid users to 0, virutally removing any dataset quota entires for such users. Are you sure you want to proceed?'),
+          buttonMsg: T('Remove'),
+        }).pipe(filter(Boolean)).subscribe(() => {
+          const payload: SetDatasetQuota[] = [];
+          for (const quota of invalidQuotas) {
+            payload.push({
+              id: quota.id.toString(),
+              quota_type: DatasetQuotaType.User,
+              quota_value: 0,
+            });
+            payload.push({
+              id: quota.id.toString(),
+              quota_type: DatasetQuotaType.UserObj,
+              quota_value: 0,
+            });
+          }
+          this.loader.open();
+          this.ws.call('pool.dataset.set_quota', [this.pk, payload]).subscribe(() => {
+            this.loader.close();
+            this.entityList.getData();
+            this.updateAddActions();
+          }, (err) => {
+            this.loader.close();
+            this.dialogService.errorReport('Error', err.reason, err.trace.formatted);
+          });
+        });
+      },
+    };
+  }
+
   constructor(protected ws: WebSocketService, protected storageService: StorageService,
     protected dialogService: DialogService, protected loader: AppLoaderService,
     protected router: Router, protected aroute: ActivatedRoute,
-    private translate: TranslateService) { }
+    private translate: TranslateService, private tableService: EntityTableService) { }
 
   getAddActions() {
-    return [
-      {
-        label: T('Toggle Display'),
-        onClick: () => {
-          this.toggleDisplay();
-        },
-      },
-      {
-        label: T('Set Quotas (Bulk)'),
-        onClick: () => {
-          this.router.navigate(['storage', 'pools', 'user-quotas-form', this.pk]);
-        },
-      },
-      {
-        label: T('Remove quotas for invalid users'),
-        onClick: () => {
-          this.dialogService.confirm({
-            title: T('Remove invalid quotas'),
-            message: T('This action will set all dataset quotas for the removed or invalid users to 0, virutally removing any dataset quota entires for such users. Are you sure you want to proceed?'),
-            buttonMsg: T('Remove'),
-          }).pipe(filter(Boolean)).subscribe(() => {
-            const payload: SetDatasetQuota[] = [];
-            for (const quota of this.invalidQuotas) {
-              payload.push({
-                id: quota.id.toString(),
-                quota_type: DatasetQuotaType.User,
-                quota_value: 0,
-              });
-              payload.push({
-                id: quota.id.toString(),
-                quota_type: DatasetQuotaType.UserObj,
-                quota_value: 0,
-              });
-            }
-            this.loader.open();
-            this.ws.call('pool.dataset.set_quota', [this.pk, payload]).subscribe(() => {
-              this.loader.close();
-              this.entityList.getData();
-              this.getInvalidQuotas();
-            }, (err) => {
-              this.loader.close();
-              this.dialogService.errorReport('Error', err.reason, err.trace.formatted);
-            });
-          });
-        },
-      },
-    ];
+    return [...this.addActions];
   }
 
   getActions(row) {
@@ -205,15 +210,22 @@ export class DatasetQuotasUserlistComponent implements OnDestroy {
     const paramMap: any = (<any> this.aroute.params).getValue();
     this.pk = paramMap.pk;
     this.useFullFilter = window.localStorage.getItem('useFullFilter') !== 'false';
-    this.getInvalidQuotas();
+    this.updateAddActions();
   }
 
-  getInvalidQuotas(): void {
+  updateAddActions(): void {
     this.ws.call(
       'pool.dataset.get_quota',
       [this.pk, DatasetQuotaType.User, [['name', '=', null]]],
     ).subscribe((quotas: DatasetQuota[]) => {
-      this.invalidQuotas = quotas;
+      if (quotas && quotas.length) {
+        this.tableService.addActionsUpdater$.next([
+          ...this.addActions,
+          this.getRemoveInvalidQuotasAction(quotas),
+        ]);
+      } else {
+        this.tableService.addActionsUpdater$.next([...this.addActions]);
+      }
     });
   }
 

--- a/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-userlist/dataset-quotas-userlist.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-quotas/dataset-quotas-userlist/dataset-quotas-userlist.component.ts
@@ -89,9 +89,10 @@ export class DatasetQuotasUserlistComponent implements OnDestroy {
               });
             }
             this.loader.open();
-            this.ws.call('pool.dataset.set_quota', [this.pk, payload]).subscribe((res) => {
+            this.ws.call('pool.dataset.set_quota', [this.pk, payload]).subscribe(() => {
               this.loader.close();
               this.entityList.getData();
+              this.getInvalidQuotas();
             }, (err) => {
               this.loader.close();
               this.dialogService.errorReport('Error', err.reason, err.trace.formatted);
@@ -204,6 +205,10 @@ export class DatasetQuotasUserlistComponent implements OnDestroy {
     const paramMap: any = (<any> this.aroute.params).getValue();
     this.pk = paramMap.pk;
     this.useFullFilter = window.localStorage.getItem('useFullFilter') !== 'false';
+    this.getInvalidQuotas();
+  }
+
+  getInvalidQuotas(): void {
     this.ws.call(
       'pool.dataset.get_quota',
       [this.pk, DatasetQuotaType.User, [['name', '=', null]]],


### PR DESCRIPTION
To test,
1. Create a two new users `user1` and `user2`
2. Set `User Quotas` for a dataset using the `Bulk` option
3. Remove the users from the system
4. Go back to the `User Quotas` page and you should see errors for quotas
5. Check the `Actions` button and click on the `Remove quotas for invalid users` button and follow through. It should remove the erroneous quota entries.
Test the same thing with `Group Quotas`

Original PR: https://github.com/truenas/webui/pull/6574
Jira URL: https://jira.ixsystems.com/browse/NAS-115110