### PR TITLE
NAS-118414 / 22.12 / Warning modal icon

### DIFF
--- a/src/app/modules/common/dialog/error-dialog/error-dialog.component.html
+++ b/src/app/modules/common/dialog/error-dialog/error-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 mat-dialog-title id="err-title">
-  <mat-icon class="warning-icon">report_problem</mat-icon>
+  <mat-icon class="warning-icon">error</mat-icon>
   {{ title | translate }}
 </h1>
 <div mat-dialog-content id="err-md-content">

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -489,10 +489,9 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
   .mat-dialog-title {
     .warning-icon {
       color: var(--orange);
-      font-size: 35px;
       margin-right: 10px;
       position: relative;
-      top: 8px;
+      top: 6px;
     }
   }
 


### PR DESCRIPTION
Before: 
<img width="290" alt="Screen Shot 2022-10-03 at 14 28 01" src="https://user-images.githubusercontent.com/22980553/193576834-a73940cb-5aea-41a6-91d6-0cdf46fc8206.png">

After: 
<img width="837" alt="Screen Shot 2022-10-03 at 15 26 54" src="https://user-images.githubusercontent.com/22980553/193576873-aa56466c-f421-421d-bc12-3d11c53d390d.png">
