### PR TITLE
NAS-116316: Added error method for ws.job

### DIFF
--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -265,10 +265,15 @@ export class WebSocketService {
       this.call(method, params).pipe(
         switchMap((jobId) => this.subscribe('core.get_jobs').pipe(filter((event) => event.id === jobId))),
         untilDestroyed(this),
-      ).subscribe((event) => {
-        observer.next(event.fields);
-        if (event.fields.state === JobState.Success) observer.complete();
-        if (event.fields.state === JobState.Failed) observer.error(event.fields);
+      ).subscribe({
+        next: (event) => {
+          observer.next(event.fields);
+          if (event.fields.state === JobState.Success) observer.complete();
+          if (event.fields.state === JobState.Failed) observer.error(event.fields);
+        },
+        error: (error) => {
+          observer.error(error);
+        },
       });
     });
   }


### PR DESCRIPTION
Check the error handler for ws.job.
For example, replace the method with a nonexistent one for ws.job. 
`this.ws.job('non-existent_method' as any, ...`