### PR TITLE
NAS-116447 / 22.02.2 / NAS-116447: Added new checkbox

### DIFF
--- a/src/app/interfaces/alert.interface.ts
+++ b/src/app/interfaces/alert.interface.ts
@@ -29,6 +29,7 @@ export interface AlertClass {
   id: string;
   level: AlertLevel;
   title: string;
+  proactive_support?: boolean;
 }
 
 export interface AlertClasses {

--- a/src/app/pages/common/entity/entity-form/components/form-checkbox/form-checkbox.component.html
+++ b/src/app/pages/common/entity/entity-form/components/form-checkbox/form-checkbox.component.html
@@ -1,5 +1,16 @@
-<div id="{{config.name}}" class="dynamic-field form-checkbox form-element" [formGroup]="group" [ngClass]="fieldShow" [class.has-tooltip]="config.tooltip" *ngIf="!config['isHidden']" [class.expanded-height]="config.expandedHeight">
+<div 
+  id="{{config.name}}"
+  class="dynamic-field form-checkbox form-element {{ config.inlineLabel ? 'inline-label' : 'not' }}"
+  [formGroup]="group" 
+  [ngClass]="fieldShow" 
+  [class.has-tooltip]="config.tooltip" 
+  *ngIf="!config['isHidden']" 
+  [class.expanded-height]="config.expandedHeight"
+>
 
+  <ng-container *ngIf="config.inlineLabel">
+    <div class="label half-width"></div>
+  </ng-container>
   <mat-checkbox
     *ngIf="!config.updater && !config.customEventMethod"
     color="primary"
@@ -7,15 +18,17 @@
     [required]="config.required"
     ix-auto ix-auto-type="checkbox" ix-auto-identifier="{{config.placeholder}}"
     (click)="(config.readonly && preventClick($event))"
+    class="{ 'full-width': !config.inlineLabel, 'half-width': config.inlineLabel }"
     (change)="onChangeCheckbox($event)"
   >
     {{ config.placeholder | translate }}
   </mat-checkbox>
 
   <mat-checkbox
+
     *ngIf="config.updater"
     color="primary"
-    class="updater"
+    class="updater { 'full-width': !config.inlineLabel, 'half-width': config.inlineLabel }"
     [formControlName]="config.name"
     [required]="config.required"
     (change)="onChangeCheckbox($event)"
@@ -27,7 +40,7 @@
   <mat-checkbox
     *ngIf="config.customEventMethod"
     color="primary"
-    class="custom-handler"
+    class="custom-handler { 'full-width': !config.inlineLabel, 'half-width': config.inlineLabel }"
     [formControlName]="config.name"
     [required]="config.required"
     (change)="onChangeCheckbox($event)"

--- a/src/app/pages/common/entity/entity-form/components/form-checkbox/form-checkbox.component.scss
+++ b/src/app/pages/common/entity/entity-form/components/form-checkbox/form-checkbox.component.scss
@@ -34,3 +34,26 @@ input {
     }
   }
 }
+
+.inline-label div.label.half-width,
+.inline-label .mat-form-field {
+  display: inline-block;
+}
+
+.inline-label div.label.half-width {
+  width: calc(50% - 16px);
+}
+
+.inline-label .mat-form-field {
+  width: calc(40% - 16px);
+}
+
+.inline-label mat-checkbox {
+  padding: 8px;
+}
+
+:host-context(app-system-alert) {
+  .inline-label label.label.input-select {
+    padding: 8px !important;
+  }
+}

--- a/src/app/pages/common/entity/entity-form/entity-form.component.scss
+++ b/src/app/pages/common/entity/entity-form/entity-form.component.scss
@@ -21,6 +21,11 @@
   max-width: 100%;
 }
 
+.break {
+  flex-basis: 100%;
+  height: 0;
+}
+
 .entity-form .form-line:last-child {
   margin-right: 24px;
 }

--- a/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
+++ b/src/app/pages/common/entity/entity-form/models/field-config.interface.ts
@@ -71,6 +71,7 @@ export interface FormCheckboxConfig<P = any> extends BaseFieldConfig<P> {
   expandedHeight?: boolean;
   onChange?(data: { event: MatCheckboxChange }): void;
   type: 'checkbox';
+  inlineLabel?: string;
   updater?: (parent: P) => void;
   customEventMethod?: () => void;
 }

--- a/src/app/pages/system/alert/alert-defaults.interface.ts
+++ b/src/app/pages/system/alert/alert-defaults.interface.ts
@@ -5,4 +5,5 @@ export interface AlertDefaults {
   id: string;
   level: AlertLevel;
   policy: AlertPolicy;
+  proactive_support?: boolean;
 }

--- a/src/app/pages/system/alert/alert.component.html
+++ b/src/app/pages/system/alert/alert.component.html
@@ -6,9 +6,13 @@
           <div [ngClass]="fieldSet.class" *ngIf="i==selectedIndex" [style.margin-bottom.px]="12" class="fieldset divider-{{fieldSet.divider}}" fxFlex="100%" fxFlex.gt-xs="calc({{fieldSet.width}} - 16px)">
             <h4 *ngIf="fieldSet.label" class="fieldset-label">{{fieldSet.name}}</h4>
             <div fxLayout="row wrap" fxLayoutAlign="start start" fxFlex="100%">
