### PR TITLE
NAS-119212 / 22.12 / Do not show "Checking HA status" on single node systems (by undsoft)

### DIFF
--- a/src/app/views/sessions/signin/signin.component.html
+++ b/src/app/views/sessions/signin/signin.component.html
@@ -3,7 +3,7 @@
     <mat-progress-bar
       value="0"
       class="session-progress"
-      [mode]="connected() ? 'determinate' : 'indeterminate'"
+      [mode]="hasLoadingIndicator ? 'indeterminate' : 'determinate'"
     ></mat-progress-bar>
     <mat-card>
       <mat-card-content>

--- a/src/app/views/sessions/signin/signin.component.html
+++ b/src/app/views/sessions/signin/signin.component.html
@@ -218,7 +218,7 @@
               </div>
             </div>
 
-            <span *ngIf="productSupportsHa && failoverStatus !== FailoverStatus.Single">
+            <span *ngIf="productSupportsHa && failoverStatus && failoverStatus !== FailoverStatus.Single">
               <div class="ha-status">
                 <div class="ha-status-txt">
                   <p>{{ haStatusText }}</p>

--- a/src/app/views/sessions/signin/signin.component.ts
+++ b/src/app/views/sessions/signin/signin.component.ts
@@ -284,6 +284,10 @@ export class SigninComponent implements OnInit, OnDestroy, AfterViewInit {
     return this.setPasswordFormGroup.get('instanceId');
   }
 
+  get hasLoadingIndicator(): boolean {
+    return !this.connected() || !this.isHaInfoReady;
+  }
+
   connected(): boolean {
     return this.ws.connected;
   }


### PR DESCRIPTION
See ticket description.
Basically replaces "Checking HA status" with a loading indicator.

Original PR: https://github.com/truenas/webui/pull/7421
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119212