### PR TITLE
NAS-117983 / 22.12 / Clickable logo on mobile screens

### DIFF
--- a/src/app/modules/common/topbar/topbar.component.html
+++ b/src/app/modules/common/topbar/topbar.component.html
@@ -13,13 +13,13 @@
     ><mat-icon>menu</mat-icon></button>
 
     <span fxFlex></span>
-   
-    <div class="mobile-logo">
+
+    <a class="mobile-logo" routerLink="/">
       <div class="mobile-logo-container">
         <ix-icon name="ix:truenas_scale_logomark_color" class="logomark"></ix-icon>
         <ix-icon name="ix:truenas_scale_logotype_color" class="logotype"></ix-icon>
       </div>
-    </div>
+    </a>
 
     <div class="topbar-mobile-footer">
       <div class="ix-systems-logo-icon">
@@ -31,9 +31,9 @@
           tabindex="0"
         ></mat-icon>
       </div>
-  
+
       <ix-truecommand-button></ix-truecommand-button>
-  
+
       <!-- finish update -->
       <button *ngIf="upgradeWaitingToFinish" mat-icon-button id="finish-update"
               [matTooltip]="tooltips.upgrade_waiting | translate" (click)="upgradePendingDialog()"

--- a/src/app/modules/common/topbar/topbar.component.scss
+++ b/src/app/modules/common/topbar/topbar.component.scss
@@ -58,8 +58,9 @@
 
 .mobile-logo {
   display: none;
+  overflow: hidden;
   width: 100%;
-  
+
   @media (max-width: $breakpoint-tablet) {
     display: flex;
     place-content: center;
@@ -75,7 +76,7 @@
     left: 10px;
     position: absolute;
     top: 10px;
-    transform: scale(1.7); 
+    transform: scale(1.7);
   }
 
   .logotype {


### PR DESCRIPTION
Focusable:
<img width="537" alt="image" src="https://user-images.githubusercontent.com/351613/187868253-814ef647-9a8c-4fbc-b783-aa654a3e4099.png">
