### PR TITLE
NAS-118541 / 22.12-RC.1 / Progress bar overflows jobs dialog

### DIFF
--- a/src/app/modules/entity/entity-job/entity-job.component.scss
+++ b/src/app/modules/entity/entity-job/entity-job.component.scss
@@ -13,7 +13,6 @@ mat-dialog-content.entity-job-dialog {
   }
 }
 
-
 .mat-dialog-close {
   position: absolute;
   right: -24px;

--- a/src/app/modules/jobs/components/jobs-panel/jobs-panel.component.ts
+++ b/src/app/modules/jobs/components/jobs-panel/jobs-panel.component.ts
@@ -68,7 +68,6 @@ export class JobsPanelComponent {
     const dialogRef = this.matDialog.open(EntityJobComponent, {
       data: { title },
       hasBackdrop: true,
-      width: '400px',
     });
 
     dialogRef.componentInstance.jobId = job.id;


### PR DESCRIPTION
Problem was with jobs-panel.component manual **400px** width passed as props.