### PR TITLE
NAS-117812 / 22.12 / Minor updates to storage pages

### DIFF
--- a/src/app/core/components/copy-btn/copy-btn.component.html
+++ b/src/app/core/components/copy-btn/copy-btn.component.html
@@ -1,27 +1,8 @@
-<ng-container *ngIf="popupIsVisible && showPopup">
-  <div class="copy-btn-popup tooltip-container">
-    <div class="text-limiter-tooltip">
-
-      <div class="copy-btn-header">
-        <div class="copy-btn-header-txt">
-          ({{ 'Copied to clipboard' | translate }})
-        </div>
-
-        <div class="copy-btn-close-trigger">
-          <button mat-icon-button (click)="onPopupClose()">
-            <mat-icon class="copy-btn-icon">close</mat-icon>
-          </button>
-        </div>
-
-      </div>
-
-      <div class="copy-btn-copied-txt">{{ text }}</div>
-
-    </div>
-  </div>
-</ng-container>
-
-<button class="copy-btn-trigger" mat-icon-button (click)="onIconClick()">
-  <mat-icon class="copy-btn-icon">assignment</mat-icon>
-  <input #el class="invisible" [value]="text" type="text">
+<button
+  mat-icon-button
+  (click)="copyToClipboard()"
+  [matTooltip]="'Copy to Clipboard' | translate"
+  matTooltipPosition="above"
+>
+  <ix-icon name="assignment"></ix-icon>
 </button>

--- a/src/app/core/components/copy-btn/copy-btn.component.scss
+++ b/src/app/core/components/copy-btn/copy-btn.component.scss
@@ -1,70 +1,8 @@
 :host {
   align-items: center;
   display: inline-flex;
-}
 
-.copy-btn-close-trigger {
-  position: absolute;
-  right: 0;
-  top: 0;
-}
-
-.copy-btn-icon {
-  font-size: 18px;
-}
-
-.copy-btn-popup {
-  position: absolute;
-  right: 10px;
-  top: -96px;
-  width: 90%;
-  z-index: 16;
-}
-
-.copy-btn-popup .copy-btn-header {
-  border-bottom: solid 1px var(--lines);
-  max-width: 100%;
-  padding: 6px 16px;
-  width: 100%;
-}
-
-.copy-btn-popup .copy-btn-header {
-  display: inline-block;
-}
-
-.copy-btn-popup .copy-btn-copied-txt {
-  background-color: rgba(0, 0, 0, 0.1);
-  font-weight: 500;
-  padding: 8px 16px;
-}
-
-div.text-limiter-tooltip {
-  background-color: var(--bg2);
-  border-radius: 4px;
-  color: var(--fg2);
-  padding: 6px 0;
-}
-
-div.text-limiter-tooltip::before {
-  background-color: var(--bg2);
-  bottom: -10px;
-  content: '';
-  display: block;
-  height: 20px;
-  position: absolute;
-  right: 26px;
-  transform: rotate(45deg);
-  width: 20px;
-  z-index: -1;
-
-}
-
-.tooltip-container {
-  filter: drop-shadow(0 4px 4px rgba(0, 0, 0, 0.75));
-}
-
-.invisible {
-  left: 0;
-  opacity: 0;
-  position: fixed;
+  ix-icon {
+    font-size: 18px;
+  }
 }

