### PR TITLE
AUTO-299 / 13.0 / Refactored NAS-T905 setting up HA works with a single failover group 

### DIFF
--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -258,7 +258,7 @@ def disable_active_directory():
     web_driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Directory Services"]').click()
     wait_on_element(7, '//mat-list-item[@ix-auto="option__Active Directory"]', 'clickable')
     web_driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Active Directory"]').click()
-    assert wait_on_element(5, '//li[span/a/text()="LDAP"]')
+    assert wait_on_element(5, '//li[span/a/text()="Active Directory"]')
     assert wait_on_element(5, '//h4[contains(text(),"Domain Credentials")]')
     wait_on_element(5, '//mat-checkbox[@ix-auto="checkbox__Enable (requires password or Kerberos principal)"]', 'clickable')
     value_exist = attribute_value_exist('//mat-checkbox[@ix-auto="checkbox__Enable (requires password or Kerberos principal)"]', 'class', 'mat-checkbox-checked')

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -74,6 +74,7 @@ def browser():
     # application/gzip is use for .tgz
     profile.set_preference("browser.helperApps.neverAsk.saveToDisk", "application/x-tar,application/gzip,application/json")
     profile.set_preference("browser.download.manager.showWhenStarting", False)
+    profile.set_preference("browser.download.alwaysOpenPanel", False)
     # browser.link.open_newwindow is frozen 2 the only way to change it is like bellow
     profile.DEFAULT_PREFERENCES["frozen"]["browser.link.open_newwindow"] = 3
     binary = '/usr/bin/firefox' if system() == "Linux" else '/usr/local/bin/firefox'
@@ -96,8 +97,8 @@ def driver():
 
 
 # Close Firefox after all tests are completed
-# def pytest_sessionfinish(session, exitstatus):
-#     web_driver.quit()
+def pytest_sessionfinish(session, exitstatus):
+    web_driver.quit()
 
 
 @pytest.mark.hookwrapper
@@ -160,9 +161,9 @@ def pytest_runtest_makereport(item):
                 if handle != initial_tab:
                     web_driver.close()
             web_driver.switch_to.window(initial_tab)
-        if 'T1010' in screenshot_name:
+        if 'T1010' in screenshot_name or 'T0933' in screenshot_name:
             disable_active_directory()
-        elif 'T1013' in screenshot_name:
+        elif 'T1013' in screenshot_name or 'T0940' in screenshot_name:
             disable_ldap()
 
 
@@ -253,33 +254,37 @@ def enable_failover():
 
 
 def disable_active_directory():
-    wait_on_element(7, '//mat-list-item[@ix-auto="option__Directory Services"]')
+    wait_on_element(7, '//mat-list-item[@ix-auto="option__Directory Services"]', 'clickable')
     web_driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Directory Services"]').click()
-    wait_on_element(7, '//mat-list-item[@ix-auto="option__Active Directory"]')
+    wait_on_element(7, '//mat-list-item[@ix-auto="option__Active Directory"]', 'clickable')
     web_driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Active Directory"]').click()
