### PR TITLE
Adjust storage widget layout

### DIFF
--- a/src/app/pages/dashboard/components/widget-storage/widget-storage.component.html
+++ b/src/app/pages/dashboard/components/widget-storage/widget-storage.component.html
@@ -21,7 +21,7 @@
             ix-auto-identifier="goBack"
             (click)="goBack()"
           >
-            <mat-icon class="back-arrow">chevron_left</mat-icon>
+            <ix-icon name="chevron_left" class="back-arrow"></ix-icon>
           </button>
 
           <span fxHide.gt-xs>&nbsp;&nbsp;</span>
@@ -43,13 +43,12 @@
               ix-auto-identifier="storageReports"
               [routerLink]="['/reportsdashboard/disk']"
             >
-              <mat-icon
+              <ix-icon
+                name="insert_chart"
                 matTooltipPosition="above"
                 aria-label="Disk Reports"
                 [matTooltip]="'Disk Reports' | translate"
-              >
-                insert_chart
-              </mat-icon>
+              ></ix-icon>
             </a>
           </div>
         </mat-toolbar-row>
@@ -89,14 +88,12 @@
                         ix-auto-identifier="poolStatus"
                         [routerLink]="['/storage', 'status', pool.id]"
                       >
-                        <mat-icon
-                          fontSet="mdi-set"
-                          fontIcon="mdi-database"
+                        <ix-icon
+                          name="mdi-database"
                           matTooltipPosition="above"
                           aria-label="Configure Pools"
                           [matTooltip]="'Pool Status' | translate"
-                        >
-                        </mat-icon>
+                        ></ix-icon>
                       </a>
                     </div>
                   </div>
@@ -106,13 +103,11 @@
                     fxLayout="row"
                     fxLayoutAlign="space-between center"
                   >
-                    <ul fxLayout="column" [fxFlex]="cols === 1 ? 31 : 100">
+                    <ul fxLayout="column" [fxFlex]="getSubwidgetColumnWidth(pool)">
                       <li fxLayout="row">
                         <span [class]="['icon', poolInfoMap[pool.name]?.status?.level]">
-                          <ix-icon
-                            [name]="poolInfoMap[pool.name]?.status?.icon"
-                          ></ix-icon
-                        ></span>
+                          <ix-icon [name]="poolInfoMap[pool.name]?.status?.icon"></ix-icon>
+                        </span>
                         <span class="label">
                           {{ 'Pool Status' | translate }}:
                         </span>
@@ -122,9 +117,7 @@
                       </li>
                       <li fxLayout="row">
                         <span [class]="['icon', poolInfoMap[pool.name]?.usedSpace?.level]">
-                          <ix-icon
-                            [name]="poolInfoMap[pool.name]?.usedSpace?.icon"
-                          ></ix-icon
+                          <ix-icon [name]="poolInfoMap[pool.name]?.usedSpace?.icon"></ix-icon
                         ></span>
                         <span class="label">
                           {{ 'Used Space' | translate }}:
@@ -138,9 +131,7 @@
                       </li>
                       <li fxLayout="row">
                         <span [class]="['icon', poolInfoMap[pool.name]?.disksWithError?.level]">
-                          <ix-icon
-                            [name]="poolInfoMap[pool.name]?.disksWithError?.icon"
-                          ></ix-icon>
+                          <ix-icon [name]="poolInfoMap[pool.name]?.disksWithError?.icon"></ix-icon>
                         </span>
                         <span class="label">
                           {{ 'Disks with Errors' | translate }}:
@@ -151,7 +142,7 @@
                       </li>
                       <li *ngIf="cols === 2 && rows === 2" fxLayout="row">
                         <span class="icon safe">
-                          <mat-icon>arrow_circle_right</mat-icon>
+                          <ix-icon name="arrow_circle_right"></ix-icon>
                         </span>
                         <span class="label">
                           {{ 'Path' | translate }}:
@@ -166,7 +157,7 @@
                     </ul>
                     <ng-container *ngIf="cols === 1">
                       <div class="divider"></div>
-                      <ul fxLayout="column" fxFlex="31">
+                      <ul fxLayout="column" [fxFlex]="getSubwidgetColumnWidth(pool)">
                         <li fxLayout="row">
                           <span class="label">
                             {{ 'Path' | translate }}:
@@ -196,7 +187,7 @@
                         </li>
                       </ul>
                       <div *ngIf="pool.topology" class="divider"></div>
-                      <ul *ngIf="pool.topology" fxLayout="column" fxFlex="31">
+                      <ul *ngIf="pool.topology" fxLayout="column" [fxFlex]="getSubwidgetColumnWidth(pool)">
                         <li fxLayout="row">
                           <span class="label">
                             {{ 'Data' | translate }}:
@@ -239,10 +230,7 @@
                   ix-auto-identifier="createNewPool"
                   [routerLink]="['/storage', 'create']"
                 >
-                  <mat-icon
-                    fontSet="mdi-set"
-                    fontIcon="mdi-database"
-                  ></mat-icon>
+                  <ix-icon name="mdi-database"></ix-icon>
                   <span>{{ 'Create Pool' | translate }}</span>
                 </a>
               </mat-grid-tile>

--- a/src/app/pages/dashboard/components/widget-storage/widget-storage.component.ts
+++ b/src/app/pages/dashboard/components/widget-storage/widget-storage.component.ts
@@ -68,6 +68,25 @@ export class WidgetStorageComponent extends WidgetComponent implements AfterView
   contentHeight = 400 - 56;
   rowHeight = 150;
 
+  getSubwidgetColumnWidth(pool: Pool): number {
+    const badStatus = [
+      PoolStatus.Locked,
+      PoolStatus.Unknown,
+      PoolStatus.Offline,
+      PoolStatus.Degraded,
+    ].includes(pool.status);
+
+    if (this.cols === 1 && !badStatus) {
+      return 31;
+    }
+
+    if (this.cols === 1 && badStatus) {
+      return 50;
+    }
+
+    return 100;
+  }
+
   constructor(public router: Router, public translate: TranslateService) {
     super(translate);
     this.configurable = false;


### PR DESCRIPTION
Before ![image](https://user-images.githubusercontent.com/351613/208364662-5ff25c74-7594-4dd2-9b74-07668fd3d87e.png)

After 
![image](https://user-images.githubusercontent.com/351613/208364732-363df64f-cc84-4e46-8bbd-232ac1d8e9a6.png)

For testing, try to export a pool and see the Storage widget on the Dashboard