### PR TITLE
NAS-119437 / 22.12.1 / Use `ErrnoMixin.ENOTAUTHENTICATED` to redirect to the login page, not… (by themylogin)

### DIFF
--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -116,7 +116,7 @@ export class WebSocketService {
       return;
     }
 
-    if ('error' in data && data.error.error === 13 /** Not Authenticated */) {
+    if ('error' in data && data.error.error === 207 /** Not Authenticated */) {
       return this.socket.close(); // will trigger onClose which handles redirection
     }
 


### PR DESCRIPTION
… `errno.EACCES` as it is a legitimate error code for many methods

Original PR: https://github.com/truenas/webui/pull/7474
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119437