### PR TITLE
NAS-115787 / 22.02.2 / NAS-115787: Keep dashboard safe

### DIFF
--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
@@ -610,6 +610,9 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
       ) {
         return false;
       }
+      if (widget.name === 'Interface' && !this.dataFromConfig(widget)) {
+        return false;
+      }
       return true;
     });
   }
@@ -635,8 +638,8 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private setDashState(dashState: DashConfigItem[]): void {
-    this.dashState = dashState;
-    this.renderedWidgets = dashState.filter((x) => x.rendered);
+    this.dashState = this.sanitizeState(dashState);
+    this.renderedWidgets = this.dashState.filter((widget) => widget.rendered);
   }
 
   private getActionsConfig(target$: Subject<CoreEvent>): EntityToolbarActionConfig {


### PR DESCRIPTION
Added extra check to ignore unexist network widgets

Testing:

- Open Network page and create a new interface with type bridge
- Go to Dashboard and enable widget for newly created interface
- Go to Network and remove the bridge
- Go to Dashboard and check if its not broken
