### PR TITLE
in Sharing / SMB / Edit Share ACL, first entry cannot be deleted even if multiple present

### DIFF
--- a/src/app/helptext/sharing/smb/smb.ts
+++ b/src/app/helptext/sharing/smb/smb.ts
@@ -195,6 +195,7 @@ export const helptext_sharing_smb = {
   // share acl
   share_acl_basic: T('Basic'),
   share_acl_entries: T('ACL Entries'),
+  share_acl_add_btn: T('Add'),
 
   share_name_placeholder: T('Share Name'),
   share_name_tooltip: T('Name that was created with the SMB share.'),

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
@@ -44,6 +44,8 @@ export class SMBAclComponent {
           type: 'list',
           name: 'share_acl',
           width: '100%',
+          deleteButtonOnFirst: true,
+          addBtnMessage: helptext_sharing_smb.share_acl_add_btn,
           listFields: [],
           templateListField: [
             {


### PR DESCRIPTION
Testing:
Sharing -> SMB -> Edit Share ACL

![image](https://user-images.githubusercontent.com/22980553/164997342-cc2ca679-030b-41cd-aa24-2f42cc759895.png)
