### PR TITLE
NAS-117301 / 22.12 / NAS-117301: Remove close icon

### DIFF
--- a/src/app/pages/vm/devices/device-list/device-list.component.ts
+++ b/src/app/pages/vm/devices/device-list/device-list.component.ts
@@ -48,15 +48,6 @@ export class DeviceListComponent implements EntityTableConfig {
     sorting: { columns: this.columns },
   };
 
-  globalConfig = {
-    id: 'config',
-    tooltip: this.translate.instant('Close (return to VM list)'),
-    icon: 'highlight_off',
-    onClick: () => {
-      this.router.navigate(['/', 'vm']);
-    },
-  };
-
   constructor(
     protected router: Router,
     protected aroute: ActivatedRoute,

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -625,7 +625,6 @@
   "Clone Boot Environment": "",
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Sync Task": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -422,7 +422,6 @@
   "Clone Boot Environment": "",
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Sync Task": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1601,7 +1601,6 @@
   "Clone To New Dataset": "Clonar a nuevo conjunto de datos",
   "Clone to New Dataset": "Clonar a un nuevo conjunto de datos",
   "Close": "Cerrar",
-  "Close (return to VM list)": "Cerrar (volver a la lista de máquinas virtuales)",
   "Close expanded row": "Cerrar fila expandida",
   "Close panel": "Cerrar panel",
   "Cloud Credentials": "Credenciales en la nube",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -612,7 +612,6 @@
   "Clone Boot Environment": "",
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1666,7 +1666,6 @@
   "Clone To New Dataset": "Cloner vers un nouveau dataset",
   "Clone to New Dataset": "Cloner vers un nouveau dataset",
   "Close": "Fermer",
-  "Close (return to VM list)": "Fermer (retour à la liste des VM)",
   "Close expanded row": "Fermer la ligne développée",
   "Close panel": "Fermer le panneau",
   "Cloud Credentials": "Identifiants Cloud",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -546,7 +546,6 @@
   "Clone Boot Environment": "",
   "Clone To New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Sync Task": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -488,7 +488,6 @@
   "Clicking Continue allows TrueNAS to finish the update in the background while  Abort stops the process and reverts the dataset ACL to the previously active ACL.": "",
   "Client Certificate": "",
   "Clone To New Dataset": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Sync Task": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -675,7 +675,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -616,7 +616,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -602,7 +602,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -636,7 +636,6 @@
   "Clone Boot Environment": "",
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Sync Task": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -227,7 +227,6 @@
   "Click for information on    <a href=\"https://www.truenas.com/docs/truenasupgrades/\" target=\"_blank\">TrueNAS SCALE Migration, Nightly trains    and other upgrade options.</a>": "",
   "Clicking Continue allows TrueNAS to finish the update in the background while  Abort stops the process and reverts the dataset ACL to the previously active ACL.": "",
   "Clone To New Dataset": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Sync Task": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -683,7 +683,6 @@
   "Clone To New Dataset": "",
   "Clone to New Dataset": "",
   "Close": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Credentials": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -970,7 +970,6 @@
   "Clone To New Dataset": "克隆到新数据集",
   "Clone to New Dataset": "克隆到新数据集",
   "Close": "关闭",
-  "Close (return to VM list)": "关闭（返回虚拟机列表）",
   "Close expanded row": "关闭扩展行",
   "Close panel": "关闭面板",
   "Cloud Credentials": "云凭据",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -510,7 +510,6 @@
   "Client Name": "",
   "Clone Boot Environment": "",
   "Clone To New Dataset": "",
-  "Close (return to VM list)": "",
   "Close expanded row": "",
   "Close panel": "",
   "Cloud Sync Task": "",


### PR DESCRIPTION
We don't need this since there is a breadcrumb leading back to the VM page.
To test just go to VMs page and choose "Devices" from the row actions. On the Devices page there should not be a close icon (x) next to the Add button in the page title area