### PR TITLE
NAS-113218 / 22.12 / Enclosure UI stage left Vdev should show name not type

### DIFF
--- a/src/app/modules/entity/entity-table/entity-table-actions/entity-table-actions.component.html
+++ b/src/app/modules/entity/entity-table/entity-table-actions/entity-table-actions.component.html
@@ -118,7 +118,7 @@
         mat-icon-button
         ix-auto-type="action"
         id="action_button_{{ action?.name }}__{{ action.id }}"
-        ix-auto-identifier="{{ action.id }}_{{ action.name.toUpperCase() }}"
+        ix-auto-identifier="{{ action.id }}_{{ action.name | uppercase }}"
         [disabled]="action.disabled"
         [ix-auto]=""
         [matTooltip]="action.label | translate"

--- a/src/app/pages/system/view-enclosure/classes/system-profiler.ts
+++ b/src/app/pages/system/view-enclosure/classes/system-profiler.ts
@@ -28,11 +28,11 @@ export interface EnclosureMetadata {
 export interface VDevMetadata {
   pool: string;
   type: string;
-  disks?: { [devName: string]: number }; // {devname: index} Only for mirrors and RAIDZ
-  diskEnclosures?: { [devName: string]: number }; // {devname: index} Only for mirrors and RAIDZ
   poolIndex: number;
   vdevIndex: number;
-
+  name: string;
+  disks?: { [devName: string]: number }; // {devname: index} Only for mirrors and RAIDZ
+  diskEnclosures?: { [devName: string]: number }; // {devname: index} Only for mirrors and RAIDZ
   topology?: PoolTopologyCategory;
   selectedDisk?: string;
   slots?: { [devName: string]: number };
@@ -188,6 +188,7 @@ export class SystemProfiler {
     pool.topology[role].forEach((vdev, vIndex) => {
       const metadata: VDevMetadata = {
         pool: pool.name,
+        name: vdev.name,
         type: vdev.type,
         topology: role,
         poolIndex: pIndex,
@@ -268,6 +269,7 @@ export class SystemProfiler {
         type: 'None',
         poolIndex: -1,
         vdevIndex: -1,
+        name: '',
       };
     }
 

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks-mini/enclosure-disks-mini.component.html
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks-mini/enclosure-disks-mini.component.html
@@ -142,7 +142,7 @@
                 <span>
                   {{
                     selectedVdev.type !== 'DISK'
-                      ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : (selectedVdev.name | titlecase)
+                      ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : (selectedVdev.name | uppercase)
                       : ('NONE' | translate)
                   }}
                 </span>

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks-mini/enclosure-disks-mini.component.html
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks-mini/enclosure-disks-mini.component.html
@@ -139,15 +139,12 @@
 
               <li>
                 <strong>{{ 'Vdev' | translate }}:</strong> &nbsp;&nbsp;&nbsp;
-                <span *ngIf="selectedVdev.type === 'DISK'">
-                  {{ 'NONE' | translate }}
-                </span>
-                <span *ngIf="selectedVdev.type !== 'DISK'">
-                  {{ selectedVdev.type === 'None' ? 'UNASSIGNED' : selectedVdev.type }}
-                </span>
-
-                <span *ngIf="selectedVdev.topology">
-                  {{ $any(selectedVdev.topology) === 'None' ? '' : '(' + selectedVdev.topology.toUpperCase() + ')' }}
+                <span>
+                  {{
+                    selectedVdev.type !== 'DISK'
+                      ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : selectedVdev.name
+                      : ('NONE' | translate)
+                  }}
                 </span>
               </li>
 

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks-mini/enclosure-disks-mini.component.html
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks-mini/enclosure-disks-mini.component.html
@@ -142,7 +142,7 @@
                 <span>
                   {{
                     selectedVdev.type !== 'DISK'
-                      ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : selectedVdev.name
+                      ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : (selectedVdev.name | titlecase)
                       : ('NONE' | translate)
                   }}
                 </span>

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
@@ -128,7 +128,7 @@
               <span>
                 {{
                   selectedVdev.type !== 'DISK'
-                    ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : selectedVdev.name
+                    ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : (selectedVdev.name | titlecase)
                     : ('NONE' | translate)
                 }}
               </span>

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
@@ -125,17 +125,18 @@
             </h1>
             <div class="title">
               <span class="semibold">{{ 'vdev' | translate }}: </span>
-              <span *ngIf="selectedVdev.type === 'DISK'">
-                {{ 'NONE' | translate }}
-              </span>
-              <span *ngIf="selectedVdev.type !== 'DISK'">
-                {{ selectedVdev.type === 'None' ? 'UNASSIGNED' : selectedVdev.type }}
+              <span>
+                {{
+                  selectedVdev.type !== 'DISK'
+                    ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : selectedVdev.name
+                    : ('NONE' | translate)
+                }}
               </span>
             </div>
             <div *ngIf="selectedVdev.type !== 'None'" class="title">
               <span class="semibold">{{ 'Function' | translate }}:</span>
               <span>
-                {{ $any(selectedVdev).topology === 'None' ? 'UNKNOWN' : selectedVdev.topology.toUpperCase() }}
+                {{ $any(selectedVdev).topology === 'None' ? ('Unknown' | translate) : selectedVdev.topology.toUpperCase() }}
               </span>
             </div>
             <div class="title">

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
@@ -128,7 +128,7 @@
               <span>
                 {{
                   selectedVdev.type !== 'DISK'
-                    ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : (selectedVdev.name | titlecase)
+                    ? selectedVdev.type === 'None' ? ('Unassigned' | translate) : (selectedVdev.name | uppercase)
                     : ('NONE' | translate)
                 }}
               </span>
@@ -136,7 +136,7 @@
             <div *ngIf="selectedVdev.type !== 'None'" class="title">
               <span class="semibold">{{ 'Function' | translate }}:</span>
               <span>
-                {{ $any(selectedVdev).topology === 'None' ? ('Unknown' | translate) : selectedVdev.topology.toUpperCase() }}
+                {{ $any(selectedVdev).topology === 'None' ? ('Unknown' | translate) : (selectedVdev.topology | uppercase) }}
               </span>
             </div>
             <div class="title">


### PR DESCRIPTION
Vdev now has a **name** property and we display it.
On MINI | M40 | other systems
<img width="1227" alt="Screen Shot 2022-11-09 at 01 16 51" src="https://user-images.githubusercontent.com/22980553/200696566-855c8fc4-83eb-4183-bf35-8c8d36c14889.png">
