### PR TITLE
NAS-118333 / 22.12 / Icons update (rounded)

### DIFF
--- a/src/app/modules/alerts/components/alert/alert.component.scss
+++ b/src/app/modules/alerts/components/alert/alert.component.scss
@@ -33,11 +33,19 @@
   text-transform: uppercase;
 
   &.warn {
-    color: var(--red);
+    color: var(--orange);
   }
 
   &.accent {
     color: var(--accent);
+  }
+
+  &.primary {
+    color: var(--primary);
+  }
+
+  &.error {
+    color: var(--red);
   }
 }
 

--- a/src/app/modules/alerts/components/alert/alert.component.spec.ts
+++ b/src/app/modules/alerts/components/alert/alert.component.spec.ts
@@ -87,7 +87,7 @@ describe('AlertComponent', () => {
 
   it('shows an alert icon', async () => {
     const icon = await alert.getIconHarness();
-    expect(await icon.getName()).toEqual('error');
+    expect(await icon.getName()).toEqual('cancel');
   });
 
   it('shows alert datetime (formatted according to system settings) and system timezone', () => {

--- a/src/app/modules/alerts/components/alert/alert.component.ts
+++ b/src/app/modules/alerts/components/alert/alert.component.ts
@@ -5,15 +5,32 @@ import {
   Input,
   OnChanges,
 } from '@angular/core';
-import { ThemePalette } from '@angular/material/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { AlertLevel, alertLevelLabels } from 'app/enums/alert-level.enum';
 import { Alert } from 'app/interfaces/alert.interface';
-import { dismissAlertPressed, reopenAlertPressed } from 'app/modules/alerts/store/alert.actions';
+import {
+  dismissAlertPressed,
+  reopenAlertPressed,
+} from 'app/modules/alerts/store/alert.actions';
 import { AppState } from 'app/store';
 import { selectTimezone } from 'app/store/system-config/system-config.selectors';
+
+enum AlertIcon {
+  Error = 'cancel',
+  Warning = 'error',
+  Info = 'info',
+  NotificationsActive = 'notifications_active',
+  CheckCircle = 'check_circle',
+}
+
+enum AlertLevelColor {
+  Warn = 'warn',
+  Error = 'error',
+  Accent = 'accent',
+  Primary = 'primary',
+}
 
 @UntilDestroy()
 @Component({
@@ -26,7 +43,7 @@ export class AlertComponent implements OnChanges {
   @Input() alert: Alert;
   @Input() isHa: boolean;
 
-  alertLevelColor: ThemePalette;
+  alertLevelColor: AlertLevelColor;
   icon: string;
   iconTooltip: string;
   timezone: string;
@@ -63,28 +80,28 @@ export class AlertComponent implements OnChanges {
     switch (true) {
       case this.alert.dismissed:
         this.alertLevelColor = undefined;
-        this.icon = 'check_circle';
+        this.icon = AlertIcon.CheckCircle;
         this.iconTooltip = this.translate.instant('Dismissed');
         break;
       case [AlertLevel.Error, AlertLevel.Critical].includes(this.alert.level):
-        this.alertLevelColor = 'warn';
-        this.icon = 'error';
+        this.alertLevelColor = AlertLevelColor.Error;
+        this.icon = AlertIcon.Error;
         break;
       case this.alert.level === AlertLevel.Warning:
-        this.alertLevelColor = 'accent';
-        this.icon = 'warning';
+        this.alertLevelColor = AlertLevelColor.Warn;
+        this.icon = AlertIcon.Warning;
         break;
       case this.alert.one_shot:
-        this.icon = 'notifications_active';
+        this.icon = AlertIcon.NotificationsActive;
         this.iconTooltip = this.translate.instant(
           "This is a ONE-SHOT {alertLevel} alert, it won't be dismissed automatically",
           { alertLevel: this.alertLevelLabel },
         );
-        this.alertLevelColor = 'primary';
+        this.alertLevelColor = AlertLevelColor.Primary;
         break;
       default:
-        this.alertLevelColor = 'primary';
-        this.icon = 'info';
+        this.alertLevelColor = AlertLevelColor.Primary;
+        this.icon = AlertIcon.Info;
     }
   }
 }

--- a/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.html
+++ b/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.html
@@ -40,7 +40,7 @@
 <ng-template #loaded>
   <!-- TODO: Consider extracting into its own component -->
   <div *ngIf="error$ | async as error" class="error">
-    <mat-icon class="icon" color="accent">warning</mat-icon>
+    <mat-icon class="icon" color="accent">cancel</mat-icon>
     <h4 class="message">
       <span class="error-word">{{ 'Error:' | translate }}</span>
       {{ error }}

--- a/src/app/modules/jobs/components/job-item/job-item.component.html
+++ b/src/app/modules/jobs/components/job-item/job-item.component.html
@@ -83,9 +83,7 @@
     type="button"
     [disabled]="true"
   >
-    <mat-icon matTooltipPosition="left" class="job-icon-failed" [matTooltip]="job.error">
-      warning
-    </mat-icon>
+    <mat-icon matTooltipPosition="left" class="job-icon-failed" [matTooltip]="job.error">cancel</mat-icon>
   </button>
 
   <button

--- a/src/app/modules/jobs/components/jobs-panel/jobs-panel.component.html
+++ b/src/app/modules/jobs/components/jobs-panel/jobs-panel.component.html
@@ -36,7 +36,7 @@
         [matTooltip]="'Failed' | translate"
       >
         <span class="job-badge-count">{{ failedJobsCount$ | async }}</span>
-        <mat-icon class="job-icon-failed">warning</mat-icon>
+        <mat-icon class="job-icon-failed">cancel</mat-icon>
       </div>
     </div>
   </div>
@@ -50,7 +50,7 @@
   </div>
 
   <div *ngIf="error$ | async as error" class="error">
-    <mat-icon class="icon" color="accent">warning</mat-icon>
+    <mat-icon class="icon" color="accent">cancel</mat-icon>
     <h4 class="message">
       <span class="error-word">{{ 'Error:' | translate }}</span>
       {{ error }}

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
@@ -245,8 +245,8 @@
                       {{ '{uptimeString} as of {dateTime}' | translate: { uptimeString, dateTime } }}
                     </span>
                   </mat-list-item>
-                  <mat-list-item class="time-warning" *ngIf="showTimeDiffWarning">
-                    <mat-icon>warning</mat-icon>
+                  <mat-list-item *ngIf="showTimeDiffWarning" class="time-warning">
+                    <mat-icon [matTooltip]="timeDiffWarning">error</mat-icon>
                     {{ timeDiffWarning }}
                   </mat-list-item>
                 </mat-list>

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
@@ -3,9 +3,8 @@
 }
 
 .time-warning {
-  color: var(--fg2);
-
   .mat-icon {
+    color: var(--orange);
     font-size: 16px;
     margin-right: 10px;
   }

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
@@ -16,7 +16,7 @@
           [matTooltip]="(isLowCapacity ? 'Low Capacity' : 'Warning') | translate"
           class="pool-icon icon-warning"
         >
-          warning
+          error
         </mat-icon>
         <mat-icon
           *ngSwitchCase="usageHealthLevel.Error"

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
@@ -90,10 +90,10 @@ describe('PoolUsageCardComponent', () => {
     expect(spectator.query('mat-card-header mat-icon')).toHaveText('check_circle');
 
     spectator.setInput('poolState', { healthy: false, status: 'ONLINE' } as unknown as Pool);
-    expect(spectator.query('mat-card-header mat-icon')).toHaveText('warning');
+    expect(spectator.query('mat-card-header mat-icon')).toHaveText('error');
 
     spectator.setInput('poolState', { healthy: true, status: 'OFFLINE' } as unknown as Pool);
-    expect(spectator.query('mat-card-header mat-icon')).toHaveText('warning');
+    expect(spectator.query('mat-card-header mat-icon')).toHaveText('error');
 
     spectator.setInput('poolState', { healthy: true, status: 'REMOVED' } as unknown as Pool);
     expect(spectator.query('mat-card-header mat-icon')).toHaveText('cancel');

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
@@ -16,7 +16,7 @@
           class="pool-icon icon-warning"
           [matTooltip]="'Warning' | translate"
         >
-          warning
+          error
         </mat-icon>
         <mat-icon
           *ngSwitchCase="topologyHealthLevel.Error"
@@ -50,7 +50,7 @@
         <b>{{ 'Data VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
           <span *ngIf="topologyState.data === mixedDev" class="warning">
-            <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
+            <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.data }}</span>
         </div>
@@ -59,7 +59,7 @@
         <b>{{ 'Metadata VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
           <span *ngIf="topologyState.metadata === mixedDev" class="warning">
-            <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
+            <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.metadata }}</span>
         </div>
@@ -68,7 +68,7 @@
         <b>{{ 'Log VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
           <span *ngIf="topologyState.log === mixedDev" class="warning">
-            <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
+            <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.log }}</span>
         </div>
@@ -77,7 +77,7 @@
         <b>{{ 'Cache VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
           <span *ngIf="topologyState.cache === mixedDev" class="warning">
-            <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
+            <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.cache }}</span>
         </div>
@@ -86,7 +86,7 @@
         <b>{{ 'Spare VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
           <span *ngIf="topologyState.spare === mixedDev" class="warning">
-            <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
+            <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.spare }}</span>
         </div>
@@ -95,7 +95,7 @@
         <b>{{ 'Dedup VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
           <span *ngIf="topologyState.dedup === mixedDev" class="warning">
-            <ix-icon name="warning" class="pool-icon icon-warning"></ix-icon>
+            <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.dedup }}</span>
         </div>

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
@@ -102,10 +102,10 @@ describe('TopologyCardComponent', () => {
     expect(spectator.query('mat-card-header mat-icon')).toHaveText('check_circle');
 
     spectator.setInput('poolState', { healthy: false, status: 'ONLINE' } as unknown as Pool);
-    expect(spectator.query('mat-card-header mat-icon')).toHaveText('warning');
+    expect(spectator.query('mat-card-header mat-icon')).toHaveText('error');
 
     spectator.setInput('poolState', { healthy: true, status: 'OFFLINE' } as unknown as Pool);
-    expect(spectator.query('mat-card-header mat-icon')).toHaveText('warning');
+    expect(spectator.query('mat-card-header mat-icon')).toHaveText('error');
 
     spectator.setInput('poolState', { healthy: true, status: 'REMOVED' } as unknown as Pool);
     expect(spectator.query('mat-card-header mat-icon')).toHaveText('cancel');

--- a/src/assets/styles/other/_fn-styles.scss
+++ b/src/assets/styles/other/_fn-styles.scss
@@ -881,3 +881,7 @@ body.safari-platform {
   line-height: 20px;
   vertical-align: middle;
 }
+
+.mat-icon.mat-warn {
+  color: var(--orange) !important;
+}


### PR DESCRIPTION
Using one style icons (Jobs short list & tasks full list)
![2022-09-27 15 58 38](https://user-images.githubusercontent.com/22980553/192532853-abd8d123-8987-49e0-b643-2fc06b0ce93e.jpg)

___

Alerts - improved UI understandability (red, orange, blue [all-rounded])
![2022-09-27 15 59 25](https://user-images.githubusercontent.com/22980553/192533014-66dfa735-f4cb-474a-9b74-93bd2d1ed9e3.jpg)
<img width="403" alt="Screen Shot 2022-09-27 at 16 06 03" src="https://user-images.githubusercontent.com/22980553/192534531-2e9f1c91-85b7-4e5d-83de-b1ff6ffb34db.png">

___

Storage (one icons style [rounded])
![2022-09-27 16 00 19](https://user-images.githubusercontent.com/22980553/192533223-ae271b3d-0a62-441f-9c92-567c340c4d53.jpg)

