### PR TITLE
NAS-112088 / 22.12 / Apps > Don't do validation on empty textboxes if they are not set required: true.

### DIFF
--- a/src/app/services/app-schema.service.spec.ts
+++ b/src/app/services/app-schema.service.spec.ts
@@ -434,6 +434,7 @@ describe('AppSchemaService', () => {
       expect(service.serializeFormValue({ a: 1 })).toEqual({ a: 1 });
       expect(service.serializeFormValue({ a: { b: 1 } })).toEqual({ a: { b: 1 } });
       expect(service.serializeFormValue({ a: { b: [{ c: 'test' }] } })).toEqual({ a: { b: ['test'] } });
+      expect(service.serializeFormValue({ a: { c: null, d: 'test' }, b: null })).toEqual({ a: { d: 'test' } });
     });
   });
 

--- a/src/app/services/app-schema.service.ts
+++ b/src/app/services/app-schema.service.ts
@@ -283,7 +283,7 @@ export class AppSchemaService {
         altDefault = false;
       }
 
-      const value = schema.default !== undefined ? schema.default : altDefault;
+      const value = schema.default !== undefined && isNew ? schema.default : altDefault;
 
       const newFormControl = new CustomUntypedFormControl(value, [
         schema.required ? Validators.required : Validators.nullValidator,
@@ -601,6 +601,9 @@ export class AppSchemaService {
     const result = {} as HierarchicalObjectMap<ChartFormValue>;
     Object.keys(groupValue).forEach((key) => {
       result[key] = this.serializeFormValue(groupValue[key]) as HierarchicalObjectMap<ChartFormValue>;
+      if (result[key] === null) {
+        delete result[key];
+      }
     });
     return result;
   }


### PR DESCRIPTION
**Testing**

At **Apps** 
1. Pick an app which has a property with `type: int, min: ..., max: ...`  in the schema of it's configuration object. Most of such properties are port numbers.  For example, app **storj** property **Owner User ID**
2. Test validation for this property on the form for adding/editing the app

