### PR TITLE
NAS-118439 / 13.0 / Cast `vlan` value ti integer or null

### DIFF
--- a/src/app/pages/network/ipmi/ipmi.component.ts
+++ b/src/app/pages/network/ipmi/ipmi.component.ts
@@ -254,6 +254,7 @@ export class IPMIComponent {
   }
 
   customSubmit(payload) {
+    payload.vlan = payload.vlan ? parseInt(payload.vlan) : null;
     let call = this.ws.call('ipmi.update', [this.selectedValue, payload]);
     if (this.remoteController) {
       call = this.ws.call('failover.call_remote', ['ipmi.update', [this.selectedValue, payload]]);


### PR DESCRIPTION
**Testing**

You should test with an M60 box, for example m60-100.dc1.ixsystems.net

On **Network** page, at **IPMI** block:

1. Click an item from IPMI block to open it for editing
1. Set **VLAN ID** to any integer
1. Save configuration
1. Erase **VLAN ID** integer
1. Save configuration
   - Expected result:  VLAN ID should be erased without an error "Is not integer value" mentioned in the ticket