### PR TITLE
NAS-116483 / 22.12 / NAS-116483: Using new `vm.device.disk_choices` endpoint in VMs.

### DIFF
--- a/setup_env.js
+++ b/setup_env.js
@@ -8,9 +8,9 @@ program
 
 var proxy_config_json = './proxy.config.json';
 var environment_ts = './src/environments/environment.ts';
-var hostname = (program.ip || '').match(/^(?:https?:\/\/)?(?:[^@\n]+@)?([^:\/\n?]+)/);
+var hostname = (program.ip || '').match(/^(?:https?:\/\/)?(?:[^@\n]+@)?([^:\/\n?]+)(?::([0-9]+))/);
 
-if (!hostname || !hostname[1]) {
+if (!hostname || !hostname[0]) {
   program.outputHelp();
   process.exit(2);
 }
@@ -21,7 +21,7 @@ var copySkel = function(file) {
     if (err) {
       return console.log(err);
     }
-    var result = data.replace(/\$SERVER\$/g, hostname[1]);
+    var result = data.replace(/\$SERVER\$/g, hostname[0]);
 
     fs.writeFile(file, result, 'utf8', function (err) {
        if (err) return console.log(err);

--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -913,6 +913,7 @@ export type ApiDirectory = {
   'vm.device.passthrough_device_choices': { params: void; response: { [id: string]: VmPassthroughDeviceChoice } };
   'vm.device.create': { params: [VmDeviceUpdate]; response: VmDevice };
   'vm.device.delete': { params: [number, VmDeviceDelete]; response: boolean };
+  'vm.device.disk_choices': { params: void; response: Choices };
   'vm.random_mac': { params: void; response: string };
   'vm.device.query': { params: QueryParams<VmDevice>; response: VmDevice[] };
   'vm.stop': { params: VmStopParams; response: void };

--- a/src/app/pages/vm/devices/device-form/device-form.component.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.ts
@@ -6,7 +6,6 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, of } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { DatasetType } from 'app/enums/dataset.enum';
 import {
   VmDeviceType, VmDiskMode, VmDisplayType, VmNicType,
 } from 'app/enums/vm.enum';
@@ -103,9 +102,7 @@ export class DeviceFormComponent implements OnInit {
     ),
   );
   readonly zvolProvider = new SimpleAsyncComboboxProvider(
-    this.ws.call('pool.dataset.query', [[['type', '=', DatasetType.Volume]]]).pipe(
-      map((zvols) => zvols.map((zvol) => ({ label: zvol.id, value: `/dev/zvol/${zvol.id}` }))),
-    ),
+    this.ws.call('vm.device.disk_choices').pipe(choicesToOptions()),
   );
 
   readonly fileNodeProvider = this.filesystemService.getFilesystemNodeProvider();

--- a/src/app/pages/vm/vm-list/vm-list.component.html
+++ b/src/app/pages/vm/vm-list/vm-list.component.html
@@ -1,4 +1,11 @@
+<ng-template #pageHeader>
+  <ix-page-title-header>
+    <button *ngIf="canAdd" mat-button color="primary" (click)="doAdd()">{{ 'Add' | translate }}</button>
+  </ix-page-title-header>
+</ng-template>
+
 <div class="vm-summary" *ngIf="hasVirtualizationSupport">
-  <p *ngIf="availMem"><strong>{{memTitle | translate}}</strong> {{availMem}} - {{memWarning | translate}}</p>
+  <p *ngIf="availableMemory"><strong>{{memTitle | translate}}</strong> {{availableMemory}} - {{memWarning | translate}}</p>
 </div>
-<ix-entity-table [title]='title' [conf]='this'></ix-entity-table>
+
+<ix-entity-table [title]="title" [conf]="this"></ix-entity-table>

--- a/src/app/pages/vm/vm.module.ts
+++ b/src/app/pages/vm/vm.module.ts
@@ -15,6 +15,7 @@ import { EntityFormService } from 'app/modules/entity/entity-form/services/entit
 import { MessageService } from 'app/modules/entity/entity-form/services/message.service';
 import { EntityModule } from 'app/modules/entity/entity.module';
 import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
+import { LayoutModule } from 'app/modules/layout/layout.module';
 import { TerminalModule } from 'app/modules/terminal/terminal.module';
 import { DeviceFormComponent } from 'app/pages/vm/devices/device-form/device-form.component';
 import { DeviceDeleteModalComponent } from 'app/pages/vm/devices/device-list/device-delete-modal/device-delete-modal.component';
@@ -47,6 +48,7 @@ import { routing } from './vm.routing';
     TerminalModule,
     IxFormsModule,
     CastModule,
+    LayoutModule,
   ],
   declarations: [
     VmListComponent,

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -635,7 +635,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Commands": "",
   "Comments about this script.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2835,7 +2835,6 @@
   "Close": "Schließen",
   "Cloud Credentials": "Cloud-Anmeldeinformationen",
   "Columns": "Spalten",
-  "Com Port": "COM Port",
   "Command": "Befehl",
   "Comment": "Kommentar",
   "Comments": "Kommentare",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1595,7 +1595,6 @@
   "Collapse": "Colapsar",
   "Collapse Row": "Colapsar Row",
   "Columns": "Columnas",
-  "Com Port": "Puerto com",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "Combine múltiples interfaces críticas para la conmutación por error en un grupo. Los grupos se aplican a sistemas individuales. Se produce una conmutación por error cuando falla cada interfaz del grupo. Los grupos con una sola interfaz desencadenan una conmutación por error cuando la interfaz falla. La configuración del sistema para la conmutación por error cuando falla cualquier interfaz requiere marcar cada interfaz como crítica y colocarlas en grupos separados.",
   "Command": "Comando",
   "Commands": "Comandos",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -622,7 +622,6 @@
   "Cluster DNS IP": "",
   "Collapse": "",
   "Collapse Row": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Commands": "",
   "Comments about this script.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1662,7 +1662,6 @@
   "Collapse": "Réduire",
   "Collapse Row": "Réduire la ligne",
   "Columns": "Colonnes",
-  "Com Port": "Port Com",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "Combinez plusieurs interfaces critiques pour le basculement (failover) dans un groupe. Les groupes s'appliquent à des systèmes individuels. Un basculement (failover) se produit lorsque chaque interface du groupe tombe en panne. Les groupes avec une seule interface déclenchent un basculement (failover) en cas de défaillance de cette interface. Pour configurer le système afin qu'il bascule en cas de défaillance d'une interface, il faut marquer chaque interface comme critique et les placer dans des groupes distincts.",
   "Command": "Commande",
   "Commands": "Commandes",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -556,7 +556,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -498,7 +498,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Commands": "",
   "Comments about this script.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -686,7 +686,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -627,7 +627,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -613,7 +613,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -646,7 +646,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -2280,7 +2280,6 @@
   "Close": "Закрыть",
   "Cloud Credentials": "Облачные учетные данные",
   "Columns": "Столбцы",
-  "Com Port": "Com порт",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "Объедините несколько критических для аварийного переключения интерфейсов в группу. Группы применяются к отдельным системам. Аварийное переключение происходит, когда происходит сбой каждого интерфейса в группе. Группы с одним интерфейсом вызывают аварийное переключение при сбое этого интерфейса. Настройка системы на аварийное переключение при сбое любого интерфейса требует пометить каждый интерфейс как критический и поместить их в отдельные группы.",
   "Command": "Команда",
   "Comment": "Комментарий",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -694,7 +694,6 @@
   "Collapse": "",
   "Collapse Row": "",
   "Columns": "",
-  "Com Port": "",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "",
   "Command": "",
   "Commands": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -966,7 +966,6 @@
   "Collapse": "折叠",
   "Collapse Row": "解散行",
   "Columns": "列",
-  "Com Port": "COM端口",
   "Combine multiple, critical-for-failover  interfaces into a group. Groups apply to single systems. A failover  occurs when every interface in the group fails. Groups with a single  interface trigger a failover when that interface fails. Configuring the  system to failover when any interface fails requires marking each  interface as critical and placing them in separate groups.": "将多个故障转移关键接口组合在一起。组适用于单个系统。组中的每个接口均发生故障时，将发生故障转移。具有单个接口的组会在该接口发生故障时触发故障转移。将系统配置为在任何接口出现故障时进行故障转移都需要将每个接口标记为关键接口，并将它们放在单独的组中。",
   "Command": "命令",
   "Commands": "命令",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -3304,7 +3304,6 @@
   "Close": "關閉",
   "Cloud Credentials": "雲端憑證",
   "Columns": "欄位",
-  "Com Port": "Com 連接埠",
   "Command": "指令",
   "Comment": "註解",
   "Comments": "註解",


### PR DESCRIPTION
Testing:
1. Create two zvols with spaces in the name.
2. Create a VM using first zvol.
3. Use Devices -> Add to add second zvol.

Also fixes:
- VM button that was missing from the toolbar in VMs.
- setup_env script will now respect port