-              <div *ngFor="let field of fieldSet.config; let ii = index" fxFlex.gt-sm="50" fxFlex.xs="100" fxFlex.gt-xs="calc({{field.width}} - 16px)" [ngClass]="field.class == 'inline' ? 'form-inline' : 'form-line'" id="{{fieldSet.name}}-{{ii}}">
-                <div id="form_field_{{field.name}}" dynamicField [config]="field"  [group]="formGroup" [fieldShow]="'show'"></div>
-              </div>
+              <ng-container *ngFor="let field of fieldSet.config; let ii = index">
+                <div *ngIf="field.class?.includes('new-line')" class="break"></div>
+                <div fxFlex.gt-sm="50" fxFlex.xs="100" fxFlex.gt-xs="calc({{field.width}} - 16px)" [ngClass]="field.class == 'inline' ? 'form-inline' : 'form-line'" id="{{fieldSet.name}}-{{ii}}">
+                  <div id="form_field_{{field.name}}" dynamicField [config]="field"  [group]="formGroup" [fieldShow]="'show'"></div>
+                </div>
+              </ng-container>
+              
             </div>
           </div>
         </ng-container>

--- a/src/app/pages/system/alert/alert.component.ts
+++ b/src/app/pages/system/alert/alert.component.ts
@@ -7,6 +7,7 @@ import { Subject } from 'rxjs';
 import { CoreService } from 'app/core/services/core-service/core.service';
 import { AlertLevel } from 'app/enums/alert-level.enum';
 import { AlertPolicy } from 'app/enums/alert-policy.enum';
+import { ProductType } from 'app/enums/product-type.enum';
 import helptext from 'app/helptext/system/alert-settings';
 import { AlertCategory } from 'app/interfaces/alert.interface';
 import { CoreEvent } from 'app/interfaces/events';
@@ -39,6 +40,7 @@ export class AlertConfigComponent implements OnInit {
   protected editCall = 'alertclasses.update' as const;
   protected isEntity = true;
   fieldSets: FieldSets;
+  readonly productType = window.localStorage.getItem('product_type') as ProductType;
   fieldConfig: FieldConfig[] = [];
   protected settingOptions: Option[] = [];
   protected warningOptions: Option[] = [
@@ -124,11 +126,30 @@ export class AlertConfigComponent implements OnInit {
               },
             );
 
-            this.defaults.push({
-              id: categoryClass.id,
-              level: categoryClass.level,
-              policy: AlertPolicy.Immediately,
-            });
+            if (categoryClass.proactive_support && this.isEnterprise) {
+              config.push({
+                type: 'checkbox',
+                name: categoryClass.id + '_proactive_support',
+                value: true,
+                inlineLabel: ' ',
+                placeholder: this.translate.instant('Proactive Support'),
+              });
+            }
+
+            if (categoryClass.proactive_support && this.isEnterprise) {
+              this.defaults.push({
+                id: categoryClass.id,
+                level: categoryClass.level,
+                policy: AlertPolicy.Immediately,
+                proactive_support: true,
+              });
+            } else {
+              this.defaults.push({
+                id: categoryClass.id,
+                level: categoryClass.level,
+                policy: AlertPolicy.Immediately,
+              });
+            }
           }
 
           const fieldSet = {
@@ -211,15 +232,20 @@ export class AlertConfigComponent implements OnInit {
     this.core.emit({ name: 'GlobalActions', data: actionsConfig, sender: this });
   }
 
+  get isEnterprise(): boolean {
+    return this.productType === ProductType.ScaleEnterprise;
+  }
+
   onSubmit(): void {
     const payload: any = { classes: {} };
-
     for (const key in this.formGroup.value) {
       const keyValues = key.split('_');
-      const alertClass = keyValues[0];
-      const classKey = keyValues[1];
-      const def = _.find(this.defaults, { id: alertClass });
-      if (def[classKey as keyof AlertDefaults].toUpperCase() !== this.formGroup.value[key].toUpperCase()) {
+      const alertClass = keyValues.shift();
+      const classKey = keyValues.reduce((prev, current) => prev + '_' + current);
+      const defaultClassValues = _.find(this.defaults, { id: alertClass });
+      const defaultValueUpperCased = defaultClassValues[classKey as keyof AlertDefaults].toString().toUpperCase();
+      const formValueUpperCased = this.formGroup.value[key].toString().toUpperCase();
+      if (defaultValueUpperCased !== formValueUpperCased) {
         // do not submit defaults in the payload
         if (!payload.classes[alertClass]) {
           payload.classes[alertClass] = {};

--- a/src/app/pages/system/alert/alert.component.ts
+++ b/src/app/pages/system/alert/alert.component.ts
@@ -108,6 +108,7 @@ export class AlertConfigComponent implements OnInit {
             config.push(
               {
                 type: 'select',
+                class: 'new-line',
                 name: categoryClass.id + '_level',
                 inlineLabel: categoryClass.title,
                 placeholder: this.translate.instant('Set Warning Level'),


### PR DESCRIPTION
To test, open the `Alerts` drop down and go to the `Alerts Settings` by clicking the cog icon. On the next page, on the top right from the select, click on `Storage`. Now on the list of new inputs, you should see `Proactive Support` as a checkbox for some inputs. (Examples are described in the ticket). Values should be persistent once saved. Default value should be `true` if you've never touched it.

Also, these checkboxes aren't supposed to show for non-enterprise products so find a way around that. Either disable the enterprise check in the new code for testing or edit the enterprise string in `localStorage` or buy a license.