### PR TITLE
NAS-116727 / 22.12 / Remove unnecessary dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: truenas-webui
 Section: web
 Priority: optional
 Maintainer: Kris Moore <kris@ixsystems.com>
-Build-Depends: debhelper (>=10), debhelper-compat (= 12), npm (>= 6.14.0), make (>= 4.2.1), python2.7 (>= 2.7.16), ca-certificates, yarnpkg
+Build-Depends: debhelper (>=10), debhelper-compat (= 12), make (>= 4.2.1), python2.7 (>= 2.7.16), ca-certificates, yarn
 Standards-Version: 4.0.0
 
 Package: truenas-webui

--- a/debian/rules
+++ b/debian/rules
@@ -29,8 +29,7 @@ binary-stamp:
 	echo "export default { product:'${PRODUCT}' }" > src/app/helptext/product.ts
 	echo "var product = '${PRODUCT}'" > src/assets/scripts/product.js
 	tar xf node_files.tgz
-	npm install -g yarn
-	/usr/local/bin/yarn run build:prod:aot
+	/usr/bin/yarn run build:prod:aot
 	date +%s > dist/assets/buildtime
 	cp -r dist/* debian/truenas-webui/usr/share/truenas/webui
 	rm -rf dist/


### PR DESCRIPTION
This commit adds changes to install yarn package as that will effectively bring in latest nodejs and install npm as well. No need to define it separately. Also we are moving away from debian yarnpkg as it brings legacy nodejs dependencies which we have no use of as we have moved on to newer nodejs version.