### PR TITLE
NAS-117017 / 22.12 / NAS-117017: Investigate the conditions for Encryption card on Dataset…

### DIFF
--- a/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.html
+++ b/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.html
@@ -27,6 +27,7 @@
   <ix-dataset-details-card [dataset]="dataset"></ix-dataset-details-card>
   <ix-permissions-card [dataset]="dataset" *ngIf="hasPermissions"></ix-permissions-card>
   <ix-zfs-encryption-card
+    *ngIf="dataset.encrypted"
     [dataset]="dataset"
     [parentDataset]="parentDataset"
   ></ix-zfs-encryption-card>

--- a/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.spec.ts
@@ -34,6 +34,7 @@ describe('DatasetDetailsPanelComponent', () => {
     name: 'root/parent/child',
     mountpoint: '/mnt/root/parent/child',
     type: DatasetType.Filesystem,
+    encrypted: true,
   } as Dataset;
   const parentDataset = {
     name: 'root/parent',


### PR DESCRIPTION
In a result of investigated if encryption can be changed post dataset creation, that edit button is to update the encrypt properties of a dataset encrypted already.
If to use the edit button post dataset creation with non-encryption, additional process to encrypte that dataset is needed before that at least, I think.
Because there is no feature like that currently, so it can't active an edit button I removed a ZFS encryption card in a case of non-encryption.