### PR TITLE
NAS-117941 / 22.12-RC.1 / Error when going to datasets after removing all pools

### DIFF
--- a/src/app/pages/datasets/datasets.module.ts
+++ b/src/app/pages/datasets/datasets.module.ts
@@ -41,7 +41,6 @@ import { routing } from 'app/pages/datasets/datasets.routing';
 import { EncryptionModule } from 'app/pages/datasets/modules/encryption/encryption.module';
 import { PermissionsModule } from 'app/pages/datasets/modules/permissions/permissions.module';
 import { SnapshotsModule } from 'app/pages/datasets/modules/snapshots/snapshots.module';
-import { DatasetTreeStore } from 'app/pages/datasets/store/dataset-store.service';
 import { DatasetCapacityManagementCardComponent } from './components/dataset-capacity-management-card/dataset-capacity-management-card.component';
 import { DatasetCapacitySettingsComponent } from './components/dataset-capacity-management-card/dataset-capacity-settings/dataset-capacity-settings.component';
 import { SpaceManagementChartComponent } from './components/dataset-capacity-management-card/space-management-chart/space-management-chart.component';
@@ -105,8 +104,6 @@ import { DatasetNodeComponent } from './components/dataset-node/dataset-node.com
     SpaceManagementChartComponent,
     DatasetCapacitySettingsComponent,
   ],
-  providers: [
-    DatasetTreeStore,
-  ],
+  providers: [],
 })
 export class DatasetsModule { }

--- a/src/app/pages/datasets/store/dataset-store.service.ts
+++ b/src/app/pages/datasets/store/dataset-store.service.ts
@@ -23,7 +23,9 @@ const initialState: DatasetTreeState = {
   selectedDatasetId: null,
 };
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class DatasetTreeStore extends ComponentStore<DatasetTreeState> {
   readonly isLoading$ = this.select((state) => state.isLoading);
   // TODO
@@ -79,6 +81,18 @@ export class DatasetTreeStore extends ComponentStore<DatasetTreeState> {
               return EMPTY;
             }),
           );
+      }),
+    );
+  });
+
+  readonly resetDatasets = this.effect((triggers$: Observable<void>) => {
+    return triggers$.pipe(
+      tap(() => {
+        this.patchState({
+          isLoading: false,
+          selectedDatasetId: null,
+          datasets: [],
+        });
       }),
     );
   });

--- a/src/app/pages/storage/components/dashboard-pool/export-disconnect-modal/export-disconnect-modal.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/export-disconnect-modal/export-disconnect-modal.component.ts
@@ -13,6 +13,7 @@ import { Process } from 'app/interfaces/process.interface';
 import { SystemDatasetConfig } from 'app/interfaces/system-dataset-config.interface';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
 import { IxValidatorsService } from 'app/modules/ix-forms/services/ix-validators.service';
+import { DatasetTreeStore } from 'app/pages/datasets/store/dataset-store.service';
 import { AppLoaderService, DialogService, WebSocketService } from 'app/services';
 
 @UntilDestroy()
@@ -76,6 +77,7 @@ export class ExportDisconnectModalComponent implements OnInit {
     private matDialog: MatDialog,
     private loader: AppLoaderService,
     private ws: WebSocketService,
+    private datasetStore: DatasetTreeStore,
     @Inject(MAT_DIALOG_DATA) public pool: Pool,
   ) {}
 
@@ -100,12 +102,15 @@ export class ExportDisconnectModalComponent implements OnInit {
       disableClose: true,
     });
     entityJobRef.componentInstance.setDescription(helptext.exporting);
+
     entityJobRef.componentInstance.setCall('pool.export', [this.pool.id, {
       destroy: value.destroy,
       cascade: value.cascade,
       restart_services: this.restartServices,
     }]);
+
     entityJobRef.componentInstance.submit();
+
     entityJobRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe({
       next: () => {
         this.isFormLoading = false;
@@ -124,6 +129,7 @@ export class ExportDisconnectModalComponent implements OnInit {
         this.dialogService.errorReportMiddleware(error);
       },
     });
+
     entityJobRef.componentInstance.failure.pipe(untilDestroyed(this)).subscribe({
       next: (failureData) => {
         let conditionalErrMessage = '';
@@ -188,6 +194,8 @@ export class ExportDisconnectModalComponent implements OnInit {
         this.dialogService.errorReportMiddleware(error);
       },
     });
+
+    this.datasetStore.resetDatasets();
   }
 
   private loadRelatedEntities(): void {


### PR DESCRIPTION
To share service in 2 different module, we can make service global as I did via **providedIn: 'root',**
or create a separate Shared Module which we will use in 2 components.

And I had 2 solutions 

--- 

1. Inside of the dataset-details-panel.component are some components which take dataset ID and make request
Since after deletion we still have datasets in store, it tries to take the ID and load some data, but this dataset is no longer existing so that’s why we see error modals.
So I put skeleton to wait for datasets to be loaded, so we know if selected dataset exists

2. After pool deletion, we can clear DATAsets store (but need to plug datasets store module to Storage)

**Selected approach number #2.**