### PR TITLE
NAS-119438 / 23.10 / Showing errors in rsync form (by undsoft)

### DIFF
--- a/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.ts
@@ -212,7 +212,9 @@ export class RsyncTaskFormComponent implements OnInit {
       },
       error: (error) => {
         this.isLoading = false;
-        this.errorHandler.handleWsFormError(error, this.form);
+        this.errorHandler.handleWsFormError(error, this.form, {
+          remotehost: 'remotepath',
+        });
         this.cdr.markForCheck();
       },
     });


### PR DESCRIPTION
I believe user has an issue where there was a validation error on one of the fields, but it was not visible because this field was behind an ngIf.
1. In Credentials -> Backup Credentials add an incorrect SSH connection.
2. In Data Protection -> Rsync try to create a task using Mode = SSH, Connect using = connection from keychain and select incorrect connection.

It's also possible that there is some other scenario for this.

Original PR: https://github.com/truenas/webui/pull/7475
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119438