### PR TITLE
NAS-116915 / 22.12 / NAS-116915: Add the pool header row on Datasets IxTreeTable (v2)

### DIFF
--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
@@ -69,6 +69,10 @@ ix-dataset-details-panel {
 
 .dataset-tree {
   border-top: 2px solid var(--lines);
+
+  ix-nested-tree-node:not(:last-child) {
+    border-bottom: 10px solid var(--bg1);
+  }
 }
 
 .dataset-tree-header {

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
@@ -70,7 +70,7 @@ ix-dataset-details-panel {
 .dataset-tree {
   border-top: 2px solid var(--lines);
 
-  ix-nested-tree-node:not(:last-child) {
+  > :not(:last-child) {
     border-bottom: 10px solid var(--bg1);
   }
 }


### PR DESCRIPTION
V2 of #6883 

<img width="428" alt="image" src="https://user-images.githubusercontent.com/20611516/183024710-f7f4eab4-c66f-4d18-bdfb-f891b47f9280.png">


**Update**: the purpose of this PR

> Let's keep current branch and PR open and try a different option with just having some visual separation between pools:
> 
> <img alt="image (3)" width="2000" src="https://user-images.githubusercontent.com/1481270/182607930-df335c32-7a69-45fa-8634-5d1a589c019e.png">