--- a/src/app/core/components/copy-btn/copy-btn.component.ts
+++ b/src/app/core/components/copy-btn/copy-btn.component.ts
@@ -1,6 +1,8 @@
 import {
-  Component, Input, ViewChild, ElementRef,
+  Component, Input,
 } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 
 @Component({
   selector: 'ix-copy-btn',
@@ -8,23 +10,22 @@ import {
   styleUrls: ['./copy-btn.component.scss'],
 })
 export class CopyButtonComponent {
-  @ViewChild('el', { static: false }) el: ElementRef;
   @Input() text: string;
-  @Input() showPopup = true;
-  popupIsVisible = false;
 
-  onIconClick(): void {
-    this.popupIsVisible = !this.popupIsVisible;
-    this.copyToClipboard();
-  }
-
-  onPopupClose(): void {
-    this.popupIsVisible = false;
-  }
+  constructor(
+    private snackbar: SnackbarService,
+    private translate: TranslateService,
+  ) {}
 
   copyToClipboard(): void {
-    this.el.nativeElement.focus();
-    this.el.nativeElement.select();
-    document.execCommand('copy');
+    if (!navigator.clipboard) {
+      /** @deprecated */
+      document.execCommand('copy', false, this.text);
+      this.snackbar.success(this.translate.instant('Copied to clipboard'));
+    } else {
+      navigator.clipboard.writeText(this.text).then(() => {
+        this.snackbar.success(this.translate.instant('Copied to clipboard'));
+      });
+    }
   }
 }

--- a/src/app/interfaces/dataset.interface.ts
+++ b/src/app/interfaces/dataset.interface.ts
@@ -206,4 +206,5 @@ export interface DatasetDetails {
   refquota_warning?: ZfsProperty<number>;
   quota_critical?: ZfsProperty<number>;
   quota_warning?: ZfsProperty<number>;
+  comments?: ZfsProperty<string>;
 }

--- a/src/app/pages/credentials/certificates-dash/view-certificate-dialog/view-certificate-dialog.component.html
+++ b/src/app/pages/credentials/certificates-dash/view-certificate-dialog/view-certificate-dialog.component.html
@@ -3,7 +3,7 @@
 <textarea class="key-textarea" readonly>{{ data.certificate }}</textarea>
 
 <div mat-dialog-actions class="actions">
-  <ix-copy-btn [text]="data.certificate" [showPopup]=false></ix-copy-btn>
+  <ix-copy-btn [text]="data.certificate"></ix-copy-btn>
   <button
     mat-button
     type="button"

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
@@ -62,12 +62,11 @@
         </span>
         <ix-copy-btn [text]="dataset.name"></ix-copy-btn>
       </div>
-      <div class="details-item">
+      <div class="details-item" *ngIf="!isLoading && hasComments">
         <span class="label">{{ 'Comments' | translate }}:</span>
-        <span *ngIf="!isLoading" class="value dataset-comments">
-          <ng-container *ngIf="dataset?.comments?.value; else notAvailable">
-            {{ dataset.comments.value }}
-          </ng-container>
+        <span class="value dataset-comments">
+          <span textLimiter threshold="128" [content]="dataset.comments.value" [popup]="false"></span>
+          <ix-copy-btn *ngIf="dataset.comments.value.length > 128" [text]="dataset.comments.value"></ix-copy-btn>
         </span>
       </div>
     </mat-card-content>

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
@@ -53,12 +53,21 @@
         </span>
       </div>
       <div class="details-item">
-        <span class="label">{{ 'Path:' | translate }} </span>
+        <span class="label">{{ 'Path' | translate }}:</span>
         <span *ngIf="!isLoading"
           [matTooltip]="dataset.name"
           matTooltipPosition="above"
           class="value dataset-path">
           {{ dataset.name }}
+        </span>
+        <ix-copy-btn [text]="dataset.name"></ix-copy-btn>
+      </div>
+      <div class="details-item">
+        <span class="label">{{ 'Comments' | translate }}:</span>
+        <span *ngIf="!isLoading" class="value dataset-comments">
+          <ng-container *ngIf="dataset?.comments?.value; else notAvailable">
+            {{ dataset.comments.value }}
+          </ng-container>
         </span>
       </div>
     </mat-card-content>

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
@@ -64,10 +64,7 @@
       </div>
       <div class="details-item" *ngIf="!isLoading && hasComments">
         <span class="label">{{ 'Comments' | translate }}:</span>
-        <span class="value dataset-comments">
-          <span textLimiter threshold="128" [content]="dataset.comments.value" [popup]="false"></span>
-          <ix-copy-btn *ngIf="dataset.comments.value.length > 128" [text]="dataset.comments.value"></ix-copy-btn>
-        </span>
+        <span class="value dataset-comments">{{ dataset.comments.value }}</span>
       </div>
     </mat-card-content>
     <mat-card-actions *ngIf="dataset.id !== dataset.pool">

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.scss
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.scss
@@ -3,17 +3,29 @@
 .card {
   @include details-card();
 
-  .value.dataset-path {
-    display: flow-root;
-    max-width: calc(100% - 85px);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
   ix-copy-btn {
     height: 24px;
     width: 24px;
+  }
+
+  .details-item {
+    align-items: flex-start;
+
+    .value.dataset-path {
+      display: flow-root;
+      max-width: calc(100% - 85px);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .value.dataset-comments {
+      flex: 1;
+      margin: 0;
+      overflow: auto;
+      text-overflow: initial;
+      white-space: normal;
+    }
   }
 }
 

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.scss
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.scss
@@ -12,7 +12,8 @@
   }
 
   ix-copy-btn {
-    margin-top: -4px;
+    height: 24px;
+    width: 24px;
   }
 }
 

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
@@ -25,6 +25,7 @@ const dataset = {
   atime: false,
   deduplication: { value: 'OFF' },
   casesensitive: false,
+  comments: { value: 'Test comment' },
 } as DatasetDetails;
 
 describe('DatasetDetailsCardComponent', () => {
@@ -76,7 +77,7 @@ describe('DatasetDetailsCardComponent', () => {
 
   it('shows details', () => {
     const details = spectator.queryAll('.details-item');
-    expect(details.length).toEqual(7);
+    expect(details.length).toEqual(8);
 
     expect(details[0].querySelector('.label')).toHaveText('Type:');
     expect(details[0].querySelector('.value')).toHaveText('FILESYSTEM');
@@ -98,6 +99,9 @@ describe('DatasetDetailsCardComponent', () => {
 
     expect(details[6].querySelector('.label')).toHaveText('Path:');
     expect(details[6].querySelector('.value')).toHaveText('pool/child');
+
+    expect(details[7].querySelector('.label')).toHaveText('Comments:');
+    expect(details[7].querySelector('.value')).toHaveText('Test comment');
   });
 
   it('opens edit dataset form when Edit button is clicked', async () => {

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
@@ -6,6 +6,7 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { MockComponents } from 'ng-mocks';
 import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 import { of } from 'rxjs';
+import { CopyButtonComponent } from 'app/core/components/copy-btn/copy-btn.component';
 import { DatasetType } from 'app/enums/dataset.enum';
 import { ZfsPropertySource } from 'app/enums/zfs-property-source.enum';
 import { DatasetDetails } from 'app/interfaces/dataset.interface';
@@ -25,7 +26,7 @@ const dataset = {
   atime: false,
   deduplication: { value: 'OFF' },
   casesensitive: false,
-  comments: { value: 'Test comment' },
+  comments: { value: 'Test comment', source: ZfsPropertySource.Local },
 } as DatasetDetails;
 
 describe('DatasetDetailsCardComponent', () => {
@@ -43,6 +44,7 @@ describe('DatasetDetailsCardComponent', () => {
       MockComponents(
         DatasetFormComponent,
         NgxSkeletonLoaderComponent,
+        CopyButtonComponent,
       ),
     ],
     providers: [

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.ts
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.ts
@@ -55,6 +55,10 @@ export class DatasetDetailsCardComponent {
     return this.dataset.type === DatasetType.Volume;
   }
 
+  get hasComments(): boolean {
+    return this.dataset.comments?.source === ZfsPropertySource.Local && !!this.dataset.comments?.value?.length;
+  }
+
   deleteDataset(): void {
     this.mdDialog.open(DeleteDatasetDialogComponent, { data: this.dataset })
       .afterClosed()

--- a/src/app/pages/storage2/components/pools-dashboard/pools-dashboard.component.ts
+++ b/src/app/pages/storage2/components/pools-dashboard/pools-dashboard.component.ts
@@ -10,6 +10,7 @@ import {
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import { filter } from 'rxjs/operators';
 import { Dataset } from 'app/interfaces/dataset.interface';
 import { EmptyConfig, EmptyType } from 'app/modules/entity/entity-empty/entity-empty.component';
 import { ImportPoolComponent } from 'app/pages/storage2/components/import-pool/import-pool.component';
@@ -86,8 +87,10 @@ export class PoolsDashboardComponent implements OnInit, AfterViewInit {
     this.store.loadDashboard();
 
     this.slideIn.onClose$
-      .pipe(untilDestroyed(this))
-      .subscribe(() => this.store.loadDashboard());
+      .pipe(
+        filter((value) => value.modalType === ImportPoolComponent && value.response === true),
+        untilDestroyed(this),
+      ).subscribe(() => this.store.loadDashboard());
   }
 
   ngAfterViewInit(): void {

--- a/src/app/pages/storage2/components/pools-dashboard/pools-dashboard.component.ts
+++ b/src/app/pages/storage2/components/pools-dashboard/pools-dashboard.component.ts
@@ -88,7 +88,7 @@ export class PoolsDashboardComponent implements OnInit, AfterViewInit {
 
     this.slideIn.onClose$
       .pipe(
-        filter((value) => value.modalType === ImportPoolComponent && value.response === true),
+        filter((value) => value.response === true),
         untilDestroyed(this),
       ).subscribe(() => this.store.loadDashboard());
   }

--- a/src/app/pages/storage2/components/pools-dashboard/topology-card/topology-card.component.html
+++ b/src/app/pages/storage2/components/pools-dashboard/topology-card/topology-card.component.html
@@ -29,7 +29,7 @@
           <span class="loader-caption" *ngIf="loading"></span>
           <div *ngIf="!loading" fxLayout="row" fxLayoutAlign="center center">
             <span *ngIf="topologyState.data === mixedDev" class="warning">
-              <mat-icon class="pool-icon icon-warning">warning</mat-icon>
+              <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
             </span>
             <span class="vdev-value">{{topologyState.data}}</span>
           </div>
@@ -39,7 +39,7 @@
           <span class="loader-caption" *ngIf="loading"></span>
           <div *ngIf="!loading" fxLayout="row" fxLayoutAlign="center center">
             <span *ngIf="topologyState.metadata === mixedDev" class="warning">
-              <mat-icon class="pool-icon icon-warning">warning</mat-icon>
+              <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
             </span>
             <span class="vdev-value">{{topologyState.metadata}}</span>
           </div>
@@ -49,7 +49,7 @@
           <span class="loader-caption" *ngIf="loading"></span>
           <div *ngIf="!loading" fxLayout="row" fxLayoutAlign="center center">
             <span *ngIf="topologyState.log === mixedDev" class="warning">
-              <mat-icon class="pool-icon icon-warning">warning</mat-icon>
+              <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
             </span>
             <span class="vdev-value">{{topologyState.log}}</span>
           </div>
@@ -59,7 +59,7 @@
           <span class="loader-caption" *ngIf="loading"></span>
           <div *ngIf="!loading" fxLayout="row" fxLayoutAlign="center center">
             <span *ngIf="topologyState.cache === mixedDev" class="warning">
-              <mat-icon class="pool-icon icon-warning">warning</mat-icon>
+              <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
             </span>
             <span class="vdev-value">{{topologyState.cache}}</span>
           </div>
@@ -69,7 +69,7 @@
           <span class="loader-caption" *ngIf="loading"></span>
           <div *ngIf="!loading" fxLayout="row" fxLayoutAlign="center center">
             <span *ngIf="topologyState.spare === mixedDev" class="warning">
-              <mat-icon class="pool-icon icon-warning">warning</mat-icon>
+              <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
             </span>
             <span class="vdev-value">{{topologyState.spare}}</span>
           </div>
@@ -79,7 +79,7 @@
           <span class="loader-caption" *ngIf="loading"></span>
           <div *ngIf="!loading" fxLayout="row" fxLayoutAlign="center center">
             <span *ngIf="topologyState.dedup === mixedDev" class="warning">
-              <mat-icon class="pool-icon icon-warning">warning</mat-icon>
+              <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
             </span>
             <span class="vdev-value">{{topologyState.dedup}}</span>
           </div>

--- a/src/app/pages/storage2/components/pools-dashboard/topology-card/topology-card.component.scss
+++ b/src/app/pages/storage2/components/pools-dashboard/topology-card/topology-card.component.scss
@@ -15,7 +15,7 @@
 
   .vdev-line {
     margin: 8px 0;
-    
+
     &:first-child {
       margin-top: 0;
     }
@@ -28,7 +28,7 @@
   }
 
   &.icon-warning {
-    color: var(--magenta);
+    color: var(--orange);
   }
 
   &.icon-faulted {

--- a/src/app/pages/storage2/components/pools-dashboard/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage2/components/pools-dashboard/topology-card/topology-card.component.spec.ts
@@ -81,7 +81,7 @@ describe('TopologyCardComponent', () => {
   it('rendering VDEVs rows', () => {
     const captions = spectator.queryAll('.vdev-line b');
     const values = spectator.queryAll('.vdev-line .vdev-value');
-    expect(spectator.queryAll('.vdev-line .warning mat-icon').length).toEqual(2);
+    expect(spectator.queryAll('.vdev-line .warning ix-icon').length).toEqual(2);
     expect(captions.length).toEqual(6);
     expect(values.length).toEqual(6);
 

--- a/src/app/pages/storage2/modules/devices/components/devices/devices.component.scss
+++ b/src/app/pages/storage2/modules/devices/components/devices/devices.component.scss
@@ -222,7 +222,7 @@ ix-disk-details-panel {
 
   align-items: center;
   color: var(--fg2);
-  
+
   // Override default fraction based values to avoid misaligned columns
   grid-template-columns: auto 125px 125px 125px 90px;
   min-height: 48px;
@@ -260,6 +260,11 @@ ix-disk-details-panel {
     background: linear-gradient(90deg, var(--bg1) 0%, var(--bg1) calc(100% - 13px), transparent 100%);
     padding-left: 8px;
     padding-right: 15px;
+  }
+
+  .disk-status-header {
+    padding-left: 8px;
+    padding-right: 8px;
   }
 }
 

--- a/src/app/pages/storage2/modules/devices/components/disk-info-card/disk-info-card.component.html
+++ b/src/app/pages/storage2/modules/devices/components/disk-info-card/disk-info-card.component.html
@@ -23,6 +23,7 @@
       <span class="label">{{ 'Serial' | translate }}:</span>
       <span *ngIf="disk?.serial; else notAvailable" class="value">
         {{ disk.serial }}
+        <ix-copy-btn [text]="disk.serial"></ix-copy-btn>
       </span>
     </div>
     <div class="details-item">

--- a/src/app/pages/storage2/modules/devices/components/disk-info-card/disk-info-card.component.scss
+++ b/src/app/pages/storage2/modules/devices/components/disk-info-card/disk-info-card.component.scss
@@ -2,4 +2,9 @@
 
 .card {
   @include details-card();
+
+  ix-copy-btn {
+    height: 24px;
+    width: 24px;
+  }
 }

--- a/src/app/pages/storage2/modules/devices/components/topology-item-node/topology-item-node.component.html
+++ b/src/app/pages/storage2/modules/devices/components/topology-item-node/topology-item-node.component.html
@@ -5,8 +5,8 @@
     </div>
     <span class="name">{{ name }}</span>
   </div>
-  <div class="cell cell-status">
-    <span [style.background-color]="statusColor">{{ status }}</span>
+  <div class="cell cell-status" [style.background-color]="statusColor">
+    <span>{{ status }}</span>
   </div>
   <div class="cell cell-capacity">
     <span>{{ capacity }}</span>

--- a/src/app/pages/storage2/modules/devices/components/topology-item-node/topology-item-node.component.scss
+++ b/src/app/pages/storage2/modules/devices/components/topology-item-node/topology-item-node.component.scss
@@ -61,6 +61,10 @@
       padding-right: 15px;
     }
   }
+
+  .cell-status {
+    padding: 0 8px;
+  }
 }
 
 // TODO: Fragile (at least with css selectors)

--- a/src/app/pages/storage2/modules/devices/components/topology-item-node/topology-item-node.component.spec.ts
+++ b/src/app/pages/storage2/modules/devices/components/topology-item-node/topology-item-node.component.spec.ts
@@ -47,7 +47,7 @@ describe('TopologyItemNodeComponent', () => {
 
   it('shows "Status"', () => {
     expect(spectator.query('.cell-status span')).toHaveText(topologyDisk.status);
-    expect(spectator.component.statusColor).toEqual('var(--magenta)');
+    expect(spectator.component.statusColor).toEqual('var(--alt-bg2)');
   });
 
   it('shows "Capacity"', () => {

--- a/src/app/pages/storage2/modules/devices/components/topology-item-node/topology-item-node.component.ts
+++ b/src/app/pages/storage2/modules/devices/components/topology-item-node/topology-item-node.component.ts
@@ -54,7 +54,7 @@ export class TopologyItemNodeComponent {
       case PoolStatus.Faulted:
         return 'var(--red)';
       case PoolStatus.Offline:
-        return 'var(--magenta)';
+        return 'var(--alt-bg2)';
       default:
         return '';
     }

--- a/src/app/pages/system/bootenv/bootenv-status/bootenv-node-item/bootenv-node-item.component.ts
+++ b/src/app/pages/system/bootenv/bootenv-status/bootenv-node-item/bootenv-node-item.component.ts
@@ -49,7 +49,7 @@ export class BootenvNodeItemComponent {
       case PoolStatus.Faulted:
         return 'var(--red)';
       case PoolStatus.Offline:
-        return 'var(--magenta)';
+        return 'var(--alt-bg2)';
       default:
         return '';
     }

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -560,17 +560,18 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
 
   .mat-dialog-content {
     overflow: hidden;
-    padding-bottom: -3px;
+    padding-bottom: 0;
 
     .more-info {
-      margin-bottom: 4px;
+      align-items: center;
+      cursor: pointer;
+      display: flex;
+      gap: 8px;
+      min-height: 40px;
     }
 
     .more-info .mat-icon {
-      cursor: pointer;
-      margin: 0 4px 12px;
-      position: relative;
-      top: 7px;
+      margin: 0 4px;
     }
 
     .info-panel {


### PR DESCRIPTION
Changes:

- Add copy button for `Disk Serial` and `Dataset Path`
- Use snack bar service for copy button user feedback
- Update warning color on Pools Dashboard (triangles)
- Update offline color for the status column on the Devices page
- Fix text alignment on the Error dialog – `+ More info`
- Fix issue when closing `Import Pool` form triggered dashboard reloading

For testing, please check the original ticket