### PR TITLE
NAS-117870 / 22.12 / NAS-117870: Properly handle change of an icon name at `ix-icon`

### DIFF
--- a/src/app/modules/ix-icon/ix-icon.component.scss
+++ b/src/app/modules/ix-icon/ix-icon.component.scss
@@ -13,8 +13,7 @@ $size: 24px;
     width: $size;
   }
 
-  &.mat-ligature-font::before,
-  &[data-mat-icon-type='svg']::before {
+  &.mat-ligature-font::before {
     display: inline-block;
     visibility: hidden;
     width: 0;

--- a/src/app/modules/ix-icon/ix-icon.component.scss
+++ b/src/app/modules/ix-icon/ix-icon.component.scss
@@ -13,7 +13,10 @@ $size: 24px;
     width: $size;
   }
 
-  &.mat-ligature-font::before {
-    content: attr(data-mat-icon-name);
+  &.mat-ligature-font::before,
+  &[data-mat-icon-type='svg']::before {
+    display: inline-block;
+    visibility: hidden;
+    width: 0;
   }
 }

--- a/src/app/modules/ix-icon/ix-icon.component.ts
+++ b/src/app/modules/ix-icon/ix-icon.component.ts
@@ -20,6 +20,8 @@ import {
   // eslint-disable-next-line @angular-eslint/no-host-metadata-property
   host: {
     class: 'ix-icon',
+    '[attr.data-mat-icon-name]': '(_svgIcon && _svgName) || fontIcon',
+    '[attr.data-mat-icon-namespace]': '(_svgIcon && _svgNamespace) || fontSet',
   },
   styleUrls: ['./ix-icon.component.scss'],
   templateUrl: 'ix-icon.component.html',
@@ -79,28 +81,29 @@ export class IxIconComponent extends MatIcon implements OnInit, OnChanges {
   }
 
   private updateIcon(iconName: string): void {
-    if (!iconName) {
-      this.svgIcon = '';
-      this.fontSet = '';
-      this.fontIcon = '';
-      this.iconLigature = '';
-      return;
-    }
-
-    if (iconName.startsWith('ix:')) {
-      this.fontIcon = '';
-      this.fontSet = '';
-      this.svgIcon = iconName;
-    } else if (iconName.startsWith('mdi')) {
-      this.svgIcon = '';
-      this.iconLigature = '';
-      this.fontSet = 'mdi-set';
-      this.fontIcon = iconName;
-    } else {
-      this.fontSet = '';
-      this.svgIcon = '';
-      this.fontIcon = iconName;
-      this.iconLigature = iconName;
+    switch (true) {
+      case ((!iconName)):
+        this.svgIcon = '';
+        this.fontSet = '';
+        this.fontIcon = '';
+        this.iconLigature = '';
+        break;
+      case (iconName.startsWith('ix:')):
+        this.fontIcon = '';
+        this.fontSet = '';
+        this.svgIcon = iconName;
+        break;
+      case (iconName.startsWith('mdi')):
+        this.svgIcon = '';
+        this.iconLigature = '';
+        this.fontSet = 'mdi-set';
+        this.fontIcon = iconName;
+        break;
+      default:
+        this.fontSet = '';
+        this.svgIcon = '';
+        this.fontIcon = iconName;
+        this.iconLigature = iconName;
     }
   }
 }

--- a/src/app/modules/ix-icon/ix-icon.component.ts
+++ b/src/app/modules/ix-icon/ix-icon.component.ts
@@ -99,7 +99,7 @@ export class IxIconComponent extends MatIcon implements OnInit, OnChanges {
     } else {
       this.fontSet = '';
       this.svgIcon = '';
-      this.fontIcon = '';
+      this.fontIcon = iconName;
       this.iconLigature = iconName;
     }
   }

--- a/src/app/modules/ix-icon/ix-icon.component.ts
+++ b/src/app/modules/ix-icon/ix-icon.component.ts
@@ -75,19 +75,32 @@ export class IxIconComponent extends MatIcon implements OnInit, OnChanges {
   }
 
   ngOnChanges(): void {
-    this.updateIcon(this.iconName);
+    this.updateIcon(this.name);
   }
 
   private updateIcon(iconName: string): void {
+    if (!iconName) {
+      this.svgIcon = '';
+      this.fontSet = '';
+      this.fontIcon = '';
+      this.iconLigature = '';
+      return;
+    }
+
     if (iconName.startsWith('ix:')) {
+      this.fontIcon = '';
+      this.fontSet = '';
       this.svgIcon = iconName;
     } else if (iconName.startsWith('mdi')) {
+      this.svgIcon = '';
+      this.iconLigature = '';
       this.fontSet = 'mdi-set';
       this.fontIcon = iconName;
     } else {
-      this.fontSet = null;
-      this.fontIcon = iconName;
-      this.iconLigature = null;
+      this.fontSet = '';
+      this.svgIcon = '';
+      this.fontIcon = '';
+      this.iconLigature = iconName;
     }
   }
 }


### PR DESCRIPTION
Check for proper handling `@Input` 'name' in the ix-icon.
Icons should be correctly drawn when dynamically changing the input name.
For ligature icon different use cases
`<ix-icon>arrow_circle_right</ix-icon>
<ix-icon [name]="arrow_circle_right"></ix-icon>`
Don't mix these two options

https://user-images.githubusercontent.com/22006748/187682970-12466cbc-f1d0-4bc3-b3d2-e186ca3fe410.mp4

