### PR TITLE
NAS-117073: fix: Pool Managers' dev type doesn't initially match the Estimated raw capacity for Safari

### DIFF
--- a/src/app/pages/storage/volumes/manager/vdev/vdev.component.ts
+++ b/src/app/pages/storage/volumes/manager/vdev/vdev.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   Component,
   ElementRef,
   Input,
@@ -46,9 +47,12 @@ export class VdevComponent implements OnInit {
   startingHeight: number;
   expandedRows: number;
 
-  constructor(public elementRef: ElementRef,
+  constructor(
+    public elementRef: ElementRef,
     public translate: TranslateService,
-    public sorter: StorageService) {}
+    public sorter: StorageService,
+    private cdr: ChangeDetectorRef,
+  ) {}
 
   ngOnInit(): void {
     if (this.group === 'data') {
@@ -122,6 +126,7 @@ export class VdevComponent implements OnInit {
         this.type = 'stripe';
       }
     }
+    this.cdr.detectChanges();
   }
 
   estimateSize(): void {


### PR DESCRIPTION
**What causes the bug?**

DOM gets updated, while Safari does not rerender the updated text. On the screenshot below compare "Mirror" in DOM vs. "Stripe" in Safari's viewport. On window resize, it renders correctly.

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/20611516/186092231-40031b72-959e-4da5-b7b5-504f055e3d78.png">

Here's what you need to replicate the bug:

1. Insert debugging code shown below into your `manager.component.ts` . This will simulate 2 disks with not empty `duplicate_serial`. (This is one of ways how user can see the bug.)

![image](https://user-images.githubusercontent.com/20611516/186094443-17c800aa-ebad-4dca-8263-14122ce22234.png)

2. In Safari 15.x, click **Show disks with non-unique serial numbers**. Check 1st and 2nd disk, and click **->** arrow button. See video depicting these steps.

https://user-images.githubusercontent.com/20611516/186094627-bf8c2e3d-3dd6-48f3-8f77-e6cd064b6e65.mp4


**Testing**

Go through steps described above