### PR TITLE
NAS-118857 / 22.12 / Using job instead of call

### DIFF
--- a/src/app/core/testing/utils/mock-entity-job-component-ref.utils.ts
+++ b/src/app/core/testing/utils/mock-entity-job-component-ref.utils.ts
@@ -19,6 +19,7 @@ export const mockEntityJobComponentRef = {
     failure: new EventEmitter(),
     wsshow: jest.fn(),
     wspost: jest.fn(),
+    updateSize: jest.fn(),
   },
   close: jest.fn(),
 } as unknown as MatDialogRef<EntityJobComponent>;

--- a/src/app/pages/datasets/modules/encryption/components/encyption-options-dialog/encryption-options-dialog.component.spec.ts
+++ b/src/app/pages/datasets/modules/encryption/components/encyption-options-dialog/encryption-options-dialog.component.spec.ts
@@ -2,8 +2,9 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialog } from '@angular/material/dialog';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { mockEntityJobComponentRef } from 'app/core/testing/utils/mock-entity-job-component-ref.utils';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { EncryptionKeyFormat } from 'app/enums/encryption-key-format.enum';
 import { Dataset } from 'app/interfaces/dataset.interface';
@@ -13,7 +14,7 @@ import { IxFormHarness } from 'app/modules/ix-forms/testing/ix-form.harness';
 import { AppLoaderModule } from 'app/modules/loader/app-loader.module';
 import { SnackbarModule } from 'app/modules/snackbar/snackbar.module';
 import { EncryptionOptionsDialogComponent } from 'app/pages/datasets/modules/encryption/components/encyption-options-dialog/encryption-options-dialog.component';
