### PR TITLE
NAS-119125 / 23.10 / Add support for external share paths

### DIFF
--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -417,7 +417,7 @@ export class SmbFormComponent implements OnInit {
             this.slideInService.close();
           },
           error: (err) => {
-            if (err.reason.includes('[ENOENT]')) {
+            if (err.reason.includes('[ENOENT]') || err.reason.includes('[EXDEV]')) {
               this.dialog.closeAllDialogs();
             } else {
               this.dialog.errorReport(err.error, err.reason, err.trace.formatted);


### PR DESCRIPTION
**Testing**

1. Create SMB share on some other machine and add it to your SCALE box using the following command:

   For example, you've created an SMB share on your other machine:

   `\\192.168.1.111\tst_smb`

   In the **Shell** of your SCALE box, run the command:

```
call sharing.smb.create '{"path": "EXTERNAL:<PUT PATH HERE>", "name": "TST_SMB"}'
```

2. View the details of newly created external share in the WebUI on your box:

   - **Expected result:** no error message should be displayed. For other errors, however, the error message should still appear. 