### PR TITLE
NAS-117028 / 22.12-BETA.2 / Nas 117028 - Fixed errored out pools on new storage pages (by Raz-Dva)

### DIFF
--- a/src/app/enums/vdev-status.enum.ts
+++ b/src/app/enums/vdev-status.enum.ts
@@ -2,4 +2,5 @@ export enum TopologyItemStatus {
   Online = 'ONLINE',
   Removed = 'REMOVED',
   Offline = 'OFFLINE',
+  Unavail = 'UNAVAIL',
 }

--- a/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.ts
@@ -49,9 +49,11 @@ export class DiskHealthCardComponent implements OnInit, OnChanges {
   };
 
   ngOnInit(): void {
-    this.diskState.smartTests = this.disks.reduce((total, disk) => total + disk.smartTests, 0);
-    this.diskState.alerts = this.disks.reduce((total, current) => total + current.alerts.length, 0);
-    this.loadTemperatures();
+    if (this.disks) {
+      this.diskState.smartTests = this.disks.reduce((total, disk) => total + disk.smartTests, 0);
+      this.diskState.alerts = this.disks.reduce((total, current) => total + current.alerts.length, 0);
+      this.loadTemperatures();
+    }
 
     this.checkVolumeHealth(this.poolState);
   }

--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.ts
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.ts
@@ -197,10 +197,13 @@ export class DevicesComponent implements OnInit, AfterViewInit {
       }
 
       dataNodes.children.sort((a: TopologyDisk, b: TopologyDisk) => {
-        const nameA = a.disk.toLowerCase();
-        const nameB = b.disk.toLowerCase();
+        if (a.disk && b.disk) {
+          const nameA = a.disk.toLowerCase();
+          const nameB = b.disk.toLowerCase();
 
-        return nameA.localeCompare(nameB);
+          return nameA.localeCompare(nameB);
+        }
+        return undefined;
       });
       this.sortDataNodesByDiskName(dataNodes.children);
     });

--- a/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.html
+++ b/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.html
@@ -33,7 +33,7 @@
       [topologyCategory]="topologyCategory"
     ></ix-zfs-info-card>
 
-    <ng-container *ngIf="isTopologyDisk">
+    <ng-container *ngIf="isTopologyDisk && hasTopologyItemDisk">
       <ix-hardware-disk-encryption
         [topologyDisk]="topologyItem | cast"
       ></ix-hardware-disk-encryption>
@@ -44,7 +44,7 @@
       ></ix-smart-info-card>
     </ng-container>
 
-    <ng-container *ngIf="isTopologyDisk">
+    <ng-container *ngIf="isTopologyDisk && hasTopologyItemDisk">
       <ix-disk-info-card [disk]="disk"></ix-disk-info-card>
     </ng-container>
   </div>

--- a/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.ts
+++ b/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.ts
@@ -6,6 +6,7 @@ import {
   EventEmitter,
 } from '@angular/core';
 import { PoolTopologyCategory } from 'app/enums/pool-topology-category.enum';
