### PR TITLE
NAS-118464 / 22.12 / Fixes saving Small Block Size on basic edit

### DIFF
--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
@@ -815,7 +815,7 @@ export class DatasetFormComponent implements FormConfiguration {
       data.quota = null;
       data.refreservation = null;
       data.reservation = null;
-      data.special_small_block_size = null;
+      data.special_small_block_size = inherit;
       data.copies = (data.copies !== undefined && data.copies !== null && data.name !== undefined) ? '1' : undefined;
     }
     // calculate and delete _unit


### PR DESCRIPTION
Test how `Metadata (Special) Small Block Size` gets saved on the dataset form when dataset is edited or added.
Previous error occurred when dataset was added in Basic mode.