### PR TITLE
NAS-117859 / 22.12 / Fixed sidenav bottom details

### DIFF
--- a/src/app/modules/common/layouts/admin-layout/admin-layout.component.scss
+++ b/src/app/modules/common/layouts/admin-layout/admin-layout.component.scss
@@ -98,11 +98,9 @@
 }
 
 .sidenav-copyright-txt {
-  bottom: 0;
   font-size: 0.6rem;
   margin: 1rem auto;
   opacity: 0.5;
-  position: absolute;
   text-align: center;
   width: 100%;
 
@@ -161,4 +159,9 @@ ix-jw-modal {
 
 .isdark {
   display: block;
+}
+
+ix-navigation {
+  height: 100%;
+  overflow: auto;
 }


### PR DESCRIPTION
Made sure that bottom info is always visible, if menu items overflow - scroll added.

<img width="358" alt="Screen Shot 2022-09-22 at 13 56 14" src="https://user-images.githubusercontent.com/22980553/191729098-11090497-d00c-4e4b-8017-94a767e7e242.png">
