### PR TITLE
NAS-118946 / 22.12 / Update styles on the Alert Panel

### DIFF
--- a/src/app/modules/alerts/components/alert/alert.component.scss
+++ b/src/app/modules/alerts/components/alert/alert.component.scss
@@ -18,6 +18,7 @@
 .alert-message {
   font-size: inherit;
   font-weight: normal;
+  line-height: inherit;
   margin-bottom: 6px;
   margin-top: 3px;
 }

--- a/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.scss
+++ b/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.scss
@@ -22,6 +22,10 @@
   flex-direction: row;
   padding: 4px 0 4px 20px;
   place-content: center space-between;
+
+  .controls {
+    opacity: 0.55;
+  }
 }
 
 .button-row {


### PR DESCRIPTION
PREV: (less line height and white icons on top)
<img width="403" alt="Screen Shot 2022-11-17 at 15 14 37" src="https://user-images.githubusercontent.com/22980553/202456132-eb06b48f-7e62-4969-8468-8808fa113180.png">

NOW: (more line height and grayish icons on top)
<img width="401" alt="Screen Shot 2022-11-17 at 15 15 03" src="https://user-images.githubusercontent.com/22980553/202456205-271db6a5-d03e-486d-8e9d-0180391ceee1.png">
