### PR TITLE
NAS-119668: Correctly report vdev width

### DIFF
--- a/src/app/core/testing/utils/mock-storage-generator.utils.ts
+++ b/src/app/core/testing/utils/mock-storage-generator.utils.ts
@@ -1,3 +1,4 @@
+import { PoolStatus } from 'app/enums/pool-status.enum';
 import { PoolTopologyCategory } from 'app/enums/pool-topology-category.enum';
 import { TopologyItemType } from 'app/enums/v-dev-type.enum';
 import { PoolInstance } from 'app/interfaces/pool.interface';
@@ -47,7 +48,7 @@ export class MockStorageGenerator {
       id: 1,
       name: 'MOCK_POOL',
       healthy: true,
-      status: 'ONLINE',
+      status: PoolStatus.Online,
       topology: {
         data: [],
         special: [],
@@ -56,7 +57,7 @@ export class MockStorageGenerator {
         cache: [],
         dedup: [],
       },
-    } as unknown as PoolInstance;
+    } as PoolInstance;
 
     const disks: StorageDashboardDisk[] = [];
 

--- a/src/app/core/testing/utils/mock-storage-generator.utils.ts
+++ b/src/app/core/testing/utils/mock-storage-generator.utils.ts
@@ -262,19 +262,17 @@ export class MockStorageGenerator {
       case TopologyItemType.Mirror: {
         const vdevDisks: TopologyDisk[] = [];
         for (let i = 0; i < width; i++) {
-          const topologyDisk: unknown = this.generateTopologyDisk();
-          vdevDisks.push(topologyDisk as TopologyDisk);
+          const topologyDisk: TopologyDisk = this.generateTopologyDisk();
+          vdevDisks.push(topologyDisk);
         }
 
-        const vdev: unknown = {
+        return {
           type: layout,
           children: vdevDisks,
           guid: Number(12345).toString(),
           unavail_disk: null,
           stats: { size: null } as TopologyItemStats,
-        };
-
-        return vdev as VDev;
+        } as VDev;
       }
       default:
         console.error('Invalid TopologyItemType. Please use STRIPE, MIRROR, RAIDZ etc');
@@ -282,7 +280,7 @@ export class MockStorageGenerator {
   }
 
   private generateTopologyDisk(): TopologyDisk {
-    const device: unknown = {
+    return {
       type: TopologyItemType.Disk,
       children: [],
       disk: null,
@@ -290,20 +288,13 @@ export class MockStorageGenerator {
       device: null,
       guid: Number(12345).toString(),
       unavail_disk: null,
-    };
-
-    return device as TopologyDisk;
+    } as TopologyDisk;
   }
 
   private calculateVdevCapacity(vdev: VDev): number {
-    const sizes: unknown[] = vdev.children.map((child) => child.stats.size);
+    const sizes: number[] = vdev.children.map((child) => child.stats.size);
     const uniqueDiskSizes = new Set(sizes);
     const smallestSize: number = Math.min.apply(this, [...uniqueDiskSizes]);
-    /* console.log({
-      sizes: sizes,
-      unique: uniqueDiskSizes,
-      smallest: smallestSize,
-    }); */
 
     switch (vdev.type) {
       case TopologyItemType.Mirror:

--- a/src/app/core/testing/utils/mock-storage-generator.utils.ts
+++ b/src/app/core/testing/utils/mock-storage-generator.utils.ts
@@ -1,0 +1,381 @@
+import { PoolTopologyCategory } from 'app/enums/pool-topology-category.enum';
+import { TopologyItemType } from 'app/enums/v-dev-type.enum';
+import { PoolInstance } from 'app/interfaces/pool.interface';
+import {
+  StorageDashboardDisk,
+  TopologyDisk,
+  TopologyItem,
+  TopologyItemStats,
+  VDev,
+} from 'app/interfaces/storage.interface';
+
+export enum MockStorageScenario {
+  Default = 'default',
+  Uniform = 'uniform',
+  Multi = 'multi', // Multiple problems
+  MixedVdevLayout = 'mixedVdevLayout',
+  MixedVdevCapacity = 'mixedVdevCapacity',
+  MixedDiskCapacity = 'mixedDiskCapacity',
+  MixedVdevWidth = 'mixedVdevWidth',
+  NoRedundancy = 'noRedundancy',
+}
+
+export interface MockStorage {
+  poolState: PoolInstance;
+  disks: StorageDashboardDisk[];
+}
+
+export interface MockTopology {
+  topologyItems: TopologyItem[];
+  disks: StorageDashboardDisk[];
+}
+
+export class MockStorageGenerator {
+  poolState: PoolInstance;
+  disks: StorageDashboardDisk[];
+
+  constructor() {
+    // Creates a pool with empty topologies
+    const storage = this.generateStorage();
+    this.poolState = storage.poolState;
+    this.disks = storage.disks;
+  }
+
+  // Generate Empty Topology & Disks
+  private generateStorage(): MockStorage {
+    const pool = {
+      id: 1,
+      name: 'MOCK_POOL',
+      healthy: true,
+      status: 'ONLINE',
+      topology: {
+        data: [],
+        special: [],
+        log: [],
+        spare: [],
+        cache: [],
+        dedup: [],
+      },
+    } as unknown as PoolInstance;
+
+    const disks: StorageDashboardDisk[] = [];
+
+    return { poolState: pool, disks };
+  }
+
+  addDataTopology(scenario: MockStorageScenario,
+    layout: TopologyItemType = TopologyItemType.Stripe,
+    diskSize = 4,
+    width = 1,
+    repeats = 1): MockStorageGenerator {
+    // The redundancy of this device should match the redundancy of the other normal devices in the pool
+    this.addRaidzCapableTopology(PoolTopologyCategory.Data, scenario, layout, diskSize, width, repeats);
+    return this;
+  }
+
+  addSpecialTopology(scenario: MockStorageScenario,
+    layout: TopologyItemType = TopologyItemType.Stripe,
+    diskSize = 4,
+    width = 1,
+    repeats = 1): MockStorageGenerator {
+    // The redundancy of this device should match the redundancy of the other normal devices in the pool
+    this.addRaidzCapableTopology(PoolTopologyCategory.Special, scenario, layout, diskSize, width, repeats);
+    return this;
+  }
+
+  addDedupTopology(scenario: MockStorageScenario,
+    layout: TopologyItemType = TopologyItemType.Stripe,
+    diskSize = 4,
+    width = 1,
+    repeats = 1): MockStorageGenerator {
+    // The redundancy of this device should match the redundancy of the other normal devices in the pool
+    this.addRaidzCapableTopology(PoolTopologyCategory.Dedup, scenario, layout, diskSize, width, repeats);
+    return this;
+  }
+
+  private addRaidzCapableTopology(category: PoolTopologyCategory,
+    scenario: MockStorageScenario,
+    layout: TopologyItemType = TopologyItemType.Stripe,
+    diskSize = 4,
+    width = 1,
+    repeats = 1): void {
+    switch (scenario) {
+      case MockStorageScenario.NoRedundancy: {
+        const noRedundancy: MockTopology = this.generateNoRedundancyTopology(4, diskSize, width);
+        this.disks = this.disks.concat(noRedundancy.disks);
+        this.poolState.topology[category] = this.poolState.topology[category]
+          .concat(noRedundancy.topologyItems);
+        break;
+      }
+      case MockStorageScenario.Uniform: {
+        if (layout === TopologyItemType.Stripe || layout === TopologyItemType.Disk) {
+          layout = TopologyItemType.Mirror;
+        }
+
+        const uniform = this.generateUniformTopology(layout, repeats, diskSize, width);
+        this.disks = this.disks.concat(uniform.disks);
+        this.poolState.topology[category] = this.poolState.topology[category].concat(uniform.topologyItems);
+        break;
+      }
+      case MockStorageScenario.MixedDiskCapacity: {
+        if (layout === TopologyItemType.Stripe || layout === TopologyItemType.Disk) {
+          layout = TopologyItemType.Mirror;
+        }
+
+        const mixedDisk = this.generateMixedDiskCapacityTopology(layout, repeats, diskSize, width);
+        this.disks = this.disks.concat(mixedDisk.disks);
+        this.poolState.topology[category] = this.poolState.topology[category]
+          .concat(mixedDisk.topologyItems);
+        break;
+      }
+    }
+  }
+
+  addLogTopology(deviceCount: number, isMirror = false, diskSize = 4): MockStorageGenerator {
+    // Only DISK or MIRROR devices. ZFS does not support RAIDZ
+    if (isMirror) {
+      this.addRaidzCapableTopology(PoolTopologyCategory.Log,
+        MockStorageScenario.Uniform,
+        TopologyItemType.Mirror,
+        diskSize,
+        2,
+        deviceCount);
+    } else {
+      this.addSingleDeviceTopology(PoolTopologyCategory.Log, deviceCount, diskSize);
+    }
+    return this;
+  }
+
+  addCacheTopology(deviceCount: number, diskSize = 4): MockStorageGenerator {
+    // Only DISK devices allowed. ZFS does not support MIRROR or RAIDZ
+    this.addSingleDeviceTopology(PoolTopologyCategory.Cache, deviceCount, diskSize);
+    return this;
+  }
+
+  addSpareTopology(deviceCount: number, diskSize = 4): MockStorageGenerator {
+    // Only DISK devices allowed. ZFS does not support MIRROR or RAIDZ
+    this.addSingleDeviceTopology(PoolTopologyCategory.Spare, deviceCount, diskSize);
+    return this;
+  }
+
+  private addSingleDeviceTopology(category: PoolTopologyCategory, deviceCount: number, diskSize = 4): void {
+    // Only DISK devices allowed. ZFS does not support MIRROR or RAIDZ
+    const topology: MockTopology = this.generateNoRedundancyTopology(deviceCount, diskSize, deviceCount);
+    this.disks = this.disks.concat(topology.disks);
+    this.poolState.topology[category] = this.poolState.topology[category].concat(topology.topologyItems);
+  }
+
+  // Generate Topology from Scenario
+  private generateUniformTopology(layout: TopologyItemType,
+    repeats: number,
+    diskSize: number,
+    width: number,
+    allDisks: StorageDashboardDisk[] = this.disks): MockTopology {
+    const vdevs: TopologyItem[] = [];
+    const disks: StorageDashboardDisk[] = [];
+
+    for (let i = 0; i < repeats; i++) {
+      const vdev: VDev = this.generateVdev(layout, width) as VDev;
+      vdev.children.forEach((child: TopologyDisk) => {
+        const disk = this.generateDisk(diskSize, (disks.length + allDisks.length));
+        child.disk = disk.name;
+        child.stats = { size: disk.size } as TopologyItemStats;
+        disks.push(disk);
+      });
+
+      vdev.stats.size = this.calculateVdevCapacity(vdev);
+      vdevs.push(vdev);
+    }
+
+    return {
+      topologyItems: vdevs,
+      disks,
+    };
+  }
+
+  private generateNoRedundancyTopology(repeats: number,
+    diskSize: number,
+    width: number,
+    allDisks: StorageDashboardDisk[] = this.disks): MockTopology {
+    const vdevs: TopologyItem[] = [];
+    const disks: StorageDashboardDisk[] = [];
+
+    for (let i = 0; i < repeats; i++) {
+      const vdev: TopologyDisk = this.generateVdev(TopologyItemType.Disk, width) as TopologyDisk;
+      const disk = this.generateDisk(diskSize, (disks.length + allDisks.length));
+      vdev.disk = disk.name;
+      vdevs.push(vdev);
+      disks.push(disk);
+    }
+
+    return {
+      topologyItems: vdevs,
+      disks,
+    };
+  }
+
+  private generateMixedDiskCapacityTopology(layout: TopologyItemType,
+    repeats: number,
+    diskSize: number,
+    width: number,
+    allDisks: StorageDashboardDisk[] = this.disks): MockTopology {
+    const vdevs: TopologyItem[] = [];
+    const disks: StorageDashboardDisk[] = [];
+
+    for (let i = 0; i < repeats; i++) {
+      const vdev: VDev = this.generateVdev(layout, width) as VDev;
+      vdev.children.forEach((child: TopologyDisk, index) => {
+        const childDiskSize = index === 0 ? diskSize + 1 : diskSize;
+        const disk = this.generateDisk(childDiskSize, (disks.length + allDisks.length));
+        child.disk = disk.name;
+        child.stats = { size: disk.size } as TopologyItemStats;
+        disks.push(disk);
+      });
+
+      vdev.stats.size = this.calculateVdevCapacity(vdev);
+      vdevs.push(vdev);
+    }
+
+    return {
+      topologyItems: vdevs,
+      disks,
+    };
+  }
+
+  // Generate VDEV
+  private generateVdev(layout: TopologyItemType, width = 1): TopologyDisk | VDev {
+    const minWidth = this.getMinLayoutWidth(layout);
+    if (width < minWidth) {
+      width = minWidth;
+    }
+
+    if (layout === TopologyItemType.Disk || layout === TopologyItemType.Stripe) {
+      return this.generateTopologyDisk();
+    }
+
+    switch (layout) {
+      case TopologyItemType.Raidz3:
+      case TopologyItemType.Raidz2:
+      case TopologyItemType.Raidz1:
+      case TopologyItemType.Raidz:
+      case TopologyItemType.Mirror: {
+        const vdevDisks: TopologyDisk[] = [];
+        for (let i = 0; i < width; i++) {
+          const topologyDisk: unknown = this.generateTopologyDisk();
+          vdevDisks.push(topologyDisk as TopologyDisk);
+        }
+
+        const vdev: unknown = {
+          type: layout,
+          children: vdevDisks,
+          guid: Number(12345).toString(),
+          unavail_disk: null,
+          stats: { size: null } as TopologyItemStats,
+        };
+
+        return vdev as VDev;
+      }
+      default:
+        console.error('Invalid TopologyItemType. Please use STRIPE, MIRROR, RAIDZ etc');
+    }
+  }
+
+  private generateTopologyDisk(): TopologyDisk {
+    const device: unknown = {
+      type: TopologyItemType.Disk,
+      children: [],
+      disk: null,
+      stats: { size: null } as TopologyItemStats,
+      device: null,
+      guid: Number(12345).toString(),
+      unavail_disk: null,
+    };
+
+    return device as TopologyDisk;
+  }
+
+  private calculateVdevCapacity(vdev: VDev): number {
+    const sizes: unknown[] = vdev.children.map((child) => child.stats.size);
+    const uniqueDiskSizes = new Set(sizes);
+    const smallestSize: number = Math.min.apply(this, [...uniqueDiskSizes]);
+    /* console.log({
+      sizes: sizes,
+      unique: uniqueDiskSizes,
+      smallest: smallestSize,
+    }); */
+
+    switch (vdev.type) {
+      case TopologyItemType.Mirror:
+        return vdev.children[0].stats.size;
+      case TopologyItemType.Raidz:
+      case TopologyItemType.Raidz1:
+        return smallestSize * (sizes.length - 1);
+      case TopologyItemType.Raidz2:
+        return smallestSize * (sizes.length - 2);
+      case TopologyItemType.Raidz3:
+        return smallestSize * (sizes.length - 3);
+    }
+  }
+
+  // Generate Disks
+  private getMinLayoutWidth(layout: TopologyItemType): number {
+    let width = 0;
+
+    switch (layout) {
+      case TopologyItemType.Stripe:
+        width = 1;
+        break;
+      case TopologyItemType.Mirror:
+        width = 2;
+        break;
+      case TopologyItemType.Raidz1:
+        width = 3;
+        break;
+      case TopologyItemType.Raidz2:
+        width = 4;
+        break;
+      case TopologyItemType.Raidz3:
+        width = 5;
+        break;
+      default:
+        width = 0;
+        break;
+    }
+
+    return width;
+  }
+
+  private generateDiskName(diskCount: number, startIndex = 0): string[] {
+    const diskNames: string[] = [];
+
+    const generateName = (index: number): string => {
+      let result = '';
+      do {
+        result = (index % 26 + 10).toString(36) + result;
+        index = Math.floor(index / 26) - 1;
+      } while (index >= 0);
+      return result;
+    };
+
+    for (let i = startIndex; i < diskCount; i++) {
+      const name = generateName(i);
+      diskNames.push('sd' + name);
+    }
+
+    return diskNames;
+  }
+
+  private generateDisk(size: number, offset: number): StorageDashboardDisk {
+    const name = this.generateDiskName(2 + offset, offset)[0];
+
+    return {
+      name,
+      devname: name,
+      size: this.terabytesToBytes(size),
+    } as StorageDashboardDisk;
+  }
+
+  private terabytesToBytes(tb: number): number {
+    return tb * 1024 * 1024 * 1024 * 1024;
+  }
+}

--- a/src/app/enums/v-dev-type.enum.ts
+++ b/src/app/enums/v-dev-type.enum.ts
@@ -1,6 +1,7 @@
 // TODO: This may actually be several enums. Consider splitting.
 export enum TopologyItemType {
   Disk = 'DISK',
+  Stripe = 'STRIPE',
   Mirror = 'MIRROR',
   Spare = 'SPARE',
   Log = 'LOG',
@@ -8,6 +9,9 @@ export enum TopologyItemType {
   Root = 'ROOT',
   File = 'FILE',
   Raidz = 'RAIDZ',
+  Raidz1 = 'RAIDZ1',
+  Raidz2 = 'RAIDZ2',
+  Raidz3 = 'RAIDZ3',
   L2Cache = 'L2CACHE',
   Replacing = 'REPLACING',
 }
@@ -18,4 +22,13 @@ export enum CreateVdevLayout {
   Raidz1 = 'RAIDZ1',
   Raidz2 = 'RAIDZ2',
   Raidz3 = 'RAIDZ3',
+}
+
+export enum TopologyWarning {
+  MixedVdevLayout = 'Mixed VDEV types',
+  MixedVdevCapacity = 'Mixed VDEV capacities',
+  MixedDiskCapacity = 'Mixed Disk Capacities',
+  MixedVdevWidth = 'Mixed VDEV widths',
+  NoRedundancy = 'No redundancy',
+  RedundancyMismatch = 'Redundancy Mismatch',
 }

--- a/src/app/enums/v-dev-type.enum.ts
+++ b/src/app/enums/v-dev-type.enum.ts
@@ -26,9 +26,9 @@ export enum CreateVdevLayout {
 
 export enum TopologyWarning {
   MixedVdevLayout = 'Mixed VDEV types',
-  MixedVdevCapacity = 'Mixed VDEV capacities',
+  MixedVdevCapacity = 'Mixed VDEV Capacities',
   MixedDiskCapacity = 'Mixed Disk Capacities',
-  MixedVdevWidth = 'Mixed VDEV widths',
-  NoRedundancy = 'No redundancy',
+  MixedVdevWidth = 'Mixed VDEV Widths',
+  NoRedundancy = 'No Redundancy',
   RedundancyMismatch = 'Redundancy Mismatch',
 }

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
@@ -19,7 +19,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Data VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.data === mixedDev" class="warning">
+          <span *ngIf="topologyState.data === mixedCapacity" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.data }}</span>
@@ -28,7 +28,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Metadata VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.metadata === mixedDev" class="warning">
+          <span *ngIf="topologyState.metadata === mixedCapacity" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.metadata }}</span>
@@ -37,7 +37,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Log VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.log === mixedDev" class="warning">
+          <span *ngIf="topologyState.log === mixedCapacity" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.log }}</span>
@@ -46,7 +46,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Cache VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.cache === mixedDev" class="warning">
+          <span *ngIf="topologyState.cache === mixedCapacity" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.cache }}</span>
@@ -55,7 +55,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Spare VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.spare === mixedDev" class="warning">
+          <span *ngIf="topologyState.spare === mixedCapacity" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.spare }}</span>
@@ -64,7 +64,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Dedup VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.dedup === mixedDev" class="warning">
+          <span *ngIf="topologyState.dedup === mixedCapacity" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.dedup }}</span>

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
@@ -19,7 +19,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Data VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.data === mixedCapacity" class="warning">
+          <span *ngIf="isTopologyWarning(topologyState.data)" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.data }}</span>
@@ -28,7 +28,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Metadata VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.metadata === mixedCapacity" class="warning">
+          <span *ngIf="isTopologyWarning(topologyState.metadata)" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.metadata }}</span>
@@ -37,7 +37,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Log VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.log === mixedCapacity" class="warning">
+          <span *ngIf="isTopologyWarning(topologyState.log)" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.log }}</span>
@@ -46,7 +46,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Cache VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.cache === mixedCapacity" class="warning">
+          <span *ngIf="isTopologyWarning(topologyState.cache)" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.cache }}</span>
@@ -55,7 +55,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Spare VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.spare === mixedCapacity" class="warning">
+          <span *ngIf="isTopologyWarning(topologyState.spare)" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.spare }}</span>
@@ -64,7 +64,7 @@
       <div class="vdev-line" fxLayoutAlign="space-between center">
         <b>{{ 'Dedup VDEVs' | translate }}</b>
         <div fxLayout="row" fxLayoutAlign="center center">
