### PR TITLE
NAS-119051 / 22.12 / Fix `as any` casts

### DIFF
--- a/src/app/interfaces/certificate.interface.ts
+++ b/src/app/interfaces/certificate.interface.ts
@@ -44,6 +44,8 @@ export interface Certificate {
   organization: string;
   organizational_unit: string;
   parsed: boolean;
+  passphrase: string;
+  passphrase2: string;
   privatekey: string;
   privatekey_path: string;
   revoked: boolean;

--- a/src/app/pages/credentials/certificates-dash/forms/certificate-add.component.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/certificate-add.component.ts
@@ -970,8 +970,8 @@ export class CertificateAddComponent implements WizardConfiguration {
       this.csrList.forEach((item) => {
         if (item.id === data.csrlist) {
           data.privatekey = item.privatekey;
-          data.passphrase = (item as any).passphrase;
-          data.passphrase2 = (item as any).passphrase2;
+          data.passphrase = item.passphrase;
+          data.passphrase2 = item.passphrase2;
         }
       });
     }


### PR DESCRIPTION
**Summary**

1st part of this ticket is a problem on middleware side.

2nd part is removing `any` casts, and it's done here: