### PR TITLE
NAS-118443 / 22.12-BETA.2 / display removed disks in Storage Devices; restore 'Replace' menu item for every disk shown (by bvasilenko)

### DIFF
--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.html
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.html
@@ -53,14 +53,17 @@
             [ixTreeNodeDefDataSource]="dataSource"
             [class.selected]="topologyItem.guid === selectedNode?.guid"
             [routerLink]="['/storage', poolId, 'devices', topologyItem.guid]"
-            (click)="openMobileDetails()"
+            (click)="openMobileDetails(topologyItem)"
           >
             <button mat-icon-button disabled></button>
             <ix-topology-item-node
               [topologyItem]="topologyItem | cast"
               [disk]="getDisk(topologyItem)"
             ></ix-topology-item-node>
-            <ix-icon name="mdi-chevron-right" class="mobile-actions"></ix-icon>
+            <ix-icon
+              [name]="isHealthyNode(topologyItem) ? 'mdi-chevron-right' : ''"
+              class="mobile-actions"
+            ></ix-icon>
           </ix-tree-node>
 
           <ix-nested-tree-node
@@ -101,7 +104,7 @@
               routerLinkActive="selected"
               [class.selected]="vdev.guid === selectedNode?.guid"
               [routerLink]="['/storage', poolId, 'devices', vdev.guid]"
-              (click)="openMobileDetails()"
+              (click)="openMobileDetails(vdev)"
             >
               <button
                 mat-icon-button
@@ -120,7 +123,7 @@
               ></ix-topology-item-node>
 
               <ix-icon
-                name="mdi-chevron-right"
+                [name]="isHealthyNode(vdev) ? 'mdi-chevron-right' : ''"
                 class="mobile-actions"
               ></ix-icon>
             </div>
@@ -140,7 +143,7 @@
     ixDetailsHeight="rightside-content-hold"
   >
     <ix-disk-details-panel
-      *ngIf="selectedNode"
+      *ngIf="selectedNode && isHealthyNode(selectedNode)"
       [topologyItem]="selectedNode | cast"
       [topologyParentItem]="selectedParentNode$ | async | cast"
       [disk]="getDisk(selectedNode)"

--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.ts
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.ts
@@ -16,9 +16,10 @@ import {
 import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { filter, map } from 'rxjs/operators';
+import { TopologyItemType } from 'app/enums/v-dev-type.enum';
 import { DeviceNestedDataNode, isVdevGroup } from 'app/interfaces/device-nested-data-node.interface';
 import {
-  Disk, isTopologyDisk, isVdev, TopologyDisk,
+  Disk, isTopologyDisk, isVdev, TopologyDisk, TopologyItem,
 } from 'app/interfaces/storage.interface';
 import { IxNestedTreeDataSource } from 'app/modules/ix-tree/ix-nested-tree-datasource';
 import { flattenTreeWithFilter } from 'app/modules/ix-tree/utils/flattern-tree-with-filter';
@@ -179,8 +180,8 @@ export class DevicesComponent implements OnInit, AfterViewInit {
   }
 
   // Expose hidden details on mobile
-  openMobileDetails(): void {
-    if (this.isMobileView) {
+  openMobileDetails(selectedNode: DeviceNestedDataNode): void {
+    if (this.isMobileView && this.isHealthyNode(selectedNode)) {
       this.showMobileDetails = true;
     }
   }
@@ -201,12 +202,16 @@ export class DevicesComponent implements OnInit, AfterViewInit {
       });
 
       dataNodes.children.sort((a: TopologyDisk, b: TopologyDisk) => {
-        const nameA = a.disk.toLowerCase();
-        const nameB = b.disk.toLowerCase();
+        const nameA = a.disk?.toLowerCase();
+        const nameB = b.disk?.toLowerCase();
 
         return nameA.localeCompare(nameB);
       });
       this.sortDataNodesByDiskName(dataNodes.children);
     });
+  }
+
+  isHealthyNode(selectedNode: DeviceNestedDataNode): boolean {
+    return (selectedNode as TopologyItem).type !== TopologyItemType.Disk || !!this.getDisk(selectedNode);
   }
 }

--- a/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.html
+++ b/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.html
@@ -6,7 +6,9 @@
         [disk]="disk"
       ></ix-topology-item-icon>
     </div>
-    <span class="name">{{ name }}</span>
+    <div class="name">
+      <span>{{ name }}</span>
+    </div>
   </div>
   <div class="cell cell-status" [style.background-color]="statusColor">
     <span>{{ status }}</span>
@@ -16,5 +18,16 @@
   </div>
   <div class="cell cell-errors">
     <span>{{ errors }}</span>
+  </div>
+  <div class="cell cell-actions">
+    <button *ngIf="isDisk" mat-icon-button [matMenuTriggerFor]="menu" (click)="$event.stopPropagation()">
+      <ix-icon name="more_vert"></ix-icon>
+    </button>
+    <mat-menu #menu="matMenu" class="menu">
+      <button mat-menu-item (click)="onReplace()">
+        <ix-icon name="mdi-file-replace"></ix-icon>
+        <span>{{ 'Replace' | translate }}</span>
+      </button>
+    </mat-menu>
   </div>
 </div>

--- a/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.scss
+++ b/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.scss
@@ -16,11 +16,11 @@
 
 
   // Override default fraction based values to avoid misaligned columns
-  grid-template-columns: auto 125px 125px 125px 40px;
+  grid-template-columns: auto 120px 120px 120px 40px;
 
   @media (max-width: $breakpoint-tablet) {
     // Override default fraction based values to avoid misaligned columns
-    grid-template-columns: auto 0 0 0 0;
+    grid-template-columns: auto 0 0 0 20px;
     width: 100%;
   }
 
