### PR TITLE
NAS-117038 / 22.02.2.1 / NAS-117038: Fixing Upgrade Pool menu item (by undsoft)

### DIFF
--- a/src/app/pages/storage/volumes/volumes-list/volumes-list-table-config.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list-table-config.ts
@@ -760,7 +760,7 @@ export class VolumesListTableConfig implements EntityTableConfig {
                       this.translate.instant('Successfully Upgraded {poolName}.', { poolName: row1.name }),
                       '500px',
                       'info',
-                    ).pipe(untilDestroyed(this)).subscribe(() => {
+                    ).pipe(untilDestroyed(this, 'destroy')).subscribe(() => {
                       this.parentVolumesListComponent.repaintMe();
                     });
                   },

--- a/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
+++ b/src/app/pages/storage/volumes/volumes-list/volumes-list.component.ts
@@ -210,13 +210,11 @@ export class VolumesListComponent extends EntityTableComponent implements OnInit
     }
 
     combineLatest([
-      this.ws.call('pool.query'),
-      this.ws.call(this.datasetQuery, this.datasetQueryOptions),
       this.ws.call('pool.query', [[], { extra: { is_upgraded: true } }]),
-    ]).pipe(untilDestroyed(this)).subscribe(([pools, datasets, upgradedPools]) => {
+      this.ws.call(this.datasetQuery, this.datasetQueryOptions),
+    ]).pipe(untilDestroyed(this)).subscribe(([pools, datasets]) => {
       this.zfsPoolRows = pools.map((originalPool) => {
         const pool = { ...originalPool } as VolumesListPool;
-        pool.is_upgraded = !!upgradedPools.find((upgradedPool) => upgradedPool.id === pool.id);
 
         /* Filter out system datasets */
         const pChild = datasets.find((set) => set.name === pool.name);


### PR DESCRIPTION
Testing:
`zpool create -o compatibility=legacy tank /dev/sdx`
where sdx is one of the unused disks.
`zpool export tank`
Import pool via UI, go to cog icon on a pool and select Upgrade pool.

Original PR: https://github.com/truenas/webui/pull/6851
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117038