### PR TITLE
NAS-117947 / 22.12 / NAS-117947: Adding otp token to SSH semi automatic form

### DIFF
--- a/src/app/helptext/system/ssh-connections.ts
+++ b/src/app/helptext/system/ssh-connections.ts
@@ -54,4 +54,6 @@ export default {
   password_placeholder: T('Password'),
   password_tooltip: T('User account password for logging into the \
  remote system.'),
+  otp_placeholder: T('One-Time Password (if necessary)'),
+  otp_tooltip: T('One-Time Password if two factor authentication is enabled.'),
 };

--- a/src/app/interfaces/ssh-connection-setup.interface.ts
+++ b/src/app/interfaces/ssh-connection-setup.interface.ts
@@ -18,6 +18,7 @@ export interface SshConnectionSetup {
     connect_timeout: number;
     cipher: CipherType;
     token?: string;
+    otp_token?: string;
   };
 }
 
@@ -33,6 +34,7 @@ export interface SshSemiAutomaticSetup {
   token?: string;
   password?: string;
   username?: string;
+  otp_token?: string;
   private_key: number;
   cipher?: CipherType;
   connect_timeout?: number;

--- a/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.html
@@ -55,6 +55,12 @@
           type="password"
           [tooltip]="helptext.password_tooltip | translate"
         ></ix-input>
+        <ix-input
+          *ngIf="!isManualSetup"
+          formControlName="otp_token"
+          [label]="'One-Time Password (if necessary)' | translate"
+          [tooltip]="helptext.otp_tooltip | translate"
+        ></ix-input>
         <ix-select
           formControlName="private_key"
           [label]="'Private Key' | translate"

--- a/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.spec.ts
+++ b/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.spec.ts
@@ -159,6 +159,7 @@ describe('SshConnectionFormComponent', () => {
       'TrueNAS URL': 'https://truenas.com',
       Username: 'john',
       Password: '12345678',
+      'One-Time Password (if necessary)': '1234',
       'Private Key': 'key2',
 
       Cipher: 'Fast',
@@ -177,6 +178,7 @@ describe('SshConnectionFormComponent', () => {
         cipher: CipherType.Fast,
         connect_timeout: 10,
         password: '12345678',
+        otp_token: '1234',
         url: 'https://truenas.com',
         username: 'john',
       },
@@ -228,6 +230,7 @@ describe('SshConnectionFormComponent', () => {
       semi_automatic_setup: {
         cipher: CipherType.Standard,
         connect_timeout: 10,
+        otp_token: '',
         password: '123456',
         url: 'https://truenas.com',
         username: 'root',

--- a/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.ts
@@ -56,6 +56,7 @@ export class SshConnectionFormComponent {
       (control) => control.parent && !this.isManualSetup,
       Validators.required,
     )],
+    otp_token: [''],
     private_key: [null as (number | typeof generateNewKeyValue), Validators.required],
 
     cipher: [CipherType.Standard],
@@ -229,6 +230,7 @@ export class SshConnectionFormComponent {
         url: values.url,
         password: values.password,
         username: values.username,
+        otp_token: values.otp_token,
         connect_timeout: values.connect_timeout,
         cipher: values.cipher,
       };

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
@@ -719,6 +719,18 @@ export class ReplicationWizardComponent implements WizardConfiguration {
         }],
       }],
     }, {
+      type: 'input',
+      name: 'otp_token',
+      placeholder: sshConnectionsHelptex.otp_placeholder,
+      tooltip: sshConnectionsHelptex.otp_tooltip,
+      relation: [{
+        action: RelationAction.Show,
+        when: [{
+          name: 'setup_method',
+          value: 'semiautomatic',
+        }],
+      }],
+    }, {
       type: 'select',
       name: 'private_key',
       placeholder: sshConnectionsHelptex.private_key_placeholder,

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2005,6 +2005,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1518,6 +1518,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -489,6 +489,8 @@
   "Offline disk {name}?": "",
   "Ok": "",
   "One time snapshot of {dataset}": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online disk {name}?": "",
   "Only appears if <i>Device</i> is selected. Select the unused zvol or zvol snapshot.": "",
   "Only first {number} examples are shown.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2145,6 +2145,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online Disk": "",
   "Online disk ": "",
   "Online disk {name}?": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -546,6 +546,8 @@
   "Offline disk {name}?": "",
   "Ok": "",
   "One time snapshot of {dataset}": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online disk {name}?": "",
   "Only appears if <i>Device</i> is selected. Select the unused zvol or zvol snapshot.": "",
   "Only first {number} examples are shown.": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2094,6 +2094,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1937,6 +1937,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online disk {name}?": "",
   "Only Replicate Snapshots Matching Schedule": "",
   "Only appears if <i>Device</i> is selected. Select the unused zvol or zvol snapshot.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2342,6 +2342,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2272,6 +2272,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2268,6 +2268,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2204,6 +2204,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -929,6 +929,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2352,6 +2352,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online": "",
   "Online Disk": "",
   "Online disk ": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -211,6 +211,8 @@
   "OQ Used": "",
   "OS Version": "",
   "Offline disk {name}?": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online disk {name}?": "",
   "Only numeric ids are allowed.": "",
   "Open Network": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1777,6 +1777,8 @@
   "One or more data vdevs has disks of different sizes.": "",
   "One time snapshot of {dataset}": "",
   "One-Time Password (OTP) Digits": "",
+  "One-Time Password (if necessary)": "",
+  "One-Time Password if two factor authentication is enabled.": "",
   "Online Disk": "",
   "Online disk ": "",
   "Online disk {name}?": "",


### PR DESCRIPTION
Testing: SSH credentials can be created in Backup Credentials and in Replication Wizard.
You can put `http://localhost` in TrueNAS URL field.
If you are going to enable 2FA on a common machine to test, please make sure to disable it afterwards.