### PR TITLE
NAS-117755 / 22.02.4 / NAS-117755: Fix downloading VM logs (by undsoft)

### DIFF
--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -567,7 +567,7 @@ export class VMListComponent implements EntityTableConfig<VirtualMachineRow>, On
       icon: 'content_paste',
       label: this.translate.instant('Download Logs'),
       onClick: (vm: VirtualMachineRow) => {
-        const path = `/var/log/libvirt/bhyve/${vm.id}_${vm.name}.log`;
+        const path = `/var/log/libvirt/qemu/${vm.id}_${vm.name}.log`;
         const filename = `${vm.id}_${vm.name}.log`;
         this.ws.call('core.download', ['filesystem.get', [path], filename]).pipe(untilDestroyed(this)).subscribe(
           ([_, url]) => {


### PR DESCRIPTION
Testing: start a VM, click Download logs.

Original PR: https://github.com/truenas/webui/pull/7014
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117755