### PR TITLE
Added results dialog

### DIFF
--- a/src/app/pages/storage/snapshots/snapshot-list/components/batch-delete-results/snapshots-batch-delete-results-dialog.component.html
+++ b/src/app/pages/storage/snapshots/snapshot-list/components/batch-delete-results/snapshots-batch-delete-results-dialog.component.html
@@ -1,0 +1,31 @@
+<h1 mat-dialog-title>Batch Operation Results</h1>
+<div mat-dialog-content>
+    <div *ngIf="errorsCount > 0">
+        <h4><strong>{{ errorsTitle  }}</strong></h4>
+        <ul>
+            <li *ngFor="let error of snapshotNamesWithErrors" class="item">
+                <div><strong>{{ 'Snapshot: ' | translate }}</strong> {{ error.snapshot }}</div>
+                <div><strong>{{ 'Error: ' | translate }}</strong> {{ error.error }}</div>
+            </li>
+        </ul>
+    </div>
+    <div *ngIf="snapshotsFailedToDelete.length">
+        <h4><strong>{{ failureMsg }}</strong></h4>
+        <ul>
+            <li *ngFor="let snapshot of snapshotsFailedToDelete">{{ snapshot }}</li>
+        </ul>
+    </div>
+    <div *ngIf="snapshotsDeleted.length">
+        <h4><strong>{{ successMsg }}</strong></h4>
+        <ul>
+            <li *ngFor="let snapshot of snapshotsDeleted">{{ snapshot }}</li>
+        </ul>
+    </div>
+</div>
+<div mat-dialog-actions>
+  <span fxFlex></span>
+  <button 
+    mat-button class="mat-button" mat-dialog-close
+    ix-auto ix-auto-type="button" x-auto-identifier="CLOSE"
+  >{{"Close" | translate }}</button>
+</div>

--- a/src/app/pages/storage/snapshots/snapshot-list/components/batch-delete-results/snapshots-batch-delete-results-dialog.component.scss
+++ b/src/app/pages/storage/snapshots/snapshot-list/components/batch-delete-results/snapshots-batch-delete-results-dialog.component.scss
@@ -1,0 +1,7 @@
+.item {
+    margin: 16px 0px;
+}
+
+.actions {
+    margin-top: 16px;
+}

--- a/src/app/pages/storage/snapshots/snapshot-list/components/batch-delete-results/snapshots-batch-delete-results-dialog.component.ts
+++ b/src/app/pages/storage/snapshots/snapshot-list/components/batch-delete-results/snapshots-batch-delete-results-dialog.component.ts
@@ -1,0 +1,50 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { T } from 'app/translate-marker';
+
+interface BatchResults {
+  arguments: [ string, [string][], string ];
+  result: { error?: string; result?: boolean }[];
+  [key: string]: any;
+}
+
+@Component({
+  templateUrl: './snapshots-batch-delete-results-dialog.component.html',
+  styleUrls: ['./snapshots-batch-delete-results-dialog.component.scss'],
+})
+export class SnapshotsBatchDeleteResultsDialogComponent {
+  snapshotNamesWithErrors: { snapshot: string; error: string }[] = [];
+  snapshotsDeleted: string[] = [];
+  snapshotsFailedToDelete: string[] = [];
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { results: BatchResults }) {
+    this.data.results.result.forEach((operationResponse, index) => {
+      const snapshotName = this.data.results.arguments[1][index][0];
+      if (operationResponse.error) {
+        this.snapshotNamesWithErrors.push({
+          snapshot: snapshotName,
+          error: operationResponse.error.replace('[EFAULT] ', ''),
+        });
+      } else if (operationResponse.result) {
+        this.snapshotsDeleted.push(snapshotName);
+      } else {
+        this.snapshotsFailedToDelete.push(snapshotName);
+      }
+    });
+  }
+
+  get errorsTitle(): string {
+    return T('Error when deleting ' + this.errorsCount + ' snapshots');
+  }
+
+  get errorsCount(): number {
+    return Object.keys(this.snapshotNamesWithErrors).length;
+  }
+
+  get successMsg(): string {
+    return T('Successfully deleted ' + this.snapshotsDeleted.length + ' snapshots');
+  }
+
+  get failureMsg(): string {
+    return T('Failed to delete ' + this.snapshotsFailedToDelete.length + ' snapshots');
+  }
+}

