### PR TITLE
NAS-117036 / 22.12 / NAS-117036: Upgrade pool button

### DIFF
--- a/src/app/interfaces/pool.interface.ts
+++ b/src/app/interfaces/pool.interface.ts
@@ -38,6 +38,11 @@ export interface Pool {
   status: PoolStatus;
   status_detail: string;
   topology: PoolTopology;
+
+  /**
+   * Available with extra is_upgraded=true
+   */
+  is_upgraded?: boolean;
 }
 
 export interface PoolTopology {

--- a/src/app/interfaces/volumes-list-pool.interface.ts
+++ b/src/app/interfaces/volumes-list-pool.interface.ts
@@ -3,7 +3,6 @@ import { Pool } from 'app/interfaces/pool.interface';
 import { VolumesListTableConfig } from 'app/pages/storage/volumes/volumes-list/volumes-list-table-config';
 
 export interface VolumesListPool extends Pool {
-  is_upgraded: boolean;
   children: VolumesListDataset[];
   volumesListTableConfig: VolumesListTableConfig;
   type: 'zpool';

--- a/src/app/pages/storage2/components/dashboard-pool/dashboard-pool.component.html
+++ b/src/app/pages/storage2/components/dashboard-pool/dashboard-pool.component.html
@@ -2,6 +2,13 @@
   <h2 class="pool-name">{{ pool.name }}</h2>
   <div class="pool-actions">
     <button
+      *ngIf="!pool.is_upgraded"
+      mat-button
+      color="primary"
+      (click)="onUpgrade()"
+    >{{ 'Upgrade' | translate }}</button>
+
+    <button
       mat-button
       (click)="onExport()"
     >{{ 'Export/Disconnect' | translate }}</button>

--- a/src/app/pages/storage2/components/dashboard-pool/dashboard-pool.component.spec.ts
+++ b/src/app/pages/storage2/components/dashboard-pool/dashboard-pool.component.spec.ts
@@ -14,6 +14,7 @@ import { DashboardPoolComponent } from 'app/pages/storage2/components/dashboard-
 import {
   ExportDisconnectModalComponent,
 } from 'app/pages/storage2/components/dashboard-pool/export-disconnect-modal/export-disconnect-modal.component';
+import { DiskHealthCardComponent } from 'app/pages/storage2/components/disk-health-card/disk-health-card.component';
 import {
   WidgetUsageComponent,
 } from 'app/pages/storage2/components/pools-dashboard/widget-usage/widget-usage.component';
@@ -33,6 +34,7 @@ describe('DashboardPoolComponent', () => {
       MockComponent(ZfsHealthCardComponent),
       MockComponent(ExportDisconnectModalComponent),
       MockComponent(WidgetUsageComponent),
+      MockComponent(DiskHealthCardComponent),
     ],
     providers: [
       mockProvider(MatDialog),
@@ -43,6 +45,7 @@ describe('DashboardPoolComponent', () => {
       }),
       mockWebsocket([
         mockCall('pool.dataset.query', []),
+        mockCall('pool.upgrade'),
         mockJob('pool.expand', fakeSuccessfulJob()),
       ]),
     ],
@@ -81,8 +84,24 @@ describe('DashboardPoolComponent', () => {
     expect(spectator.inject(SnackbarService).success).toHaveBeenCalled();
   });
 
+  it('shows an Upgrade button that upgrades pool with confirmation when pool is not upgraded', async () => {
+    const upgradeButton = await loader.getHarness(MatButtonHarness.with({ text: 'Upgrade' }));
+    await upgradeButton.click();
+
+    expect(spectator.inject(DialogService).confirm).toHaveBeenCalled();
+    expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith('pool.upgrade', [pool.id]);
+
+    expect(spectator.inject(SnackbarService).success).toHaveBeenCalled();
+  });
+
   it('shows a ZFS Health card for the pool', () => {
     const card = spectator.query(ZfsHealthCardComponent);
+    expect(card).toBeTruthy();
+    expect(card.pool).toBe(pool);
+  });
+
+  it('shows a disk health card for the pool', () => {
+    const card = spectator.query(DiskHealthCardComponent);
     expect(card).toBeTruthy();
     expect(card.pool).toBe(pool);
   });

--- a/src/app/pages/storage2/components/dashboard-pool/dashboard-pool.component.ts
+++ b/src/app/pages/storage2/components/dashboard-pool/dashboard-pool.component.ts
@@ -118,4 +118,30 @@ export class DashboardPoolComponent implements OnInit {
       )
       .subscribe();
   }
+
+  onUpgrade(): void {
+    this.dialogService.confirm({
+      title: this.translate.instant('Upgrade Pool'),
+      message: this.translate.instant(helptext.upgradePoolDialog_warning) + this.pool.name,
+    }).pipe(
+      filter(Boolean),
+      switchMap(() => {
+        this.loader.open();
+        return this.ws.call('pool.upgrade', [this.pool.id]);
+      }),
+      tap(() => {
+        this.loader.close();
+        this.snackbar.success(
+          this.translate.instant('Pool {name} successfully upgraded.', { name: this.pool.name }),
+        );
+        this.poolsUpdated.emit();
+      }),
+      catchError((error) => {
+        this.loader.close();
+        new EntityUtils().handleWsError(this, error, this.dialogService);
+        return EMPTY;
+      }),
+      untilDestroyed(this),
+    ).subscribe();
+  }
 }

--- a/src/app/pages/storage2/components/pools-dashboard/pools-dashboard.component.ts
+++ b/src/app/pages/storage2/components/pools-dashboard/pools-dashboard.component.ts
@@ -55,7 +55,7 @@ export class PoolsDashboardComponent implements OnInit, AfterViewInit {
     // TODO: Add loading indicator
     // TODO: Handle error
     this.isPoolsLoading = true;
-    this.ws.call('pool.query').pipe(untilDestroyed(this)).subscribe(
+    this.ws.call('pool.query', [[], { extra: { is_upgraded: true } }]).pipe(untilDestroyed(this)).subscribe(
       (pools: Pool[]) => {
         this.pools = pools;
         this.isPoolsLoading = false;

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2081,6 +2081,7 @@
   "Pool Options Saved": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pools in Enclosure": "",
   "Port": "",
   "Port number on the remote system to use for the SSH  connection.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1589,6 +1589,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pools": "",
   "Pools in Enclosure": "",
   "Port": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -470,6 +470,7 @@
   "Pool": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pools in Enclosure": "",
   "Portal": "",
   "Post Init": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2241,6 +2241,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -563,6 +563,7 @@
   "Pool Options Saved": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pools in Enclosure": "",
   "Port": "",
   "Portals": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2200,6 +2200,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2016,6 +2016,7 @@
   "Pool Options Saved": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2449,6 +2449,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2378,6 +2378,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2375,6 +2375,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2292,6 +2292,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -956,6 +956,7 @@
   "Pool Options Saved": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pools in Enclosure": "",
   "Portals": "",
   "Ports": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2459,6 +2459,7 @@
   "Pool Status": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pool/Dataset": "",
   "Pools": "",
   "Pools in Enclosure": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -146,6 +146,7 @@
   "Pending Sync Keys Cleared": "",
   "Performance": "",
   "Pool has been unset.": "",
+  "Pool {name} successfully upgraded.": "",
   "Product": "",
   "Production": "",
   "Prototyping": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1844,6 +1844,7 @@
   "Pool Options Saved": "",
   "Pool has been unset.": "",
   "Pool options for {poolName} successfully saved.": "",
+  "Pool {name} successfully upgraded.": "",
   "Pools in Enclosure": "",
   "Port number on the remote system to use for the SSH  connection.": "",
   "Portals": "",


### PR DESCRIPTION
Testing:
`zpool create -o compatibility=legacy tank /dev/sdx`
where sdx is one of the unused disks.
`zpool export tank`
Import pool via UI and use Upgrade button on pools dashboard.

Pool will likely become offline after this one. This is likely middleware and unrelated to this PR.