### PR TITLE
NAS-118258 / 22.12 / Fix icon color in sidebar

### DIFF
--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -1315,7 +1315,7 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
     .mat-list-item-content > a {
       background-color: var(--bg2);
 
-      mat-icon {
+      ix-icon {
         color: var(--primary);
       }
     }


### PR DESCRIPTION
Manual cherry-pick a fix from https://github.com/truenas/webui/pull/7035

Preview:
![image](https://user-images.githubusercontent.com/351613/191286004-070db7c4-2e26-494a-88ce-f94185eee900.png)
![image](https://user-images.githubusercontent.com/351613/191286015-dc4b790c-7def-4436-8abc-b8cb2e250446.png)
