### PR TITLE
NAS-118065 / 22.12 / NAS-118065: Add Extend button inside ZFS Info block

### DIFF
--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.html
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.html
@@ -23,6 +23,10 @@
     </div>
   </mat-card-content>
   <mat-card-actions *ngIf="isDisk">
+    <button *ngIf="canExtendDisk" mat-stroked-button (click)="onExtend()">
+      {{ 'Extend' | translate }}
+    </button>
+
     <button *ngIf="canRemoveDisk" mat-stroked-button (click)="onRemove()">
       {{ 'Remove' | translate }}
     </button>

--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
@@ -39,6 +39,12 @@ export class ZfsInfoCardComponent {
     return isTopologyDisk(this.topologyItem);
   }
 
+  get canExtendDisk(): boolean {
+    return this.topologyParentItem.type !== TopologyItemType.Mirror
+      && this.topologyItem.type === TopologyItemType.Disk
+      && this.topologyCategory === PoolTopologyCategory.Data;
+  }
+
   get canRemoveDisk(): boolean {
     return this.topologyParentItem.type !== TopologyItemType.Mirror
       && this.topologyCategory !== PoolTopologyCategory.Data;


### PR DESCRIPTION
**Testing**

You should have a single disk pool, and an available disk

1. On **Storage > (Choose a single-disk pool) > Manage Devices** , select the single disk of the pool
2. Test the **Extend** button and the **Extend Dialog** 