### PR TITLE
NAS-119301 / 23.10 / NAS-119370: Edit permissions - long dataset name problem

### DIFF
--- a/src/app/pages/datasets/modules/permissions/components/acl-editor-list/acl-editor-list.component.ts
+++ b/src/app/pages/datasets/modules/permissions/components/acl-editor-list/acl-editor-list.component.ts
@@ -97,6 +97,7 @@ export class AclEditorListComponent implements OnChanges {
   }
 
   onAceSelected(index: number): void {
-    this.store.selectAce(index);
+    this.store.selectAce(null);
+    setTimeout(() => this.store.selectAce(index));
   }
 }

--- a/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.ts
+++ b/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.ts
@@ -91,11 +91,11 @@ export class EditNfsAceComponent implements OnChanges, OnInit {
   ) {}
 
   get isUserTag(): boolean {
-    return this.ace.tag === NfsAclTag.User;
+    return this.form.value.tag === NfsAclTag.User;
   }
 
   get isGroupTag(): boolean {
-    return this.ace.tag === NfsAclTag.UserGroup;
+    return this.form.value.tag === NfsAclTag.UserGroup;
   }
 
   get arePermissionsBasic(): boolean {

--- a/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.ts
+++ b/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.ts
@@ -56,11 +56,11 @@ export class EditPosixAceComponent implements OnInit, OnChanges {
   ) {}
 
   get isUserTag(): boolean {
-    return this.ace.tag === PosixAclTag.User;
+    return this.form.value.tag === PosixAclTag.User;
   }
 
   get isGroupTag(): boolean {
-    return this.ace.tag === PosixAclTag.Group;
+    return this.form.value.tag === PosixAclTag.Group;
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
Testing: 
1. See bug [video]: 

https://user-images.githubusercontent.com/22980553/207462681-6b41692b-4ab9-4316-b823-26418dfd9f52.mp4

**2. Go to edit ACL page and check fix.**