@@ -41,6 +41,16 @@
         display: inline-flex;
       }
     }
+
+    &:last-child {
+      display: inline-flex;
+
+      button {
+        @media (min-width: $breakpoint-hidden) {
+          right: 20px;
+        }
+      }
+    }
   }
 
   .cell-name {
@@ -59,6 +69,13 @@
       background: linear-gradient(90deg, var(--bg2) 0%, var(--bg2) calc(100% - 11px), transparent 100%);
       display: inline-flex;
       padding-right: 15px;
+
+      span {
+        max-width: 105px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 
@@ -97,4 +114,8 @@ $padding-left: 8px;
       }
     }
   }
+}
+
+::ng-deep .menu {
+  min-height: 0;
 }

--- a/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.spec.ts
+++ b/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.spec.ts
@@ -1,4 +1,4 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { DiskType } from 'app/enums/disk-type.enum';
 import { TopologyItemType } from 'app/enums/v-dev-type.enum';
@@ -6,6 +6,7 @@ import { TopologyItemStatus } from 'app/enums/vdev-status.enum';
 import { Disk, TopologyDisk } from 'app/interfaces/storage.interface';
 import { TopologyItemIconComponent } from 'app/pages/storage/modules/devices/components/topology-item-icon/topology-item-icon.component';
 import { TopologyItemNodeComponent } from 'app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component';
+import { DevicesStore } from 'app/pages/storage/modules/devices/stores/devices-store.service';
 
 describe('TopologyItemNodeComponent', () => {
   let spectator: Spectator<TopologyItemNodeComponent>;
@@ -30,6 +31,9 @@ describe('TopologyItemNodeComponent', () => {
     component: TopologyItemNodeComponent,
     declarations: [
       MockComponent(TopologyItemIconComponent),
+    ],
+    providers: [
+      mockProvider(DevicesStore),
     ],
   });
 

--- a/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.ts
+++ b/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.ts
@@ -1,12 +1,18 @@
 import {
   ChangeDetectionStrategy, Component, Input,
 } from '@angular/core';
-import { UntilDestroy } from '@ngneat/until-destroy';
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute } from '@angular/router';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import { filter } from 'rxjs';
 import { PoolStatus } from 'app/enums/pool-status.enum';
+import { TopologyItemType } from 'app/enums/v-dev-type.enum';
 import { TopologyItemStatus } from 'app/enums/vdev-status.enum';
 import { Disk, TopologyDisk, TopologyItem } from 'app/interfaces/storage.interface';
 import { WidgetUtils } from 'app/pages/dashboard/utils/widget-utils';
+import { DevicesStore } from 'app/pages/storage/modules/devices/stores/devices-store.service';
+import { ReplaceDiskDialogComponent, ReplaceDiskDialogData } from 'app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component';
 
 @UntilDestroy()
 @Component({
@@ -23,12 +29,21 @@ export class TopologyItemNodeComponent {
 
   constructor(
     protected translate: TranslateService,
+    private matDialog: MatDialog,
+    private route: ActivatedRoute,
+    private devicesStore: DevicesStore,
   ) {
     this.utils = new WidgetUtils();
   }
 
   get name(): string {
-    return (this.topologyItem as TopologyDisk).disk || this.topologyItem.type;
+    if ((this.topologyItem as TopologyDisk).disk) {
+      return (this.topologyItem as TopologyDisk).disk;
+    }
+    if (this.isDisk) {
+      return this.topologyItem.path;
+    }
+    return this.topologyItem.type;
   }
 
   get status(): string {
@@ -58,5 +73,29 @@ export class TopologyItemNodeComponent {
       default:
         return '';
     }
+  }
+
+  get isDisk(): boolean {
+    return Boolean(this.topologyItem.type === TopologyItemType.Disk && this.topologyItem.path);
+  }
+
+  onReplace(): void {
+    const poolId = this.route.snapshot.params.poolId;
+    this.matDialog
+      .open(ReplaceDiskDialogComponent, {
+        data: {
+          poolId: Number(poolId),
+          guid: this.topologyItem.guid,
+          diskName: this.disk?.name || this.topologyItem.path,
+        } as ReplaceDiskDialogData,
+      })
+      .afterClosed()
+      .pipe(
+        filter(Boolean),
+        untilDestroyed(this),
+      )
+      .subscribe(() => {
+        this.devicesStore.reloadList();
+      });
   }
 }

--- a/src/app/pages/storage/modules/devices/devices.module.ts
+++ b/src/app/pages/storage/modules/devices/devices.module.ts
@@ -5,6 +5,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatMenuModule } from '@angular/material/menu';
 import { RouterModule } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxFilesizeModule } from 'ngx-filesize';
@@ -50,6 +51,7 @@ import { ExtendDialogComponent } from './components/zfs-info-card/extend-dialog/
     MatButtonModule,
     MatCardModule,
     MatDialogModule,
+    MatMenuModule,
     IxIconModule,
     NgxFilesizeModule,
     NgxSkeletonLoaderModule.forRoot({


### PR DESCRIPTION
**Testing**

1. Have a Mirrored pool of 2 drives
1. Remove a drive from that pool. And by remove, I mean physically pull the drive. Pool does show degraded.
1. Then attempt to replace the drive by going to **Storage > Pool > Topology > Manage Devices**.

Original PR: https://github.com/truenas/webui/pull/7216
Jira URL: https://ixsystems.atlassian.net/browse/NAS-118443