### PR TITLE
NAS-118891 / 22.12 / Used snapshot size not showed on the storage page

### DIFF
--- a/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.html
@@ -16,7 +16,7 @@
           class="pool-icon icon-warning"
           [matTooltip]="'Warning' | translate"
         >
-          warning
+          error
         </mat-icon>
         <mat-icon
           *ngSwitchCase="diskHealthLevel.Error"

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
@@ -87,14 +87,10 @@
               </span>
             </span>
           </li>
-          <li class="item-caption">
-            <span class="snapshots-caption" fxLayoutAlign="start center">
-              <b>{{ 'Used by Snapshots' | translate }}:</b>
-              <span class="value-caption">
-                {{ (rootDataset?.usedbysnapshots?.parsed | filesize: { standard: 'iec' }) || ('Unknown' | translate) }}
-              </span>
-            </span>
-          </li>
+          <!--
+              TODO: Used by Snapshots was removed.
+              Details in comments sections: https://ixsystems.atlassian.net/browse/NAS-118891
+          -->
         </ul>
       </div>
       <a

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
@@ -74,7 +74,6 @@ describe('PoolUsageCardComponent', () => {
     expect(spectator.query('.capacity-caption')).toHaveText('Usable Capacity: 3.99 GiB');
     expect(spectator.query('.used-caption')).toHaveText('Used: 3.15 GiB');
     expect(spectator.query('.available-caption')).toHaveText('Available: 858.01 MiB');
-    expect(spectator.query('.snapshots-caption')).toHaveText('Used by Snapshots: 117.19 KiB');
     expect(spectator.query('.warning-container')).not.toBeVisible();
     expect(spectator.query('mat-card-header mat-icon')).toHaveText('check_circle');
     expect(spectator.query(GaugeChartComponent).label).toBe('79%');
@@ -95,7 +94,6 @@ describe('PoolUsageCardComponent', () => {
     expect(spectator.query('.capacity-caption')).toHaveText('Usable Capacity: 2.47 TiB');
     expect(spectator.query('.used-caption')).toHaveText('Used: 2 TiB');
     expect(spectator.query('.available-caption')).toHaveText('Available: 480.56 GiB');
-    expect(spectator.query('.snapshots-caption')).toHaveText('Used by Snapshots: 0 B');
     expect(spectator.query('.warning-container')).toBeVisible();
     expect(spectator.query('.warning-container')).toHaveText('Warning: Low Capacity');
     expect(spectator.query(GaugeChartComponent).label).toBe('81%');

--- a/src/app/pages/storage/components/dashboard-pool/zfs-health-card/zfs-health-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/zfs-health-card/zfs-health-card.component.html
@@ -16,7 +16,7 @@
           class="pool-icon icon-warning"
           [matTooltip]="'Degraded' | translate"
         >
-          warning
+          error
         </mat-icon>
         <mat-icon
           *ngSwitchCase="pool.status === PoolStatus.Faulted"


### PR DESCRIPTION
made warning icons one style

<img width="1011" alt="Screen Shot 2022-11-10 at 15 02 50" src="https://user-images.githubusercontent.com/22980553/201098607-357cd2a9-3b98-416e-9f02-7fde4b2d5951.png">

Prev:
<img width="1417" alt="Screen Shot 2022-11-10 at 15 13 51" src="https://user-images.githubusercontent.com/22980553/201100938-f1ed95af-8d9d-49d5-bd4e-5acef4a30188.png">

and  removed Used by snapshots  block, check comments: https://ixsystems.atlassian.net/browse/NAS-118891