### PR TITLE
NAS-113691 / 22.12 / NAS-113691: invalidate committed network changes, after user visits network settings

### DIFF
--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -550,6 +550,7 @@ export type ApiDirectory = {
   'interface.lacpdu_rate_choices': { params: void; response: Choices };
   'interface.default_route_will_be_removed': { params: void; response: boolean };
   'interface.save_default_route': { params: string[]; response: void };
+  'interface.cancel_rollback': { params: void; response: void };
 
   // iSCSI
   'iscsi.initiator.query': { params: QueryParams<IscsiInitiatorGroup>; response: IscsiInitiatorGroup[] };

--- a/src/app/pages/network/network.component.ts
+++ b/src/app/pages/network/network.component.ts
@@ -216,9 +216,11 @@ export class NetworkComponent implements OnInit, OnDestroy {
 
     this.slideInService.onClose$.pipe(untilDestroyed(this)).subscribe(() => {
       this.staticRoutesTableConf.tableComponent.getData();
+      this.getInterfaces();
       this.checkInterfacePendingChanges();
     });
 
+    this.getInterfaces();
     this.checkInterfacePendingChanges();
     this.core
       .register({ observerClass: this, eventName: 'NetworkInterfacesChanged' })
@@ -261,51 +263,67 @@ export class NetworkComponent implements OnInit, OnDestroy {
     });
   }
 
-  checkInterfacePendingChanges(): void {
+  private async checkInterfacePendingChanges(): Promise<void> {
+    let hasPendingChanges = await this.getPendingChanges();
+    let checkinWaitingSeconds = await this.getCheckinWaitingSeconds();
+
+    if (hasPendingChanges && checkinWaitingSeconds > 0) {
+      await this.cancelCommit();
+      hasPendingChanges = await this.getPendingChanges();
+      checkinWaitingSeconds = await this.getCheckinWaitingSeconds();
+    }
+
+    this.hasPendingChanges = hasPendingChanges;
+    this.handleWaitingCheckin(checkinWaitingSeconds);
+  }
+
+  private getInterfaces(): void {
     if (this.interfaceTableConf.tableComponent) {
       this.interfaceTableConf.tableComponent.getData();
     }
-    this.checkPendingChanges();
-    this.checkWaitingCheckin();
   }
 
-  checkPendingChanges(): void {
-    this.ws
-      .call('interface.has_pending_changes')
+  private getCheckinWaitingSeconds(): Promise<number> {
+    return this.ws.call('interface.checkin_waiting')
       .pipe(untilDestroyed(this))
-      .subscribe((hasPendingChanges) => {
-        this.hasPendingChanges = hasPendingChanges;
-      });
+      .toPromise();
   }
 
-  checkWaitingCheckin(): void {
-    this.ws
-      .call('interface.checkin_waiting')
+  private getPendingChanges(): Promise<boolean> {
+    return this.ws.call('interface.has_pending_changes')
       .pipe(untilDestroyed(this))
-      .subscribe((seconds) => {
-        if (seconds !== null) {
-          if (seconds > 0 && this.checkinRemaining === null) {
-            this.checkinRemaining = Math.round(seconds);
-            this.checkinInterval = setInterval(() => {
-              if (this.checkinRemaining > 0) {
-                this.checkinRemaining -= 1;
-              } else {
-                this.checkinRemaining = null;
-                this.checkinWaiting = false;
-                clearInterval(this.checkinInterval);
-                window.location.reload(); // should just refresh after the timer goes off
-              }
-            }, 1000);
-          }
-          this.checkinWaiting = true;
-        } else {
-          this.checkinWaiting = false;
-          this.checkinRemaining = null;
-          if (this.checkinInterval) {
+      .toPromise();
+  }
+
+  private async cancelCommit(): Promise<void> {
+    await this.ws.call('interface.cancel_rollback')
+      .pipe(untilDestroyed(this))
+      .toPromise();
+  }
+
+  private handleWaitingCheckin(seconds: number): void {
+    if (seconds !== null) {
+      if (seconds > 0 && this.checkinRemaining === null) {
+        this.checkinRemaining = Math.round(seconds);
+        this.checkinInterval = setInterval(() => {
+          if (this.checkinRemaining > 0) {
+            this.checkinRemaining -= 1;
+          } else {
+            this.checkinRemaining = null;
+            this.checkinWaiting = false;
             clearInterval(this.checkinInterval);
+            window.location.reload(); // should just refresh after the timer goes off
           }
-        }
-      });
+        }, 1000);
+      }
+      this.checkinWaiting = true;
+    } else {
+      this.checkinWaiting = false;
+      this.checkinRemaining = null;
+      if (this.checkinInterval) {
+        clearInterval(this.checkinInterval);
+      }
+    }
   }
 
   commitPendingChanges(): void {
@@ -348,7 +366,7 @@ export class NetworkComponent implements OnInit, OnDestroy {
                 .call('interface.commit', [{ checkin_timeout: this.checkinTimeout }])
                 .pipe(untilDestroyed(this))
                 .subscribe(
-                  () => {
+                  async () => {
                     this.core.emit({
                       name: 'NetworkInterfacesChanged',
                       data: { commit: true, checkin: false },
@@ -356,7 +374,7 @@ export class NetworkComponent implements OnInit, OnDestroy {
                     });
                     this.interfaceTableConf.tableComponent.getData();
                     this.loader.close();
-                    this.checkWaitingCheckin();
+                    this.handleWaitingCheckin(await this.getCheckinWaitingSeconds());
                   },
                   (err) => {
                     this.loader.close();


### PR DESCRIPTION
## Testing

1. Enter **Network** page, open settings of your network adapter, make a change
   
   <img width="280" alt="image" src="https://user-images.githubusercontent.com/20611516/187707931-2a5000bd-4f2a-4d5f-8c75-920f91baeb66.png">

    After you save your changes, you will see **unapplied changes** ui block with the **Test Changes** button and the input box to specify how long (in seconds) changes will be kept:
   
   <img width="427" alt="image" src="https://user-images.githubusercontent.com/20611516/187708427-e4f260d4-212c-48b1-9c83-23d598193434.png">

   
2. Click **Test changes** button
    After you click it, you’ll see **temporarily applied changes** ui block, counting down the amount of seconds. 
    
   <img width="567" alt="image" src="https://user-images.githubusercontent.com/20611516/187708532-a5441e6f-3a76-4262-abe2-56fe13abb5d6.png">


   - Normally, to apply your changes, you need to click the **Save Changes** button before this countdown reaches “0”, and if you do so, your changes will be persisted. If you won’t be quick enough, your changes will be unapplied, and you will be taken back to **unapplied changes** ui block.

   - To replicate the previously buggy scenario, ignore the normal scenario described above, and instead go to step 3

3. Before the countdown reaches “0”, open settings of your network adapter again, make another change and submit it.

   
    <img width="293" alt="image" src="https://user-images.githubusercontent.com/20611516/187708711-13a0a388-2237-41ab-b822-0c699adffa4f.png">


Expected result: after another change is submitted, 
- you should not be able to continue normal scenario:
   - **temporarily applied changes** ui block should not be kept visible
   - countdown should be stopped and nothing should happen after you wait for remaining amount of seconds
- instead, you should be taken back to **unapplied changes** ui block, from where you should be able to follow normal scenario
