### PR TITLE
NAS-117366 / 22.12 / NAS-117366: Make `patch` status check optional on codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
 github_checks:
   annotations: false
+coverage:
+  patch:
+    default:
+      informational: true


### PR DESCRIPTION
This _should_ disable the status check that complains that not enough % was covered in the diff.