### PR TITLE
Fix typo for word Compatibility

### DIFF
--- a/src/app/helptext/sharing/iscsi/iscsi.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi.ts
@@ -149,7 +149,7 @@ export const helptextSharingIscsi = {
 
   fieldset_extent_basic: T('Basic Info'),
   fieldset_extent_type: T('Type'),
-  fieldset_extent_options: T('Compatability'),
+  fieldset_extent_options: T('Compatibility'),
 
   extent_placeholder_name: T('Name'),
   extent_tooltip_name: T(

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -637,7 +637,7 @@
   "Common": "",
   "Common Name": "",
   "Common: ": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2801,7 +2801,7 @@
   "Command": "Befehl",
   "Comment": "Kommentar",
   "Comments": "Kommentare",
-  "Compatability": "Kompatibilität",
+  "Compatibility": "Kompatibilität",
   "Complete the Upgrade": "Upgrade fertigstellen",
   "Compress": "Komprimieren",
   "Compression": "Kompression",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1568,7 +1568,7 @@
   "Common Name": "Nombre común",
   "Common: ": "Común: ",
   "Community": "Comunidad",
-  "Compatability": "Compatibilidad",
+  "Compatibility": "Compatibilidad",
   "Complete the Upgrade": "Completa la actualización",
   "Completed": "Completado",
   "Compress": "Comprimir",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3792,7 +3792,7 @@
   "Comment": "Comentario",
   "Comments": "Comentarios",
   "Community": "Comunidad",
-  "Compatability": "Compatibilidad",
+  "Compatibility": "Compatibilidad",
   "Compression": "Compresión",
   "Compression level": "Nivel de compresión",
   "Configure": "Configurar",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1641,7 +1641,7 @@
   "Common Name": "Nom commun",
   "Common: ": "Commun: ",
   "Community": "Communauté",
-  "Compatability": "Compatibilité",
+  "Compatibility": "Compatibilité",
   "Complete the Upgrade": "Terminer la mise à niveau",
   "Completed": "Terminé",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "Répliquer complètement le dataset sélectionné. Le dataset cible aura toutes les propriétés du dataset source, les datasets enfants, les clones et les instantanés qui correspondent au schéma de nommage spécifié. Définissez l'expression régulière du nom de l'instantané sur .* pour répliquer tous les instantanés.",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -559,7 +559,7 @@
   "Common": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",
   "Compress Connections": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3572,7 +3572,7 @@
   "Comments": "コメント",
   "Common Name": "共通名",
   "Community": "コミュニティー",
-  "Compatability": "互換性",
+  "Compatibility": "互換性",
   "Completed": "完了",
   "Compress": "圧縮",
   "Compression Ratio": "圧縮比",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -692,7 +692,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -633,7 +633,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -619,7 +619,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -649,7 +649,7 @@
   "Common": "",
   "Common Name": "",
   "Common: ": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -2250,7 +2250,7 @@
   "Comments about this script.": "Комментарии об этом скрипте.",
   "Common Name": "Общее имя",
   "Community": "Сообщество",
-  "Compatability": "Совместимость",
+  "Compatibility": "Совместимость",
   "Complete the Upgrade": "Завершить обновление",
   "Completed": "Завершенный",
   "Compress": "Сжатие",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -700,7 +700,7 @@
   "Common Name": "",
   "Common: ": "",
   "Community": "",
-  "Compatability": "",
+  "Compatibility": "",
   "Complete the Upgrade": "",
   "Completed": "",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -938,7 +938,7 @@
   "Common Name": "通用名",
   "Common: ": "常见的：",
   "Community": "社区",
-  "Compatability": "兼容性",
+  "Compatibility": "兼容性",
   "Complete the Upgrade": "完成升级",
   "Completed": "完成",
   "Completely replicate the selected dataset. The target dataset will have all of the source dataset's properties, child datasets, clones and snapshots that match the specified naming schema. Set Snapshot Name Regular Expression to .* to replicate all snapshots.": "完全复制所选数据集。 目标数据集将具有与指定命名模式匹配的所有源数据集的属性、子数据集、克隆和快照。 将快照名称正则表达式设置为 .* 以复制所有快照。",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -3272,7 +3272,7 @@
   "Comments": "註解",
   "Common Name": "一般名稱",
   "Community": "社群",
-  "Compatability": "相容性",
+  "Compatibility": "相容性",
   "Completed": "已完成",
   "Compress": "壓縮",
   "Compression Ratio": "壓縮比",


### PR DESCRIPTION
The word _Compatibility_ was misspelled in the source code and in the `i18n/*.json` files.

Compat-a-bility -> Compat-i-bility