### PR TITLE
NAS-116609 / 22.02.2 / add proper strings so enclosure mapping works

### DIFF
--- a/src/app/pages/system/view-enclosure/enclosure-disks/enclosure-disks-mini.component.ts
+++ b/src/app/pages/system/view-enclosure/enclosure-disks/enclosure-disks-mini.component.ts
@@ -48,15 +48,22 @@ export class EnclosureDisksMiniComponent extends EnclosureDisksComponent {
 
   createEnclosure(enclosure: EnclosureMetadata = this.selectedEnclosure): void {
     switch (enclosure.model) {
-      case ('FREENAS-MINI-3.0-E' || 'TRUENAS-MINI-3.0-E'):
-      case ('FREENAS-MINI-3.0-E+' || 'TRUENAS-MINI-3.0-E+'):
+      case 'FREENAS-MINI-3.0-E':
         this.chassis = new MINI();
         break;
-      case ('FREENAS-MINI-3.0-X' || 'TRUENAS-MINI-3.0-X'):
-      case ('FREENAS-MINI-3.0-X+' || 'TRUENAS-MINI-3.0-X+'):
+      case 'TRUENAS-MINI-3.0-E':
+        this.chassis = new MINI();
+        break;
+      case 'FREENAS-MINI-3.0-X':
         this.chassis = new MINIX();
         break;
-      case ('FREENAS-MINI-3.0-XL+' || 'TRUENAS-MINI-3.0-XL+'):
+      case 'TRUENAS-MINI-3.0-X':
+        this.chassis = new MINIX();
+        break;
+      case 'FREENAS-MINI-3.0-XL+':
+        this.chassis = new MINIXLPLUS();
+        break;
+      case 'TRUENAS-MINI-3.0-XL+':
         this.chassis = new MINIXLPLUS();
         break;
       default:

--- a/src/app/pages/system/view-enclosure/enclosure-disks/enclosure-disks-mini.component.ts
+++ b/src/app/pages/system/view-enclosure/enclosure-disks/enclosure-disks-mini.component.ts
@@ -48,15 +48,15 @@ export class EnclosureDisksMiniComponent extends EnclosureDisksComponent {
 
   createEnclosure(enclosure: EnclosureMetadata = this.selectedEnclosure): void {
     switch (enclosure.model) {
-      case 'FREENAS-MINI-3.0-E':
-      case 'FREENAS-MINI-3.0-E+':
+      case ('FREENAS-MINI-3.0-E' || 'TRUENAS-MINI-3.0-E'):
+      case ('FREENAS-MINI-3.0-E+' || 'TRUENAS-MINI-3.0-E+'):
         this.chassis = new MINI();
         break;
-      case 'FREENAS-MINI-3.0-X':
-      case 'FREENAS-MINI-3.0-X+':
+      case ('FREENAS-MINI-3.0-X' || 'TRUENAS-MINI-3.0-X'):
+      case ('FREENAS-MINI-3.0-X+' || 'TRUENAS-MINI-3.0-X+'):
         this.chassis = new MINIX();
         break;
-      case 'FREENAS-MINI-3.0-XL+':
+      case ('FREENAS-MINI-3.0-XL+' || 'TRUENAS-MINI-3.0-XL+'):
         this.chassis = new MINIXLPLUS();
         break;
       default:

--- a/src/app/pages/system/view-enclosure/enclosure-disks/enclosure-disks-mini.component.ts
+++ b/src/app/pages/system/view-enclosure/enclosure-disks/enclosure-disks-mini.component.ts
@@ -49,20 +49,14 @@ export class EnclosureDisksMiniComponent extends EnclosureDisksComponent {
   createEnclosure(enclosure: EnclosureMetadata = this.selectedEnclosure): void {
     switch (enclosure.model) {
       case 'FREENAS-MINI-3.0-E':
-        this.chassis = new MINI();
-        break;
       case 'TRUENAS-MINI-3.0-E':
         this.chassis = new MINI();
         break;
       case 'FREENAS-MINI-3.0-X':
-        this.chassis = new MINIX();
-        break;
       case 'TRUENAS-MINI-3.0-X':
         this.chassis = new MINIX();
         break;
       case 'FREENAS-MINI-3.0-XL+':
-        this.chassis = new MINIXLPLUS();
-        break;
       case 'TRUENAS-MINI-3.0-XL+':
         this.chassis = new MINIXLPLUS();
         break;

--- a/src/app/pages/system/view-enclosure/enclosure-disks/enclosure-disks-mini.component.ts
+++ b/src/app/pages/system/view-enclosure/enclosure-disks/enclosure-disks-mini.component.ts
@@ -49,11 +49,15 @@ export class EnclosureDisksMiniComponent extends EnclosureDisksComponent {
   createEnclosure(enclosure: EnclosureMetadata = this.selectedEnclosure): void {
     switch (enclosure.model) {
       case 'FREENAS-MINI-3.0-E':
+      case 'FREENAS-MINI-3.0-E+':
       case 'TRUENAS-MINI-3.0-E':
+      case 'TRUENAS-MINI-3.0-E+':
         this.chassis = new MINI();
         break;
       case 'FREENAS-MINI-3.0-X':
+      case 'FREENAS-MINI-3.0-X+':
       case 'TRUENAS-MINI-3.0-X':
+      case 'TRUENAS-MINI-3.0-X+':
         this.chassis = new MINIX();
         break;
       case 'FREENAS-MINI-3.0-XL+':


### PR DESCRIPTION
This causes webUI to display the following error on SCALE MINI XL+
![image](https://user-images.githubusercontent.com/30729806/172237353-50adcbf7-d778-4747-897c-040e23772a1a.png)

Since we have rebranded to TrueNAS, most of the systems we ship out the door are flashed with the `TRUENAS-` prefix in SMBIOS. I know basically 0 about typescript but I think this will fix it?