### PR TITLE
NAS-119394 / 23.10 / Fix broken link on widgets

### DIFF
--- a/src/app/pages/dashboard/components/widget-pool/widget-pool.component.html
+++ b/src/app/pages/dashboard/components/widget-pool/widget-pool.component.html
@@ -57,7 +57,7 @@
               mat-icon-button
               ix-auto-type="button"
               ix-auto-identifier="poolStatus"
-              [routerLink]="['/storage', 'status', poolState.id]"
+              [routerLink]="['/storage']"
               [ix-auto]="poolState.name"
             >
               <mat-icon

--- a/src/app/pages/dashboard/components/widget-storage/widget-storage.component.html
+++ b/src/app/pages/dashboard/components/widget-storage/widget-storage.component.html
@@ -87,7 +87,7 @@
                         ix-auto
                         ix-auto-type="button"
                         ix-auto-identifier="poolStatus"
-                        [routerLink]="['/storage', 'status', pool.id]"
+                        [routerLink]="['/storage']"
                       >
                         <mat-icon
                           fontSet="mdi-set"


### PR DESCRIPTION
The Pool Status page does not exist anymore. However, some of that information is available on Pool Dashboard.