### PR TITLE
NAS-117573 / 22.12 / NAS-117573: Update search box

### DIFF
--- a/src/app/modules/common/search-input/search-input.component.ts
+++ b/src/app/modules/common/search-input/search-input.component.ts
@@ -6,6 +6,7 @@ import {
   HostListener, Input,
   Output,
   ViewChild,
+  OnInit,
 } from '@angular/core';
 
 @Component({
@@ -14,8 +15,9 @@ import {
   styleUrls: ['./search-input.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SearchInputComponent {
+export class SearchInputComponent implements OnInit {
   @Input() disabled = false;
+  @Input() value = '';
   @Output() search = new EventEmitter<string>();
 
   @ViewChild('searchInput') input: ElementRef<HTMLInputElement>;
@@ -24,6 +26,10 @@ export class SearchInputComponent {
 
   get shouldShowReset(): boolean {
     return Boolean(this.searchValue);
+  }
+
+  ngOnInit(): void {
+    this.searchValue = this.value;
   }
 
   @HostListener('click')

--- a/src/app/modules/entity/entity-table/entity-table-add-actions/entity-table-add-actions-config.interface.ts
+++ b/src/app/modules/entity/entity-table/entity-table-add-actions/entity-table-add-actions-config.interface.ts
@@ -12,4 +12,5 @@ export interface EntityTableAddActionsConfig {
     icon?: string;
     onClick: () => void;
   };
+  filterValue?: string;
 }

--- a/src/app/modules/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.html
+++ b/src/app/modules/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.html
@@ -12,6 +12,7 @@
         ix-auto-type="input"
         ix-auto-identifier="Filter {{conf.title}}"
         autocomplete="off"
+        [value]="conf.filterValue"
       >
       <span
         class="reset-icon-wrapper"

--- a/src/app/modules/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.ts
+++ b/src/app/modules/entity/entity-table/entity-table-add-actions/entity-table-add-actions.component.ts
@@ -41,6 +41,8 @@ export class EntityTableAddActionsComponent implements OnInit, AfterViewInit {
     this.entityTableService.addActionsUpdater$.pipe(untilDestroyed(this)).subscribe((actions: EntityTableAction[]) => {
       this.actions = actions;
     });
+
+    this.filterValue = this.entity.conf.filterValue;
   }
 
   ngAfterViewInit(): void {
@@ -58,6 +60,8 @@ export class EntityTableAddActionsComponent implements OnInit, AfterViewInit {
           this.filterValue = this.filter.nativeElement.value;
           this.entity.filter(this.filter.nativeElement.value);
         });
+
+      this.entity.filter(this.entity.conf.filterValue);
     }
   }
 

--- a/src/app/modules/entity/entity-table/entity-table.interface.ts
+++ b/src/app/modules/entity/entity-table/entity-table.interface.ts
@@ -47,6 +47,7 @@ export interface EntityTableConfig<Row = unknown> {
   inlineActions?: boolean;
   addBtnDisabled?: boolean;
   routeAddTooltip?: string;
+  filterValue?: string;
 
   /**
    * Returns EmptyConfig for EmptyType or returns null if default behavior is acceptable for that EmptyType

--- a/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
@@ -42,6 +42,7 @@ export class CloudsyncListComponent implements EntityTableConfig<CloudSyncTaskUi
   wsDelete = 'cloudsync.delete' as const;
   entityList: EntityTableComponent;
   asyncView = true;
+  filterValue = '';
 
   columns = [
     { name: this.translate.instant('Description'), prop: 'description', always_display: true },
@@ -78,8 +79,6 @@ export class CloudsyncListComponent implements EntityTableConfig<CloudSyncTaskUi
     },
   };
 
-  private dataset: string;
-
   constructor(
     protected ws: WebSocketService,
     protected translate: TranslateService,
@@ -91,7 +90,7 @@ export class CloudsyncListComponent implements EntityTableConfig<CloudSyncTaskUi
     private matDialog: MatDialog,
     private route: ActivatedRoute,
   ) {
-    this.dataset = this.route.snapshot.paramMap.get('dataset') || '';
+    this.filterValue = this.route.snapshot.paramMap.get('dataset') || '';
   }
 
   afterInit(entityList: EntityTableComponent): void {
@@ -102,10 +101,7 @@ export class CloudsyncListComponent implements EntityTableConfig<CloudSyncTaskUi
   }
 
   resourceTransformIncomingRestData(tasks: CloudSyncTask[]): CloudSyncTaskUi[] {
-    const tasksToShow = tasks.filter((cloud) => {
-      return cloud.path.replace('/mnt/', '') === this.dataset || cloud.path.includes(`${this.dataset}/`);
-    });
-    return tasksToShow.map((task) => {
+    return tasks.map((task) => {
       const transformed = { ...task } as CloudSyncTaskUi;
       const formattedCronSchedule = `${task.schedule.minute} ${task.schedule.hour} ${task.schedule.dom} ${task.schedule.month} ${task.schedule.dow}`;
       transformed.credential = task.credentials.name;

--- a/src/app/pages/data-protection/replication/replication-list/replication-list.component.ts
+++ b/src/app/pages/data-protection/replication/replication-list/replication-list.component.ts
@@ -53,6 +53,7 @@ export class ReplicationListComponent implements EntityTableConfig {
   routeSuccess: string[] = ['tasks', 'replication'];
   entityList: EntityTableComponent;
   asyncView = true;
+  filterValue = '';
 
   columns = [
     { name: this.translate.instant('Name'), prop: 'name', always_display: true },
@@ -79,8 +80,6 @@ export class ReplicationListComponent implements EntityTableConfig {
     },
   };
 
-  private dataset: string;
-
   constructor(
     private ws: WebSocketService,
     private dialog: DialogService,
@@ -91,7 +90,7 @@ export class ReplicationListComponent implements EntityTableConfig {
     private matDialog: MatDialog,
     private route: ActivatedRoute,
   ) {
-    this.dataset = this.route.snapshot.paramMap.get('dataset') || '';
+    this.filterValue = this.route.snapshot.paramMap.get('dataset') || '';
   }
 
   afterInit(entityList: EntityTableComponent): void {
@@ -102,10 +101,7 @@ export class ReplicationListComponent implements EntityTableConfig {
   }
 
   resourceTransformIncomingRestData(tasks: ReplicationTask[]): ReplicationTaskUi[] {
-    const tasksToShow = tasks.filter((task) => task.target_dataset === this.dataset
-      || task.source_datasets.includes(this.dataset)
-      || task.name.includes(`${this.dataset}/`));
-    return tasksToShow.map((task) => {
+    return tasks.map((task) => {
       return {
         ...task,
         ssh_connection: task.ssh_credentials ? (task.ssh_credentials as any).name : '-',

--- a/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
@@ -30,6 +30,7 @@ export class RsyncTaskListComponent implements EntityTableConfig {
   routeEdit: string[] = ['tasks', 'rsync', 'edit'];
   entityList: EntityTableComponent;
   asyncView = true;
+  filterValue = '';
 
   columns = [
     { name: this.translate.instant('Path'), prop: 'path', always_display: true },
@@ -67,8 +68,6 @@ export class RsyncTaskListComponent implements EntityTableConfig {
     },
   };
 
-  private dataset: string;
-
   constructor(
     protected ws: WebSocketService,
     protected taskService: TaskService,
@@ -78,7 +77,7 @@ export class RsyncTaskListComponent implements EntityTableConfig {
     protected translate: TranslateService,
     private route: ActivatedRoute,
   ) {
-    this.dataset = this.route.snapshot.paramMap.get('dataset') || '';
+    this.filterValue = this.route.snapshot.paramMap.get('dataset') || '';
   }
 
   afterInit(entityList: EntityTableComponent): void {
@@ -146,11 +145,7 @@ export class RsyncTaskListComponent implements EntityTableConfig {
   }
 
   resourceTransformIncomingRestData(tasks: RsyncTaskUi[]): RsyncTaskUi[] {
-    const tasksToShow = tasks.filter((task) => {
-      return task.path.replace('/mnt/', '') === this.dataset
-        || task.path.includes(`${this.dataset}/`);
-    });
-    return tasksToShow.map((task) => {
+    return tasks.map((task) => {
       task.cron_schedule = `${task.schedule.minute} ${task.schedule.hour} ${task.schedule.dom} ${task.schedule.month} ${task.schedule.dow}`;
       task.next_run = this.taskService.getTaskNextRun(task.cron_schedule);
       task.frequency = this.taskService.getTaskCronDescription(task.cron_schedule);

--- a/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
@@ -27,6 +27,7 @@ export class SnapshotListComponent implements EntityTableConfig<PeriodicSnapshot
   routeEdit: string[] = ['tasks', 'snapshot', 'edit'];
   entityList: EntityTableComponent;
   asyncView = true;
+  filterValue = '';
 
   columns = [
     { name: this.translate.instant('Pool/Dataset'), prop: 'dataset', always_display: true },
@@ -53,8 +54,6 @@ export class SnapshotListComponent implements EntityTableConfig<PeriodicSnapshot
     },
   };
 
-  private dataset: string;
-
   constructor(
     private dialogService: DialogService,
     private ws: WebSocketService,
@@ -63,7 +62,7 @@ export class SnapshotListComponent implements EntityTableConfig<PeriodicSnapshot
     private slideInService: IxSlideInService,
     private route: ActivatedRoute,
   ) {
-    this.dataset = this.route.snapshot.paramMap.get('dataset') || '';
+    this.filterValue = this.route.snapshot.paramMap.get('dataset') || '';
   }
 
   afterInit(entityList: EntityTableComponent): void {
@@ -74,11 +73,7 @@ export class SnapshotListComponent implements EntityTableConfig<PeriodicSnapshot
   }
 
   resourceTransformIncomingRestData(tasks: PeriodicSnapshotTask[]): PeriodicSnapshotTaskUi[] {
-    const tasksToShow = tasks.filter((row) => {
-      return row.dataset === this.dataset
-        || row.dataset.includes(`${this.dataset}/`);
-    });
-    return tasksToShow.map((task) => {
+    return tasks.map((task) => {
       const transformedTask = {
         ...task,
         keepfor: `${task.lifetime_value} ${task.lifetime_unit}(S)`,

--- a/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.html
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.html
@@ -1,6 +1,6 @@
 <ng-template #pageHeader>
   <ix-page-title-header>
-    <ix-search-input [disabled]="isLoading$ | async" (search)="onSearch($event)"></ix-search-input>
+    <ix-search-input [disabled]="isLoading$ | async" [value]="dataset" (search)="onSearch($event)"></ix-search-input>
     <mat-slide-toggle
       (click)="toggleExtraColumns($event)"
       [checked]="showExtraColumns"

--- a/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.ts
@@ -80,7 +80,7 @@ export class SnapshotListComponent implements OnInit, AfterViewInit {
   readonly defaultColumns: string[] = ['select', 'dataset', 'snapshot_name', 'actions'];
   readonly defaultExtraColumns: string[] = ['select', 'dataset', 'snapshot_name', 'used', 'created', 'referenced', 'actions'];
   displayedColumns: string[] = this.defaultColumns;
-  private dataset: string;
+  dataset = '';
 
   constructor(
     private dialogService: DialogService,
@@ -125,11 +125,7 @@ export class SnapshotListComponent implements OnInit, AfterViewInit {
       select(selectSnapshots),
       untilDestroyed(this),
     ).subscribe((snapshots) => {
-      const snapshotsToShow = snapshots.filter((snapshot) => {
-        return snapshot.dataset === this.dataset
-        || snapshot.dataset.includes(`${this.dataset}/`);
-      });
-      this.createDataSource(snapshotsToShow);
+      this.createDataSource(snapshots);
       this.cdr.markForCheck();
     }, () => {
       this.createDataSource();
@@ -176,6 +172,7 @@ export class SnapshotListComponent implements OnInit, AfterViewInit {
       this.dataSource.sort = this.sort;
       this.cdr.markForCheck();
     }, 0);
+    this.dataSource.filter = this.dataset;
   }
 
   toggleExtraColumns(event: MouseEvent): void {


### PR DESCRIPTION
**Testing:**
Datasets => Data Protection Card

- Manage Snapshots
- Manage Snapshot Tasks
- Manage Replication Tasks
- Manage Cloud Sync Tasks
- Manage Rsync Tasks

Check for those 5 links.

_Result:_
- The search box should be filled as a chosen dataset string and an icon to clear the filter should exist there.
- The list on the routed page should expose the result for the chosen dataset on the first loading.

![image](https://user-images.githubusercontent.com/22980553/185368953-4caef76d-9200-40f8-9973-a80c9d551d52.png)
