### PR TITLE
NAS-117714 / 22.12 / FTP "Certificate" dropdown should be under "Enable TLS" checkbox

### DIFF
--- a/src/app/pages/services/components/service-ftp/service-ftp.component.html
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.html
@@ -114,6 +114,7 @@
                   formControlName="ssltls_certificate"
                   [label]="'Certificate' | translate"
                   [tooltip]="helptext.ssltls_certificate_tooltip | translate"
+                  [required]="true"
                   [options]="certificates$"
                 ></ix-select>
               </div>

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.html
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.html
@@ -47,19 +47,6 @@
               [tooltip]="helptext.timeout_tooltip | translate"
               type="number"
             ></ix-input>
-            <div class="linked-select">
-              <div class="link-wrapper">
-                <a class="link" (click)="onLinkClicked()">
-                  {{ 'Manage Certificates' | translate }}
-                </a>
-              </div>
-              <ix-select
-                formControlName="ssltls_certificate"
-                [label]="'Certificate' | translate"
-                [tooltip]="helptext.ssltls_certificate_tooltip | translate"
-                [options]="certificates$"
-              ></ix-select>
-            </div>
           </ix-fieldset>
 
           <ng-container *ngIf="isAdvancedMode">
@@ -117,6 +104,19 @@
               [tooltip]="helptext.tls_tooltip | translate"
             ></ix-checkbox>
             <ng-container *ngIf="isTlsEnabled$ | async">
+              <div class="linked-select">
+                <div class="link-wrapper">
+                  <a class="link" (click)="onLinkClicked()">
+                    {{ 'Manage Certificates' | translate }}
+                  </a>
+                </div>
+                <ix-select
+                  formControlName="ssltls_certificate"
+                  [label]="'Certificate' | translate"
+                  [tooltip]="helptext.ssltls_certificate_tooltip | translate"
+                  [options]="certificates$"
+                ></ix-select>
+              </div>
               <ix-select
                 formControlName="tls_policy"
                 [label]="'TLS Policy' | translate"

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.spec.ts
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.spec.ts
@@ -107,7 +107,6 @@ describe('ServiceFtpComponent', () => {
       'Login Attempts': '1',
       'Notransfer Timeout': '300',
       Timeout: '600',
-      Certificate: 'Secure certificate',
     });
   });
 


### PR DESCRIPTION
**Testing:**

System Settings → Services → FTP
The `Certificate` dropdown should be under `Enable TLS` checkbox in the `Advanced settings`.