-          <span *ngIf="topologyState.dedup === mixedCapacity" class="warning">
+          <span *ngIf="isTopologyWarning(topologyState.dedup)" class="warning">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.dedup }}</span>

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
@@ -35,31 +35,39 @@ describe('TopologyCardComponent', () => {
             data: [
               {
                 type: CreateVdevLayout.Raidz1,
-                children: [{ type: 'DISK', disk: 'sda' }, { type: 'DISK', disk: 'sdb' }, { type: 'DISK', disk: 'sdc' }],
+                children: [
+                  { type: 'DISK', disk: 'sda' },
+                  { type: 'DISK', disk: 'sdb' },
+                  { type: 'DISK', disk: 'sdc' },
+                ],
               },
               {
                 type: CreateVdevLayout.Raidz1,
-                children: [{ type: 'DISK', disk: 'sdd' }, { type: 'DISK', disk: 'sde' }],
+                children: [
+                  { type: 'DISK', disk: 'sdd' },
+                  { type: 'DISK', disk: 'sde' },
+                  { type: 'DISK', disk: 'sdf' },
+                ],
               },
             ],
             log: [
               {
                 type: CreateVdevLayout.Mirror,
-                children: [{ type: 'DISK', disk: 'sdf' }, { type: 'DISK', disk: 'sdg' }],
+                children: [{ type: 'DISK', disk: 'sdg' }, { type: 'DISK', disk: 'sdh' }],
               },
             ],
             cache: [
-              { type: 'DISK', disk: 'sdh', children: [] },
               { type: 'DISK', disk: 'sdi', children: [] },
+              { type: 'DISK', disk: 'sdj', children: [] },
             ],
             spare: [
-              { type: 'DISK', disk: 'sdj', children: [] },
               { type: 'DISK', disk: 'sdk', children: [] },
+              { type: 'DISK', disk: 'sdl', children: [] },
             ],
             special: [
               {
                 type: CreateVdevLayout.Mirror,
-                children: [{ type: 'DISK', disk: 'sdl' }, { type: 'DISK', disk: 'sdm' }],
+                children: [{ type: 'DISK', disk: 'sdm' }, { type: 'DISK', disk: 'sdn' }],
               },
             ],
             dedup: [],
@@ -71,14 +79,15 @@ describe('TopologyCardComponent', () => {
           { name: 'sdc', devname: 'sdc', size: 1073741824 * 2 },
           { name: 'sdd', devname: 'sdd', size: 1073741824 * 2 },
           { name: 'sde', devname: 'sde', size: 1073741824 * 2 },
-          { name: 'sdf', devname: 'sdf', size: 1048576 * 5 },
+          { name: 'sdf', devname: 'sdf', size: 1073741824 * 2 },
           { name: 'sdg', devname: 'sdg', size: 1048576 * 5 },
-          { name: 'sdh', devname: 'sdh', size: 1048576 * 6 },
+          { name: 'sdh', devname: 'sdh', size: 1048576 * 5 },
           { name: 'sdi', devname: 'sdi', size: 1048576 * 6 },
-          { name: 'sdj', devname: 'sdj', size: 1048576 * 4 },
-          { name: 'sdk', devname: 'sdk', size: 1048576 * 3 },
-          { name: 'sdl', devname: 'sdl', size: 1073741824 * 2 },
-          { name: 'sdm', devname: 'sdm', size: 1073741824 * 1 },
+          { name: 'sdj', devname: 'sdj', size: 1048576 * 6 },
+          { name: 'sdk', devname: 'sdk', size: 1048576 * 4 },
+          { name: 'sdl', devname: 'sdl', size: 1048576 * 3 },
+          { name: 'sdm', devname: 'sdm', size: 1073741824 * 2 },
+          { name: 'sdn', devname: 'sdn', size: 1073741824 * 1 },
         ] as StorageDashboardDisk[],
       },
     });
