### PR TITLE
NAS-115675 / 22.02.2 / NAS-115675: Fixed race condition

### DIFF
--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
@@ -409,6 +409,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     });
 
     this.volumeData = vd;
+    this.isDataReady();
   }
 
   getDisksData(): void {
@@ -455,7 +456,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
 
   isDataReady(): void {
     const isReady = Boolean(
-      this.statsDataEvent$ && Array.isArray(this.pools) && this.nics,
+      this.statsDataEvent$ && Array.isArray(this.pools) && this.nics && !!this.volumeData,
     );
 
     if (isReady) {


### PR DESCRIPTION
This addresses the Storage widget not showing up. But pool specific widgets simply don't show up because you have to enable them on the dashboard via the config button at the top right. But this fixes the issue with the storage widget. Normally, if you navigate away to a different page and then come back to the dashboard without refreshing the page, the storage page wouldn't show up 99% of the time. This fixes the issue with that.