### PR TITLE
NAS-119264 / 23.10 / Refresh dataset tree when zvol form is submitted

### DIFF
--- a/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.ts
+++ b/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.ts
@@ -4,6 +4,7 @@ import {
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import { filter } from 'rxjs';
 import { DatasetType } from 'app/enums/dataset.enum';
 import { DatasetDetails } from 'app/interfaces/dataset.interface';
 import { DatasetFormComponent } from 'app/pages/datasets/components/dataset-form/dataset-form.component';
@@ -40,9 +41,14 @@ export class DatasetDetailsPanelComponent implements OnInit {
     this.modalService.onClose$.pipe(untilDestroyed(this)).subscribe(() => {
       this.datasetStore.datasetUpdated();
     });
-    this.slideIn.onClose$.pipe(untilDestroyed(this)).subscribe(() => {
-      this.datasetStore.datasetUpdated();
-    });
+    this.slideIn.onClose$
+      .pipe(
+        filter((value) => value.response === true),
+        untilDestroyed(this),
+      )
+      .subscribe(() => {
+        this.datasetStore.datasetUpdated();
+      });
   }
 
   get datasetHasRoles(): boolean {

--- a/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
+++ b/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
@@ -585,7 +585,7 @@ export class ZvolFormComponent {
     this.ws.call('pool.dataset.create', [data as DatasetCreate]).pipe(untilDestroyed(this)).subscribe({
       next: () => {
         this.isLoading = false;
-        this.slideInService.close();
+        this.slideInService.close(null, true);
       },
       error: (error) => {
         this.isLoading = false;
@@ -648,7 +648,7 @@ export class ZvolFormComponent {
           this.ws.call('pool.dataset.update', [this.parentId, data as DatasetUpdate]).pipe(untilDestroyed(this)).subscribe({
             next: () => {
               this.isLoading = false;
-              this.slideInService.close();
+              this.slideInService.close(null, true);
             },
             error: (error) => {
               this.isLoading = false;
@@ -659,7 +659,7 @@ export class ZvolFormComponent {
         } else {
           this.isLoading = false;
           this.dialogService.errorReport(helptext.zvol_save_errDialog.title, helptext.zvol_save_errDialog.msg);
-          this.slideInService.close();
+          this.slideInService.close(null, false);
         }
       },
       error: (error): void => {


### PR DESCRIPTION
For testing, you can go to the datasets page and click on the `Add Zvol (new)` button, and just close it. The `datasetUpdated` action should be ignored if the form wasn't submitted.