--- a/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/storage/snapshots/snapshot-list/snapshot-list.component.ts
@@ -12,6 +12,7 @@ import helptext from '../../../../helptext/storage/snapshots/snapshots';
 import { DialogFormConfiguration } from '../../../common/entity/entity-dialog/dialog-form-configuration.interface';
 import { MatDialog } from '@angular/material/dialog';
 import { FieldConfig } from '../../../common/entity/entity-form/models/field-config.interface';
+import { SnapshotsBatchDeleteResultsDialogComponent } from 'app/pages/storage/snapshots/snapshot-list/components/batch-delete-results/snapshots-batch-delete-results-dialog.component';
 
 @Component({
   selector: 'app-snapshot-list',
@@ -288,10 +289,11 @@ export class SnapshotListComponent {
       dialogRef.close();
       this.entityList.getData();
       this.entityList.selected = [];
-
-      let infoMessage: string = T('Deleted') + ' ' + params[1].length + ' ';
-      infoMessage += params[1].length > 1 ? T('snapshots') : T('snapshot');
-      this.dialogService.report(infoMessage, '', '320px', 'info', true);
+      this.dialog.open(SnapshotsBatchDeleteResultsDialogComponent, {
+        data: {
+          results: job_res,
+        },
+      });
     });
 
     dialogRef.componentInstance.failure.subscribe((err) => {

--- a/src/app/pages/storage/storage.module.ts
+++ b/src/app/pages/storage/storage.module.ts
@@ -20,8 +20,6 @@ import { SnapshotDetailsComponent, SnapshotListComponent } from './snapshots/sna
 import { DatasetFormComponent } from './volumes/datasets/dataset-form';
 import { DatasetPermissionsComponent } from './volumes/datasets/dataset-permissions';
 import { DatasetAclComponent } from './volumes/datasets/dataset-acl';
-import { DatasetUnlockComponent } from './volumes/datasets/dataset-unlock';
-import { UnlockDialogComponent } from './volumes/datasets/dataset-unlock/unlock-dialog/unlock-dialog.component';
 import { ImportDiskComponent } from './import-disk/import-disk.component';
 
 import { DiskComponent, ManagerComponent, VdevComponent } from './volumes/manager';
@@ -49,6 +47,9 @@ import { DatasetQuotasUserlistComponent } from './volumes/datasets/dataset-quota
 import { DatasetQuotasGrouplistComponent } from './volumes/datasets/dataset-quotas/dataset-quotas-grouplist/dataset-quotas-grouplist.component';
 import { UserQuotaFormComponent } from './volumes/datasets/dataset-quotas/dataset-quotas-userlist/user-quota-form/user-quota-form.component';
 import { GroupQuotaFormComponent } from './volumes/datasets/dataset-quotas/dataset-quotas-grouplist/group-quota-form/group-quota-form.component';
+import { SnapshotsBatchDeleteResultsDialogComponent } from 'app/pages/storage/snapshots/snapshot-list/components/batch-delete-results/snapshots-batch-delete-results-dialog.component';
+import { DatasetUnlockComponent } from 'app/pages/storage/volumes/datasets/dataset-unlock/dataset-unlock.component';
+import { UnlockDialogComponent } from 'app/pages/storage/volumes/datasets/dataset-unlock/unlock-dialog/unlock-dialog.component';
 
 @NgModule({
   imports: [
@@ -68,6 +69,7 @@ import { GroupQuotaFormComponent } from './volumes/datasets/dataset-quotas/datas
     VolumeAddkeyFormComponent,
     VolumeCreatekeyFormComponent,
     VolumeChangekeyFormComponent,
+    SnapshotsBatchDeleteResultsDialogComponent,
     ZvolFormComponent,
     VolumeImportWizardComponent,
     SnapshotListComponent,
@@ -92,7 +94,7 @@ import { GroupQuotaFormComponent } from './volumes/datasets/dataset-quotas/datas
     UserQuotaFormComponent,
     GroupQuotaFormComponent,
   ],
-  entryComponents: [SnapshotDetailsComponent, UnlockDialogComponent],
+  entryComponents: [SnapshotDetailsComponent, UnlockDialogComponent, SnapshotsBatchDeleteResultsDialogComponent],
   providers: [UserService, StorageService, MessageService, JobService, TranslateService],
 })
 export class StorageModule {


### PR DESCRIPTION
To test, create a snapshot (say 'testSnapshot') on dataset (say 'testDataset'). Now, run the following command on your shell `zfs hold keep testDataset@testsnapshot`. Now try to delete `testSnapshot`. Previously, UI would wrongly tell you that the operation was successful. Now, it should show you the errors it ran into. Also try deleting multiple snapshots together. The new dialog should show which snapshots faced errors when deleting and which snapshots were deleted successfully.