### PR TITLE
NAS-118446 / 22.12 / add MISMATCH_VERSIONS to failover topbar

### DIFF
--- a/src/app/enums/failover-disabled-reason.enum.ts
+++ b/src/app/enums/failover-disabled-reason.enum.ts
@@ -7,7 +7,7 @@ export enum FailoverDisabledReason {
   NoLicense = 'NO_LICENSE',
   DisagreeVip = 'DISAGREE_VIP',
   MismatchDisks = 'MISMATCH_DISKS',
-  MismatchVersionss = 'MISMATCH_VERSIONS',
+  MismatchVersions = 'MISMATCH_VERSIONS',
   NoCriticalInterfaces = 'NO_CRITICAL_INTERFACES',
   NoFenced = 'NO_FENCED',
   NoJournalSync = 'NO_JOURNAL_SYNC',

--- a/src/app/enums/failover-disabled-reason.enum.ts
+++ b/src/app/enums/failover-disabled-reason.enum.ts
@@ -7,6 +7,7 @@ export enum FailoverDisabledReason {
   NoLicense = 'NO_LICENSE',
   DisagreeVip = 'DISAGREE_VIP',
   MismatchDisks = 'MISMATCH_DISKS',
+  MismatchVersionss = 'MISMATCH_VERSIONS',
   NoCriticalInterfaces = 'NO_CRITICAL_INTERFACES',
   NoFenced = 'NO_FENCED',
   NoJournalSync = 'NO_JOURNAL_SYNC',

--- a/src/app/helptext/topbar.ts
+++ b/src/app/helptext/topbar.ts
@@ -16,6 +16,7 @@ export default {
     [FailoverDisabledReason.NoLicense]: T('Other TrueNAS controller has no license.'),
     [FailoverDisabledReason.DisagreeVip]: T('Nodes Virtual IP states do not agree.'),
     [FailoverDisabledReason.MismatchDisks]: T('The TrueNAS controllers do not have the same quantity of disks.'),
+    [FailoverDisabledReason.MismatchVersions]: T('TrueNAS software versions do not match between storage controllers.'),
     [FailoverDisabledReason.NoCriticalInterfaces]: T('No network interfaces are marked critical for failover.'),
     [FailoverDisabledReason.NoFenced]: T('Fenced is not running.'),
     [FailoverDisabledReason.NoJournalSync]: T('Thread responsible for syncing db transactions not running on this node.'),


### PR DESCRIPTION
Added this on backend here: https://github.com/truenas/middleware/pull/9937