@@ -92,7 +101,7 @@ describe('TopologyCardComponent', () => {
     expect(values).toHaveLength(6);
 
     expect(captions[0]).toHaveText('Data VDEVs');
-    expect(values[0]).toHaveText('2 x RAIDZ1 | 5 wide | 2 GiB');
+    expect(values[0]).toHaveText('2 x RAIDZ1 | 3 wide | 2 GiB');
     expect(captions[1]).toHaveText('Metadata');
     expect(values[1]).toHaveText('Mixed Capacity VDEVs');
     expect(captions[2]).toHaveText('Log VDEVs');

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
@@ -34,14 +34,21 @@ describe('TopologyCardComponent', () => {
     const storage = new MockStorageGenerator();
 
     // Add Topologies to Storage
-    // storage.addDataTopology(MockStorageScenario.NoRedundancy)
-    // storage.addDataTopology(MockStorageScenario.Uniform, TopologyItemType.Raidz1,6,3,400)
-    storage.addDataTopology(MockStorageScenario.MixedDiskCapacity, TopologyItemType.Raidz1, 8, 12, 1)
-      .addSpecialTopology(MockStorageScenario.Uniform, TopologyItemType.Mirror, 8, 3, 2)
-      .addLogTopology(2, true, 2)
+    storage.addDataTopology({
+      scenario: MockStorageScenario.MixedDiskCapacity,
+      layout: TopologyItemType.Raidz1,
+      diskSize: 8,
+      width: 12,
+      repeats: 1,
+    }).addSpecialTopology({
+      scenario: MockStorageScenario.Uniform,
+      layout: TopologyItemType.Mirror,
+      diskSize: 8,
+      width: 3,
+      repeats: 2,
+    }).addLogTopology(2, true, 2)
       .addCacheTopology(2, 2)
       .addSpareTopology(3, 8);
-    // .addDedupTopology(MockStorageScenario.Uniform, TopologyItemType.Raidz3,12,4,2)
 
     spectator = createComponent({
       props: {

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
@@ -36,10 +36,10 @@ describe('TopologyCardComponent', () => {
     // Add Topologies to Storage
     storage.addDataTopology({
       scenario: MockStorageScenario.Uniform,
-      layout: TopologyItemType.Raidz2,
+      layout: TopologyItemType.Mirror,
       diskSize: 8,
-      width: 12,
-      repeats: 1,
+      width: 2,
+      repeats: 6,
     }).addSpecialTopology({
       scenario: MockStorageScenario.Uniform,
       layout: TopologyItemType.Mirror,
@@ -66,8 +66,7 @@ describe('TopologyCardComponent', () => {
     expect(values).toHaveLength(6);
 
     expect(captions[0]).toHaveText('Data VDEVs');
-    expect(values[0]).toHaveText('1 x RAIDZ2 | 12 wide | 8 TiB');
-    // expect(values[0]).toHaveText('Mixed Disk Capacities');
+    expect(values[0]).toHaveText('6 x MIRROR | 2 wide | 8 TiB');
 
     // Can be Disk or MIRROR
     expect(captions[2]).toHaveText('Log VDEVs');

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
@@ -2,7 +2,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { PoolCardIconType } from 'app/enums/pool-card-icon-type.enum';
-import { CreateVdevLayout } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, TopologyItemType } from 'app/enums/v-dev-type.enum';
 import { Pool } from 'app/interfaces/pool.interface';
 import { StorageDashboardDisk } from 'app/interfaces/storage.interface';
 import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
@@ -36,17 +36,17 @@ describe('TopologyCardComponent', () => {
               {
                 type: CreateVdevLayout.Raidz1,
                 children: [
-                  { type: 'DISK', disk: 'sda' },
-                  { type: 'DISK', disk: 'sdb' },
-                  { type: 'DISK', disk: 'sdc' },
+                  { type: TopologyItemType.Disk, disk: 'sda' },
+                  { type: TopologyItemType.Disk, disk: 'sdb' },
+                  { type: TopologyItemType.Disk, disk: 'sdc' },
                 ],
               },
               {
                 type: CreateVdevLayout.Raidz1,
                 children: [
-                  { type: 'DISK', disk: 'sdd' },
-                  { type: 'DISK', disk: 'sde' },
-                  { type: 'DISK', disk: 'sdf' },
+                  { type: TopologyItemType.Disk, disk: 'sdd' },
+                  { type: TopologyItemType.Disk, disk: 'sde' },
+                  { type: TopologyItemType.Disk, disk: 'sdf' },
                 ],
               },
             ],
@@ -54,25 +54,25 @@ describe('TopologyCardComponent', () => {
               {
                 type: CreateVdevLayout.Mirror,
                 children: [
-                  { type: 'DISK', disk: 'sdg' },
-                  { type: 'DISK', disk: 'sdh' },
+                  { type: TopologyItemType.Disk, disk: 'sdg' },
+                  { type: TopologyItemType.Disk, disk: 'sdh' },
                 ],
               },
             ],
             cache: [
-              { type: 'DISK', disk: 'sdi', children: [] },
-              { type: 'DISK', disk: 'sdj', children: [] },
+              { type: TopologyItemType.Disk, disk: 'sdi', children: [] },
+              { type: TopologyItemType.Disk, disk: 'sdj', children: [] },
             ],
             spare: [
-              { type: 'DISK', disk: 'sdk', children: [] },
-              { type: 'DISK', disk: 'sdl', children: [] },
+              { type: TopologyItemType.Disk, disk: 'sdk', children: [] },
+              { type: TopologyItemType.Disk, disk: 'sdl', children: [] },
             ],
             special: [
               {
                 type: CreateVdevLayout.Mirror,
                 children: [
-                  { type: 'DISK', disk: 'sdm' },
-                  { type: 'DISK', disk: 'sdn' },
+                  { type: TopologyItemType.Disk, disk: 'sdm' },
+                  { type: TopologyItemType.Disk, disk: 'sdn' },
                 ],
               },
             ],

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
@@ -35,8 +35,8 @@ describe('TopologyCardComponent', () => {
 
     // Add Topologies to Storage
     storage.addDataTopology({
-      scenario: MockStorageScenario.MixedDiskCapacity,
-      layout: TopologyItemType.Raidz1,
+      scenario: MockStorageScenario.Uniform,
+      layout: TopologyItemType.Raidz2,
       diskSize: 8,
       width: 12,
       repeats: 1,
@@ -45,7 +45,7 @@ describe('TopologyCardComponent', () => {
       layout: TopologyItemType.Mirror,
       diskSize: 8,
       width: 3,
-      repeats: 2,
+      repeats: 1,
     }).addLogTopology(2, true, 2)
       .addCacheTopology(2, 2)
       .addSpareTopology(3, 8);
@@ -66,8 +66,8 @@ describe('TopologyCardComponent', () => {
     expect(values).toHaveLength(6);
 
     expect(captions[0]).toHaveText('Data VDEVs');
-    // expect(values[0]).toHaveText('400 x RAIDZ1 | 3 wide | 6 TiB');
-    expect(values[0]).toHaveText('Mixed Disk Capacities');
+    expect(values[0]).toHaveText('1 x RAIDZ2 | 12 wide | 8 TiB');
+    // expect(values[0]).toHaveText('Mixed Disk Capacities');
 
     // Can be Disk or MIRROR
     expect(captions[2]).toHaveText('Log VDEVs');

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
@@ -1,12 +1,15 @@
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
+import { MockStorageGenerator, MockStorageScenario } from 'app/core/testing/utils/mock-storage-generator.utils';
+import { mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { PoolCardIconType } from 'app/enums/pool-card-icon-type.enum';
-import { CreateVdevLayout, TopologyItemType } from 'app/enums/v-dev-type.enum';
+import { TopologyItemType } from 'app/enums/v-dev-type.enum';
 import { Pool } from 'app/interfaces/pool.interface';
-import { StorageDashboardDisk } from 'app/interfaces/storage.interface';
 import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
-import { PoolCardIconComponent } from 'app/pages/storage/components/dashboard-pool/pool-card-icon/pool-card-icon.component';
+import {
+  PoolCardIconComponent,
+} from 'app/pages/storage/components/dashboard-pool/pool-card-icon/pool-card-icon.component';
 import { TopologyCardComponent } from 'app/pages/storage/components/dashboard-pool/topology-card/topology-card.component';
 
 describe('TopologyCardComponent', () => {
@@ -21,80 +24,29 @@ describe('TopologyCardComponent', () => {
     declarations: [
       MockComponent(PoolCardIconComponent),
     ],
+    providers: [
+      mockWebsocket(),
+    ],
   });
 
   beforeEach(() => {
+    // Create storage object with empty topologies
+    const storage = new MockStorageGenerator();
+
+    // Add Topologies to Storage
+    // storage.addDataTopology(MockStorageScenario.NoRedundancy)
+    // storage.addDataTopology(MockStorageScenario.Uniform, TopologyItemType.Raidz1,6,3,400)
+    storage.addDataTopology(MockStorageScenario.MixedDiskCapacity, TopologyItemType.Raidz1, 8, 12, 1)
+      .addSpecialTopology(MockStorageScenario.Uniform, TopologyItemType.Mirror, 8, 3, 2)
+      .addLogTopology(2, true, 2)
+      .addCacheTopology(2, 2)
+      .addSpareTopology(3, 8);
+    // .addDedupTopology(MockStorageScenario.Uniform, TopologyItemType.Raidz3,12,4,2)
+
     spectator = createComponent({
       props: {
-        poolState: {
-          id: 1,
-          name: 'test pool',
-          healthy: true,
-          status: 'ONLINE',
-          topology: {
-            data: [
-              {
-                type: CreateVdevLayout.Raidz1,
-                children: [
-                  { type: TopologyItemType.Disk, disk: 'sda' },
-                  { type: TopologyItemType.Disk, disk: 'sdb' },
-                  { type: TopologyItemType.Disk, disk: 'sdc' },
-                ],
-              },
-              {
-                type: CreateVdevLayout.Raidz1,
-                children: [
-                  { type: TopologyItemType.Disk, disk: 'sdd' },
-                  { type: TopologyItemType.Disk, disk: 'sde' },
-                  { type: TopologyItemType.Disk, disk: 'sdf' },
-                ],
-              },
-            ],
-            log: [
-              {
-                type: CreateVdevLayout.Mirror,
-                children: [
-                  { type: TopologyItemType.Disk, disk: 'sdg' },
-                  { type: TopologyItemType.Disk, disk: 'sdh' },
-                ],
-              },
-            ],
-            cache: [
-              { type: TopologyItemType.Disk, disk: 'sdi', children: [] },
-              { type: TopologyItemType.Disk, disk: 'sdj', children: [] },
-            ],
-            spare: [
-              { type: TopologyItemType.Disk, disk: 'sdk', children: [] },
-              { type: TopologyItemType.Disk, disk: 'sdl', children: [] },
-            ],
-            special: [
-              {
-                type: CreateVdevLayout.Mirror,
-                children: [
-                  { type: TopologyItemType.Disk, disk: 'sdm' },
-                  { type: TopologyItemType.Disk, disk: 'sdn' },
-                ],
-              },
-            ],
-            dedup: [],
-          },
-        } as unknown as Pool,
-        disks: [
-          { name: 'sda', devname: 'sda', size: 1073741824 * 2 },
-          { name: 'sdb', devname: 'sdb', size: 1073741824 * 2 },
-          { name: 'sdc', devname: 'sdc', size: 1073741824 * 2 },
-          { name: 'sdd', devname: 'sdd', size: 1073741824 * 2 },
-          { name: 'sde', devname: 'sde', size: 1073741824 * 2 },
-          { name: 'sdf', devname: 'sdf', size: 1073741824 * 2 },
-          { name: 'sdg', devname: 'sdg', size: 1048576 * 5 },
-          { name: 'sdh', devname: 'sdh', size: 1048576 * 5 },
-          { name: 'sdi', devname: 'sdi', size: 1048576 * 6 },
-          { name: 'sdj', devname: 'sdj', size: 1048576 * 6 },
-          { name: 'sdk', devname: 'sdk', size: 1048576 * 4 },
-          { name: 'sdl', devname: 'sdl', size: 1048576 * 3 },
-          { name: 'sdm', devname: 'sdm', size: 1073741824 * 2 },
-          { name: 'sdn', devname: 'sdn', size: 1073741824 * 1 },
-        ] as StorageDashboardDisk[],
+        poolState: storage.poolState as unknown as Pool,
+        disks: storage.disks,
       },
     });
   });
@@ -102,20 +54,29 @@ describe('TopologyCardComponent', () => {
   it('rendering VDEVs rows', () => {
     const captions = spectator.queryAll('.vdev-line b');
     const values = spectator.queryAll('.vdev-line .vdev-value');
-    expect(spectator.queryAll('.vdev-line .warning ix-icon')).toHaveLength(2);
+    expect(spectator.queryAll('.vdev-line .warning ix-icon')).toHaveLength(1);
     expect(captions).toHaveLength(6);
     expect(values).toHaveLength(6);
 
     expect(captions[0]).toHaveText('Data VDEVs');
-    expect(values[0]).toHaveText('2 x RAIDZ1 | 3 wide | 2 GiB');
-    expect(captions[1]).toHaveText('Metadata');
-    expect(values[1]).toHaveText('Mixed Capacity VDEVs');
+    // expect(values[0]).toHaveText('400 x RAIDZ1 | 3 wide | 6 TiB');
+    expect(values[0]).toHaveText('Mixed Disk Capacities');
+
+    // Can be Disk or MIRROR
     expect(captions[2]).toHaveText('Log VDEVs');
-    expect(values[2]).toHaveText('1 x MIRROR | 2 wide | 5 MiB');
+    expect(values[2]).toHaveText('2 x MIRROR | 2 wide | 2 TiB');
+
+    // Can be DISK Only
     expect(captions[3]).toHaveText('Cache VDEVs');
-    expect(values[3]).toHaveText('2 x 6 MiB');
+    expect(values[3]).toHaveText('2 x 2 TiB');
+
+    // Can be DISK only but should also be same size or larger than disk sizes used in data VDEVs
     expect(captions[4]).toHaveText('Spare VDEVs');
-    expect(values[4]).toHaveText('Mixed Capacity VDEVs');
+    expect(values[4]).toHaveText('3 x 8 TiB');
+
+    // Redundancy level should match data VDEVs
+    expect(captions[1]).toHaveText('Metadata');
+    expect(values[1]).toHaveText('Redundancy Mismatch');
     expect(captions[5]).toHaveText('Dedup VDEVs');
     expect(values[5]).toHaveText('VDEVs not assigned');
   });

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
@@ -53,7 +53,10 @@ describe('TopologyCardComponent', () => {
             log: [
               {
                 type: CreateVdevLayout.Mirror,
-                children: [{ type: 'DISK', disk: 'sdg' }, { type: 'DISK', disk: 'sdh' }],
+                children: [
+                  { type: 'DISK', disk: 'sdg' },
+                  { type: 'DISK', disk: 'sdh' },
+                ],
               },
             ],
             cache: [
@@ -67,7 +70,10 @@ describe('TopologyCardComponent', () => {
             special: [
               {
                 type: CreateVdevLayout.Mirror,
-                children: [{ type: 'DISK', disk: 'sdm' }, { type: 'DISK', disk: 'sdn' }],
+                children: [
+                  { type: 'DISK', disk: 'sdm' },
+                  { type: 'DISK', disk: 'sdn' },
+                ],
               },
             ],
             dedup: [],

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
@@ -97,7 +97,7 @@ export class TopologyCardComponent implements OnInit, OnChanges {
     let isMixedCapacity = false;
     let isMixedWidth = false;
     let vdevWidth = 0;
-    // let allVdevWidths: number[] = []; // There should only be one value
+
     const allVdevWidths = new Set<number>(); // There should only be one value
     const type = devs[0]?.type;
     const size = devs[0]?.children.length

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
@@ -157,6 +157,7 @@ export class TopologyCardComponent implements OnInit, OnChanges {
 
     switch (topologyState) {
       case TopologyWarning.NoRedundancy:
+      case TopologyWarning.RedundancyMismatch:
       case TopologyWarning.MixedVdevLayout:
       case TopologyWarning.MixedVdevCapacity:
       case TopologyWarning.MixedDiskCapacity:

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
@@ -111,9 +111,16 @@ export class TopologyCardComponent implements OnInit, OnChanges {
 
     // There should only be one value
     const allVdevWidths: Set<number> = this.storageService.getVdevWidths(vdevs);
-
     const isMixedWidth = this.storageService.isMixedWidth(allVdevWidths);
-    if (!isMixedWidth) {
+    let isSingleDeviceCategory = false;
+
+    switch (category) {
+      case PoolTopologyCategory.Spare:
+      case PoolTopologyCategory.Cache:
+        isSingleDeviceCategory = true;
+    }
+
+    if (!isMixedWidth && !isSingleDeviceCategory) {
       vdevWidth = allVdevWidths.values().next().value;
     }
 

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
@@ -8,7 +8,7 @@ import filesize from 'filesize';
 import { PoolCardIconType } from 'app/enums/pool-card-icon-type.enum';
 import { PoolStatus } from 'app/enums/pool-status.enum';
 import { PoolTopologyCategory } from 'app/enums/pool-topology-category.enum';
-import { TopologyItemType, TopologyWarning } from 'app/enums/v-dev-type.enum';
+import { TopologyWarning } from 'app/enums/v-dev-type.enum';
 import { Pool, PoolTopology } from 'app/interfaces/pool.interface';
 import { StorageDashboardDisk, TopologyDisk, TopologyItem } from 'app/interfaces/storage.interface';
 import { StorageService } from 'app/services';
@@ -84,15 +84,26 @@ export class TopologyCardComponent implements OnInit, OnChanges {
     }
 
     this.topologyState.data = this.parseDevs(topology.data, PoolTopologyCategory.Data);
-    this.topologyState.metadata = this.parseDevs(topology.special, PoolTopologyCategory.Special, topology.data[0].type);
     this.topologyState.log = this.parseDevs(topology.log, PoolTopologyCategory.Log);
     this.topologyState.cache = this.parseDevs(topology.cache, PoolTopologyCategory.Cache);
     this.topologyState.spare = this.parseDevs(topology.spare, PoolTopologyCategory.Spare);
-    this.topologyState.dedup = this.parseDevs(topology.dedup, PoolTopologyCategory.Dedup, topology.data[0].type);
+
+    this.topologyState.metadata = this.parseDevs(
+      topology.special,
+      PoolTopologyCategory.Special,
+      topology.data,
+    );
+    this.topologyState.dedup = this.parseDevs(
+      topology.dedup,
+      PoolTopologyCategory.Dedup,
+      topology.data,
+    );
   }
 
-  private parseDevs(vdevs: TopologyItem[], category: PoolTopologyCategory, dataLayout?: TopologyItemType): string {
-    const warnings = this.storageService.validateVdevs(category, vdevs, this.disks, dataLayout);
+  private parseDevs(vdevs: TopologyItem[],
+    category: PoolTopologyCategory,
+    dataVdevs?: TopologyItem[]): string {
+    const warnings = this.storageService.validateVdevs(category, vdevs, this.disks, dataVdevs);
     let outputString = vdevs.length ? '' : notAssignedDev;
 
     // Check VDEV Widths

--- a/src/app/services/storage.service.spec.ts
+++ b/src/app/services/storage.service.spec.ts
@@ -1,4 +1,12 @@
 import { HttpClient } from '@angular/common/http';
+import {
+  AddTopologyOptions,
+  MockStorageGenerator,
+  MockStorageScenario,
+} from 'app/core/testing/utils/mock-storage-generator.utils';
+import { PoolTopologyCategory } from 'app/enums/pool-topology-category.enum';
+import { TopologyItemType, TopologyWarning } from 'app/enums/v-dev-type.enum';
+import { TopologyDisk, TopologyItem, VDev } from 'app/interfaces/storage.interface';
 import { StorageService } from 'app/services/storage.service';
 import { WebSocketService } from 'app/services/ws.service';
 
@@ -25,6 +33,399 @@ describe('StorageService', () => {
       const transformed = storageService.convertBytesToHumanReadable('44722');
 
       expect(transformed).toBe('43.67 KiB');
+    });
+  });
+
+  describe('getRedundancyLevel', () => {
+    it('return width minus one with mirrors', () => {
+      const mirror = {
+        type: TopologyItemType.Mirror,
+        children: [{}, {}, {}] as TopologyDisk[],
+      } as VDev;
+      const redundancy = storageService.getRedundancyLevel(mirror as TopologyItem);
+
+      expect(redundancy).toBe(2);
+    });
+
+    it('return 0 disk redundancy for Stripe and Disk', () => {
+      const stripe = storageService.getRedundancyLevel({ type: TopologyItemType.Stripe } as TopologyItem);
+      expect(stripe).toBe(0);
+
+      const disk = storageService.getRedundancyLevel({ type: TopologyItemType.Disk } as TopologyItem);
+      expect(disk).toBe(0);
+    });
+
+    it('return 1 disk redundancy for Raidz and Raidz1', () => {
+      const raidz = storageService.getRedundancyLevel({ type: TopologyItemType.Raidz } as TopologyItem);
+      expect(raidz).toBe(1);
+
+      const raidz1 = storageService.getRedundancyLevel({ type: TopologyItemType.Raidz1 } as TopologyItem);
+      expect(raidz1).toBe(1);
+    });
+
+    it('return 2 disk redundancy for Raidz2', () => {
+      const raidz2 = storageService.getRedundancyLevel({ type: TopologyItemType.Raidz2 } as TopologyItem);
+      expect(raidz2).toBe(2);
+    });
+
+    it('return 3 disk redundancy for Raidz3', () => {
+      const raidz3 = storageService.getRedundancyLevel({ type: TopologyItemType.Raidz3 } as TopologyItem);
+      expect(raidz3).toBe(3);
+    });
+
+    it('return -1 for anything else', () => {
+      const unsupported: TopologyItemType[] = [
+        TopologyItemType.Missing,
+        TopologyItemType.File,
+        TopologyItemType.L2Cache,
+        TopologyItemType.Replacing,
+        TopologyItemType.Root,
+      ];
+
+      unsupported.forEach((layout: TopologyItemType) => {
+        const unsupportedLayout = storageService.getRedundancyLevel({ type: layout } as TopologyItem);
+        expect(unsupportedLayout).toBe(-1);
+      });
+    });
+  });
+
+  describe('can check VDEV widths', () => {
+    const mockStorage = new MockStorageGenerator();
+    const dataOptions: AddTopologyOptions = {
+      scenario: MockStorageScenario.Uniform,
+      layout: TopologyItemType.Raidz2,
+      diskSize: 8,
+      width: 8,
+      repeats: 6,
+    };
+    // Add Topologies to Storage
+    mockStorage.addDataTopology(dataOptions).addCacheTopology(3, 2);
+
+    it('detects width of VDEVs', () => {
+      const vdevWidth = storageService.getVdevWidths(mockStorage.poolState.topology.data);
+
+      expect(vdevWidth.size).toBe(1);
+      expect(vdevWidth.values().next().value).toBe(dataOptions.width);
+    });
+
+    it('detects width of Stripes and Disks', () => {
+      const stripeWidth: Set<number> = storageService.getVdevWidths(mockStorage.poolState.topology.cache);
+
+      expect(stripeWidth.size).toBe(1);
+      expect(stripeWidth.values().next().value).toBe(1);
+    });
+
+    it('detects mixed VDEV widths', () => {
+      const mixed = [1, 2, 3];
+      const uniform = [1, 1, 1];
+      const mixedIsMixed: boolean = storageService.isMixedWidth(new Set(mixed));
+      const uniformIsMixed: boolean = storageService.isMixedWidth(new Set(uniform));
+
+      expect(mixedIsMixed).toBe(true);
+      expect(uniformIsMixed).toBe(false);
+    });
+  });
+
+  describe('can check VDEV capacities', () => {
+    const mockStorage = new MockStorageGenerator();
+    const dataOptions: AddTopologyOptions = {
+      scenario: MockStorageScenario.MixedVdevCapacity,
+      layout: TopologyItemType.Mirror,
+      diskSize: 2,
+      width: 2,
+      repeats: 2,
+    };
+    const dedupOptions: AddTopologyOptions = {
+      scenario: MockStorageScenario.Uniform,
+      layout: TopologyItemType.Mirror,
+      diskSize: 2,
+      width: 2,
+      repeats: 2,
+    };
+
+    mockStorage.addDataTopology(dataOptions).addDedupTopology(dedupOptions);
+
+    /*
+    * NOTE: When setting options.scenario to MixedVdevCapacity, the Storage
+    * Generator will make the first VDEV 2 TB larger than configured.
+    * So first MIRROR will be 2 x 4 TiB and second VDEV will be 2 x 2 TiB as
+    * specified by options.diskSize.
+    * */
+
+    const dataVdevCapacities: Set<number> = storageService.getVdevCapacities(mockStorage.poolState.topology.data);
+    const dedupVdevCapacities: Set<number> = storageService.getVdevCapacities(mockStorage.poolState.topology.dedup);
+
+    it('detects VDEV capacity for category', () => {
+      const capacities: number[] = Array.from(dataVdevCapacities);
+      expect(capacities[0]).toBe(mockStorage.terabytesToBytes(dataOptions.diskSize + 2));
+
+      for (let index = 1; index < capacities.length; index++) {
+        expect(capacities[index]).toBe(mockStorage.terabytesToBytes(dataOptions.diskSize));
+        expect(capacities[index]).toEqual(mockStorage.poolState.topology.data[index].stats.size);
+      }
+    });
+
+    it('detects mixed VDEV capacities in category', () => {
+      // Check mixed data VDEVs
+      expect(dataVdevCapacities.size).toBe(2);
+      const isDataMixed: boolean = storageService.isMixedVdevCapacity(dataVdevCapacities);
+      expect(isDataMixed).toBe(true);
+
+      // Check uniform dedup VDEVs
+      expect(dedupVdevCapacities.size).toBe(1);
+      const isDedupMixed: boolean = storageService.isMixedVdevCapacity(dedupVdevCapacities);
+      expect(isDedupMixed).toBe(false);
+    });
+  });
+
+  describe('can check VDEV disk capacities in category', () => {
+    const mockStorage = new MockStorageGenerator();
+    const configuredDiskSize = 4;
+    const generatedDiskSizeInBytes: number = mockStorage.terabytesToBytes(configuredDiskSize + 1);
+
+    mockStorage.addDataTopology({
+      scenario: MockStorageScenario.MixedDiskCapacity,
+      layout: TopologyItemType.Raidz1,
+      diskSize: configuredDiskSize,
+      width: 4,
+      repeats: 1,
+    }).addDedupTopology({
+      scenario: MockStorageScenario.MixedVdevCapacity,
+      layout: TopologyItemType.Raidz1,
+      diskSize: configuredDiskSize,
+      width: 4,
+      repeats: 2,
+    }).addSpecialTopology({
+      scenario: MockStorageScenario.Uniform,
+      layout: TopologyItemType.Raidz1,
+      diskSize: configuredDiskSize,
+      width: 4,
+      repeats: 1,
+    });
+
+    /*
+    * NOTE: When generating a MixedDiskCapacity setting, Mock Storage Generator
+    * will make the first disk of every VDEV 1 TiB larger than specified
+    * */
+
+    const dataDiskSizes = storageService.getVdevDiskCapacities(
+      mockStorage.poolState.topology.data,
+      mockStorage.disks,
+    );
+
+    const specialDiskSizes = storageService.getVdevDiskCapacities(
+      mockStorage.poolState.topology.special,
+      mockStorage.disks,
+    );
+
+    const dedupDiskSizes = storageService.getVdevDiskCapacities(
+      mockStorage.poolState.topology.dedup,
+      mockStorage.disks,
+    );
+
+    it('checks for disk capacity', () => {
+      expect(dataDiskSizes[0].has(generatedDiskSizeInBytes)).toBe(true);
+      expect(specialDiskSizes[0].has(generatedDiskSizeInBytes)).toBe(false);
+      expect(dedupDiskSizes[0].has(generatedDiskSizeInBytes)).toBe(false);
+      expect(dedupDiskSizes[1].has(generatedDiskSizeInBytes)).toBe(false);
+    });
+
+    it('detects mixed disk capacities within a VDEV', () => {
+      const isDataMixed = storageService.isMixedVdevDiskCapacity(dataDiskSizes);
+      const isDedupMixed = storageService.isMixedVdevDiskCapacity(dedupDiskSizes);
+      const isSpecialMixed = storageService.isMixedVdevDiskCapacity(specialDiskSizes);
+
+      expect(isDataMixed).toBe(true);
+      expect(isSpecialMixed).toBe(false);
+      expect(isDedupMixed).toBe(false);
+
+      /*
+      * NOTE: Disk capacities are checked on a per VDEV basis.
+      * This is why Dedup topology returns false even though
+      * there are different disk sizes in each VDEV
+      * */
+    });
+  });
+
+  describe('detects mixed VDEV types', () => {
+    const mockStorage = new MockStorageGenerator();
+
+    mockStorage.addDataTopology({
+      scenario: MockStorageScenario.MixedVdevLayout,
+      layout: TopologyItemType.Mirror,
+      diskSize: 4,
+      width: 2,
+      repeats: 1,
+    }).addSpecialTopology({
+      scenario: MockStorageScenario.Uniform,
+      layout: TopologyItemType.Raidz1,
+      diskSize: 4,
+      width: 4,
+      repeats: 1,
+    });
+
+    const dataLayouts = storageService.getVdevTypes(mockStorage.poolState.topology.data);
+    const specialLayouts = storageService.getVdevTypes(mockStorage.poolState.topology.special);
+
+    it('can detect VDEV layouts', () => {
+      expect(dataLayouts.size).toBe(2);
+      expect(specialLayouts.size).toBe(1);
+    });
+
+    it('can detect mixed layouts', () => {
+      const isDataMixed: boolean = storageService.isMixedVdevType(dataLayouts);
+      const isSpecialMixed: boolean = storageService.isMixedVdevType(specialLayouts);
+
+      expect(isDataMixed).toBe(true);
+      expect(isSpecialMixed).toBe(false);
+    });
+  });
+
+  describe('VDEV validator', () => {
+    /*
+    * NOTE:
+    * Validator generally only validates a single topology category at a time.
+    * The only exception to this is with Special and Dedup VDEVs. Best practices
+    * dictate that the redundancy level should match the Data VDEVs. For this reason
+    * we also pass in the data topology to the validator.
+    * */
+
+    it('generates warning for "No Redundancy"', () => {
+      const stripeStorage = new MockStorageGenerator();
+
+      stripeStorage.addDataTopology({
+        scenario: MockStorageScenario.NoRedundancy,
+        layout: TopologyItemType.Stripe,
+        diskSize: 4,
+        width: 1,
+        repeats: 2,
+      });
+
+      const warnings = storageService.validateVdevs(
+        PoolTopologyCategory.Data,
+        stripeStorage.poolState.topology.data,
+        stripeStorage.disks,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toBe(TopologyWarning.NoRedundancy);
+    });
+
+    it('generates warning for "Mixed VDEV Capacities"', () => {
+      const storage = new MockStorageGenerator();
+
+      storage.addDataTopology({
+        scenario: MockStorageScenario.MixedVdevCapacity,
+        layout: TopologyItemType.Mirror,
+        diskSize: 4,
+        width: 2,
+        repeats: 3,
+      });
+
+      const warnings = storageService.validateVdevs(
+        PoolTopologyCategory.Data,
+        storage.poolState.topology.data,
+        storage.disks,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toBe(TopologyWarning.MixedVdevCapacity);
+    });
+
+    it('generates warning for "Mixed Disk Capacities"', () => {
+      const storage = new MockStorageGenerator();
+
+      storage.addDataTopology({
+        scenario: MockStorageScenario.MixedDiskCapacity,
+        layout: TopologyItemType.Mirror,
+        diskSize: 4,
+        width: 2,
+        repeats: 3,
+      });
+
+      const warnings = storageService.validateVdevs(
+        PoolTopologyCategory.Data,
+        storage.poolState.topology.data,
+        storage.disks,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toBe(TopologyWarning.MixedDiskCapacity);
+    });
+
+    it('generates warning for "Mixed VDEV Width"', () => {
+      const storage = new MockStorageGenerator();
+
+      storage.addDataTopology({
+        scenario: MockStorageScenario.MixedVdevWidth,
+        layout: TopologyItemType.Mirror,
+        diskSize: 4,
+        width: 2,
+        repeats: 3,
+      });
+
+      const warnings = storageService.validateVdevs(
+        PoolTopologyCategory.Data,
+        storage.poolState.topology.data,
+        storage.disks,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toBe(TopologyWarning.MixedVdevWidth);
+    });
+
+    it('generates warning for "Mixed VDEV Layouts"', () => {
+      const storage = new MockStorageGenerator();
+
+      storage.addDataTopology({
+        scenario: MockStorageScenario.MixedVdevLayout,
+        layout: TopologyItemType.Mirror,
+        diskSize: 4,
+        width: 2,
+        repeats: 3,
+      });
+
+      const warnings = storageService.validateVdevs(
+        PoolTopologyCategory.Data,
+        storage.poolState.topology.data,
+        storage.disks,
+      );
+
+      // Will trigger multiple warnings as VDEV widths will differ.
+      // Let's just check to see if the our warning is present
+      expect(warnings).toContain(TopologyWarning.MixedVdevLayout);
+    });
+
+    it('generates warning for "Redundancy Mismatch"', () => {
+      /*
+      * NOTE: Special and Dedup categories should match redundancy level of data VDEVs
+      * */
+
+      const storage = new MockStorageGenerator();
+
+      storage.addDataTopology({
+        scenario: MockStorageScenario.Uniform,
+        layout: TopologyItemType.Mirror,
+        diskSize: 4,
+        width: 2,
+        repeats: 4,
+      }).addSpecialTopology({
+        scenario: MockStorageScenario.Uniform,
+        layout: TopologyItemType.Mirror,
+        diskSize: 4,
+        width: 3,
+        repeats: 1,
+      });
+
+      const warnings = storageService.validateVdevs(
+        PoolTopologyCategory.Special,
+        storage.poolState.topology.special,
+        storage.disks,
+        storage.poolState.topology.data,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings).toContain(TopologyWarning.RedundancyMismatch);
     });
   });
 });

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -401,6 +401,7 @@ export class StorageService {
   getRedundancyLevel(vdev: TopologyItem): number {
     switch (vdev.type) {
       case TopologyItemType.Disk:
+      case TopologyItemType.Stripe:
         return 0;
       case TopologyItemType.Mirror:
         return vdev.children.length - 1;
@@ -419,13 +420,21 @@ export class StorageService {
 
   getVdevWidths(vdevs: TopologyItem[]): Set<number> {
     const allVdevWidths = new Set<number>(); // There should only be one value
+
     vdevs.forEach((vdev) => {
       let vdevWidthCounter = 0;
-      vdev.children.forEach(() => {
-        vdevWidthCounter += 1;
-      });
-      allVdevWidths.add(vdevWidthCounter);
+
+      if (vdev.type === TopologyItemType.Disk || vdev.type === TopologyItemType.Stripe || vdev.children.length === 0) {
+        // Width of single disk VDEVs should be 1
+        allVdevWidths.add(1);
+      } else {
+        vdev.children.forEach(() => {
+          vdevWidthCounter += 1;
+        });
+        allVdevWidths.add(vdevWidthCounter);
+      }
     });
+
     return allVdevWidths;
   }
 

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -4,9 +4,11 @@ import { SortDirection } from '@angular/material/sort';
 import { format } from 'date-fns-tz';
 import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
+import { PoolTopologyCategory } from 'app/enums/pool-topology-category.enum';
+import { TopologyItemType, TopologyWarning } from 'app/enums/v-dev-type.enum';
 import { FileSystemStat } from 'app/interfaces/filesystem-stat.interface';
 import { Option } from 'app/interfaces/option.interface';
-import { Disk } from 'app/interfaces/storage.interface';
+import { Disk, StorageDashboardDisk, TopologyItem } from 'app/interfaces/storage.interface';
 import { WebSocketService } from './ws.service';
 
 function isStringArray(items: unknown[]): items is string[] {
@@ -23,7 +25,8 @@ export class StorageService {
   constructor(
     protected ws: WebSocketService,
     private http: HttpClient,
-  ) {}
+  ) {
+  }
 
   filesystemStat(path: string): Observable<FileSystemStat> {
     return this.ws.call('filesystem.stat', [path]);
@@ -112,7 +115,11 @@ export class StorageService {
     // also include bytes unit, which will get from convertBytesToHumanReadable function
     if (isStringArray(tempArr)
       && (tempArr[n].slice(-2) === ' B' || /\s[KMGT]iB$/.test(tempArr[n].slice(-4)) || tempArr[n].slice(-6) === ' bytes')) {
-      let bytes = []; let kbytes = []; let mbytes = []; let gbytes = []; let
+      let bytes = [];
+      let kbytes = [];
+      let mbytes = [];
+      let gbytes = [];
+      let
         tbytes = [];
       for (const i of tempArr) {
         if (i) {
@@ -149,7 +156,11 @@ export class StorageService {
     } else if (isStringArray(tempArr)
       && tempArr[n][tempArr[n].length - 1].match(/[KMGTB]/)
       && tempArr[n][tempArr[n].length - 2].match(/[0-9]/)) {
-      let bytes = []; let kiloBytes = []; let megaBytes = []; let gigaBytes = []; let teraBytes = [];
+      let bytes = [];
+      let kiloBytes = [];
+      let megaBytes = [];
+      let gigaBytes = [];
+      let teraBytes = [];
       for (const i of tempArr) {
         switch (i.slice(-1)) {
           case 'B':
@@ -178,7 +189,7 @@ export class StorageService {
 
       sorter = bytes.concat(kiloBytes, megaBytes, gigaBytes, teraBytes);
 
-    // Select strings that Date.parse can turn into a number (ie, that are a legit date)
+      // Select strings that Date.parse can turn into a number (ie, that are a legit date)
     } else if (isStringArray(tempArr)
       && !Number.isNaN(Date.parse(tempArr[n]))) {
       let timeArr = [];
@@ -385,5 +396,150 @@ export class StorageService {
       units = hideBytes ? '' : 'bytes';
     }
     return `${bytes.toFixed(dec)} ${units}`;
+  }
+
+  getRedundancyLevel(vdev: TopologyItem): number {
+    switch (vdev.type) {
+      case TopologyItemType.Disk:
+        return 0;
+      case TopologyItemType.Mirror:
+        return vdev.children.length - 1;
+      case TopologyItemType.Raidz:
+      case TopologyItemType.Raidz1:
+        return 1;
+      case TopologyItemType.Raidz2:
+        return 2;
+      case TopologyItemType.Raidz3:
+        return 3;
+      default:
+        // VDEV type property also includes values unrelated to layout.
+        return -1;
+    }
+  }
+
+  getVdevWidths(vdevs: TopologyItem[]): Set<number> {
+    const allVdevWidths = new Set<number>(); // There should only be one value
+    vdevs.forEach((vdev) => {
+      let vdevWidthCounter = 0;
+      vdev.children.forEach(() => {
+        vdevWidthCounter += 1;
+      });
+      allVdevWidths.add(vdevWidthCounter);
+    });
+    return allVdevWidths;
+  }
+
+  isMixedWidth(allVdevWidths: Set<number>): boolean {
+    return allVdevWidths.size > 1;
+  }
+
+  // Get usable space on VDEV.
+  getVdevCapacities(vdevs: TopologyItem[]): Set<number> {
+    const allVdevCapacities = new Set<number>(); // There should only be one value
+    vdevs.forEach((vdev) => {
+      allVdevCapacities.add(vdev.stats.size);
+    });
+    return allVdevCapacities;
+  }
+
+  // Check to see if every VDEV has the same capacity. Best practices dictate every vdev should be uniform
+  isMixedVdevCapacity(allVdevCapacities: Set<number>): boolean {
+    return allVdevCapacities.size > 1;
+  }
+
+  getVdevDiskCapacities(vdevs: TopologyItem[], disks: StorageDashboardDisk[]): Set<number>[] {
+    const allDiskCapacities: Set<number>[] = [];
+    vdevs.forEach((vdev) => {
+      const vdevDiskCapacities = new Set<number>(); // There should only be one value
+      if (vdev.children.length) {
+        vdev.children.forEach((child) => {
+          const diskSize = disks?.find((disk) => disk.name === child.disk)?.size;
+          vdevDiskCapacities.add(diskSize);
+        });
+      } else {
+        // Topology items of type DISK will not have children
+        vdevDiskCapacities.add(vdev.stats.size);
+      }
+      allDiskCapacities.push(vdevDiskCapacities);
+    });
+    return allDiskCapacities;
+  }
+
+  // Check to see if any individual VDEVs have non-uniform disk sizes.
+  // Every disk in a VDEV should ideally be the same size
+  isMixedVdevDiskCapacity(allVdevDiskCapacities: Set<number>[]): boolean {
+    const isMixed = allVdevDiskCapacities.filter((vdev) => vdev.size > 1);
+    return isMixed.length > 0;
+  }
+
+  getVdevTypes(vdevs: TopologyItem[]): Set<string> {
+    const vdevTypes = new Set<string>();
+    vdevs.forEach((vdev) => {
+      vdevTypes.add(vdev.type);
+    });
+    return vdevTypes;
+  }
+
+  isMixedVdevType(vdevTypes: Set<string>): boolean {
+    return vdevTypes.size > 1;
+  }
+
+  validateVdevs(category: PoolTopologyCategory,
+    vdevs: TopologyItem[],
+    disks: StorageDashboardDisk[],
+    dataVdevsLayout?: TopologyItemType): string[] {
+    const warnings: string[] = [];
+    let isMixedVdevCapacity = false;
+    let isMixedDiskCapacity = false;
+    let isMixedWidth = false;
+    let isMixedLayout = false;
+
+    // Check for non-uniform VDEV Capacities
+    const allVdevCapacities: Set<number> = this.getVdevCapacities(vdevs); // There should only be one value
+    isMixedVdevCapacity = this.isMixedVdevCapacity(allVdevCapacities);
+
+    // Check for non-uniform Disk Capacities within each VDEV
+    const allVdevDiskCapacities: Set<number>[] = this.getVdevDiskCapacities(vdevs, disks);
+    isMixedDiskCapacity = this.isMixedVdevDiskCapacity(allVdevDiskCapacities);
+
+    // Check VDEV Widths
+    const allVdevWidths: Set<number> = this.getVdevWidths(vdevs); // There should only be one value
+    isMixedWidth = this.isMixedWidth(allVdevWidths);
+
+    // While not recommended, ZFS does allow creating a pool with mixed VDEV types.
+    // Even though the UI does not allow such pools to be created,
+    // users might still try to import such a pool.
+    const allVdevLayouts = this.getVdevTypes(vdevs);
+    isMixedLayout = this.isMixedVdevType(allVdevLayouts);
+
+    if (vdevs.length) {
+      if (isMixedLayout) {
+        warnings.push(TopologyWarning.MixedVdevLayout);
+      }
+
+      if (isMixedDiskCapacity) {
+        warnings.push(TopologyWarning.MixedDiskCapacity);
+      }
+
+      if (isMixedVdevCapacity) {
+        warnings.push(TopologyWarning.MixedVdevCapacity);
+      }
+
+      if (isMixedWidth) {
+        warnings.push(TopologyWarning.MixedVdevWidth);
+      }
+
+      // Check Redundancy
+      if (category === PoolTopologyCategory.Data && this.getRedundancyLevel(vdevs[0]) === 0) {
+        warnings.push(TopologyWarning.NoRedundancy);
+      }
+
+      const isMismatchCategory = (category === PoolTopologyCategory.Dedup || category === PoolTopologyCategory.Special);
+      if (isMismatchCategory && dataVdevsLayout && (dataVdevsLayout !== vdevs[0].type)) {
+        warnings.push(TopologyWarning.RedundancyMismatch);
+      }
+    }
+
+    return warnings;
   }
 }


### PR DESCRIPTION
To test:

Create each configuration and check the reported width in the Storage Dashboard topology card.

- Two raidz1 vdevs with 5 disks in each vdev. Topology card should say "5 wide"
- Two mirror vdevs with 2 disks in each vdev. Topology card should say "2 wide"
- Two mirrors. One made with two disks and another with 3 disks. Topology card should say "Mixed Width VDEVs"
