### PR TITLE
NAS-113762 / 22.12 / Fixed missing toolbar in Mozilla

### DIFF
--- a/src/assets/styles/other/_fn-styles.scss
+++ b/src/assets/styles/other/_fn-styles.scss
@@ -523,7 +523,6 @@ body .mat-select-trigger {
 
 .sidebar-panel.mat-sidenav {
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-  min-height: 620px;
   min-width: var(--sidenav-width); /*15rem;*/
   width: var(--sidenav-width); /*15rem;*/
 }

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -1257,7 +1257,7 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
 
   .slidein-nav {
     background-color: var(--contrast-darker);
-    height: 100vh;
+    height: calc(100vh - 48px);
     left: -239px;
     position: absolute;
     top: 48px;

--- a/src/assets/styles/scss-imports/splitview.scss
+++ b/src/assets/styles/scss-imports/splitview.scss
@@ -13,5 +13,5 @@ $breakpoint-dualcolumn-slim: 1680px;
 $breakpoint-dualcolumn: $breakpoint-lg;
 $breakpoint-triplecolumn: 2500px;
 $breakpoint-flex: 3132px;
-$breakpoint-hidden: calc($breakpoint-singlecolumn - 1px); 
+$breakpoint-hidden: calc($breakpoint-singlecolumn - 1px);
 


### PR DESCRIPTION
Go to System Settings -> Services  and run this command in below in the dev console 
`window.document.evaluate('//tr[contains(.,"WebDAV")]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.scrollIntoView(true)`
Expected: toolbar should not disappear or change its position

![image](https://user-images.githubusercontent.com/22006748/197510971-234ccb5c-cf45-4ae4-abb1-c4e5305fe4cb.png)
