### PR TITLE
NAS-116937 / 22.12 / Locking a dataset doesn't refresh a tree

### DIFF
--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.ts
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.ts
@@ -1,14 +1,41 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit,
+} from '@angular/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Dataset } from 'app/interfaces/dataset.interface';
+import { DatasetStore } from 'app/pages/datasets/store/dataset-store.service';
+import { WebSocketService } from 'app/services';
 
+@UntilDestroy()
 @Component({
   selector: 'ix-dataset-node',
   templateUrl: './dataset-node.component.html',
   styleUrls: ['./dataset-node.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DatasetNodeComponent {
+export class DatasetNodeComponent implements OnInit {
   @Input() dataset: Dataset;
+
+  constructor(
+    private ws: WebSocketService,
+    private cdr: ChangeDetectorRef,
+    private datasetStore: DatasetStore,
+  ) { }
+
+  ngOnInit(): void {
+    this.datasetStore.onReloadList
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.reloadDataset());
+  }
+
+  reloadDataset(): void {
+    this.ws.call('pool.dataset.query', [[['id', '=', this.dataset.id]]])
+      .pipe(untilDestroyed(this))
+      .subscribe((datasets) => {
+        this.dataset = datasets[0];
+        this.cdr.markForCheck();
+      });
+  }
 
   get nameSegments(): string[] {
     return this.dataset.name.split('/');


### PR DESCRIPTION
Testing:
Datasets -> Select a Dataset (password protected) -> ZFS Encryption Card -> Click `Lock/Unlock` button
Check if refresh a tree by locking the dataset.