### PR TITLE
NAS-118303 / 22.12 / New reasons in `failover.disabled.reasons`

### DIFF
--- a/src/app/enums/failover-disabled-reason.enum.ts
+++ b/src/app/enums/failover-disabled-reason.enum.ts
@@ -9,4 +9,7 @@ export enum FailoverDisabledReason {
   MismatchDisks = 'MISMATCH_DISKS',
   NoCriticalInterfaces = 'NO_CRITICAL_INTERFACES',
   NoFenced = 'NO_FENCED',
+  NoJournalSync = 'NO_JOURNAL_SYNC',
+  RemNoJournalSync = 'REM_NO_JOURNAL_SYNC',
+  RemFailoverOngoing = 'REM_FAILOVER_ONGOING',
 }

--- a/src/app/helptext/topbar.ts
+++ b/src/app/helptext/topbar.ts
@@ -18,6 +18,9 @@ export default {
     [FailoverDisabledReason.MismatchDisks]: T('The TrueNAS controllers do not have the same quantity of disks.'),
     [FailoverDisabledReason.NoCriticalInterfaces]: T('No network interfaces are marked critical for failover.'),
     [FailoverDisabledReason.NoFenced]: T('Fenced is not running.'),
+    [FailoverDisabledReason.NoJournalSync]: T('Thread responsible for syncing db transactions not running on this node.'),
+    [FailoverDisabledReason.RemNoJournalSync]: T('Thread responsible for syncing db transactions not running on other node.'),
+    [FailoverDisabledReason.RemFailoverOngoing]: T('Other node is currently processing a failover event.'),
   },
   updateRunning_dialog: {
     title: T('Update in Progress'),


### PR DESCRIPTION
Added 3 new reasons in PR: https://github.com/truenas/middleware/pull/9904 so adding them here.