### PR TITLE
NAS-116461 / 13.0 / Unsetting "UPS - No Communication Warning Time" gives error

### DIFF
--- a/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
+++ b/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
@@ -74,6 +74,8 @@ export class FormInputComponent implements Field {
       if (phrasedValue) {
         this.group.controls[this.config.name].setValue(phrasedValue);
       }
+    } else if (this.config.inputType === 'number' && !this.group.controls[this.config.name].value) {
+      this.group.controls[this.config.name].setValue(null);
     }
   }
 

--- a/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
+++ b/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
@@ -74,8 +74,6 @@ export class FormInputComponent implements Field {
       if (phrasedValue) {
         this.group.controls[this.config.name].setValue(phrasedValue);
       }
-    } else if (this.config.inputType === 'number' && !this.group.controls[this.config.name].value) {
-      this.group.controls[this.config.name].setValue(null);
     }
   }
 

--- a/src/app/pages/services/components/service-ups/service-ups.component.ts
+++ b/src/app/pages/services/components/service-ups/service-ups.component.ts
@@ -219,6 +219,7 @@ export class ServiceUPSComponent {
           name: 'nocommwarntime',
           placeholder: helptext.ups_nocommwarntime_placeholder,
           tooltip: helptext.ups_nocommwarntime_tooltip,
+          value: '300',
         },
         {
           type: 'input',

--- a/src/app/pages/services/components/service-ups/service-ups.component.ts
+++ b/src/app/pages/services/components/service-ups/service-ups.component.ts
@@ -219,7 +219,6 @@ export class ServiceUPSComponent {
           name: 'nocommwarntime',
           placeholder: helptext.ups_nocommwarntime_placeholder,
           tooltip: helptext.ups_nocommwarntime_tooltip,
-          value: '300',
         },
         {
           type: 'input',
@@ -307,5 +306,14 @@ export class ServiceUPSComponent {
 
   beforeSubmit(data: any) {
     data.driver = this.ups_driver_key;
+    if (data.nocommwarntime === '') {
+      data.nocommwarntime = null;
+    }
+    if (data.hostsync === '') {
+      data.hostsync = null;
+    }
+    if (data.shutdowntimer === '') {
+      data.shutdowntimer = null;
+    }
   }
 }

--- a/src/app/pages/services/components/service-ups/service-ups.component.ts
+++ b/src/app/pages/services/components/service-ups/service-ups.component.ts
@@ -219,7 +219,6 @@ export class ServiceUPSComponent {
           name: 'nocommwarntime',
           placeholder: helptext.ups_nocommwarntime_placeholder,
           tooltip: helptext.ups_nocommwarntime_tooltip,
-          value: '300',
         },
         {
           type: 'input',


### PR DESCRIPTION
Testing:
Services -> UPS -> Unset `No Communication Warning Time`

Changes:
Set null if the value of type `number` input is empty string