### PR TITLE
NAS-117269 / 22.02.3 / add NO_FENCED to disabled reason enum

### DIFF
--- a/src/app/enums/failover-disabled-reason.enum.ts
+++ b/src/app/enums/failover-disabled-reason.enum.ts
@@ -8,4 +8,5 @@ export enum FailoverDisabledReason {
   DisagreeCarp = 'DISAGREE_CARP',
   MismatchDisks = 'MISMATCH_DISKS',
   NoCriticalInterfaces = 'NO_CRITICAL_INTERFACES',
+  NoFenced = 'NO_FENCED',
 }

--- a/src/app/helptext/topbar.ts
+++ b/src/app/helptext/topbar.ts
@@ -17,6 +17,7 @@ export default {
     [FailoverDisabledReason.DisagreeCarp]: T('Nodes CARP states do not agree.'),
     [FailoverDisabledReason.MismatchDisks]: T('The TrueNAS controllers do not have the same quantity of disks.'),
     [FailoverDisabledReason.NoCriticalInterfaces]: T('No network interfaces are marked critical for failover.'),
+    [FailoverDisabledReason.NoFenced]: T('Fenced is not running.'),
   },
   updateRunning_dialog: {
     title: T('Update in Progress'),


### PR DESCRIPTION
Changes were made to fix a problem with HA systems here: https://github.com/truenas/middleware/pull/9439. I added a new `NO_FENCED` value to be returned so I'm adding it here on front-end.