### PR TITLE
NAS-117996 / 22.12 / Inherit border width for inputs on focus

### DIFF
--- a/src/app/modules/ix-forms/components/ix-chips/ix-chips.component.scss
+++ b/src/app/modules/ix-forms/components/ix-chips/ix-chips.component.scss
@@ -25,7 +25,6 @@
 
   &:focus-within {
     border-color: var(--primary);
-    border-width: 1.5px;
   }
 
   &.disabled {

--- a/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.scss
+++ b/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.scss
@@ -14,7 +14,7 @@
 
 .input-container {
   background: var(--bg1);
-  border: 1.5px solid var(--lines);
+  border: solid 1.5px var(--lines);
   border-radius: 2px;
   display: flex;
   flex-direction: row;

--- a/src/app/modules/ix-forms/components/ix-input/ix-input.component.scss
+++ b/src/app/modules/ix-forms/components/ix-input/ix-input.component.scss
@@ -24,7 +24,6 @@
 
   &:focus-within {
     border-color: var(--primary);
-    border-width: 1px;
   }
 
   &.disabled {

--- a/src/app/modules/ix-forms/components/ix-select/ix-select.component.scss
+++ b/src/app/modules/ix-forms/components/ix-select/ix-select.component.scss
@@ -30,7 +30,6 @@
 
   &:focus-within {
     border-color: var(--primary);
-    border-width: 1px;
   }
 
   &.disabled {

--- a/src/app/pages/api-keys/components/api-key-list/api-key-list.component.scss
+++ b/src/app/pages/api-keys/components/api-key-list/api-key-list.component.scss
@@ -59,7 +59,6 @@
 
       &:focus-within {
         border-color: var(--primary);
-        border-width: 1px;
       }
     }
 

--- a/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.html
+++ b/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.html
@@ -16,8 +16,8 @@
     </span>
 
     <div class="full-path">
-        <ix-dataset-icon [dataset]="dataset"></ix-dataset-icon>
-        <span class="own-name">{{ ownName }}</span>
+      <ix-dataset-icon [dataset]="dataset"></ix-dataset-icon>
+      <span class="own-name">{{ ownName }}</span>
     </div>
   </h3>
 

--- a/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.html
+++ b/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.html
@@ -11,14 +11,14 @@
 
   <mat-card-content>
     <div class="file-information" *ngIf="stat?.user || isLoading">
-        <div class="details-item">
-          <div class="label">{{ 'Owner:' | translate }}</div>
-          <div *ngIf="!isLoading; else loaderDetailsItem" class="value">{{ stat.user }}</div>
-        </div>
-        <div class="details-item">
-          <div class="label">{{ 'Group:' | translate }}</div>
-          <div *ngIf="!isLoading; else loaderDetailsItem" class="value">{{ stat.group }}</div>
-        </div>
+      <div class="details-item">
+        <div class="label">{{ 'Owner:' | translate }}</div>
+        <div *ngIf="!isLoading; else loaderDetailsItem" class="value">{{ stat.user }}</div>
+      </div>
+      <div class="details-item">
+        <div class="label">{{ 'Group:' | translate }}</div>
+        <div *ngIf="!isLoading; else loaderDetailsItem" class="value">{{ stat.group }}</div>
+      </div>
     </div>
     <div *ngIf="acl; else loaderPermissions" class="permissions">
       <ix-view-trivial-permissions *ngIf="acl.trivial; else nonTrivial" [stat]="stat"></ix-view-trivial-permissions>


### PR DESCRIPTION
Before:
When you focus on `ix-input` it jumps due to border-width changes. (normal - 1.5px, focus - 1px).
After:
`ix-input` and other controls will inherit the border width on focusing