### PR TITLE
NAS-116894 / 22.12 / NAS-116894: Application Events is not sorted

### DIFF
--- a/src/app/interfaces/chart-release-event.interface.ts
+++ b/src/app/interfaces/chart-release-event.interface.ts
@@ -10,7 +10,7 @@ export interface ChartReleaseEvent {
   kind: unknown;
   last_timestamp: ApiTimestamp;
   message: string;
-  metadata: unknown;
+  metadata: ChartEventMetadata;
   reason: string;
   related: unknown;
   reporting_component: string;
@@ -43,4 +43,13 @@ export interface ChartRollbackParams {
   recreate_resources?: boolean;
   rollback_snapshot?: boolean;
   item_version: string;
+}
+
+export interface ChartEventMetadata {
+  creation_timestamp?: {
+    $date?: number;
+  };
+  namespace: string;
+  name: string;
+  uid: string;
 }

--- a/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.html
+++ b/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.html
@@ -76,7 +76,7 @@
       <div class="expansion-content">
         <div *ngIf="chartEvents.length > 0; else no_event">
           <div fxLayout="row" fxLayoutAlign="start start" *ngFor="let event of chartEvents; let i = index" class="detail-row" [ngClass]="{'row-dark': i%2==0}">
-            <div class="event-time">{{ event.first_timestamp?.$date | date: 'yyyy-MM-dd H:mm:ss' }}</div>
+            <div class="event-time">{{ event.metadata.creation_timestamp?.$date | date: 'yyyy-MM-dd H:mm:ss' }}</div>
             <div class="event-message">{{ event.message }}</div>
           </div>
         </div>

--- a/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.ts
+++ b/src/app/pages/applications/dialogs/chart-events/chart-events-dialog.component.ts
@@ -45,7 +45,9 @@ export class ChartEventsDialogComponent implements OnInit {
         this.catalogApp = charts[0];
       }
       if (events) {
-        this.chartEvents = events.reverse();
+        this.chartEvents = [...events].sort((a, b) => {
+          return b.metadata.creation_timestamp?.$date - a.metadata.creation_timestamp?.$date;
+        });
       }
     });
   }
@@ -88,7 +90,9 @@ export class ChartEventsDialogComponent implements OnInit {
     this.loader.open();
     this.appService.getChartReleaseEvents(this.catalogApp.name).pipe(untilDestroyed(this)).subscribe((evt) => {
       this.loader.close();
-      this.chartEvents = evt.reverse();
+      this.chartEvents = [...evt].sort((a, b) => {
+        return b.metadata.creation_timestamp?.$date - a.metadata.creation_timestamp?.$date;
+      });
       this.eventsPanel.open();
     });
   }


### PR DESCRIPTION
Apps -> Installed Applications 
Check sorting of Application Events
_metadata.creation_timestamp?.$date_ was used instead of _first_timestamp?.$date_

![image](https://user-images.githubusercontent.com/22006748/179968086-a2e75fca-feac-4fb5-b099-9bf8b6a2008b.png)
