### PR TITLE
NAS-117464 / 22.12 / Fix `No active network interfaces` on network widget

### DIFF
--- a/src/app/enums/network-interface.enum.ts
+++ b/src/app/enums/network-interface.enum.ts
@@ -40,6 +40,7 @@ export enum XmitHashPolicy {
 export enum LinkState {
   Up = 'LINK_STATE_UP',
   Down = 'LINK_STATE_DOWN',
+  Unknown = 'LINK_STATE_UNKNOWN',
 }
 
 export enum LacpduRate {

--- a/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
+++ b/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
@@ -173,7 +173,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
   }
 
   ngOnInit(): void {
-    this.availableNics = this.nics.filter((nic) => nic.state.link_state === LinkState.Up);
+    this.availableNics = this.nics.filter((nic) => nic.state.link_state !== LinkState.Down);
 
     this.updateGridInfo();
     this.updateMapInfo();


### PR DESCRIPTION
For unknown reasons given network interface has `"link_state": "LINK_STATE_UNKNOWN"`

Before:
![image](https://user-images.githubusercontent.com/351613/187739225-4b84114f-08a3-4f6d-9652-c66332de6917.png)
After:
![image](https://user-images.githubusercontent.com/351613/187739240-0a13e54f-fdb4-4985-906c-ead961fc7136.png)
