### PR TITLE
NAS-117902 / 22.12 / NAS-117902: Fix form when show_if is '!='

### DIFF
--- a/src/app/pages/applications/forms/chart-form/chart-form.component.spec.ts
+++ b/src/app/pages/applications/forms/chart-form/chart-form.component.spec.ts
@@ -386,7 +386,6 @@ describe('ChartFormComponent', () => {
       version: '1.2.1',
       updateStrategy: 'Recreate',
       hostNetwork: true,
-      externalInterfaces: [],
     });
   });
 

--- a/src/app/services/app-schema.service.ts
+++ b/src/app/services/app-schema.service.ts
@@ -497,7 +497,7 @@ export class AppSchemaService {
                 parentControl.hidden$.pipe(
                   take(1),
                 ).subscribe((isParentHidden) => {
-                  if (value !== null && isParentHidden) {
+                  if (value !== null && !isParentHidden) {
                     const formField = (formGroup.controls[chartSchemaNode.variable] as CustomUntypedFormField);
                     if (!formField.hidden$) {
                       formField.hidden$ = new BehaviorSubject<boolean>(false);


### PR DESCRIPTION
## Testing

1. Pick any app, for example **jackett**
1. Go to **Services**
1. Change **Service Type** to **LoadBalancer**
   
   - Expected Result: It should show LoadBalancer IP, External IP’s, IP Family Policy and IP Families