### PR TITLE
NAS-116082 / 22.02.2 / NAS-116082: Update Tunable/Sysctl Variable tooltips for SCALE

### DIFF
--- a/src/app/helptext/system/tunable.ts
+++ b/src/app/helptext/system/tunable.ts
@@ -9,15 +9,10 @@ export const helptextSystemTunable = {
   var: {
     placeholder: T('Variable'),
     tooltip: T(
-      'Enter the name of the loader, sysctl, or rc.conf\
- variable to configure. <i>loader</i> tunables are used\
- to specify parameters to pass to the kernel or load\
- additional modules at boot time. <i>rc.conf</i>\
- tunables are for enabling system services and daemons\
- and only take effect after a reboot. <i>sysctl</i> \
- tunables are used to configure kernel parameters while\
- the system is running and generally take effect\
- immediately.',
+      'Enter the name of the sysctl variable to configure.\
+ <i>sysctl</i> tunables are used to configure kernel\
+ parameters while the system is running and generally\
+ take effect immediately.',
     ),
     validation: [Validators.required],
   },


### PR DESCRIPTION
Remove text about rc.conf and loader variables as these no longer apply in SCALE.