### PR TITLE
NAS-119042 / 22.12 / Fixing various inconsistencies with ACL editor

### DIFF
--- a/src/app/pages/datasets/modules/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.ts
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.ts
@@ -128,7 +128,7 @@ export class DatasetAclEditorComponent implements OnInit {
       .afterClosed()
       .pipe(untilDestroyed(this))
       .subscribe((wasStripped) => {
-        if (wasStripped) {
+        if (!wasStripped) {
           return;
         }
 

--- a/src/app/pages/datasets/modules/permissions/stores/dataset-acl-editor.store.ts
+++ b/src/app/pages/datasets/modules/permissions/stores/dataset-acl-editor.store.ts
@@ -54,7 +54,8 @@ export class DatasetAclEditorStore extends ComponentStore<DatasetAclEditorState>
   readonly loadAcl = this.effect((mountpoints$: Observable<string>) => {
     return mountpoints$.pipe(
       tap((mountpoint) => {
-        this.patchState({
+        this.setState({
+          ...initialState,
           mountpoint,
           isLoading: true,
         });


### PR DESCRIPTION
Fixes:
* Stripping ACL would not redirect user back to datasets.
* ACL editor would remember last opened ACL and therefore Select Preset ACL prompt was shown inconsistently.