### PR TITLE
NAS-118545 / 22.12-RC.1 / Make Dataset Space Management chart smaller

### DIFF
--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.scss
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.scss
@@ -11,7 +11,6 @@
 
     .details-item {
       margin: 20px 0 0;
-
     }
   }
 
@@ -24,19 +23,17 @@
   .details .label {
     @media (max-width: calc($breakpoint-dualcolumn - 1px)) {
       display: block;
-      margin-top: 6px;
       padding: 0;
       width: 100%;
     }
   }
-
 }
 
 .details {
   border-top: 1px solid var(--lines);
   box-sizing: border-box;
-  margin: 20px -25px 0; // Fragile. Rely on external styles
-  padding: 20px 25px 0 !important; // Fragile. Rely on external styles
+  margin: 10px 0 0; // Fragile. Rely on external styles
+  padding: 10px 0 0 !important; // Fragile. Rely on external styles
 }
 
 ix-space-management-chart {

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.scss
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.scss
@@ -32,14 +32,15 @@
 .details {
   border-top: 1px solid var(--lines);
   box-sizing: border-box;
-  margin: 10px 0 0; // Fragile. Rely on external styles
-  padding: 10px 0 0 !important; // Fragile. Rely on external styles
+  margin: 10px 0 0;
+  padding: 10px 0 0 !important;
 }
 
 ix-space-management-chart {
   display: grid;
+  grid-gap: 15px;
   grid-template-columns: 1fr 2fr;
-  padding: 0 0 0 8px;
+  padding: 0 0 5px;
 
   @media (max-width: $breakpoint-dualcolumn) {
     padding-left: 0;

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.scss
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.scss
@@ -37,6 +37,8 @@
 }
 
 ix-space-management-chart {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
   padding: 0 0 0 8px;
 
   @media (max-width: $breakpoint-dualcolumn) {

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.html
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.html
@@ -5,8 +5,8 @@
     chartType="doughnut"
     [datasets]="chartData"
     [options]="chartOptions"
-    [width]="180"
-    [height]="180"
+    [width]="120"
+    [height]="120"
   ></canvas>
 </div>
 

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.html
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.html
@@ -5,8 +5,8 @@
     chartType="doughnut"
     [datasets]="chartData"
     [options]="chartOptions"
-    [width]="120"
-    [height]="120"
+    [width]="100"
+    [height]="100"
   ></canvas>
 </div>
 
@@ -20,11 +20,18 @@
   <div class="legend-wrapper">
     <div class="legend-list-item" *ngIf="dataset.usedbydataset.parsed">
       <span class="legend-label">
-        <span class="legend-swatch" [style.background-color]="swatchColors?.usedbydataset?.backgroundColor"></span>
+        <span
+          class="legend-swatch"
+          [style.background-color]="
+            swatchColors?.usedbydataset?.backgroundColor
+          "
+        ></span>
         {{ 'Data Written' | translate }}
       </span>
       <span class="legend-value">
-        {{ dataset.usedbydataset.parsed | filesize: { standard: 'iec', round: 0 } }}
+        {{
+          dataset.usedbydataset.parsed | filesize: { standard: 'iec', round: 0 }
+        }}
         <ng-container *ngIf="dataset.usedbydataset.parsed">
           ({{ dataset.usedbydataset.parsed / dataset.used.parsed | percent }})
         </ng-container>
@@ -32,12 +39,24 @@
     </div>
     <div class="legend-list-item" *ngIf="dataset.usedbysnapshots.parsed">
       <span class="legend-label">
-        <span class="legend-swatch" [style.background-color]="swatchColors?.usedbysnapshots?.backgroundColor"></span>
-        <ng-container *ngIf="!isZvol">{{ 'Snapshots' | translate }}</ng-container>
-        <ng-container *ngIf="isZvol">{{ 'Used by Snapshots' | translate }}</ng-container>
+        <span
+          class="legend-swatch"
+          [style.background-color]="
+            swatchColors?.usedbysnapshots?.backgroundColor
+          "
+        ></span>
+        <ng-container *ngIf="!isZvol">{{
+          'Snapshots' | translate
+        }}</ng-container>
+        <ng-container *ngIf="isZvol">{{
+          'Used by Snapshots' | translate
+        }}</ng-container>
       </span>
       <span class="legend-value">
-        {{ dataset.usedbysnapshots.parsed | filesize: { standard: 'iec', round: 0 } }}
+        {{
+          dataset.usedbysnapshots.parsed
+            | filesize: { standard: 'iec', round: 0 }
+        }}
         <ng-container *ngIf="dataset.usedbysnapshots.parsed">
           ({{ dataset.usedbysnapshots.parsed / dataset.used.parsed | percent }})
         </ng-container>
@@ -46,13 +65,23 @@
     <ng-container *ngIf="!isZvol">
       <div class="legend-list-item" *ngIf="dataset.usedbychildren.parsed">
         <span class="legend-label">
-          <span class="legend-swatch" [style.background-color]="swatchColors?.usedbychildren?.backgroundColor"></span>
+          <span
+            class="legend-swatch"
+            [style.background-color]="
+              swatchColors?.usedbychildren?.backgroundColor
+            "
+          ></span>
           {{ 'Children' | translate }}
         </span>
         <span class="legend-value">
-          {{ dataset.usedbychildren.parsed | filesize: { standard: 'iec', round: 0 } }}
+          {{
+            dataset.usedbychildren.parsed
+              | filesize: { standard: 'iec', round: 0 }
+          }}
           <ng-container *ngIf="dataset.usedbychildren.parsed">
-            ({{ dataset.usedbychildren.parsed / dataset.used.parsed | percent }})
+            ({{
+              dataset.usedbychildren.parsed / dataset.used.parsed | percent
+            }})
           </ng-container>
         </span>
       </div>

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.scss
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.scss
@@ -1,5 +1,5 @@
 @import '~assets/styles/scss-imports/splitview';
-$chart-size: 120px;
+$chart-size: 100px;
 
 :host {
   display: flex;

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.scss
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.scss
@@ -1,5 +1,5 @@
 @import '~assets/styles/scss-imports/splitview';
-$chart-size: 150px;
+$chart-size: 120px;
 
 :host {
   display: flex;
@@ -37,8 +37,8 @@ $chart-size: 150px;
   font-size: 18px;
   font-weight: normal;
   gap: 8px;
-  margin-bottom: 12px;
-  padding: 16px 8px 12px;
+  margin-bottom: 10px;
+  padding: 0 0 10px;
   white-space: nowrap;
 }
 
@@ -83,6 +83,10 @@ $chart-size: 150px;
   display: flex;
   justify-content: space-between;
   margin-bottom: 8px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 
   .legend-label {
     align-items: center;

--- a/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.scss
+++ b/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.scss
@@ -10,7 +10,7 @@
       border-bottom: 1px solid var(--lines);
       display: flex;
       flex-wrap: wrap;
-      padding: 20px 25px 10px;
+      padding: 16px 16px 10px;
 
       .details-item:not(:last-child) {
         width: 50%;
@@ -27,7 +27,7 @@
           text-overflow: ellipsis;
           white-space: nowrap;
         }
-      
+
         ix-copy-btn {
           margin-top: -4px;
         }

--- a/src/assets/styles/components/_charts.scss
+++ b/src/assets/styles/components/_charts.scss
@@ -22,7 +22,7 @@
 
 .legend-wrapper {
   min-height: 32px;
-  padding: 0 8px;
+  padding: 0;
 }
 
 .legend-item {

--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -138,7 +138,7 @@
 
   mat-card-content {
     margin: 0;
-    padding: 20px 25px;
+    padding: 16px;
 
     > div {
       padding: 0;


### PR DESCRIPTION
So, in result the chart & card are more tight and smaller now.

Before:
<img width="336" alt="Screen Shot 2022-10-20 at 09 12 02" src="https://user-images.githubusercontent.com/22980553/196870371-b19d5d65-0ec4-4a7c-bd26-43f25a72c680.png">

After: 
<img width="374" alt="Screen Shot 2022-10-21 at 13 08 57" src="https://user-images.githubusercontent.com/22980553/197171462-6480096d-3060-4955-a59b-38825ad813c0.png">

