### PR TITLE
NAS-119437 / 23.10 / Use `ErrnoMixin.ENOTAUTHENTICATED` to redirect to the login page, not…

### DIFF
--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -116,7 +116,7 @@ export class WebSocketService {
       return;
     }
 
-    if ('error' in data && data.error.error === 13 /** Not Authenticated */) {
+    if ('error' in data && data.error.error === 207 /** Not Authenticated */) {
       return this.socket.close(); // will trigger onClose which handles redirection
     }
 


### PR DESCRIPTION
… `errno.EACCES` as it is a legitimate error code for many methods