### PR TITLE
NAS-118777 / 22.12 / Default cloudsync credential name to provider name

### DIFF
--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.html
@@ -7,13 +7,6 @@
   <mat-card-content>
     <form class="ix-form-container" (submit)="onSubmit()">
       <ix-fieldset [title]="'Name and Provider' | translate" [formGroup]="commonForm">
-        <ix-input
-          formControlName="name"
-          [label]="'Name' | translate"
-          [required]="true"
-          [tooltip]="helptext.name.tooltip | translate"
-        ></ix-input>
-
         <ix-select
           formControlName="provider"
           [label]="'Provider' | translate"
@@ -21,6 +14,13 @@
           [options]="providerOptions"
           [tooltip]="helptext.provider.tooltip | translate"
         ></ix-select>
+
+        <ix-input
+          formControlName="name"
+          [label]="'Name' | translate"
+          [required]="true"
+          [tooltip]="helptext.name.tooltip | translate"
+        ></ix-input>
       </ix-fieldset>
 
       <ng-container #providerFormContainer></ng-container>

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.spec.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.spec.ts
@@ -270,5 +270,33 @@ describe('CloudCredentialsFormComponent', () => {
       expect(spectator.inject(IxSlideInService).close).toHaveBeenCalledWith();
       expect(spectator.inject(SnackbarService).success).toHaveBeenCalled();
     });
+
+    it('sets default name when provider is selected and name field has not been touched by the user', async () => {
+      await form.fillForm({
+        Provider: 'Amazon S3',
+      });
+      expect(await form.getValues()).toMatchObject({
+        Name: 'Amazon S3',
+      });
+
+      await form.fillForm({
+        Provider: 'Box',
+      });
+      expect(await form.getValues()).toMatchObject({
+        Name: 'Box',
+      });
+
+      await form.fillForm({
+        Name: 'My Box',
+      });
+      await form.fillForm({
+        Provider: 'Amazon S3',
+      });
+
+      expect(await form.getValues()).toEqual({
+        Name: 'My Box',
+        Provider: 'Amazon S3',
+      });
+    });
   });
 });

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -248,7 +248,17 @@ export class CloudCredentialsFormComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe(() => {
         this.renderProviderForm();
+
+        this.setDefaultName();
       });
+  }
+
+  private setDefaultName(): void {
+    if (!this.isNew || this.commonForm.controls.name.touched) {
+      return;
+    }
+
+    this.commonForm.controls.name.setValue(this.selectedProvider.title);
   }
 
   private renderProviderForm(): void {

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -80,7 +80,7 @@ import { IxSlideInService } from 'app/services/ix-slide-in.service';
 })
 export class CloudCredentialsFormComponent implements OnInit {
   commonForm = this.formBuilder.group({
-    name: ['', Validators.required],
+    name: ['Storj', Validators.required],
     provider: [CloudsyncProviderName.Storj],
   });
 


### PR DESCRIPTION
Go to Credentials -> Backup credentials. 
When adding a new cloud credential the order of fields is different and name will default to provider name until user interacts with Name control.