### PR TITLE
NAS-117509 / 22.12 / NAS-117509: Sync colors and fonts

### DIFF
--- a/src/app/pages/storage2/components/pools-dashboard/pool-usage-card/gauge-chart/gauge-chart.component.scss
+++ b/src/app/pages/storage2/components/pools-dashboard/pool-usage-card/gauge-chart/gauge-chart.component.scss
@@ -8,9 +8,10 @@
 .label {
   font-size: 40px;
   font-weight: bold;
+  font-family: "Epilogue", var(--font-family-body);
   left: 50%;
   letter-spacing: -1px;
   position: absolute;
   top: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -42%);
 }

--- a/src/app/pages/storage2/components/pools-dashboard/pool-usage-card/pool-usage-card.component.html
+++ b/src/app/pages/storage2/components/pools-dashboard/pool-usage-card/pool-usage-card.component.html
@@ -24,13 +24,13 @@
       <span class="loader-chart" *ngIf="loading"></span>
       <ng-container *ngIf="!loading">
         <ix-gauge-chart
-          [colorFill]="usageState.usedPct === 0 ? '#1E1E1E' : isLowCapacity ? 'red' : '#0095D5'"
+          [colorFill]="usageState.usedPct === 0 ? '#1E1E1E' : isLowCapacity ? '#CE2929' : '#0095D5'"
           [colorBlank]="'#1E1E1E'"
           [width]="160"
           [height]="160"
           [label]="usageState.usedPct + '%'"
           [value]="usageState.usedPct > 100 ? 100 : usageState.usedPct"
-          [style]="isLowCapacity ? 'color: red;' : ''"
+          [style]="isLowCapacity ? 'color: var(--red);' : ''"
         ></ix-gauge-chart>
         <div fxLayout="row" class="warning-container" *ngIf="isLowCapacity">
           <!-- <mat-icon class="pool-icon icon-warning">warning</mat-icon> -->

--- a/src/app/pages/storage2/components/pools-dashboard/pool-usage-card/pool-usage-card.component.spec.ts
+++ b/src/app/pages/storage2/components/pools-dashboard/pool-usage-card/pool-usage-card.component.spec.ts
@@ -70,7 +70,7 @@ describe('PoolUsageCardComponent', () => {
     // expect(spectator.query('.warning-container mat-icon')).toHaveText('warning');
     expect(spectator.query(GaugeChartComponent).label).toBe('81%');
     expect(spectator.query(GaugeChartComponent).value).toBe(81);
-    expect(spectator.query(GaugeChartComponent).colorFill).toBe('red');
+    expect(spectator.query(GaugeChartComponent).colorFill).toBe('#CE2929');
   });
 
   it('rendering status icon', () => {


### PR DESCRIPTION
**Testing**
Go to **Storage** page. On the **Usage** card gauge chart should have:
- same share of red color as in other places
- same font as the number of "Unassigned disks"