### PR TITLE
NAS-119482: Make TranslateService.instant more type safe

### DIFF
--- a/src/app/pages/dashboard/components/widget-storage/widget-storage.component.ts
+++ b/src/app/pages/dashboard/components/widget-storage/widget-storage.component.ts
@@ -130,7 +130,7 @@ export class WidgetStorageComponent extends WidgetComponent implements AfterView
   getStatusItemInfo(pool: Pool): ItemInfo {
     let level = StatusLevel.Safe;
     let icon = StatusIcon.CheckCircle;
-    let value = pool.status;
+    let value: string = pool.status;
 
     switch (pool.status) {
       case PoolStatus.Online:

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -258,11 +258,12 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, O
       pmin = '0' + pmin;
     }
 
+    // TODO: Replace with ICU strings
     if (days > 0) {
       if (days === 1) {
-        this.uptimeString += days + this.translate.instant(' day, ');
+        this.uptimeString += `${days}${this.translate.instant(' day, ')}`;
       } else {
-        this.uptimeString += days + this.translate.instant(' days, ') + `${hrs}:${pmin}`;
+        this.uptimeString += `${days}${this.translate.instant(' days, ')}${hrs}:${pmin}`;
       }
     } else if (hrs > 0) {
       this.uptimeString += `${hrs}:${pmin}`;

--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -91,10 +91,10 @@ export class CloudsyncFormComponent {
   });
 
   isLoading = false;
-  bucketPlaceholder = helptext.bucket_placeholder;
-  bucketTooltip = helptext.bucket_tooltip;
-  bucketInputPlaceholder = helptext.bucket_input_placeholder;
-  bucketInputTooltip = helptext.bucket_input_tooltip;
+  bucketPlaceholder: string = helptext.bucket_placeholder;
+  bucketTooltip: string = helptext.bucket_tooltip;
+  bucketInputPlaceholder: string = helptext.bucket_input_placeholder;
+  bucketInputTooltip: string = helptext.bucket_input_tooltip;
 
   readonly transferModeTooltip = `
     ${helptext.transfer_mode_warning_sync}<br><br>

--- a/src/app/pages/sharing/iscsi/iscsi.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi.component.ts
@@ -17,31 +17,31 @@ import { waitForSystemInfo } from 'app/store/system-info/system-info.selectors';
 export class IscsiComponent implements OnInit {
   activeTab = 'configuration';
   navLinks = [{
-    label: this.translate.instant('Target Global Configuration') as string,
+    label: this.translate.instant('Target Global Configuration'),
     path: '/sharing/iscsi/configuration',
   },
   {
-    label: this.translate.instant('Portals') as string,
+    label: this.translate.instant('Portals'),
     path: '/sharing/iscsi/portals',
   },
   {
-    label: this.translate.instant('Initiators Groups') as string,
+    label: this.translate.instant('Initiators Groups'),
     path: '/sharing/iscsi/initiator',
   },
   {
-    label: this.translate.instant('Authorized Access') as string,
+    label: this.translate.instant('Authorized Access'),
     path: '/sharing/iscsi/auth',
   },
   {
-    label: this.translate.instant('Targets') as string,
+    label: this.translate.instant('Targets'),
     path: '/sharing/iscsi/target',
   },
   {
-    label: this.translate.instant('Extents') as string,
+    label: this.translate.instant('Extents'),
     path: '/sharing/iscsi/extent',
   },
   {
-    label: this.translate.instant('Associated Targets') as string,
+    label: this.translate.instant('Associated Targets'),
     path: '/sharing/iscsi/associatedtarget',
   },
   ];

--- a/src/app/pages/sharing/iscsi/target/target-list/target-list.component.ts
+++ b/src/app/pages/sharing/iscsi/target/target-list/target-list.component.ts
@@ -31,12 +31,12 @@ export class TargetListComponent implements EntityTableConfig<IscsiTarget>, OnIn
 
   columns = [
     {
-      name: this.translate.instant('Target Name') as string,
+      name: this.translate.instant('Target Name'),
       prop: 'name',
       always_display: true,
     },
     {
-      name: this.translate.instant('Target Alias') as string,
+      name: this.translate.instant('Target Alias'),
       prop: 'alias',
     },
   ];

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -60,22 +60,22 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
 
   entityList: EntityTableComponent<VirtualMachineRow>;
   columns = [
-    { name: this.translate.instant('Name') as string, prop: 'name', always_display: true },
+    { name: this.translate.instant('Name'), prop: 'name', always_display: true },
     {
-      name: this.translate.instant('State') as string, prop: 'state', always_display: true, toggle: true,
+      name: this.translate.instant('State'), prop: 'state', always_display: true, toggle: true,
     },
     {
-      name: this.translate.instant('Autostart') as string, prop: 'autostart', checkbox: true, always_display: true,
+      name: this.translate.instant('Autostart'), prop: 'autostart', checkbox: true, always_display: true,
     },
-    { name: this.translate.instant('Virtual CPUs') as string, prop: 'vcpus', hidden: true },
-    { name: this.translate.instant('Cores') as string, prop: 'cores', hidden: true },
-    { name: this.translate.instant('Threads') as string, prop: 'threads', hidden: true },
-    { name: this.translate.instant('Memory Size') as string, prop: 'memoryString', hidden: true },
-    { name: this.translate.instant('Boot Loader Type') as string, prop: 'bootloader', hidden: true },
-    { name: this.translate.instant('System Clock') as string, prop: 'time', hidden: true },
-    { name: this.translate.instant('Display Port') as string, prop: 'port', hidden: true },
-    { name: this.translate.instant('Description') as string, prop: 'description', hidden: true },
-    { name: this.translate.instant('Shutdown Timeout') as string, prop: 'shutdownTimeoutString', hidden: true },
+    { name: this.translate.instant('Virtual CPUs'), prop: 'vcpus', hidden: true },
+    { name: this.translate.instant('Cores'), prop: 'cores', hidden: true },
+    { name: this.translate.instant('Threads'), prop: 'threads', hidden: true },
+    { name: this.translate.instant('Memory Size'), prop: 'memoryString', hidden: true },
+    { name: this.translate.instant('Boot Loader Type'), prop: 'bootloader', hidden: true },
+    { name: this.translate.instant('System Clock'), prop: 'time', hidden: true },
+    { name: this.translate.instant('Display Port'), prop: 'port', hidden: true },
+    { name: this.translate.instant('Description'), prop: 'description', hidden: true },
+    { name: this.translate.instant('Shutdown Timeout'), prop: 'shutdownTimeoutString', hidden: true },
   ];
   config = {
     paging: true,

--- a/src/app/types/ngx-translate-core.d.ts
+++ b/src/app/types/ngx-translate-core.d.ts
@@ -1,0 +1,7 @@
+import '@ngx-translate/core';
+
+declare module '@ngx-translate/core/lib/translate.service' {
+  interface TranslateService {
+    instant(key: string, interpolateParams?: Record<string, unknown>): string;
+  }
+}


### PR DESCRIPTION
`instant` in original `TranslateService` supports different styles of arguments and is typed to return `any`.
Since this is not something we need, this updates the typing.
Code review is enough.


If you have errors about JIT compilation, try removing `.angular` and `node_modules`.

