### PR TITLE
NAS-117372 :Add client side validation for app names

### DIFF
--- a/src/app/modules/entity/entity-job/entity-job.component.html
+++ b/src/app/modules/entity/entity-job/entity-job.component.html
@@ -57,7 +57,7 @@
     </div>
   </div>
 
-  
+
 
 </mat-dialog-content>
 

--- a/src/app/pages/applications/forms/chart-form/chart-form.component.ts
+++ b/src/app/pages/applications/forms/chart-form/chart-form.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
 import { FormBuilder, UntypedFormControl, Validators } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { TranslateService } from '@ngx-translate/core';
 import _ from 'lodash';
 import {
   noop, of, Subject, Subscription,
@@ -21,6 +22,7 @@ import { Job } from 'app/interfaces/job.interface';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
 import { EntityUtils } from 'app/modules/entity/utils';
 import { CustomUntypedFormField } from 'app/modules/ix-forms/components/ix-dynamic-form/classes/custom-untyped-form-field';
+import { IxValidatorsService } from 'app/modules/ix-forms/services/ix-validators.service';
 import { DialogService } from 'app/services';
 import { AppSchemaService } from 'app/services/app-schema.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
@@ -55,6 +57,8 @@ export class ChartFormComponent implements OnDestroy {
     private dialogService: DialogService,
     private appSchemaService: AppSchemaService,
     private mdDialog: MatDialog,
+    private validatorsService: IxValidatorsService,
+    private translate: TranslateService,
   ) {}
 
   ngOnDestroy(): void {
@@ -109,8 +113,14 @@ export class ChartFormComponent implements OnDestroy {
       this.selectedVersionKey = versionKeys[0];
     }
 
-    this.form.addControl('release_name', new UntypedFormControl('', [Validators.required]));
     this.form.addControl('version', new UntypedFormControl(this.selectedVersionKey, [Validators.required]));
+    this.form.addControl('release_name', new UntypedFormControl('', [Validators.required]));
+    this.form.controls['release_name'].setValidators(
+      this.validatorsService.withMessage(
+        Validators.pattern('^[a-z](?:[a-z0-9-]*[a-z0-9])?$'),
+        this.translate.instant('Invalid format or character. Allowed e.g abc123, abc, abcd-1232'),
+      ),
+    );
 
     this.dynamicSection.push({
       name: 'Application name',

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1563,6 +1563,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1140,6 +1140,7 @@
   "Invalid Pod name": "",
   "Invalid file": "",
   "Invalid format or character": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -287,6 +287,7 @@
   "Interfaces": "",
   "Invalid Pod name": "",
   "Invalid format or character": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid value. Must be greater than or equal to ": "",
   "Invalid value. Must be less than or equal to ": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1672,6 +1672,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -321,6 +321,7 @@
   "Interfaces": "",
   "Invalid file": "",
   "Invalid format or character": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Isolated GPU Device(s)": "",
   "Isolated GPU PCI Id's": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1593,6 +1593,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1471,6 +1471,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1841,6 +1841,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1773,6 +1773,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1767,6 +1767,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1732,6 +1732,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -653,6 +653,7 @@
   "Invalid Pod name": "",
   "Invalid file": "",
   "Invalid format or character": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid value. Must be greater than or equal to ": "",
   "Invalid value. Must be less than or equal to ": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1851,6 +1851,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -139,6 +139,7 @@
   "Inherited Quotas": "",
   "Initial Deployment/Setup": "",
   "Inquiry": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "KVM implements Hyper-V Enlightenments   for Windows guests. These features make Windows think they're   running on top of a Hyper-V compatible hypervisor and use Hyper-V specific features.   In some cases enabling these Enlightenments might improve usability and performance on the guest.": "",
   "Keys Synced": "",
   "Keys pending to be synced between KMIP server and TN database were cleared.": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1364,6 +1364,7 @@
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",
+  "Invalid format or character. Allowed e.g abc123, abc, abcd-1232": "",
   "Invalid image": "",
   "Invalid network address list. Check for typos or missing CIDR netmasks and      separate addresses by pressing <code>Enter</code>.": "",
   "Invalid option selected": "",


### PR DESCRIPTION
App -> Available Applications -> Install application
The user should get an immediate message error while typing a name (field Application name)
Application name must have the following:
Lowercase alphanumeric characters can be specified
Name must start with an alphabetic character and can end with alphanumeric character
Hyphen '-' is allowed but not as the first or last character
 e.g abc123, abc, abcd-1232