### PR TITLE
NAS-117720 / 22.12 / NAS-117720: Bluefin HA testing: UI logout when saving failover settings

### DIFF
--- a/src/app/pages/system/failover-settings/failover-settings.component.spec.ts
+++ b/src/app/pages/system/failover-settings/failover-settings.component.spec.ts
@@ -112,6 +112,7 @@ describe('FailoverComponent', () => {
   it(`warns when Default TrueNAS controller checkbox is ticked off
     and changes Save button to Save And Failover`, async () => {
     await form.fillForm({
+      'Disable Failover': true,
       'Default TrueNAS controller': false,
     });
 

--- a/src/app/pages/system/failover-settings/failover-settings.component.ts
+++ b/src/app/pages/system/failover-settings/failover-settings.component.ts
@@ -31,7 +31,7 @@ export class FailoverSettingsComponent implements OnInit {
   subscriptions: Subscription[] = [];
 
   submitButtonText$ = this.form.select((values) => {
-    if (!values.master && !values.disabled) {
+    if (!values.master) {
       return this.translate.instant('Save And Failover');
     }
     return this.translate.instant('Save');
@@ -55,7 +55,7 @@ export class FailoverSettingsComponent implements OnInit {
 
   onSubmit(): void {
     this.isLoading = true;
-    const values = this.form.value;
+    const values = this.form.getRawValue();
 
     this.ws.call('failover.update', [values])
       .pipe(
@@ -201,7 +201,7 @@ export class FailoverSettingsComponent implements OnInit {
   private setFormRelations(): void {
     this.subscriptions.push(
       this.form.controls.master.disabledWhile(
-        this.form.select((values) => values.disabled),
+        this.form.select((values) => !values.disabled),
       ),
     );
   }


### PR DESCRIPTION
Some conditions were previously incorrectly ported. You can compare with the old, now deleted `failover.component.ts`:
https://github.com/truenas/webui/pull/6604/files#diff-a8f298f0b8de3eceda6579ed4a16184ff720f82dfa5ef8ad74856b71040321f0

I will also DM you with a machine that can be used for testing.