### PR TITLE
NAS-117628 / 22.12 / NAS-117628: Dataset quota is not shown

### DIFF
--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.html
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.html
@@ -43,11 +43,16 @@
         </span>
         <span class="value">{{ dataset.available.parsed | filesize: { standard: 'iec', round: 0 } }}</span>
       </div>
-      <div class="details-item" *ngIf="isFilesystem && hasQuota">
-        <span class="label">{{ 'Applied Dataset Quotas' | translate }}:</span>
-        <span class="value">
+      <div class="details-item" *ngIf="isFilesystem && hasQuota || hasRefQuota">
+        <span class="label">{{ 'Applied Dataset Quota' | translate }}:</span>
+        <span class="value" *ngIf="hasQuota; else refquotaValue">
           {{ '{n} (applies to descendants)' | translate: { n: dataset.quota.parsed | filesize: { standard: 'iec', round: 0 } } }}
         </span>
+        <ng-template #refquotaValue>
+          <span class="value">
+            {{ '{n}' | translate: { n: dataset.refquota.parsed | filesize: { standard: 'iec', round: 0 } } }}
+          </span>
+        </ng-template>
       </div>
       <div class="details-item" *ngIf="hasInheritedQuotas">
         <span class="label">{{ 'Inherited Quotas' | translate }}:</span>

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.spec.ts
@@ -115,7 +115,7 @@ describe('DatasetCapacityManagementCardComponent', () => {
       expect(items.length).toEqual(3);
       expect(items[0].querySelector('.label')).toHaveText('Space Available to Dataset:');
       expect(items[0].querySelector('.value')).toHaveText('1 GiB');
-      expect(items[1].querySelector('.label')).toHaveText('Applied Dataset Quotas:');
+      expect(items[1].querySelector('.label')).toHaveText('Applied Dataset Quota:');
       expect(items[1].querySelector('.value')).toHaveText('8 MiB');
       expect(items[2].querySelector('.label')).toHaveText('Inherited Quotas:');
       expect(items[2].querySelector('.value')).toHaveText('16 MiB');

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.ts
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.ts
@@ -46,6 +46,10 @@ export class DatasetCapacityManagementCardComponent implements OnChanges, OnInit
     return Boolean(this.dataset?.quota?.parsed);
   }
 
+  get hasRefQuota(): boolean {
+    return Boolean(this.dataset?.refquota?.parsed);
+  }
+
   get hasInheritedQuotas(): boolean {
     return this.inheritedQuotasDataset?.quota?.parsed && this.inheritedQuotasDataset?.id !== this.dataset?.id;
   }


### PR DESCRIPTION
**Testing:**
Datasets => Dataset Space Management card

- If `Quota for this dataset and all children` field is changed as not 0:

![image](https://user-images.githubusercontent.com/22980553/184519372-361d378b-8820-42d6-8117-5567153cbfb0.png)

- If `Quota for this dataset and all children` field is changed as 0 and `Quota for this dataset` field is changed as not 0:

![image](https://user-images.githubusercontent.com/22980553/184519393-3111e3ba-043b-4fb8-8f10-9e1f68902a93.png)

