### PR TITLE
NAS-119604 / 23.10 / Design flaw: If the error log is too large, it will be displayed beyond the log window

### DIFF
--- a/src/app/modules/common/dialog/show-logs-dialog/show-logs-dialog.component.scss
+++ b/src/app/modules/common/dialog/show-logs-dialog/show-logs-dialog.component.scss
@@ -13,6 +13,7 @@
 
     pre {
       max-height: 300px;
+      overflow: auto;
 
       code {
         display: flex;

--- a/src/app/modules/common/dialog/show-logs-dialog/show-logs-dialog.component.scss
+++ b/src/app/modules/common/dialog/show-logs-dialog/show-logs-dialog.component.scss
@@ -18,6 +18,7 @@
       code {
         display: flex;
         overflow: auto;
+        white-space: pre-line;
       }
     }
 


### PR DESCRIPTION
Now it scrolls by the max-height of `300px`:

<img width="830" alt="Screenshot 2023-01-05 at 14 55 26" src="https://user-images.githubusercontent.com/22980553/210784866-b639bd49-8537-40f4-aa73-94683769db78.png">
