### PR TITLE
NAS-118443 / 22.12-BETA.2 / Filter disks when 'disk' or 'device' is null (by bvasilenko)

### DIFF
--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.ts
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.ts
@@ -196,6 +196,10 @@ export class DevicesComponent implements OnInit, AfterViewInit {
         return;
       }
 
+      dataNodes.children = dataNodes.children.filter((child) => {
+        return child.disk !== null && child.device !== null;
+      });
+
       dataNodes.children.sort((a: TopologyDisk, b: TopologyDisk) => {
         const nameA = a.disk.toLowerCase();
         const nameB = b.disk.toLowerCase();


### PR DESCRIPTION
**Testing**

You should have a pool with 2 or more drives. Remove one drive from a pool in order to simulate replacement of the drive. 

Now, **Storage > tank > Topology > Manage Devices** should display the remaining drives correctly.

Original PR: https://github.com/truenas/webui/pull/7172
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118443