### PR TITLE
NAS-116140 / 22.02.2 / NAS-116140: iSCSI wizard breaks down when middleware returns errors

### DIFF
--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
@@ -951,15 +951,17 @@ export class IscsiWizardComponent implements WizardConfiguration {
     return this.ws.call((this.createCalls as any)[item], [payload]).toPromise();
   }
 
-  rollBack(items: any[]): void {
-    items.forEach((item, i) => {
-      if (item != null) {
-        this.ws.call((this.deleteCalls as any)[i], [item]).pipe(untilDestroyed(this)).subscribe(
-          (res) => {
-            console.info('rollback ' + i, res);
-          },
-        );
+  rollBack(items: Record<string, unknown>): void {
+    Object.entries(items).forEach(([type, id]) => {
+      if (id === null) {
+        return;
       }
+
+      this.ws.call((this.deleteCalls as any)[type], [id]).pipe(untilDestroyed(this)).subscribe(
+        (res) => {
+          console.info('rollback ' + type, res);
+        },
+      );
     });
   }
 


### PR DESCRIPTION
Testing: Shares -> iSCSI -> Configure -> Wizard -> submit wizard in a way that would trigger middleware errors.
Previously form would break - you'd see an infinite spinner and won't be able to continue.
You're likely to hit some validation errors even if you just submit form as is.