### PR TITLE
NAS-117943 / 22.12 / NAS-117943: Close slide-in while navigating in browser

### DIFF
--- a/src/app/services/ix-slide-in.service.ts
+++ b/src/app/services/ix-slide-in.service.ts
@@ -1,3 +1,4 @@
+import { PlatformLocation } from '@angular/common';
 import { Injectable, Type } from '@angular/core';
 import { Subject } from 'rxjs';
 import { IxSlideInComponent } from 'app/modules/ix-forms/components/ix-slide-in/ix-slide-in.component';
@@ -15,6 +16,10 @@ export class IxSlideInService {
   private slideInComponent: IxSlideInComponent;
   private slideInClosed$ = new Subject<ResponseOnClose>();
   modalType: Type<unknown>;
+
+  constructor(private location: PlatformLocation) {
+    this.location.onPopState(() => this.close());
+  }
 
   setModal(modal: IxSlideInComponent): void {
     this.slideInComponent = modal;

--- a/src/app/services/modal.service.ts
+++ b/src/app/services/modal.service.ts
@@ -1,3 +1,4 @@
+import { PlatformLocation } from '@angular/common';
 import {
   ComponentFactoryResolver, Injectable, Injector, Type,
 } from '@angular/core';
@@ -27,7 +28,10 @@ export class ModalService {
   constructor(
     private componentFactoryResolver: ComponentFactoryResolver,
     private injector: Injector,
-  ) {}
+    private location: PlatformLocation,
+  ) {
+    this.location.onPopState(() => this.closeSlideIn());
+  }
 
   refreshTable(): void {
     this.refreshTable$.next();


### PR DESCRIPTION
## Testing

1. Go to **Sharing**

2. Go to **Data Protection** and click **Add** button to open slide-in panel

3. Click browser's **Back** button

Expected Result: Slide in is closed and user goes back.