### PR TITLE
NAS-117836 / 22.12 / NAS-117836: Use new method for updating Isolated GPUs

### DIFF
--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -788,6 +788,7 @@ export type ApiDirectory = {
   // System
   'system.feature_enabled': { params: [feature: string]; response: boolean };
   'system.advanced.update': { params: [Partial<AdvancedConfigUpdate>]; response: AdvancedConfig };
+  'system.advanced.update_gpu_pci_ids': { params: [isolated_gpu_pci_ids: string[]]; response: void };
   'system.reboot': { params: { delay?: number }; response: void };
   'system.shutdown': { params: { delay?: number }; response: void };
   'system.advanced.serial_port_choices': { params: void; response: Choices };

--- a/src/app/pages/system/advanced/isolated-gpu-pcis/isolated-gpu-pcis-form.component.spec.ts
+++ b/src/app/pages/system/advanced/isolated-gpu-pcis/isolated-gpu-pcis-form.component.spec.ts
@@ -43,7 +43,7 @@ describe('IsolatedGpuPcisFormComponent', () => {
         mockCall('system.advanced.config', {
           isolated_gpu_pci_ids: ['0000:00:02.0'],
         } as AdvancedConfig),
-        mockCall('system.advanced.update'),
+        mockCall('system.advanced.update_gpu_pci_ids'),
       ]),
       mockProvider(SystemGeneralService),
       mockProvider(IxSlideInService),
@@ -77,8 +77,6 @@ describe('IsolatedGpuPcisFormComponent', () => {
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
-    expect(ws.call).toHaveBeenCalledWith('system.advanced.update', [{
-      isolated_gpu_pci_ids: ['0000:00:01.0'],
-    }]);
+    expect(ws.call).toHaveBeenCalledWith('system.advanced.update_gpu_pci_ids', [['0000:00:01.0']]);
   });
 });

--- a/src/app/pages/system/advanced/isolated-gpu-pcis/isolated-gpu-pcis-form.component.ts
+++ b/src/app/pages/system/advanced/isolated-gpu-pcis/isolated-gpu-pcis-form.component.ts
@@ -89,7 +89,7 @@ export class IsolatedGpuPcisFormComponent implements OnInit {
     this.isFormLoading = true;
     const isolatedGpuPciIds = this.formGroup.controls['isolated_gpu_pci_ids'].value;
 
-    this.ws.call('system.advanced.update', [{ isolated_gpu_pci_ids: isolatedGpuPciIds }]).pipe(
+    this.ws.call('system.advanced.update_gpu_pci_ids', [isolatedGpuPciIds]).pipe(
       untilDestroyed(this),
     ).subscribe(() => {
       this.isFormLoading = false;


### PR DESCRIPTION
**Testing**

On the **System settings > Advanced** page, at the **Isolated GPU Device(s)** section, after clicking **Settings** button, slide-in form **Isolated GPU PCI Id's** appears.

When saving changes, it should call `system.advanced.update_gpu_pci_ids` method, instead of `system.advanced.update`. 