### PR TITLE
NAS-116648 / 13.0 / NAS-116648: Warning messages when upgrading to Scale

### DIFF
--- a/src/app/helptext/system/update.ts
+++ b/src/app/helptext/system/update.ts
@@ -7,6 +7,35 @@ export const helptext_system_update = {
     paraText: T('<b>Current Version:</b> '),
   },
 
+  scaleUpdate: {
+    title: T('Updating to SCALE'),
+    warning: T(`<p>TrueNAS SCALE migrations are still in development and can risk configuration errors or even data loss.
+    Please back up any critical data to an external system before attempting the migration. Migrating to SCALE is intended to be a one-time event.
+    Reverting back to CORE after migration is unsupported.</p>
+
+    <p>These CORE configuration items cannot migrate to SCALE:</p>
+    <p>
+      <ul>
+        <li>&mdash; NIS Data</li>
+        <li>&mdash; Jails/Plugins</li>
+        <li>&mdash; Tunables</li>
+        <li>&mdash; System Boot Environments</li>
+        <li>&mdash; GELI encrypted pools</li>
+        <li>&mdash; AFP Shares</li>
+      </ul>
+    </p>
+
+    <p>For more details, please see the
+    <a href="https://www.truenas.com/docs/scale/gettingstarted/migratingfromcore/" target="_blank" style="text-decoration: underline;">CORE migration documentation</a>.
+    Please ensure the system is prepared for the migration and review the system configuration post-migration
+     to immediately resolve any configuration issues that might have occurred.</p>`),
+    haWarning: T(`Migrating a High Availability (HA) system from TrueNAS CORE to TrueNAS SCALE requires the entire
+    system go offline for some time to migrate and synchronize both controllers on the new operating system.
+    It is strongly recommended to contact iXsystems Support for assistance with the migration process.
+    Before migrating, please back up any critical data and schedule the system outage accordingly.
+    In the unlikely event of an error during migration, please be prepared to activate a previous system boot environment.`),
+  },
+
   filelocation: {
     placeholder: T('Update File Temporary Storage Location'),
     tooltip: T(

--- a/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
+++ b/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
@@ -74,6 +74,8 @@ export class FormInputComponent implements Field {
       if (phrasedValue) {
         this.group.controls[this.config.name].setValue(phrasedValue);
       }
+    } else if (this.config.inputType === 'number' && !this.group.controls[this.config.name].value) {
+      this.group.controls[this.config.name].setValue(null);
     }
   }
 

--- a/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
+++ b/src/app/pages/common/entity/entity-form/components/form-input/form-input.component.ts
@@ -74,8 +74,6 @@ export class FormInputComponent implements Field {
       if (phrasedValue) {
         this.group.controls[this.config.name].setValue(phrasedValue);
       }
-    } else if (this.config.inputType === 'number' && !this.group.controls[this.config.name].value) {
-      this.group.controls[this.config.name].setValue(null);
     }
   }
 

--- a/src/app/pages/services/components/service-ups/service-ups.component.ts
+++ b/src/app/pages/services/components/service-ups/service-ups.component.ts
@@ -219,6 +219,7 @@ export class ServiceUPSComponent {
           name: 'nocommwarntime',
           placeholder: helptext.ups_nocommwarntime_placeholder,
           tooltip: helptext.ups_nocommwarntime_tooltip,
+          value: '300',
         },
         {
           type: 'input',

--- a/src/app/pages/services/components/service-ups/service-ups.component.ts
+++ b/src/app/pages/services/components/service-ups/service-ups.component.ts
@@ -219,7 +219,6 @@ export class ServiceUPSComponent {
           name: 'nocommwarntime',
           placeholder: helptext.ups_nocommwarntime_placeholder,
           tooltip: helptext.ups_nocommwarntime_tooltip,
-          value: '300',
         },
         {
           type: 'input',
@@ -307,5 +306,14 @@ export class ServiceUPSComponent {
 
   beforeSubmit(data: any) {
     data.driver = this.ups_driver_key;
+    if (data.nocommwarntime === '') {
+      data.nocommwarntime = null;
+    }
+    if (data.hostsync === '') {
+      data.hostsync = null;
+    }
+    if (data.shutdowntimer === '') {
+      data.shutdowntimer = null;
+    }
   }
 }

--- a/src/app/pages/services/components/service-ups/service-ups.component.ts
+++ b/src/app/pages/services/components/service-ups/service-ups.component.ts
@@ -219,7 +219,6 @@ export class ServiceUPSComponent {
           name: 'nocommwarntime',
           placeholder: helptext.ups_nocommwarntime_placeholder,
           tooltip: helptext.ups_nocommwarntime_tooltip,
-          value: '300',
         },
         {
           type: 'input',

--- a/src/app/pages/system/update/update.component.ts
+++ b/src/app/pages/system/update/update.component.ts
@@ -230,22 +230,29 @@ export class UpdateComponent implements OnInit, OnDestroy {
     });
   }
 
-  onTrainChanged(event) {
+  onTrainChanged(newTrain: string) {
     // For the case when the user switches away, then BACK to the train of the current OS
-    if (event === this.selectedTrain) {
+    if (newTrain === this.selectedTrain) {
       this.currentTrainDescription = this.trainDescriptionOnPageLoad;
       this.setTrainAndCheck();
       return;
     }
 
     let warning = '';
-    if (this.fullTrainList[event].description.includes('[nightly]')) {
+    if (newTrain.toLocaleLowerCase().includes('scale')) {
+      warning = helptext.scaleUpdate.warning;
+      if (this.isHA) {
+        warning += ' ' + helptext.scaleUpdate.haWarning;
+      }
+    }
+
+    if (this.fullTrainList[newTrain].description.includes('[nightly]')) {
       warning = T('Changing to a nightly train is one-way. Changing back to a stable train is not supported! ');
     }
 
-    this.dialogService.confirm(T('Switch Train'), warning + T('Switch update trains?')).subscribe((train_res) => {
+    this.dialogService.confirm(T('Switch Train'), warning + T('<p>Switch update trains?</p>')).subscribe((train_res) => {
       if (train_res) {
-        this.train = event;
+        this.train = newTrain;
         this.setTrainDescription();
         this.setTrainAndCheck();
       } else {


### PR DESCRIPTION
Two things to test:
1. When you go to Manual update and select a scale update file, you should see a warning.
2. When you select a scale update train on main Update screen, you should see a warning.

Additional text if this is an HA system.
The only way to see more trains is to mock response in:
src/app/pages/system/update/update.component.ts:142
```
res = {
          "trains": {
            "TrueNAS-13.0-STABLE": {
              "description": "Community Release Only - Not Enterprise Supported [nightly]",
              "sequence": "75b35b700a587c9aad032005a55834d8"
            },
            "TrueNAS-SCALE-Angelfish": {
              "description": "TrueNAS SCALE Angelfish"
            }
          },
          "current": "TrueNAS-13.0-STABLE",
          "selected": "TrueNAS-SCALE-Angelfish"
        };
```