### PR TITLE
NAS-118870 / 13.0 / Update `Name` field after first folder click

### DIFF
--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -542,7 +542,7 @@ export class SMBFormComponent {
     /*  If name is empty, auto-populate after path selection */
     entityForm.formGroup.controls['path'].valueChanges.subscribe((path) => {
       const nameControl = entityForm.formGroup.controls['name'];
-      if (path && !nameControl.value) {
+      if (path && !nameControl.dirty) {
         const v = path.split('/').pop();
         nameControl.setValue(v);
       }


### PR DESCRIPTION
**Testing**

1. Click **Sharing > Windows Shares (SMB) > ADD**
1. Click on any folder. Note that the ‘Name’ field is updated to match the name of the folder you clicked on.
1. Now click on another folder.
   Expected result: The ‘Name’ field is updated to match the selected folder.
