### PR TITLE
NAS-119172 / 23.10 / fixed ix-select displays ids instead of labels (by Raz-Dva)

### DIFF
--- a/src/app/modules/ix-forms/components/ix-select/ix-select.component.html
+++ b/src/app/modules/ix-forms/components/ix-select/ix-select.component.html
@@ -16,7 +16,7 @@
       (ngModelChange)="onChange($event)"
     >
       <mat-select-trigger *ngIf="multiple">
-        {{ value }}
+        {{ multipleLabels }}
       </mat-select-trigger>
 
       <ng-container *ngIf="opts$ | async as opts; else loadingOrError">

--- a/src/app/modules/ix-forms/components/ix-select/ix-select.component.spec.ts
+++ b/src/app/modules/ix-forms/components/ix-select/ix-select.component.spec.ts
@@ -183,7 +183,9 @@ describe('IxSelectComponent', () => {
       await select.open();
       await select.clickOptions({ text: 'GBR' });
       await select.clickOptions({ text: 'GRL' });
+      const currentValue = await select.getValueText();
 
+      expect(currentValue).toBe('GBR, GRL');
       expect(control.value).toEqual(['Great Britain', 'Greenland']);
     });
   });

--- a/src/app/modules/ix-forms/components/ix-select/ix-select.component.ts
+++ b/src/app/modules/ix-forms/components/ix-select/ix-select.component.ts
@@ -34,11 +34,11 @@ export class IxSelectComponent implements ControlValueAccessor, OnChanges {
   hasErrorInOptions = false;
   opts$: Observable<SelectOption[]>;
   isLoading = false;
-  private opts: Option[];
+  private opts: Option[] = [];
 
   get multipleLabels(): string[] {
     const selectedLabels: string[] = [];
-    this?.opts?.forEach((opt) => {
+    this.opts.forEach((opt) => {
       if (Array.isArray(this.value)) {
         if (this.value.some((val) => val === opt.value)) {
           selectedLabels.push(` ${opt.label}`);
@@ -47,7 +47,7 @@ export class IxSelectComponent implements ControlValueAccessor, OnChanges {
         return null;
       }
     });
-    return selectedLabels.length ? selectedLabels : null;
+    return selectedLabels.length > 0 ? selectedLabels : null;
   }
 
   constructor(

--- a/src/app/modules/ix-forms/components/ix-select/ix-select.component.ts
+++ b/src/app/modules/ix-forms/components/ix-select/ix-select.component.ts
@@ -5,10 +5,10 @@ import {
 import {
   ControlValueAccessor, NgControl,
 } from '@angular/forms';
-import { UntilDestroy } from '@ngneat/until-destroy';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { EMPTY, Observable } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
-import { SelectOption } from 'app/interfaces/option.interface';
+import { Option, SelectOption } from 'app/interfaces/option.interface';
 
 type IxSelectValue = string | number | string[] | number[];
 
@@ -34,6 +34,21 @@ export class IxSelectComponent implements ControlValueAccessor, OnChanges {
   hasErrorInOptions = false;
   opts$: Observable<SelectOption[]>;
   isLoading = false;
+  private opts: Option[];
+
+  get multipleLabels(): string[] {
+    const selectedLabels: string[] = [];
+    this?.opts?.forEach((opt) => {
+      if (Array.isArray(this.value)) {
+        if (this.value.some((val) => val === opt.value)) {
+          selectedLabels.push(` ${opt.label}`);
+        }
+      } else {
+        return null;
+      }
+    });
+    return selectedLabels.length ? selectedLabels : null;
+  }
 
   constructor(
     public controlDirective: NgControl,
@@ -58,6 +73,10 @@ export class IxSelectComponent implements ControlValueAccessor, OnChanges {
           this.cdr.markForCheck();
         }),
       );
+
+      this.opts$.pipe(untilDestroyed(this)).subscribe((opts) => {
+        this.opts = opts;
+      });
     }
   }
 


### PR DESCRIPTION
Go to Credentials -> Local User -> root -> Edit
The field Auxiliary Groups should display labels not values.
Check out ix-select on other forms.

![image](https://user-images.githubusercontent.com/22006748/205405906-983384bb-4316-4bf6-8449-913374584476.png)
![image](https://user-images.githubusercontent.com/22006748/205405968-466224f3-c0e4-4fcc-95e3-d7306e0f6db8.png)


Original PR: https://github.com/truenas/webui/pull/7422
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119172