### PR TITLE
NAS-119046 / 22.12 / Remove redundant header

### DIFF
--- a/src/app/pages/storage/components/unused-resources/unused-resources.component.html
+++ b/src/app/pages/storage/components/unused-resources/unused-resources.component.html
@@ -1,13 +1,7 @@
-<div *ngIf="unusedDisks.length" class="header">
-  <h2 class="title">{{ 'Unused Resources' | translate }}</h2>
-</div>
-
-<div class="cards">
-  <ng-container *ngIf="unusedDisks.length">
-    <ix-unused-disk-card
-      class="unused-resources"
-      [pools]="pools"
-      [unusedDisks]="unusedDisks"
-    ></ix-unused-disk-card>
-  </ng-container>
+<div *ngIf="unusedDisks.length" class="cards">
+  <ix-unused-disk-card
+    class="unused-resources"
+    [pools]="pools"
+    [unusedDisks]="unusedDisks"
+  ></ix-unused-disk-card>
 </div>

--- a/src/app/pages/storage/components/unused-resources/unused-resources.component.spec.ts
+++ b/src/app/pages/storage/components/unused-resources/unused-resources.component.spec.ts
@@ -35,10 +35,6 @@ describe('UnusedResourcesComponent', () => {
     });
   });
 
-  it('shows a title', () => {
-    expect(spectator.query('.title')).toHaveText('Unused Resources');
-  });
-
   it('shows an \'Unassigned Disks\' card when exists unused disks', () => {
     expect(spectator.query('ix-unused-disk-card')).toBeVisible();
   });

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -3274,7 +3274,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update 'Time Machine'": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2435,7 +2435,6 @@
   "Unshare": "",
   "Unsupported Hardware": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Update 'Time Machine'": "",
   "Update Available": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -998,7 +998,6 @@
   "Unset": "",
   "Unset Pool": "",
   "Unsupported Hardware": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Update 'Time Machine'": "",
   "Update Available": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3508,7 +3508,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -635,7 +635,6 @@
   "Unlock Child Encrypted Roots": "",
   "Unlocked": "",
   "Unsupported Hardware": "",
-  "Unused Resources": "",
   "Update 'Time Machine'": "",
   "Updated 'Use as Home Share'": "",
   "Updating": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3516,7 +3516,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3167,7 +3167,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update 'Time Machine'": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3759,7 +3759,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -3818,7 +3818,6 @@
   "Unsupported Hardware": "Niet-ondersteunde hardware",
   "Until": "Tot",
   "Until: ": "Tot: ",
-  "Unused Resources": "Niet-gebruikte bronnen",
   "Up to date": "Up-to-date",
   "Upcoming tasks": "Aankomende taken",
   "Update": "Updaten",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3664,7 +3664,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3686,7 +3686,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3558,7 +3558,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1716,7 +1716,6 @@
   "Unshare": "",
   "Unsupported Hardware": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Update 'Time Machine'": "",
   "Update Production Status": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -3831,7 +3831,6 @@
   "Unsupported Hardware": "Непідтримуване обладнання",
   "Until": "До",
   "Until: ": "До:",
-  "Unused Resources": "Невикористані ресурси",
   "Up to date": "Актуальний",
   "Upcoming tasks": "Майбутні завдання",
   "Update": "Оновлення",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3768,7 +3768,6 @@
   "Unsupported Hardware": "",
   "Until": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -449,7 +449,6 @@
   "Unknown Disk": "",
   "Unlocked": "",
   "Unsupported Hardware": "",
-  "Unused Resources": "",
   "Update 'Time Machine'": "",
   "Updated 'Use as Home Share'": "",
   "Updating key type": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2814,7 +2814,6 @@
   "Unshare": "",
   "Unsupported Hardware": "",
   "Until: ": "",
-  "Unused Resources": "",
   "Up to date": "",
   "Upcoming tasks": "",
   "Update 'Time Machine'": "",


### PR DESCRIPTION
From Ticket Description...

> This "Unused Resources" header doesn’t seem to add much considering that at the moment there will only be one card that might be in this area. We should remove it.
> 
> 
![image](https://user-images.githubusercontent.com/29865743/202511641-fd041acc-150e-4e1f-ab80-17267143dc1c.png)

