### PR TITLE
NAS-118359 / 22.12 / Update entities in docker-images store

### DIFF
--- a/src/app/pages/applications/docker-images/docker-images-list/docker-images-list.component.ts
+++ b/src/app/pages/applications/docker-images/docker-images-list/docker-images-list.component.ts
@@ -76,6 +76,7 @@ export class DockerImagesListComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit(): void {
+    this.store.loadEntities();
     this.getDockerImages();
   }
 


### PR DESCRIPTION
**Testing**

On the **Apps** page double check that contents of **Docker Images** tab gets refreshed when user switches to other tag, and then switches back to **Docker Images** tab.