### PR TITLE
NAS-116092 / 22.02.2 / System dataset update validation errors are not displayed

### DIFF
--- a/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
+++ b/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
@@ -10,6 +10,7 @@ import {
 import {
   catchError, filter, map, switchMap, tap,
 } from 'rxjs/operators';
+import { JobState } from 'app/enums/job-state.enum';
 import { choicesToOptions } from 'app/helpers/options.helper';
 import helptext from 'app/helptext/apps/apps';
 import { KubernetesConfig, KubernetesConfigUpdate } from 'app/interfaces/kubernetes-config.interface';
@@ -125,9 +126,11 @@ export class KubernetesSettingsComponent implements OnInit {
           this.ws.job('kubernetes.update', [values]),
           this.appService.updateContainerConfig(enableContainerImageUpdate),
         ]).pipe(
-          tap(() => {
-            this.loader.close();
-            this.slideInService.close();
+          tap(([job]) => {
+            if (job.state === JobState.Success) {
+              this.loader.close();
+              this.slideInService.close();
+            }
           }),
           catchError((error) => {
             this.loader.close();

--- a/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
+++ b/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
@@ -135,7 +135,7 @@ export class KubernetesSettingsComponent implements OnInit {
           catchError((error) => {
             this.loader.close();
 
-            this.errorHandler.handleWsFormError(error, this.form);
+            this.errorHandler.handleWsFormError({ ...error, ...(error.exc_info || {}) }, this.form);
             return EMPTY;
           }),
         );

--- a/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
+++ b/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
@@ -127,10 +127,11 @@ export class KubernetesSettingsComponent implements OnInit {
           this.appService.updateContainerConfig(enableContainerImageUpdate),
         ]).pipe(
           tap(([job]) => {
-            if (job.state === JobState.Success) {
-              this.loader.close();
-              this.slideInService.close();
+            if (job.state !== JobState.Success) {
+              return;
             }
+            this.loader.close();
+            this.slideInService.close();
           }),
           catchError((error) => {
             this.loader.close();

--- a/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
+++ b/src/app/pages/applications/kubernetes-settings/kubernetes-settings.component.ts
@@ -136,7 +136,7 @@ export class KubernetesSettingsComponent implements OnInit {
           catchError((error) => {
             this.loader.close();
 
-            this.errorHandler.handleWsFormError({ ...error, ...(error.exc_info || {}) }, this.form);
+            this.errorHandler.handleWsFormError(error, this.form);
             return EMPTY;
           }),
         );

--- a/src/app/pages/system/advanced/syslog-form/syslog-form.component.ts
+++ b/src/app/pages/system/advanced/syslog-form/syslog-form.component.ts
@@ -102,7 +102,7 @@ export class SyslogFormComponent implements OnInit {
         }),
         catchError((error) => {
           this.isFormLoading = false;
-          this.errorHandler.handleWsFormError({ ...error, ...(error.exc_info || {}) }, this.form);
+          this.errorHandler.handleWsFormError(error, this.form);
           this.cdr.markForCheck();
           return EMPTY;
         }),

--- a/src/app/pages/system/advanced/syslog-form/syslog-form.component.ts
+++ b/src/app/pages/system/advanced/syslog-form/syslog-form.component.ts
@@ -13,6 +13,7 @@ import { choicesToOptions } from 'app/helpers/options.helper';
 import { helptextSystemAdvanced, helptextSystemAdvanced as helptext } from 'app/helptext/system/advanced';
 import { AdvancedConfigUpdate } from 'app/interfaces/advanced-config.interface';
 import { EntityUtils } from 'app/pages/common/entity/utils';
+import { FormErrorHandlerService } from 'app/pages/common/ix-forms/services/form-error-handler.service';
 import { DialogService, SystemGeneralService, WebSocketService } from 'app/services';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
 
@@ -61,6 +62,7 @@ export class SyslogFormComponent implements OnInit {
     private slideInService: IxSlideInService,
     private dialogService: DialogService,
     private cdr: ChangeDetectorRef,
+    private errorHandler: FormErrorHandlerService,
   ) {}
 
   ngOnInit(): void {
@@ -99,7 +101,7 @@ export class SyslogFormComponent implements OnInit {
         }),
         catchError((error) => {
           this.isFormLoading = false;
-          new EntityUtils().handleWsError(this, error);
+          this.errorHandler.handleWsFormError({ ...error, ...(error.exc_info || {}) }, this.form);
           this.cdr.markForCheck();
           return EMPTY;
         }),

--- a/src/app/pages/system/advanced/syslog-form/syslog-form.component.ts
+++ b/src/app/pages/system/advanced/syslog-form/syslog-form.component.ts
@@ -92,12 +92,13 @@ export class SyslogFormComponent implements OnInit {
     this.ws.call('system.advanced.update', [configUpdate]).pipe(
       switchMap(() => this.ws.job('systemdataset.update', [{ syslog }]).pipe(
         tap((job) => {
-          if (job.state === JobState.Success) {
-            this.isFormLoading = false;
-            this.sysGeneralService.refreshSysGeneral();
-            this.cdr.markForCheck();
-            this.slideInService.close();
+          if (job.state !== JobState.Success) {
+            return;
           }
+          this.isFormLoading = false;
+          this.sysGeneralService.refreshSysGeneral();
+          this.cdr.markForCheck();
+          this.slideInService.close();
         }),
         catchError((error) => {
           this.isFormLoading = false;

--- a/src/app/pages/system/advanced/system-dataset-pool/system-dataset-pool.component.spec.ts
+++ b/src/app/pages/system/advanced/system-dataset-pool/system-dataset-pool.component.spec.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
+import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
 import { mockCall, mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { IxFormsModule } from 'app/pages/common/ix-forms/ix-forms.module';
 import { FormErrorHandlerService } from 'app/pages/common/ix-forms/services/form-error-handler.service';
@@ -40,7 +41,7 @@ describe('SystemDatasetPoolComponent', () => {
           'current-pool': 'current-pool',
           'new-pool': 'new-pool',
         }),
-        mockJob('systemdataset.update'),
+        mockJob('systemdataset.update', fakeSuccessfulJob()),
       ]),
       mockProvider(IxSlideInService),
       mockProvider(FormErrorHandlerService),

--- a/src/app/pages/system/advanced/system-dataset-pool/system-dataset-pool.component.ts
+++ b/src/app/pages/system/advanced/system-dataset-pool/system-dataset-pool.component.ts
@@ -83,7 +83,7 @@ export class SystemDatasetPoolComponent implements OnInit {
           }),
           catchError((error) => {
             this.isFormLoading = false;
-            this.errorHandler.handleWsFormError({ ...error, ...(error.exc_info || {}) }, this.form);
+            this.errorHandler.handleWsFormError(error, this.form);
             this.cdr.markForCheck();
             return EMPTY;
           }),

--- a/src/app/pages/system/advanced/system-dataset-pool/system-dataset-pool.component.ts
+++ b/src/app/pages/system/advanced/system-dataset-pool/system-dataset-pool.component.ts
@@ -6,8 +6,11 @@ import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import _ from 'lodash';
-import { Observable, of } from 'rxjs';
-import { filter, switchMap } from 'rxjs/operators';
+import { EMPTY, Observable, of } from 'rxjs';
+import {
+  catchError, filter, switchMap, tap,
+} from 'rxjs/operators';
+import { JobState } from 'app/enums/job-state.enum';
 import { FormErrorHandlerService } from 'app/pages/common/ix-forms/services/form-error-handler.service';
 import { DialogService, SystemGeneralService, WebSocketService } from 'app/services';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
@@ -67,21 +70,24 @@ export class SystemDatasetPoolComponent implements OnInit {
 
     this.confirmSmbRestartIfNeeded().pipe(
       filter(Boolean),
-      switchMap(() => this.ws.job('systemdataset.update', [values])),
+      switchMap(() => this.ws.job('systemdataset.update', [values]).pipe(
+        tap((job) => {
+          if (job.state === JobState.Success) {
+            this.isFormLoading = false;
+            this.sysGeneralService.refreshSysGeneral();
+            this.cdr.markForCheck();
+            this.slideInService.close();
+          }
+        }),
+        catchError((error) => {
+          this.isFormLoading = false;
+          this.errorHandler.handleWsFormError(error, this.form);
+          this.cdr.markForCheck();
+          return EMPTY;
+        }),
+      )),
       untilDestroyed(this),
-    ).subscribe(
-      () => {
-        this.isFormLoading = false;
-        this.sysGeneralService.refreshSysGeneral();
-        this.cdr.markForCheck();
-        this.slideInService.close();
-      },
-      (error) => {
-        this.isFormLoading = false;
-        this.errorHandler.handleWsFormError(error, this.form);
-        this.cdr.markForCheck();
-      },
-    );
+    ).subscribe();
   }
 
   /**

--- a/src/app/pages/system/advanced/system-dataset-pool/system-dataset-pool.component.ts
+++ b/src/app/pages/system/advanced/system-dataset-pool/system-dataset-pool.component.ts
@@ -81,7 +81,7 @@ export class SystemDatasetPoolComponent implements OnInit {
         }),
         catchError((error) => {
           this.isFormLoading = false;
-          this.errorHandler.handleWsFormError(error, this.form);
+          this.errorHandler.handleWsFormError({ ...error, ...(error.exc_info || {}) }, this.form);
           this.cdr.markForCheck();
           return EMPTY;
         }),


### PR DESCRIPTION
Fixed error that goes to next even if the state of the job is not successful when using `switchMap` with `ws.job` in `SyslogFormComponent`, `KubernetesSettingsComponent`, `SystemDatasetPoolComponent`.