-import { DialogService, WebSocketService } from 'app/services';
+import { AppLoaderService, DialogService, WebSocketService } from 'app/services';
 import { EncryptionOptionsDialogData } from './encryption-options-dialog-data.interface';
 
 describe('EncryptionOptionsDialogComponent', () => {
@@ -34,6 +35,10 @@ describe('EncryptionOptionsDialogComponent', () => {
       { provide: MAT_DIALOG_DATA, useValue: {} },
       mockProvider(MatDialogRef),
       mockProvider(DialogService),
+      mockProvider(MatDialog, {
+        open: jest.fn(() => mockEntityJobComponentRef),
+      }),
+      mockProvider(AppLoaderService),
       mockWebsocket([
         mockCall('pool.dataset.change_key'),
         mockCall('pool.dataset.inherit_parent_encryption_properties'),
@@ -148,7 +153,7 @@ describe('EncryptionOptionsDialogComponent', () => {
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
-    expect(websocket.call).toHaveBeenCalledWith(
+    expect(mockEntityJobComponentRef.componentInstance.setCall).toHaveBeenCalledWith(
       'pool.dataset.change_key',
       ['pool/parent/child', { key, generate_key: false }],
     );
@@ -169,7 +174,7 @@ describe('EncryptionOptionsDialogComponent', () => {
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
-    expect(websocket.call).toHaveBeenCalledWith(
+    expect(mockEntityJobComponentRef.componentInstance.setCall).toHaveBeenCalledWith(
       'pool.dataset.change_key',
       ['pool/parent/child', { generate_key: true }],
     );
@@ -192,7 +197,7 @@ describe('EncryptionOptionsDialogComponent', () => {
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
-    expect(websocket.call).toHaveBeenCalledWith(
+    expect(mockEntityJobComponentRef.componentInstance.setCall).toHaveBeenCalledWith(
       'pool.dataset.change_key',
       ['pool/parent/child', { passphrase: '12345678', pbkdf2iters: 350001 }],
     );

--- a/src/app/pages/datasets/modules/encryption/components/encyption-options-dialog/encryption-options-dialog.component.ts
+++ b/src/app/pages/datasets/modules/encryption/components/encyption-options-dialog/encryption-options-dialog.component.ts
@@ -2,7 +2,7 @@ import {
   ChangeDetectionStrategy, Component, Inject, OnInit,
 } from '@angular/core';
 import { Validators } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialog } from '@angular/material/dialog';
 import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
@@ -15,6 +15,7 @@ import { DatasetChangeKeyParams } from 'app/interfaces/dataset-change-key.interf
 import { Dataset } from 'app/interfaces/dataset.interface';
 import { WebsocketError } from 'app/interfaces/websocket-error.interface';
 import { matchOtherValidator } from 'app/modules/entity/entity-form/validators/password-validation/password-validation';
+import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
 import { FormErrorHandlerService } from 'app/modules/ix-forms/services/form-error-handler.service';
 import { IxValidatorsService } from 'app/modules/ix-forms/services/ix-validators.service';
 import { findInTree } from 'app/modules/ix-tree/utils/find-in-tree.utils';
@@ -78,6 +79,7 @@ export class EncryptionOptionsDialogComponent implements OnInit {
     private validatorsService: IxValidatorsService,
     private errorHandler: FormErrorHandlerService,
     private snackbar: SnackbarService,
+    private mdDialog: MatDialog,
     @Inject(MAT_DIALOG_DATA) public data: EncryptionOptionsDialogData,
   ) {}
 
@@ -149,20 +151,28 @@ export class EncryptionOptionsDialogComponent implements OnInit {
       body.pbkdf2iters = Number(values.pbkdf2iters);
     }
 
-    this.loader.open();
-    this.ws.call('pool.dataset.change_key', [this.data.dataset.id, body])
-      .pipe(untilDestroyed(this))
-      .subscribe({
-        next: () => {
-          this.loader.close();
-          this.showSuccessDialog();
-          this.dialogRef.close(true);
-        },
-        error: (error: WebsocketError) => {
-          this.loader.close();
-          this.errorHandler.handleWsFormError(error, this.form);
-        },
-      });
+    const jobDialogRef = this.mdDialog.open(EntityJobComponent, {
+      data: {
+        title: this.translate.instant('Updating key type'),
+      },
+    });
+    jobDialogRef.componentInstance.setCall('pool.dataset.change_key', [this.data.dataset.id, body]);
+    jobDialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe({
+      next: () => {
+        jobDialogRef.close();
+        this.showSuccessDialog();
+        this.dialogRef.close(true);
+      },
+      error: (error: WebsocketError) => {
+        this.errorHandler.handleWsFormError(error, this.form);
+      },
+    });
+    jobDialogRef.componentInstance.failure.pipe(untilDestroyed(this)).subscribe({
+      next: (error) => {
+        this.errorHandler.handleWsFormError(error, this.form);
+      },
+    });
+    jobDialogRef.componentInstance.submit();
   }
 
   private showSuccessDialog(): void {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -3270,6 +3270,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Waiting to Finish": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2423,6 +2423,7 @@
   "Updates Available": "",
   "Updating": "",
   "Updating Dataset ACL": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Waiting to Finish": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -980,6 +980,7 @@
   "Update Available": "",
   "Update Image": "",
   "Updated 'Use as Home Share'": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrading...": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3506,6 +3506,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1079,6 +1079,7 @@
   "Update 'Time Machine'": "",
   "Updated 'Use as Home Share'": "",
   "Updating": "",
+  "Updating key type": "",
   "Usable Capacity": "",
   "Usages": "",
   "Use compressed WRITE records to make the  stream more efficient. The destination system must also support  compressed WRITE records. See  <a href=\"https://linux.die.net/man/8/zfs\"  target=\"_blank\">zfs(8)</a>.": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3516,6 +3516,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3165,6 +3165,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3759,6 +3759,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -61,6 +61,7 @@
   "Thread responsible for syncing db transactions not running on this node.": "",
   "TrueNAS software versions do not match between storage controllers.": "",
   "USB Passthrough Device": "",
+  "Updating key type": "",
   "User deleted": "",
   "VMware Snapshot Integration": "",
   "Vendor ID": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3664,6 +3664,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3686,6 +3686,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3558,6 +3558,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Waiting to Finish": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1701,6 +1701,7 @@
   "Updated 'Use as Home Share'": "",
   "Updates Available": "",
   "Updating Dataset ACL": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Waiting to Finish": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -119,6 +119,7 @@
   "UID": "",
   "USB Passthrough Device": "",
   "UTC": "",
+  "Updating key type": "",
   "User deleted": "",
   "VM": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3768,6 +3768,7 @@
   "Updating": "",
   "Updating Dataset ACL": "",
   "Updating group members": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrade": "",
   "Upgrade Pool": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -428,6 +428,7 @@
   "Unused Resources": "",
   "Update 'Time Machine'": "",
   "Updated 'Use as Home Share'": "",
+  "Updating key type": "",
   "Usable Capacity": "",
   "Use compressed WRITE records to make the  stream more efficient. The destination system must also support  compressed WRITE records. See  <a href=\"https://linux.die.net/man/8/zfs\"  target=\"_blank\">zfs(8)</a>.": "",
   "Used by Snapshots": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2806,6 +2806,7 @@
   "Updates Available": "",
   "Updating": "",
   "Updating Dataset ACL": "",
+  "Updating key type": "",
   "Updating production status...": "",
   "Upgrades both controllers. Files are downloaded to the Active Controller and then transferred to the Standby Controller. The upgrade process starts concurrently on both TrueNAS Controllers. Continue with download?": "",
   "Upload Chunk Size (MiB)": "",


### PR DESCRIPTION
Changing the encryption type from key to passphrase of datasets should show correct info on the datasets page afterwards without having to reload.