+import { TopologyItemStatus } from 'app/enums/vdev-status.enum';
 import { Disk, isTopologyDisk, TopologyItem } from 'app/interfaces/storage.interface';
 
 @Component({
@@ -32,10 +33,17 @@ export class DiskDetailsPanelComponent {
   }
 
   get isTopologyDisk(): boolean {
-    return isTopologyDisk(this.topologyItem);
+    return isTopologyDisk(this.topologyItem)
+      && this.topologyItem.status !== TopologyItemStatus.Unavail;
   }
 
   onCloseMobileDetails(): void {
     this.closeMobileDetails.emit();
+  }
+
+  get hasTopologyItemDisk(): boolean {
+    if (isTopologyDisk(this.topologyItem)) {
+      return this.topologyItem.disk !== null;
+    }
   }
 }

--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
@@ -42,7 +42,8 @@ export class ZfsInfoCardComponent {
   get canExtendDisk(): boolean {
     return this.topologyParentItem.type !== TopologyItemType.Mirror
       && this.topologyItem.type === TopologyItemType.Disk
-      && this.topologyCategory === PoolTopologyCategory.Data;
+      && this.topologyCategory === PoolTopologyCategory.Data
+      && this.topologyItem.status !== TopologyItemStatus.Unavail;
   }
 
   get canRemoveDisk(): boolean {
@@ -60,12 +61,14 @@ export class ZfsInfoCardComponent {
 
   get canOfflineDisk(): boolean {
     return this.topologyItem.status !== TopologyItemStatus.Offline
-      && ![PoolTopologyCategory.Spare, PoolTopologyCategory.Cache].includes(this.topologyCategory);
+      && ![PoolTopologyCategory.Spare, PoolTopologyCategory.Cache].includes(this.topologyCategory)
+      && this.topologyItem.status !== TopologyItemStatus.Unavail;
   }
 
   get canOnlineDisk(): boolean {
     return this.topologyItem.status !== TopologyItemStatus.Online
-      && ![PoolTopologyCategory.Spare, PoolTopologyCategory.Cache].includes(this.topologyCategory);
+      && ![PoolTopologyCategory.Spare, PoolTopologyCategory.Cache].includes(this.topologyCategory)
+      && this.topologyItem.status !== TopologyItemStatus.Unavail;
   }
 
   constructor(
@@ -105,7 +108,7 @@ export class ZfsInfoCardComponent {
   onOnline(): void {
     this.dialogService.confirm({
       title: this.translate.instant('Online Disk'),
-      message: this.translate.instant('Online disk {name}?', { name: this.disk.devname }),
+      message: this.translate.instant('Online disk {name}?', { name: this.disk?.devname }),
       buttonMsg: this.translate.instant('Online'),
     }).pipe(
       filter(Boolean),
@@ -130,7 +133,7 @@ export class ZfsInfoCardComponent {
   onDetach(): void {
     this.dialogService.confirm({
       title: this.translate.instant('Detach Disk'),
-      message: this.translate.instant('Detach disk {name}?', { name: this.disk.devname }),
+      message: this.translate.instant('Detach disk {name}?', { name: this.disk?.devname }),
       buttonMsg: this.translate.instant('Detach'),
     }).pipe(
       filter(Boolean),

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -3158,6 +3158,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2332,6 +2332,7 @@
   "TrueCommand IP": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -910,6 +910,7 @@
   "TrueCommand": "",
   "TrueCommand IP": "",
   "TrueNAS Help": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3394,6 +3394,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1022,6 +1022,7 @@
   "Transport": "",
   "TrueCommand": "",
   "TrueCommand IP": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3398,6 +3398,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3056,6 +3056,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3642,6 +3642,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3547,6 +3547,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3569,6 +3569,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3443,6 +3443,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1615,6 +1615,7 @@
   "TrueCommand IP": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -78,6 +78,7 @@
   "Thread responsible for syncing db transactions not running on other node.": "",
   "Thread responsible for syncing db transactions not running on this node.": "",
   "TrueCommand": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "UID": "",
   "UTC": "",
   "VM": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3651,6 +3651,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -379,6 +379,7 @@
   "Total Down": "",
   "Total Snapshots": "",
   "Total ZFS Errors": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",
   "Unassigned Disks": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2828,6 +2828,7 @@
   "TrueNAS Controller": "",
   "TrueNAS Help": "",
   "TrueNAS URL": "",
+  "TrueNAS software versions do not match between storage controllers.": "",
   "TrueNAS was unable to reach update servers.": "",
   "TrueNAS {product} is Free and <a href=\"https://github.com/truenas/\" target=\"_blank\"> Open Source</a> software, which is provided as-is with no warranty.": "",
   "Trust Guest Filters": "",


### PR DESCRIPTION
Put pools in a bad state. For example, you could create a pool in VM and then remove a disk that belongs to this pool.
Check new storage and Devices

Original PR: https://github.com/truenas/webui/pull/7177
Jira URL: https://ixsystems.atlassian.net/browse/NAS-117028