### PR TITLE
NAS-115796 / 22.02.2 / NAS-115796: Deleting 'textLimiter' attribute (by bvasilenko)

### DIFF
--- a/src/app/pages/applications/catalog/catalog.component.html
+++ b/src/app/pages/applications/catalog/catalog.component.html
@@ -25,11 +25,10 @@
             </div>
           </div>
         </div>
-        <div class="content" fxLayout="column" fxLayoutAlign="center center">
+        <div class="content" fxLayout="column" fxLayoutAlign="space-between center">
           <div class="catalog-title">
-            <h3 textLimiter threshold="15" content="{{item.name}}"></h3>
-          </div>
-          <div class="catalog-version" textLimiter threshold="32" fxFlex="100%" content="{{ item.latest_human_version }}">
+            <h3>{{item.name}}</h3>
+            <div class="catalog-version">{{ item.latest_human_version }}</div>
           </div>
           <div class="button-row" (click)="$event.stopPropagation()">
             <button


### PR DESCRIPTION
Summary: `textLimiter` was instantiated too many times, and it was consuming resources. I've changed the code so it won't rely on `textLimiter` at all.

**Testing:**

Enter **Apps** page, and make sure you don't see lagging, which was depicted on the video **2022-04-16 11-57-46.mkv** inside the ticket.

Original PR: https://github.com/truenas/webui/pull/6753
Jira URL: https://jira.ixsystems.com/browse/NAS-115796