### PR TITLE
NAS-117719 / 22.12 / Nas-117719 Do not run CI checks when only RE tests were changed

### DIFF
--- a/.github/workflows/docker_internal.yml
+++ b/.github/workflows/docker_internal.yml
@@ -5,6 +5,8 @@ on:
     types:
       - 'synchronize'
       - 'opened'
+    paths-ignore:
+      - 'tests/**'
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'tests/**'
 
 jobs:
   docker:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'tests/**'
   pull_request:
     branches:
       - '**'
+    paths-ignore:
+      - 'tests/**'
 jobs:
   install:
     name: Checkout and Install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
       - '**'
     paths-ignore:
       - 'tests/**'
+
 jobs:
   install:
     name: Checkout and Install


### PR DESCRIPTION
Changes made in the main.yml file. Added path-ignore.
github actions should not be executed if changes are made only in the "/tests" directory