-    wait_on_element(5, '//mat-checkbox[@ix-auto="checkbox__Enable (requires password or Kerberos principal)"]')
+    assert wait_on_element(5, '//li[span/a/text()="LDAP"]')
+    assert wait_on_element(5, '//h4[contains(text(),"Domain Credentials")]')
+    wait_on_element(5, '//mat-checkbox[@ix-auto="checkbox__Enable (requires password or Kerberos principal)"]', 'clickable')
     value_exist = attribute_value_exist('//mat-checkbox[@ix-auto="checkbox__Enable (requires password or Kerberos principal)"]', 'class', 'mat-checkbox-checked')
     if value_exist:
         web_driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__Enable (requires password or Kerberos principal)"]').click()
     wait_on_element(7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     web_driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    if wait_on_element_disappear(120, '//h6[contains(.,"Please wait")]') is False:
-        web_driver.refresh()
+    assert wait_on_element_disappear(60, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element(7, '//div[contains(.,"Settings saved.")]')
 
 
 def disable_ldap():
     wait_on_element(5, '//span[contains(.,"root")]')
     element = web_driver.find_element_by_xpath('//span[contains(.,"root")]')
     web_driver.execute_script("arguments[0].scrollIntoView();", element)
-    wait_on_element(7, '//mat-list-item[@ix-auto="option__Directory Services"]')
+    wait_on_element(7, '//mat-list-item[@ix-auto="option__Directory Services"]', 'clickable')
     web_driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Directory Services"]').click()
-    wait_on_element(7, '//mat-list-item[@ix-auto="option__LDAP"]')
+    wait_on_element(7, '//mat-list-item[@ix-auto="option__LDAP"]', 'clickable')
     web_driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__LDAP"]').click()
-    wait_on_element(5, '//mat-checkbox[@ix-auto="checkbox__Enable"]')
+    assert wait_on_element(5, '//li[span/a/text()="LDAP"]')
+    assert wait_on_element(5, '//div[contains(.,"Server Credentials")]')
+    wait_on_element(5, '//mat-checkbox[@ix-auto="checkbox__Enable"]', 'clickable')
     value_exist = attribute_value_exist('//mat-checkbox[@ix-auto="checkbox__Enable"]', 'class', 'mat-checkbox-checked')
     if value_exist:
         web_driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__Enable"]').click()
     wait_on_element(5, '//button[@ix-auto="button__SAVE"]', 'clickable')
     web_driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    if wait_on_element_disappear(60, '//h6[contains(.,"Please wait")]') is False:
-        web_driver.refresh()
+    assert wait_on_element_disappear(60, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element(7, '//div[contains(.,"Settings saved.")]')

--- a/tests/bdd/ha-bhyve02/function.py
+++ b/tests/bdd/ha-bhyve02/function.py
@@ -69,14 +69,14 @@ def refresh_if_element_missing(driver, wait, xpath):
     timeout = time.time() + wait
     while time.time() <= timeout:
         time.sleep(5)
-        if wait_on_element(driver, 3, xpaths.login.user_input):
+        if wait_on_element(driver, 2, xpaths.login.user_input):
             driver.find_element_by_xpath(xpaths.login.user_input).clear()
             driver.find_element_by_xpath(xpaths.login.user_input).send_keys('root')
             driver.find_element_by_xpath(xpaths.login.password_input).clear()
             driver.find_element_by_xpath(xpaths.login.password_input).send_keys('testing')
             assert wait_on_element(driver, 7, xpaths.login.signin_button)
             driver.find_element_by_xpath(xpaths.login.signin_button).click()
-        if wait_on_element(driver, 3, xpath):
+        if wait_on_element(driver, 5, xpath):
             return True
         driver.refresh()
     else:

--- a/tests/bdd/ha-bhyve02/function.py
+++ b/tests/bdd/ha-bhyve02/function.py
@@ -5,6 +5,7 @@ import os
 import re
 import requests
 import time
+import xpaths
 from selenium.common.exceptions import (
     NoSuchElementException,
     TimeoutException
@@ -60,6 +61,24 @@ def wait_on_element_disappear(driver, wait, xpath):
             return True
         # this just to slow down the loop
         time.sleep(0.1)
+    else:
+        return False
+
+
+def refresh_if_element_missing(driver, wait, xpath):
+    timeout = time.time() + wait
+    while time.time() <= timeout:
+        time.sleep(5)
+        if wait_on_element(driver, 3, xpaths.login.user_input):
+            driver.find_element_by_xpath(xpaths.login.user_input).clear()
+            driver.find_element_by_xpath(xpaths.login.user_input).send_keys('root')
+            driver.find_element_by_xpath(xpaths.login.password_input).clear()
+            driver.find_element_by_xpath(xpaths.login.password_input).send_keys('testing')
+            assert wait_on_element(driver, 7, xpaths.login.signin_button)
+            driver.find_element_by_xpath(xpaths.login.signin_button).click()
+        if wait_on_element(driver, 3, xpath):
+            return True
+        driver.refresh()
     else:
         return False
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0904.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0904.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn09) feature tests."""
 
+import xpaths
 import time
 from function import (
     is_element_present,
@@ -35,23 +36,23 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def login_appear_enter_root_and_password(driver, user, password):
     """login appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
 
 
 @then('you should see the dashboard')
 def you_should_see_the_dashboard(driver):
     """you should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    if wait_on_element(driver, 5, '//div[contains(.,"Looking for help?")]'):
+    if wait_on_element(driver, 5, xpaths.popupTitle.help):
         assert wait_on_element(driver, 5, '//button[@ix-auto="button__CLOSE"]', 'clickable')
         driver.find_element_by_xpath('//button[@ix-auto="button__CLOSE"]').click()
-    assert wait_on_element(driver, 5, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 5, xpaths.dashboard.system_information)
 
 
 @then('navigate to Services')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0905.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0905.py
@@ -7,7 +7,8 @@ from function import (
     wait_on_element,
     wait_on_element_disappear,
     is_element_present,
-    refresh_if_element_missing
+    refresh_if_element_missing,
+    get
 )
 from pytest_bdd import (
     given,
@@ -51,10 +52,12 @@ def login_appear_enter_root_and_password(driver, password):
 
 
 @then(parsers.parse('you should see the dashboard and "{information}"'))
-def you_should_see_the_dashboard_and_serial_number_should_show_serial1(driver, information):
+def you_should_see_the_dashboard_and_serial_number_should_show_serial1(driver, information, nas_url):
     """you should see the dashboard and "information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
     assert wait_on_element(driver, 7, f'//span[contains(.,"{information}")]')
+    assert get(nas_url, 'system/ready/', ('root', 'testing')) is True
+    assert get(nas_url.replace('nodea', 'nodeb'), 'system/ready/', ('root', 'testing')) is True
 
 
 @then('navigate to System and click Support')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0905.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0905.py
@@ -1,8 +1,14 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
-from function import wait_on_element, wait_on_element_disappear, is_element_present
+from function import (
+    wait_on_element,
+    wait_on_element_disappear,
+    is_element_present,
+    refresh_if_element_missing
+)
 from pytest_bdd import (
     given,
     scenario,
@@ -29,13 +35,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def login_appear_enter_root_and_password(driver, password):
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
         """login appear enter "root" and "password"."""
-        assert wait_on_element(driver, 7, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys('root')
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 7, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys('root')
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -95,7 +101,7 @@ def click_save_license(driver):
 @then('the following should appear "Reload the page for the license to take effect"')
 def the_following_should_appear_reload_the_page_for_the_license_to_take_effect(driver):
     """the following should appear "Reload the page for the license to take effect"."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//h1[contains(.,"Reload the page")]')
 
 
@@ -117,7 +123,7 @@ def click_agree(driver):
     """click Agree."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__I AGREE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__I AGREE"]').click()
-    if wait_on_element(driver, 2, '//div[contains(.,"Looking for help?")]'):
+    if wait_on_element(driver, 2, xpaths.popupTitle.help):
         assert wait_on_element(driver, 10, '//button[@ix-auto="button__CLOSE"]')
         driver.find_element_by_xpath('//button[@ix-auto="button__CLOSE"]').click()
 
@@ -181,7 +187,7 @@ def click_save_when_finished(driver):
 @then('"Please wait" should appear while settings are being applied You should be returned to the same Global Configuration screen and "Settings saved." should appear below the save button at the bottom')
 def please_wait_should_appear_while_settings_are_being_applied_you_should_be_returned_to_the_same_global_configuration_screen_and_settings_saved_should_appear_below_the_save_button_at_the_bottom(driver):
     """"Please wait" should appear while settings are being applied You should be returned to the same Global Configuration screen and "Settings saved." should appear below the save button at the bottom."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Settings saved.")]')
 
 
@@ -197,8 +203,10 @@ def navigate_to_system_click_failover_click_disable_failover_click_save(driver):
     assert wait_on_element(driver, 7, '//mat-list-item[@ix-auto="option__Reporting"]', 'clickable')
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Failover"]').click()
     assert wait_on_element(driver, 7, '//h4[contains(.,"Failover Configuration")]')
+    time.sleep(0.5)
+    assert wait_on_element(driver, 7, '//mat-checkbox[@ix-auto="checkbox__Disable Failover"]', 'clickable')
     driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__Disable Failover"]').click()
-    assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]')
+    assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
     assert wait_on_element(driver, 7, '//h1[contains(.,"Disable Failover")]')
     driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__CONFIRM"]').click()
@@ -270,27 +278,41 @@ def click_apply_and_please_wait_should_appear_while_settings_are_being_applied(d
     """click Apply and "Please wait" should appear while settings are being applied."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__APPLY"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__APPLY"]').click()
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
 
 
 @then('click Test Changes, check Confirm, click Test Changes again')
 def click_test_changes_check_confirm_click_test_changes_again(driver):
     """click Test Changes, check Confirm, click Test Changes again."""
-    assert wait_on_element(driver, 7, '//button[contains(.,"TEST CHANGES")]', 'clickable')
+    assert wait_on_element(driver, 10, '//button[contains(.,"TEST CHANGES")]', 'clickable')
     driver.find_element_by_xpath('//button[contains(.,"TEST CHANGES")]').click()
     assert wait_on_element(driver, 7, '//h1[contains(.,"Test Changes")]', 'clickable')
     driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__CONFIRM"]').click()
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__TEST CHANGES"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__TEST CHANGES"]').click()
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
 
 
-@then('Please wait should appear while settings are being applied')
-def please_wait_should_appear_while_settings_are_being_applied(driver):
-    """Please wait should appear while settings are being applied."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
-    assert wait_on_element(driver, 7, '//button[contains(.,"SAVE CHANGES")]', 'clickable')
-    driver.find_element_by_xpath('//button[contains(.,"SAVE CHANGES")]').click()
-    assert wait_on_element(driver, 7, '//h1[contains(.,"Save Changes")]')
+@then(parsers.parse('switch to the virtual hostname "{virtual_hostname}" and login'))
+def switch_to_the_virtual_hostname_virtual_hostname_and_login(driver, virtual_hostname, password):
+    """switch to the virtual hostname "{virtual_hostname}" and login."""
+    driver.get(f"http://{virtual_hostname}")
+    time.sleep(1)
+    """login appear enter "root" and "password"."""
+    assert wait_on_element(driver, 7, xpaths.login.user_input)
+    driver.find_element_by_xpath(xpaths.login.user_input).clear()
+    driver.find_element_by_xpath(xpaths.login.user_input).send_keys('root')
+    driver.find_element_by_xpath(xpaths.login.password_input).clear()
+    driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+    assert wait_on_element(driver, 7, xpaths.login.signin_button)
+    driver.find_element_by_xpath(xpaths.login.signin_button).click()
+
+
+@then('on the virtual hostname Dashboard Save the network interface changes')
+def once_on_the_virtual_hostname_Dashboard_Save_the_network_interface_changes(driver):
+    """on the virtual hostname Dashboard Save the network interface changes."""
+    assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
+    assert wait_on_element(driver, 7, '//h1[text()="Save Changes"]')
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__CLOSE"]', 'clickable')
@@ -314,9 +336,9 @@ def navigate_to_storage_click_disks_then_click_name_several_times_to_sort_in_alp
         ada0 = driver.find_element_by_xpath('(//datatable-body-cell[2]/div/div)[1]').text
 
 
-@then('the list of disks should appear in alphabetical order starting with ada0 (the boot devices) and da0 to da1 the disks we will wipe in next step to create pools')
-def the_list_of_disks_should_appear_in_alphabetical_order_starting_with_ada0_the_boot_devices_and_da0_to_da15_the_disks_we_will_wipe_in_next_step_to_create_pools(driver):
-    """the list of disks should appear in alphabetical order starting with ada0 (the boot devices) and da0 to da1 the disks we will wipe in next step to create pools."""
+@then('the list of disks should appear in alphabetical order starting with ada0 (the boot devices) and da0 to da1')
+def the_list_of_disks_should_appear_in_alphabetical_order_starting_with_ada0_the_boot_devices_and_da0_to_da1(driver):
+    """the list of disks should appear in alphabetical order starting with ada0 (the boot devices) and da0 to da1."""
     # Verify disk are sorted
     disk_list = {1: 'ada0', 2: 'da0', 3: 'da1'}
     for num in list(disk_list.keys()):
@@ -429,11 +451,12 @@ def navigate_to_dashboard_wait_for_ha_to_be_online(driver):
     time.sleep(0.5)
     assert wait_on_element(driver, 7, '//mat-list-item[@ix-auto="option__Dashboard"]', 'clickable')
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Dashboard"]').click()
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
     # need to wait for all controller to be online.
     assert wait_on_element(driver, 60, '//div[contains(.,"truenas")]')
-    assert wait_on_element(driver, 600, '//div[contains(.,"truenas-b")]')
-    assert wait_on_element(driver, 60, '//mat-icon[@svgicon="ha_enabled"]')
+    # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
+    assert refresh_if_element_missing(driver, 600, '//div[contains(.,"truenas-b")]')
+    assert wait_on_element(driver, 60, xpaths.topToolbar.ha_enable)
     time.sleep(5)
 
 
@@ -460,7 +483,7 @@ def enter_hostname_and_hostname_truenas_controller_2(driver, host1, host2):
 @then('"Please wait" should appear while settings are being applied and You should be returned to Network page')
 def please_wait_should_appear_while_settings_are_being_applied_and_you_should_be_returned_to_network_page(driver):
     """"Please wait" should appear while settings are being applied and You should be returned to Network page."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Settings saved.")]')
     time.sleep(2)
 
@@ -474,8 +497,8 @@ def navigate_to_dashboard_verify_both_controller_hostname(driver):
     time.sleep(0.5)
     assert wait_on_element(driver, 7, '//mat-list-item[@ix-auto="option__Dashboard"]', 'clickable')
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Dashboard"]').click()
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
-    assert wait_on_element(driver, 20, '//mat-icon[@svgicon="ha_enabled"]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
+    assert wait_on_element(driver, 20, xpaths.topToolbar.ha_enable)
     assert wait_on_element(driver, 20, '//div[contains(.,"tn-bhyve03-nodea")]')
     assert wait_on_element(driver, 20, '//div[contains(.,"tn-bhyve03-nodeb")]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0905.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0905.py
@@ -427,7 +427,7 @@ def create_pool_should_appear_while_pool_is_being_created_you_should_be_returned
 
 
 @then('navigate to System then Failover, uncheck disable failover, click save')
-def navigate_to_system_then_failover_click_disable_failover_click_save(driver):
+def navigate_to_system_then_failover_click_disable_failover_click_save(driver, nas_url):
     """navigate to System then Failover, uncheck disable failover, click save."""
     # scroll up the mat-list-item
     element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -438,6 +438,8 @@ def navigate_to_system_then_failover_click_disable_failover_click_save(driver):
     assert wait_on_element(driver, 7, '//mat-list-item[@ix-auto="option__Reporting"]', 'clickable')
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Failover"]').click()
     assert wait_on_element(driver, 7, '//h4[contains(.,"Failover Configuration")]')
+    assert get(nas_url, 'system/ready/', ('root', 'testing')).json() is True
+    assert get(nas_url.replace('nodea', 'nodeb'), 'system/ready/', ('root', 'testing')).json() is True
     assert wait_on_element(driver, 7, '//mat-checkbox[@ix-auto="checkbox__Disable Failover"]', 'clickable')
     driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__Disable Failover"]').click()
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
@@ -458,7 +460,7 @@ def navigate_to_dashboard_wait_for_ha_to_be_online(driver):
     # need to wait for all controller to be online.
     assert wait_on_element(driver, 60, '//div[contains(.,"truenas")]')
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert refresh_if_element_missing(driver, 600, '//div[contains(.,"truenas-b")]')
+    assert refresh_if_element_missing(driver, 300, '//div[contains(.,"truenas-b")]')
     assert wait_on_element(driver, 60, xpaths.topToolbar.ha_enable)
     time.sleep(5)
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0905.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0905.py
@@ -312,7 +312,7 @@ def switch_to_the_virtual_hostname_virtual_hostname_and_login(driver, virtual_ho
 
 
 @then('on the virtual hostname Dashboard Save the network interface changes')
-def once_on_the_virtual_hostname_Dashboard_Save_the_network_interface_changes(driver):
+def once_on_the_virtual_hostname_Dashboard_Save_the_network_interface_changes(driver, nas_url):
     """on the virtual hostname Dashboard Save the network interface changes."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
     assert wait_on_element(driver, 7, '//h1[text()="Save Changes"]')
@@ -320,6 +320,8 @@ def once_on_the_virtual_hostname_Dashboard_Save_the_network_interface_changes(dr
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__CLOSE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__CLOSE"]').click()
+    assert get(nas_url, 'system/ready/', ('root', 'testing')).json() is True
+    assert get(nas_url.replace('nodea', 'nodeb'), 'system/ready/', ('root', 'testing')).json() is True
 
 
 @then('navigate to Storage click Disks then click name several times to sort in alphabetical order')
@@ -390,8 +392,10 @@ def navigate_to_storage_click_pools_click_add_select_create_new_pool(driver):
 
 
 @then('click create pool, enter tank for pool name, check the box next to da0, press under data vdev, click create, check confirm, click CREATE POOL')
-def click_create_pool_enter_tank_for_pool_name_check_the_box_next_to_da0_press_under_data_vdev_click_create_check_confirm_click_create_pool(driver):
+def click_create_pool_enter_tank_for_pool_name_check_the_box_next_to_da0_press_under_data_vdev_click_create_check_confirm_click_create_pool(driver, nas_url):
     """click create pool, enter tank for pool name, check the box next to da0, press under data vdev, click create, check confirm, click CREATE POOL."""
+    assert get(nas_url, 'system/ready/', ('root', 'testing')).json() is True
+    assert get(nas_url.replace('nodea', 'nodeb'), 'system/ready/', ('root', 'testing')).json() is True
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__CREATE POOL"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__CREATE POOL"]').click()
     assert wait_on_element(driver, 7, '//div[contains(.,"Pool Manager")]')
@@ -414,6 +418,8 @@ def click_create_pool_enter_tank_for_pool_name_check_the_box_next_to_da0_press_u
     driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__CONFIRM"]').click()
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__CREATE POOL"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__CREATE POOL"]').click()
+    assert get(nas_url, 'system/ready/', ('root', 'testing')).json() is True
+    assert get(nas_url.replace('nodea', 'nodeb'), 'system/ready/', ('root', 'testing')).json() is True
 
 
 @then('create Pool should appear while pool is being created. You should be returned to list of pools and tank should appear in the list')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0905.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0905.py
@@ -56,8 +56,8 @@ def you_should_see_the_dashboard_and_serial_number_should_show_serial1(driver, i
     """you should see the dashboard and "information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
     assert wait_on_element(driver, 7, f'//span[contains(.,"{information}")]')
-    assert get(nas_url, 'system/ready/', ('root', 'testing')) is True
-    assert get(nas_url.replace('nodea', 'nodeb'), 'system/ready/', ('root', 'testing')) is True
+    assert get(nas_url, 'system/ready/', ('root', 'testing')).json() is True
+    assert get(nas_url.replace('nodea', 'nodeb'), 'system/ready/', ('root', 'testing')).json() is True
 
 
 @then('navigate to System and click Support')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0905.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0905.py
@@ -215,6 +215,7 @@ def navigate_to_system_click_failover_click_disable_failover_click_save(driver):
     driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__CONFIRM"]').click()
     assert wait_on_element(driver, 7, '//h1[contains(.,"Disable Failover")]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__OK"]').click()
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
 
 
 @then('after settings are applied you should see "Settings applied"')
@@ -450,6 +451,7 @@ def navigate_to_system_then_failover_click_disable_failover_click_save(driver, n
     driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__Disable Failover"]').click()
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
 
 
 @then('navigate to dashboard, wait for HA to be online')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0905.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0905.py
@@ -458,7 +458,7 @@ def navigate_to_dashboard_wait_for_ha_to_be_online(driver):
     # need to wait for all controller to be online.
     assert wait_on_element(driver, 60, '//div[contains(.,"truenas")]')
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert wait_on_element(driver, 300, '//div[contains(.,"truenas-b")]')
+    assert refresh_if_element_missing(driver, 600, '//div[contains(.,"truenas-b")]')
     assert wait_on_element(driver, 60, xpaths.topToolbar.ha_enable)
     time.sleep(5)
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0905.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0905.py
@@ -458,7 +458,7 @@ def navigate_to_dashboard_wait_for_ha_to_be_online(driver):
     # need to wait for all controller to be online.
     assert wait_on_element(driver, 60, '//div[contains(.,"truenas")]')
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert refresh_if_element_missing(driver, 600, '//div[contains(.,"truenas-b")]')
+    assert wait_on_element(driver, 300, '//div[contains(.,"truenas-b")]')
     assert wait_on_element(driver, 60, xpaths.topToolbar.ha_enable)
     time.sleep(5)
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0908.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0908.py
@@ -1,7 +1,12 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
-from function import wait_on_element, wait_on_element_disappear
+import xpaths
+from function import (
+    wait_on_element,
+    wait_on_element_disappear,
+    is_element_present
+)
 import time
 from pytest_bdd import (
     given,
@@ -20,27 +25,29 @@ def test_add_user(driver):
 @given(parsers.parse('The browser is open navigate to "{nas_url}"'))
 def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
     """The browser is open navigate to "{nas_url}"."""
-    driver.get(f"http://{nas_url}")
-    time.sleep(3)
+    if nas_url not in driver.current_url:
+        driver.get(f"http://{nas_url}")
+        time.sleep(1)
 
 
 @when(parsers.parse('If login page appear enter "{user}" and "{password}"'))
 def if_login_appear_enter_user_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
-    assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-    driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-    driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-    driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-    driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-    assert wait_on_element(driver, 7, '//button[@name="signin_button"]', 'clickable')
-    driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+    if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button, 'clickable')
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
 
 
 @then('You should see the dashboard and "System Information"')
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    if wait_on_element(driver, 3, '//div[contains(.,"Looking for help?")]'):
+    if wait_on_element(driver, 3, xpaths.popupTitle.help):
         assert wait_on_element(driver, 10, '//button[@ix-auto="button__CLOSE"]', 'clickable')
         driver.find_element_by_xpath('//button[@ix-auto="button__CLOSE"]').click()
     assert wait_on_element(driver, 7, '//span[contains(text(),"System Information")]')
@@ -109,6 +116,6 @@ def fill_in_the_following_fields_full_name_username_password_confirm_password_an
 @then('User should be created and added to the user list')
 def user_should_be_created_and_added_to_the_user_list(driver):
     """User should be created and added to the user list."""
-    assert wait_on_element_disappear(driver, 30, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 30, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Users")]')
     driver.find_element_by_xpath('//div[@ix-auto="value__ericbsd_Username"]')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0909.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0909.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 from function import wait_on_element, is_element_present, wait_on_element_disappear
 import time
 from pytest_bdd import (
@@ -29,13 +30,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "root" and "testing"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -48,7 +49,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')
@@ -124,7 +125,7 @@ def change_the_users_shell_and_click_save(driver):
 @then('Change should be saved')
 def change_should_be_saved(driver):
     """Change should be saved."""
-    assert wait_on_element_disappear(driver, 30, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 30, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Users")]')
     assert wait_on_element(driver, 7, '//div[@id="ericbsd_Username"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0910.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0910.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 from function import wait_on_element, is_element_present, wait_on_element_disappear
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
@@ -31,13 +32,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_user_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -50,7 +51,7 @@ def if_login_page_appear_enter_user_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')
@@ -123,7 +124,7 @@ def enable_permit_sudo_and_click_save(driver):
 @then('Change should be saved')
 def change_should_be_saved(driver):
     """Change should be saved."""
-    assert wait_on_element_disappear(driver, 30, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 30, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Users")]')
     assert wait_on_element(driver, 7, '//div[@id="ericbsd_Username"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0911.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0911.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 from function import wait_on_element, is_element_present, wait_on_element_disappear
 import time
 from pytest_bdd import (
@@ -29,13 +30,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -48,7 +49,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')
@@ -122,7 +123,7 @@ def change_the_users_email_and_click_save(driver, email):
 @then('Change should be saved')
 def change_should_be_saved(driver):
     """Change should be saved."""
-    assert wait_on_element_disappear(driver, 7, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 7, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Users")]')
     assert wait_on_element(driver, 7, '//div[@id="ericbsd_Username"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0912.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0912.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 from function import wait_on_element, is_element_present, wait_on_element_disappear
 from selenium.webdriver.common.keys import Keys
 import time
@@ -30,13 +31,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -49,7 +50,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')
@@ -122,7 +123,7 @@ def add_user_to_additional_groups_like_wheel_and_save_change(driver):
 @then('Change should be saved')
 def change_should_be_saved(driver):
     """Change should be saved."""
-    assert wait_on_element_disappear(driver, 30, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 30, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Users")]')
     assert wait_on_element(driver, 7, '//div[@id="ericbsd_Username"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0913.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0913.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 from function import wait_on_element, is_element_present, wait_on_element_disappear
 import time
 from pytest_bdd import (
@@ -29,13 +30,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -48,7 +49,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')
@@ -121,7 +122,7 @@ def change_should_be_saved(driver):
     """Change should be saved."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 30, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 30, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 5, '//div[contains(.,"Users")]')
     assert wait_on_element(driver, 7, '//div[@id="ericbsd_Username"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0914.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0914.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 from function import wait_on_element, is_element_present, wait_on_element_disappear
 from selenium.webdriver.common.action_chains import ActionChains
@@ -31,13 +32,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -50,7 +51,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')
@@ -123,7 +124,7 @@ def change_should_be_saved(driver):
     """Change should be saved."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 30, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 30, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Users")]')
     assert wait_on_element(driver, 7, '//div[@id="ericbsd_Username"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0915.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0915.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 from function import wait_on_element, is_element_present, wait_on_element_disappear
 from selenium.webdriver.common.action_chains import ActionChains
@@ -31,13 +32,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -50,7 +51,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')
@@ -123,7 +124,7 @@ def change_should_be_saved(driver):
     """Change should be saved."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 30, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 30, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Users")]')
     assert wait_on_element(driver, 7, '//div[@id="ericbsd_Username"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0916.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0916.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 from function import wait_on_element, is_element_present, wait_on_element_disappear
 from selenium.webdriver.common.action_chains import ActionChains
@@ -31,13 +32,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -50,7 +51,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')
@@ -123,7 +124,7 @@ def change_should_be_saved(driver):
     """Change should be saved."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 7, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 7, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Users")]')
     assert wait_on_element(driver, 7, '//div[@id="ericbsd_Username"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0917.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0917.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 from function import wait_on_element, is_element_present
 from pytest_bdd import (
@@ -29,13 +30,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -48,7 +49,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0927.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0927.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 from function import wait_on_element, is_element_present
 from pytest_bdd import (
@@ -29,13 +30,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -48,7 +49,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts, Click on Users')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0929.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0929.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 from function import wait_on_element, is_element_present, attribute_value_exist
 from pytest_bdd import (
@@ -29,13 +30,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 5, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 5, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -48,7 +49,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 5, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 5, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts, Click on Users')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0930.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0930.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 import os
 import pytest
@@ -58,13 +59,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 5, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 5, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     else:
         assert wait_on_element(driver, 5, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -77,7 +78,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 5, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 5, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts, Click on Users')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0931.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0931.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 import os
 import pytest
@@ -58,13 +59,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 5, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 5, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     else:
         assert wait_on_element(driver, 5, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -77,7 +78,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 5, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 5, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts, Click on Users')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0932.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0932.py
@@ -1,8 +1,14 @@
 # coding=utf-8
 """High Availability (bhyve02) feature tests."""
 
+import xpaths
 import time
-from function import wait_on_element, is_element_present, wait_on_element_disappear
+from function import (
+    wait_on_element,
+    is_element_present,
+    wait_on_element_disappear,
+    refresh_if_element_missing
+)
 from pytest_bdd import (
     given,
     scenario,
@@ -29,13 +35,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_user_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -48,7 +54,7 @@ def if_login_page_appear_enter_user_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 5, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 5, xpaths.dashboard.system_information)
 
 
 @then('Navigate to Storage click Pools')
@@ -143,9 +149,9 @@ def the_configure_system_dataset_page_should_open(driver):
     assert wait_on_element(driver, 5, '//h4[contains(.,"Configure System Dataset")]')
 
 
-@then('Click on System Dataser Pool select dozer')
-def click_on_system_dataser_pool_select_dozer(driver):
-    """Click on System Dataser Pool select dozer."""
+@then('Click on System Dataset Pool select dozer')
+def click_on_system_dataset_pool_select_dozer(driver):
+    """Click on System Dataset Pool select dozer."""
     assert wait_on_element(driver, 5, '//mat-select[@ix-auto="select__System Dataset Pool"]')
     driver.find_element_by_xpath('//mat-select[@ix-auto="select__System Dataset Pool"]').click()
     assert wait_on_element(driver, 5, '//mat-option[@ix-auto="option__System Dataset Pool_dozer"]')
@@ -171,7 +177,7 @@ def click_save(driver):
 @then('Please wait should appear while settings are being applied')
 def Please_wait_should_appear_while_settings_are_being_applied(driver):
     """Please wait should appear while settings are being applied."""
-    assert wait_on_element_disappear(driver, 30, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 30, xpaths.popupTitle.please_wait)
 
 
 @then('Navigate to dashboard')
@@ -181,19 +187,14 @@ def navigate_to_dashboard(driver):
     driver.execute_script("arguments[0].scrollIntoView();", element)
     time.sleep(0.5)
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Dashboard"]').click()
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
-@then(parsers.parse('Second node should be rebootting'))
-def second_node_should_be_rebooting(driver):
-    """Second node should be rebootting."""
-    assert is_element_present(driver, '//mat-icon[@svgicon="ha_disabled"]')
-
-
-@then('Wait for second node to be up')
-def wait_for_second_node_to_be_up(driver):
-    """Wait for second node to be up"""
-    assert wait_on_element(driver, 420, '//mat-list-item[contains(.,"nodeb")]')
-    assert wait_on_element(driver, 60, '//mat-icon[@svgicon="ha_enabled"]')
+@then('HA should be disable wait for it to be enable')
+def ha_should_be_disable_wait_for_it_to_be_enable(driver):
+    """HA should be disable wait for it to be enable."""
+    assert is_element_present(driver, xpaths.topToolbar.ha_disabled)
+    # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
+    assert refresh_if_element_missing(driver, 420, xpaths.topToolbar.ha_enable)
     # This 5 seconds of sleep is to let the system ketchup.
     time.sleep(5)

--- a/tests/bdd/ha-bhyve02/test_NAS_T0932.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0932.py
@@ -195,6 +195,6 @@ def ha_should_be_disable_wait_for_it_to_be_enable(driver):
     """HA should be disable wait for it to be enable."""
     assert is_element_present(driver, xpaths.topToolbar.ha_disabled)
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert refresh_if_element_missing(driver, 420, xpaths.topToolbar.ha_enable)
+    assert wait_on_element(driver, 420, xpaths.topToolbar.ha_enable)
     # This 5 seconds of sleep is to let the system ketchup.
     time.sleep(5)

--- a/tests/bdd/ha-bhyve02/test_NAS_T0932.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0932.py
@@ -195,6 +195,6 @@ def ha_should_be_disable_wait_for_it_to_be_enable(driver):
     """HA should be disable wait for it to be enable."""
     assert is_element_present(driver, xpaths.topToolbar.ha_disabled)
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert wait_on_element(driver, 420, xpaths.topToolbar.ha_enable)
+    assert refresh_if_element_missing(driver, 420, xpaths.topToolbar.ha_enable)
     # This 5 seconds of sleep is to let the system ketchup.
     time.sleep(5)

--- a/tests/bdd/ha-bhyve02/test_NAS_T0933.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0933.py
@@ -253,7 +253,7 @@ def navigate_to_dashboard(driver):
 def press_initiate_failover_check_confirm_and_press_failover(driver):
     """Press INITIATE FAILOVER, check confirm and press FAILOVER"""
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert refresh_if_element_missing(driver, 10, xpaths.topToolbar.ha_enable)
+    assert wait_on_element(driver, 10, xpaths.topToolbar.ha_enable)
     assert wait_on_element(driver, 60, xpaths.button.initiate_failover, 'clickable')
     driver.find_element_by_xpath(xpaths.button.initiate_failover).click()
     assert wait_on_element(driver, 5, xpaths.popupTitle.initiate_failover)
@@ -285,7 +285,7 @@ def at_the_login_page_enter_root_and_password(driver, user, password):
         assert wait_on_element(driver, 10, '//button[@ix-auto="button__CLOSE"]', 'clickable')
         driver.find_element_by_xpath('//button[@ix-auto="button__CLOSE"]').click()
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert refresh_if_element_missing(driver, 10, xpaths.topToolbar.ha_enable)
+    assert wait_on_element(driver, 10, xpaths.topToolbar.ha_enable)
 
 
 @then(parsers.parse('ssh and input {tdbdump_command} after failover'))

--- a/tests/bdd/ha-bhyve02/test_NAS_T0933.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0933.py
@@ -253,7 +253,7 @@ def navigate_to_dashboard(driver):
 def press_initiate_failover_check_confirm_and_press_failover(driver):
     """Press INITIATE FAILOVER, check confirm and press FAILOVER"""
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert refresh_if_element_missing(driver, 10, xpaths.topToolbar.ha_enable)
+    assert refresh_if_element_missing(driver, 25, xpaths.topToolbar.ha_enable)
     assert wait_on_element(driver, 60, xpaths.button.initiate_failover, 'clickable')
     driver.find_element_by_xpath(xpaths.button.initiate_failover).click()
     assert wait_on_element(driver, 5, xpaths.popupTitle.initiate_failover)
@@ -285,7 +285,7 @@ def at_the_login_page_enter_root_and_password(driver, user, password):
         assert wait_on_element(driver, 10, '//button[@ix-auto="button__CLOSE"]', 'clickable')
         driver.find_element_by_xpath('//button[@ix-auto="button__CLOSE"]').click()
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert refresh_if_element_missing(driver, 10, xpaths.topToolbar.ha_enable)
+    assert refresh_if_element_missing(driver, 25, xpaths.topToolbar.ha_enable)
 
 
 @then(parsers.parse('ssh and input {tdbdump_command} after failover'))

--- a/tests/bdd/ha-bhyve02/test_NAS_T0933.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0933.py
@@ -253,7 +253,7 @@ def navigate_to_dashboard(driver):
 def press_initiate_failover_check_confirm_and_press_failover(driver):
     """Press INITIATE FAILOVER, check confirm and press FAILOVER"""
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert wait_on_element(driver, 10, xpaths.topToolbar.ha_enable)
+    assert refresh_if_element_missing(driver, 10, xpaths.topToolbar.ha_enable)
     assert wait_on_element(driver, 60, xpaths.button.initiate_failover, 'clickable')
     driver.find_element_by_xpath(xpaths.button.initiate_failover).click()
     assert wait_on_element(driver, 5, xpaths.popupTitle.initiate_failover)
@@ -285,7 +285,7 @@ def at_the_login_page_enter_root_and_password(driver, user, password):
         assert wait_on_element(driver, 10, '//button[@ix-auto="button__CLOSE"]', 'clickable')
         driver.find_element_by_xpath('//button[@ix-auto="button__CLOSE"]').click()
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert wait_on_element(driver, 10, xpaths.topToolbar.ha_enable)
+    assert refresh_if_element_missing(driver, 10, xpaths.topToolbar.ha_enable)
 
 
 @then(parsers.parse('ssh and input {tdbdump_command} after failover'))

--- a/tests/bdd/ha-bhyve02/test_NAS_T0933.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0933.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import pytest
+import xpaths
 import time
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
@@ -9,7 +11,8 @@ from function import (
     is_element_present,
     wait_on_element_disappear,
     attribute_value_exist,
-    ssh_cmd
+    ssh_cmd,
+    refresh_if_element_missing
 )
 from pytest_bdd import (
     given,
@@ -20,6 +23,7 @@ from pytest_bdd import (
 )
 
 
+@pytest.mark.dependency(name="NAS-T933")
 @scenario('features/NAS-T933.feature', 'Verify Active Directory works after failover with new system dataset')
 def test_setting_up_active_directory_with_the_new_system_dataset(driver):
     """Verify Active Directory works after failover with new system dataset."""
@@ -41,13 +45,13 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
     global passwd
     passwd = password
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     else:
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
         driver.execute_script("arguments[0].scrollIntoView();", element)
@@ -68,7 +72,7 @@ def verify_midclt_call_smb_get_smb_ha_mode_return_UNIFIED_or_LEGACY(driver):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 5, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 5, xpaths.dashboard.system_information)
 
 
 @then('Navigate to Network then Global Configuration')
@@ -102,15 +106,15 @@ def click_save_please_wait_should_appear_while_settings_are_being_applied(driver
     """Click SAVE "Please wait" should appear while settings are being applied."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Settings saved.")]')
 
 
 @then('Navigate to Directory Services then Active Directory')
 def navigate_to_directory_services_then_active_directory(driver):
     """Navigate to Directory Services then Active Directory."""
-    assert wait_on_element(driver, 7, '//mat-list-item[@ix-auto="option__Directory Services"]')
-    driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Directory Services"]').click()
+    assert wait_on_element(driver, 7, xpaths.sideMenu.directory_services)
+    driver.find_element_by_xpath(xpaths.sideMenu.directory_services).click()
     assert wait_on_element(driver, 7, '//mat-list-item[@ix-auto="option__Active Directory"]')
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Active Directory"]').click()
 
@@ -155,7 +159,7 @@ def check_the_enable_box_and_click_save(driver):
 @then('Active Directory should successfully save and start without an error')
 def active_directory_should_successfully_save_and_start_without_an_error(driver):
     """Active Directory should successfully save and start without an error."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 10, '//div[contains(.,"Settings saved.")]')
     assert wait_on_element_disappear(driver, 20, '//h1[contains(text(),"Configuring Active Directory")]')
     assert wait_on_element(driver, 7, '//div[contains(.,"Settings saved.")]')
@@ -242,42 +246,46 @@ def navigate_to_dashboard(driver):
     driver.execute_script("arguments[0].scrollIntoView();", element)
     time.sleep(0.5)
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Dashboard"]').click()
-    assert wait_on_element(driver, 10, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 10, xpaths.dashboard.system_information)
 
 
 @then('Press INITIATE FAILOVER, check confirm and press FAILOVER')
 def press_initiate_failover_check_confirm_and_press_failover(driver):
     """Press INITIATE FAILOVER, check confirm and press FAILOVER"""
-    assert wait_on_element(driver, 60, '//button[@ix-auto="button__INITIATE FAILOVER"]', 'clickable')
-    driver.find_element_by_xpath('//button[@ix-auto="button__INITIATE FAILOVER"]').click()
-    assert wait_on_element(driver, 5, '//h1[contains(.,"Initiate Failover")]')
-    driver.find_element_by_xpath('//mat-checkbox').click()
-    assert wait_on_element(driver, 5, '//div[2]/button[2]/span')
-    driver.find_element_by_xpath('//div[2]/button[2]/span').click()
+    # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
+    assert refresh_if_element_missing(driver, 10, xpaths.topToolbar.ha_enable)
+    assert wait_on_element(driver, 60, xpaths.button.initiate_failover, 'clickable')
+    driver.find_element_by_xpath(xpaths.button.initiate_failover).click()
+    assert wait_on_element(driver, 5, xpaths.popupTitle.initiate_failover)
+    driver.find_element_by_xpath(xpaths.checkbox.confirm).click()
+    assert wait_on_element(driver, 5, xpaths.button.failover)
+    driver.find_element_by_xpath(xpaths.button.failover).click()
 
 
 @then('Wait for the login page to appear')
 def wait_for_the_login_page_to_appear(driver):
     """Wait for the login page to appear"""
-    assert wait_on_element(driver, 120, '//input[@placeholder="Username"]')
+    assert wait_on_element(driver, 120, xpaths.login.user_input)
     # wait for HA is enabled to avoid UI refreshing
-    assert wait_on_element(driver, 300, '//p[contains(.,"HA is enabled")]')
+    assert wait_on_element(driver, 300, xpaths.login.ha_status('HA is enabled'))
 
 
 @then(parsers.parse('At the login page enter "{user}" and "{password}"'))
 def at_the_login_page_enter_root_and_password(driver, user, password):
     """At the login page enter "{user}" and "{password}"."""
-    assert wait_on_element(driver, 7, '//input[@placeholder="Username"]')
-    driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-    driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-    driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-    driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-    assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-    driver.find_element_by_xpath('//button[@name="signin_button"]').click()
-    assert wait_on_element(driver, 60, '//span[contains(.,"System Information")]')
-    if wait_on_element(driver, 5, '//div[contains(.,"Looking for help?")]'):
+    assert wait_on_element(driver, 7, xpaths.login.user_input)
+    driver.find_element_by_xpath(xpaths.login.user_input).clear()
+    driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+    driver.find_element_by_xpath(xpaths.login.password_input).clear()
+    driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+    assert wait_on_element(driver, 4, xpaths.login.signin_button)
+    driver.find_element_by_xpath(xpaths.login.signin_button).click()
+    assert wait_on_element(driver, 60, xpaths.dashboard.system_information)
+    if wait_on_element(driver, 5, xpaths.popupTitle.help):
         assert wait_on_element(driver, 10, '//button[@ix-auto="button__CLOSE"]', 'clickable')
         driver.find_element_by_xpath('//button[@ix-auto="button__CLOSE"]').click()
+    # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
+    assert refresh_if_element_missing(driver, 10, xpaths.topToolbar.ha_enable)
 
 
 @then(parsers.parse('ssh and input {tdbdump_command} after failover'))
@@ -341,7 +349,7 @@ def input_dataset_name_my_acl_dataset_and_click_save(driver, dataset_name):
 @then(parsers.parse('"{dataset_name}" should be created'))
 def my_acl_dataset_should_be_created(driver, dataset_name):
     """"my_acl_dataset" should be created."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 10, f'//span[contains(.,"{dataset_name}")]')
 
 
@@ -394,7 +402,7 @@ def click_the_save_button(driver):
     """Click the Save button, should be return to pool page"""
     assert wait_on_element(driver, 5, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 5, '//mat-panel-title[contains(.,"dozer")]')
     driver.find_element_by_xpath('//td[@ix-auto="value__dozer_name"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0933.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0933.py
@@ -267,7 +267,7 @@ def wait_for_the_login_page_to_appear(driver):
     """Wait for the login page to appear"""
     assert wait_on_element(driver, 120, xpaths.login.user_input)
     # wait for HA is enabled to avoid UI refreshing
-    assert wait_on_element(driver, 300, xpaths.login.ha_status('HA is enabled'))
+    assert wait_on_element_disappear(driver, 300, xpaths.login.ha_status('HA is enabled'))
 
 
 @then(parsers.parse('At the login page enter "{user}" and "{password}"'))

--- a/tests/bdd/ha-bhyve02/test_NAS_T0934.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0934.py
@@ -1,12 +1,14 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 from function import (
     wait_on_element,
     is_element_present,
     attribute_value_exist
 )
+from pytest_dependency import depends
 from pytest_bdd import (
     given,
     scenario,
@@ -22,8 +24,9 @@ def test_add_an_acl_item_and_verify_is_preserve():
 
 
 @given(parsers.parse('The browser is open navigate to "{nas_url}"'))
-def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
+def the_browser_is_open_navigate_to_nas_url(driver, nas_url, request):
     """The browser is open navigate to "{nas_url}"."""
+    depends(request, ['NAS-T933'], scope='session')
     if nas_url not in driver.current_url:
         driver.get(f"http://{nas_url}/ui/dashboard/")
         time.sleep(1)
@@ -33,13 +36,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "{user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -52,7 +55,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 5, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 5, xpaths.dashboard.system_information)
 
 
 @then('Navigate to Storage click Pools')
@@ -158,4 +161,4 @@ def navigate_to_dashboard(driver):
     driver.execute_script("arguments[0].scrollIntoView();", element)
     time.sleep(0.5)
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Dashboard"]').click()
-    assert wait_on_element(driver, 10, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 10, xpaths.dashboard.system_information)

--- a/tests/bdd/ha-bhyve02/test_NAS_T0939.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0939.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve02) feature tests."""
 
+import xpaths
 import time
 from function import (
     wait_on_element,
@@ -10,6 +11,8 @@ from function import (
     run_cmd,
     post
 )
+from pytest_dependency import depends
+
 from pytest_bdd import (
     given,
     scenario,
@@ -25,8 +28,9 @@ def test_create_a_smb_share_the_acl_dataset(driver):
 
 
 @given(parsers.parse('The browser is open navigate to "{nas_url}"'))
-def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
+def the_browser_is_open_navigate_to_nas_url(driver, nas_url, request):
     """The browser is open navigate to "{nas_url}"."""
+    depends(request, ['NAS-T933'], scope='session')
     if nas_url not in driver.current_url:
         driver.get(f"http://{nas_url}/ui/dashboard/")
         time.sleep(1)
@@ -36,13 +40,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "user" and "password"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -55,7 +59,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 5, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 5, xpaths.dashboard.system_information)
 
 
 @then('Click on Sharing then Windows Shares(SMB)')
@@ -184,8 +188,8 @@ def Verify_that_the_is_on_url_with_root_and_password(driver, nas_url, user, pass
 @then('Click on Directory Services then Active Directory')
 def click_on_directory_services_then_active_directory(driver):
     """Click on Directory Services then Active Directory."""
-    assert wait_on_element(driver, 7, '//mat-list-item[@ix-auto="option__Directory Services"]', 'clickable')
-    driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Directory Services"]').click()
+    assert wait_on_element(driver, 7, xpaths.sideMenu.directory_services, 'clickable')
+    driver.find_element_by_xpath(xpaths.sideMenu.directory_services).click()
     assert wait_on_element(driver, 7, '//mat-list-item[@ix-auto="option__Active Directory"]', 'clickable')
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Active Directory"]').click()
 
@@ -197,5 +201,5 @@ def click_the_enable_checkbox_and_click_save(driver):
     driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__Enable (requires password or Kerberos principal)"]').click()
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 10, '//div[contains(.,"Settings saved.")]')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0940.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0940.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import pytest
 import time
 from function import (
     wait_on_element,
@@ -17,6 +18,7 @@ from pytest_bdd import (
 )
 
 
+@pytest.mark.dependency(name='NAS-T940')
 @scenario('features/NAS-T940.feature', 'Setting up LDAP')
 def test_setting_up_ldap(driver):
     """Setting up LDAP."""

--- a/tests/bdd/ha-bhyve02/test_NAS_T0941.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0941.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import xpaths
 import time
 from function import (
     wait_on_element,
@@ -8,6 +9,7 @@ from function import (
     wait_on_element_disappear,
     wait_for_attribute_value
 )
+from pytest_dependency import depends
 from pytest_bdd import (
     given,
     scenario,
@@ -23,8 +25,9 @@ def test_create_a_new_dataset_with_the_ldap_user_and_group(driver):
 
 
 @given(parsers.parse('The browser is open navigate to "{nas_url}"'))
-def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
+def the_browser_is_open_navigate_to_nas_url(driver, nas_url, request):
     """The browser is open navigate to "{nas_url}"."""
+    depends(request, ['NAS-T940'], scope='session')
     if nas_url not in driver.current_url:
         driver.get(f"http://{nas_url}/ui/dashboard/")
         time.sleep(1)
@@ -34,13 +37,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "user" and "password"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -53,7 +56,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Go to Storage click Pools')
@@ -97,7 +100,7 @@ def input_dataset_name_my_ldap_dataset_and_click_save(driver, dataset_name):
 @then(parsers.parse('"{dataset_name}" should be created'))
 def my_ldap_dataset_should_be_created(driver, dataset_name):
     """"my_ldap_dataset" should be created."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 10, f'//span[contains(.,"{dataset_name}")]')
 
 
@@ -136,7 +139,7 @@ def click_the_save_button_should_be_return_to_pool_page(driver):
     """Click the Save button, should be return to pool page."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//mat-panel-title[contains(.,"dozer")]')
     driver.find_element_by_xpath('//td[@ix-auto="value__dozer_name"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0965.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0965.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import xpaths
 import time
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.keys import Keys
@@ -12,6 +13,7 @@ from function import (
     run_cmd,
     post
 )
+from pytest_dependency import depends
 from pytest_bdd import (
     given,
     scenario,
@@ -27,8 +29,9 @@ def test_create_a_smb_share_the_ldap_dataset(driver):
 
 
 @given(parsers.parse('The browser is open navigate to "{nas_url}"'))
-def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
+def the_browser_is_open_navigate_to_nas_url(driver, nas_url, request):
     """The browser is open navigate to "nas_url"."""
+    depends(request, ['NAS-T940'], scope='session')
     if nas_url not in driver.current_url:
         driver.get(f"http://{nas_url}/ui/dashboard/")
         time.sleep(1)
@@ -38,13 +41,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "user" and "password"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -57,7 +60,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Go on Sharing click Windows Shares(SMB)')
@@ -193,9 +196,9 @@ def go_to_directory_services_and_select_ldap(driver):
     element = driver.find_element_by_xpath('//span[contains(.,"root")]')
     driver.execute_script("arguments[0].scrollIntoView();", element)
     time.sleep(0.5)
-    driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Directory Services"]').click()
-    assert wait_on_element(driver, 7, '//mat-list-item[@ix-auto="option__LDAP"]')
-    driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__LDAP"]').click()
+    driver.find_element_by_xpath(xpaths.sideMenu.directory_services).click()
+    assert wait_on_element(driver, 7, xpaths.sideMenu.directory_services_ldap)
+    driver.find_element_by_xpath(xpaths.sideMenu.directory_services_ldap).click()
 
 
 @then('Click the Enable checkbox and click SAVE')
@@ -205,5 +208,5 @@ def click_the_enable_checkbox_and_click_save(driver):
     driver.find_element_by_xpath('//mat-checkbox[@ix-auto="checkbox__Enable"]').click()
     assert wait_on_element(driver, 5, '//button[@ix-auto="button__SAVE"]')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 5, '//div[contains(.,"Settings saved.")]')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0966.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0966.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import xpaths
 import time
 from function import (
     wait_on_element,
@@ -34,13 +35,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "user" and "password"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -53,7 +54,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Go to Storage click Pools')
@@ -97,7 +98,7 @@ def input_dataset_name_my_wheel_dataset_and_click_save(driver, dataset_name):
 @then(parsers.parse('"{dataset_name}" should be created'))
 def my_wheel_dataset_should_be_created(driver, dataset_name):
     """"{dataset_name}" should be created."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 10, f'//span[contains(.,"{dataset_name}")]')
 
 
@@ -142,7 +143,7 @@ def click_the_save_button_should_be_return_to_pool_page(driver):
     """Click the Save button, should be return to pool page."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//mat-panel-title[contains(.,"tank")]')
     driver.find_element_by_xpath('//td[@ix-auto="value__tank_name"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0967.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0967.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import xpaths
 import time
 from function import (
     wait_on_element,
@@ -33,13 +34,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_appear_enter_user_and_password(driver, user, password):
     """If login page appear enter "user" and "password"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -52,7 +53,7 @@ def if_login_appear_enter_user_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Click on the Accounts item in the left side menu')
@@ -113,6 +114,6 @@ def fill_in_the_following_fields_full_name_username_password_confirm_password_an
 @then('User should be created and added to the user list')
 def user_should_be_created_and_added_to_the_user_list(driver):
     """User should be created and added to the user list."""
-    assert wait_on_element_disappear(driver, 7, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 7, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//div[contains(.,"Users")]')
     driver.find_element_by_xpath('//div[@ix-auto="value__user2_Username"]')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0968.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0968.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import xpaths
 import time
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.keys import Keys
@@ -37,13 +38,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_appear_enter_user_and_password(driver, user, password):
     """If login page appear enter "user" and "password"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -56,7 +57,7 @@ def if_login_appear_enter_user_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Go on Sharing click Windows Shares(SMB)')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0969.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0969.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import xpaths
 import time
 from function import (
     wait_on_element,
@@ -34,13 +35,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_page_appear_enter_root_and_password(driver, user, password):
     """If login page appear enter "user" and "password"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -53,7 +54,7 @@ def if_login_page_appear_enter_root_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Go to Storage click Pools')
@@ -97,7 +98,7 @@ def input_dataset_name_my_wheel_dataset_and_click_save(driver, dataset_name):
 @then(parsers.parse('"{dataset_name}" should be created'))
 def my_wheel_dataset_should_be_created(driver, dataset_name):
     """"{dataset_name}" should be created."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 10, f'//span[contains(.,"{dataset_name}")]')
 
 
@@ -143,7 +144,7 @@ def click_the_save_button_should_be_return_to_pool_page(driver):
     """Click the Save button, should be return to pool page."""
     assert wait_on_element(driver, 7, '//button[@ix-auto="button__SAVE"]')
     driver.find_element_by_xpath('//button[@ix-auto="button__SAVE"]').click()
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 7, '//mat-panel-title[contains(.,"tank")]')
     driver.find_element_by_xpath('//td[@ix-auto="value__tank_name"]')
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0971.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0971.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import xpaths
 import time
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.keys import Keys
@@ -37,13 +38,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_appear_enter_user_and_password(driver, user, password):
     """If login page appear enter "user" and "password"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -56,7 +57,7 @@ def if_login_appear_enter_user_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Go on Sharing click Windows Shares(SMB)')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0973.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0973.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import xpaths
 import time
 from function import (
     wait_on_element,
@@ -33,13 +34,13 @@ def the_browser_is_open_navigate_to_nas_url(driver, nas_url):
 def if_login_appear_enter_user_and_password(driver, user, password):
     """If login page appear enter "user" and "password"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 10, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 4, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 10, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 4, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     if not is_element_present(driver, '//li[contains(.,"Dashboard")]'):
         assert wait_on_element(driver, 10, '//span[contains(.,"root")]')
         element = driver.find_element_by_xpath('//span[contains(.,"root")]')
@@ -52,7 +53,7 @@ def if_login_appear_enter_user_and_password(driver, user, password):
 def you_should_see_the_dashboard_and_system_information(driver):
     """You should see the dashboard and "System Information"."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 7, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 7, xpaths.dashboard.system_information)
 
 
 @then('Go to Storage click Pools')
@@ -99,5 +100,5 @@ def input_ds1_for_zvol_name_and_1_gib_for_zvol_size(driver, zvol_name, zvol_size
 @then(parsers.parse('"{zvol_name}" should be created'))
 def ds1_should_be_created(driver, zvol_name):
     """"ds1" should be created."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 10, f'//span[contains(.,"{zvol_name}")]')

--- a/tests/bdd/ha-bhyve02/test_NAS_T0977.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0977.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """High Availability (tn-bhyve03) feature tests."""
 
+import xpaths
 import time
 import random
 import string
@@ -27,7 +28,7 @@ MOUNT_POINT = f'/tmp/iscsi_{"".join(random.choices(string.digits, k=3))}'
 def click_summit(driver):
     assert wait_on_element(driver, 5, '//button[@ix-auto="button__SUBMIT"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__SUBMIT"]').click()
-    assert wait_on_element_disappear(driver, 15, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 15, xpaths.popupTitle.please_wait)
 
 
 @scenario('features/NAS-T977.feature', 'Verify that iSCSI connection on HA works')
@@ -47,13 +48,13 @@ def the_browser_is_open_navigate_to_nas_hostname(driver, nas_hostname):
 def if_login_page_appear_enter_root_and_password(driver, nas_user, password):
     """If login page appear enter "{nas_user}" and "{password}"."""
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(nas_user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 7, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(nas_user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 7, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     else:
         driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Dashboard"]').click()
 
@@ -62,7 +63,7 @@ def if_login_page_appear_enter_root_and_password(driver, nas_user, password):
 def you_should_see_the_dashboard(driver):
     """You should see the dashboard."""
     assert wait_on_element(driver, 7, '//a[text()="Dashboard"]')
-    assert wait_on_element(driver, 20, '//span[contains(.,"System Information")]')
+    assert wait_on_element(driver, 20, xpaths.dashboard.system_information)
 
 
 @then('go to sharing then click iscsi the iscsi page should open')

--- a/tests/bdd/ha-bhyve02/test_NAS_T1073.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T1073.py
@@ -147,4 +147,4 @@ def wait_on_the_login_to_appear(driver):
     # wait for HA is enabled to avoid UI refreshing
     driver.refresh()
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert refresh_if_element_missing(driver, 120, xpaths.login.ha_status('HA is enabled'))
+    assert wait_on_element(driver, 120, xpaths.login.ha_status('HA is enabled'))

--- a/tests/bdd/ha-bhyve02/test_NAS_T1073.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T1073.py
@@ -147,4 +147,4 @@ def wait_on_the_login_to_appear(driver):
     # wait for HA is enabled to avoid UI refreshing
     driver.refresh()
     # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
-    assert wait_on_element(driver, 120, xpaths.login.ha_status('HA is enabled'))
+    assert refresh_if_element_missing(driver, 120, xpaths.login.ha_status('HA is enabled'))

--- a/tests/bdd/ha-bhyve02/test_NAS_T1073.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T1073.py
@@ -1,12 +1,14 @@
 # coding=utf-8
 """Enterprise HA UI feature tests."""
 
+import xpaths
 import time
 from function import (
     wait_on_element,
     is_element_present,
     attribute_value_exist,
     wait_on_element_disappear,
+    refresh_if_element_missing,
     put
 
 )
@@ -40,13 +42,13 @@ def if_the_login_page_appears_enter_user_and_password(driver, user, password):
     global passwd
     passwd = password
     if not is_element_present(driver, '//mat-list-item[@ix-auto="option__Dashboard"]'):
-        assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys(user)
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-        driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(password)
-        assert wait_on_element(driver, 5, '//button[@name="signin_button"]')
-        driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+        assert wait_on_element(driver, 5, xpaths.login.user_input)
+        driver.find_element_by_xpath(xpaths.login.user_input).clear()
+        driver.find_element_by_xpath(xpaths.login.user_input).send_keys(user)
+        driver.find_element_by_xpath(xpaths.login.password_input).clear()
+        driver.find_element_by_xpath(xpaths.login.password_input).send_keys(password)
+        assert wait_on_element(driver, 5, xpaths.login.signin_button)
+        driver.find_element_by_xpath(xpaths.login.signin_button).click()
     else:
         assert wait_on_element(driver, 5, '//mat-list-item[@ix-auto="option__Dashboard"]', 'clickable')
         driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Dashboard"]').click()
@@ -85,14 +87,14 @@ def click_on_enable_twofactor_authentication_button_then_confirm(driver):
 @then('when Two-factor Authentication is enabled, logout')
 def when_twofactor_authentication_is_enabled_logout(driver):
     """when Two-factor Authentication is enabled, logout."""
-    assert wait_on_element_disappear(driver, 20, '//h6[contains(.,"Please wait")]')
+    assert wait_on_element_disappear(driver, 20, xpaths.popupTitle.please_wait)
     assert wait_on_element(driver, 5, '//p[contains(.,"Two-factor authentication IS currently enabled")]')
     assert wait_on_element(driver, 5, '//button[@ix-auto="button__power"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="button__power"]').click()
     assert wait_on_element(driver, 5, '//button[@ix-auto="option__Log Out"]', 'clickable')
     driver.find_element_by_xpath('//button[@ix-auto="option__Log Out"]').click()
-    assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-    assert wait_on_element(driver, 60, '//p[contains(.,"HA is enabled")]')
+    assert wait_on_element(driver, 5, xpaths.login.user_input)
+    assert wait_on_element(driver, 60, xpaths.login.ha_status('HA is enabled'))
 
 
 @then('verify the Two-Factor Authentication code entry is visible')
@@ -106,13 +108,13 @@ def disable_twofactor_authentication_with_api_and_login(driver):
     """disable Two-Factor Authentication with API and login."""
     results = put(hostname, 'auth/twofactor/', ('root', passwd), {"enabled": False})
     assert results.status_code == 200, results.text
-    assert wait_on_element(driver, 5, '//input[@placeholder="Username"]')
-    driver.find_element_by_xpath('//input[@placeholder="Username"]').clear()
-    driver.find_element_by_xpath('//input[@placeholder="Username"]').send_keys('root')
-    driver.find_element_by_xpath('//input[@placeholder="Password"]').clear()
-    driver.find_element_by_xpath('//input[@placeholder="Password"]').send_keys(passwd)
-    assert wait_on_element(driver, 5, '//button[@name="signin_button"]')
-    driver.find_element_by_xpath('//button[@name="signin_button"]').click()
+    assert wait_on_element(driver, 5, xpaths.login.user_input)
+    driver.find_element_by_xpath(xpaths.login.user_input).clear()
+    driver.find_element_by_xpath(xpaths.login.user_input).send_keys('root')
+    driver.find_element_by_xpath(xpaths.login.password_input).clear()
+    driver.find_element_by_xpath(xpaths.login.password_input).send_keys(passwd)
+    assert wait_on_element(driver, 5, xpaths.login.signin_button)
+    driver.find_element_by_xpath(xpaths.login.signin_button).click()
 
 
 @then('enable Two-Factor Authentication with API')
@@ -130,18 +132,19 @@ def on_the_dashboard_click_on_failover_initiate_failover(driver):
     driver.execute_script("arguments[0].scrollIntoView();", element)
     assert wait_on_element(driver, 5, '//mat-list-item[@ix-auto="option__Dashboard"]', 'clickable')
     driver.find_element_by_xpath('//mat-list-item[@ix-auto="option__Dashboard"]').click()
-    assert wait_on_element(driver, 60, '//button[@ix-auto="button__INITIATE FAILOVER"]', 'clickable')
-    driver.find_element_by_xpath('//button[@ix-auto="button__INITIATE FAILOVER"]').click()
-    assert wait_on_element(driver, 5, '//h1[contains(.,"Initiate Failover")]')
-    driver.find_element_by_xpath('//mat-checkbox').click()
-    assert wait_on_element(driver, 5, '//div[2]/button[2]/span')
-    driver.find_element_by_xpath('//div[2]/button[2]/span').click()
+    assert wait_on_element(driver, 60, xpaths.button.initiate_failover, 'clickable')
+    driver.find_element_by_xpath(xpaths.button.initiate_failover).click()
+    assert wait_on_element(driver, 5, xpaths.popupTitle.initiate_failover)
+    driver.find_element_by_xpath(xpaths.checkbox.confirm).click()
+    assert wait_on_element(driver, 5, xpaths.button.failover)
+    driver.find_element_by_xpath(xpaths.button.failover).click()
 
 
 @then('wait on the login to appear')
 def wait_on_the_login_to_appear(driver):
     """wait on the login to appear."""
-    assert wait_on_element(driver, 60, '//input[@placeholder="Username"]')
+    assert wait_on_element(driver, 60, xpaths.login.user_input)
     # wait for HA is enabled to avoid UI refreshing
     driver.refresh()
-    assert wait_on_element(driver, 60, '//p[contains(.,"HA is enabled")]')
+    # refresh_if_element_missing need to be replace with wait_on_element when NAS-118299
+    assert refresh_if_element_missing(driver, 120, xpaths.login.ha_status('HA is enabled'))

--- a/tests/bdd/ha-bhyve02/xpaths.py
+++ b/tests/bdd/ha-bhyve02/xpaths.py
@@ -1,0 +1,47 @@
+
+class breadcrumb:
+    dashboard = '//a[text()="Dashboard"]'
+
+
+class button:
+    close = '//button[@ix-auto="button__CLOSE"]'
+    save = '//button[@ix-auto="button__SAVE"]'
+    advanced_options = '//button[@ix-auto="button__ADVANCED OPTIONS"]'
+    initiate_failover = '//button[@ix-auto="button__INITIATE FAILOVER"]'
+    failover = '//button[span/text()="Failover"]'
+
+
+class checkbox:
+    confirm = '//mat-checkbox[contains(.,"Confirm")]'
+
+
+class dashboard:
+    system_information = '//span[contains(.,"System Information")]'
+
+
+class login:
+    user_input = '//input[@placeholder="Username"]'
+    password_input = '//input[@placeholder="Password"]'
+    signin_button = '//button[@name="signin_button"]'
+
+    def ha_status(message):
+        return f'//p[contains(.,"{message}")]'
+
+
+class popupTitle:
+    please_wait = '//h6[contains(.,"Please wait")]'
+    initiate_failover = '//h1[text()="Initiate Failover"]'
+    help = '//div[contains(.,"Looking for help?")]'
+
+
+class sideMenu:
+    """xpath for the menu on the left side"""
+    root = '//span[contains(.,"root")]'
+    dashboard = '//mat-list-item[@ix-auto="option__Dashboard"]'
+    directory_services = '//mat-list-item[@ix-auto="option__Directory Services"]'
+    directory_services_ldap = '//mat-list-item[@ix-auto="option__LDAP"]'
+
+
+class topToolbar:
+    ha_enable = '//mat-icon[@svgicon="ha_enabled"]'
+    ha_disabled = '//mat-icon[@svgicon="ha_disabled"]'


### PR DESCRIPTION
Added missing step to switch to virtual hostname to same interface setting
Added xpath.py to source HA UI test xpaths and started to source some xpath
Improved test_NAS_T0932.py step
Added refresh_if_element_missing for refreshing elements for HA
Added teardown for HA AD UI test and LDAP UI test failure
Added test dependency to AD and LDAP test
Improved disable_active_directory and disable_ldap in the main teardown