### PR TITLE
NAS-118412 / 22.12 / Pool processing modal width jumping fix

### DIFF
--- a/src/app/modules/entity/entity-job/entity-job.component.scss
+++ b/src/app/modules/entity/entity-job/entity-job.component.scss
@@ -5,8 +5,8 @@
 
 mat-dialog-content.entity-job-dialog {
   max-height: 350px;
-  max-width: 500px;
-  min-width: 200px;
+  max-width: 400px;
+  min-width: 400px;
 
   .mat-dialog-content {
     overflow: auto !important;

--- a/src/app/pages/storage/components/pools-dashboard/pools-dashboard.component.html
+++ b/src/app/pages/storage/components/pools-dashboard/pools-dashboard.component.html
@@ -42,7 +42,6 @@
 
 <ng-container *ngIf="!isEmptyPools && !(arePoolsLoading$ | async)">
   <div fxFlex="100%" fxLayout="column">
-    <!-- TODO: https://ixsystems.atlassian.net/browse/NAS-117820 -->
     <ix-unused-resources
       *ngIf="!isEmptyPools"
       [pools]="pools$ | async"


### PR DESCRIPTION
Before:
<img width="397" alt="Screen Shot 2022-10-03 at 13 06 44" src="https://user-images.githubusercontent.com/22980553/193580319-226d53dd-5fbe-444f-8d0f-3bac2c0b1e9f.png">

<img width="381" alt="Screen Shot 2022-10-03 at 13 13 21" src="https://user-images.githubusercontent.com/22980553/193580342-ee33944a-20ad-47c2-a8f8-35588deb377d.png">

After: (one size)
<img width="525" alt="Screen Shot 2022-10-03 at 15 40 16" src="https://user-images.githubusercontent.com/22980553/193580370-4d2e4166-1af7-4871-95be-c811335eba5b.png">
