### PR TITLE
NAS-116300 / 22.02.2 / NAS-116300: Fixed overflow-y

### DIFF
--- a/src/app/pages/common/error-dialog/error-dialog.component.scss
+++ b/src/app/pages/common/error-dialog/error-dialog.component.scss
@@ -12,3 +12,7 @@
   display: flex;
   flex-direction: column-reverse;
 }
+
+#err-md-content {
+  overflow-y: auto !important;
+}


### PR DESCRIPTION
The `!important` is required because the style that overrides it already has important in it.

To test, go to any component and type the following code in `ngOnInit` and load the component in the browser to see the problematic dialog
```
    let myWarning = '';
    for(let i = 0; i < 50000; i++) {
      if(i % 250 === 0) {
        myWarning += '<br/>';
      }
      myWarning += i;
    }
    this.dialog.errorReport(this.translate.instant('Warning'), `<pre>${myWarning}</pre>`);
```
