### PR TITLE
Fix variant of the 256-bit NIST ECC curve

### DIFF
--- a/src/app/enums/ec-curve.enum.ts
+++ b/src/app/enums/ec-curve.enum.ts
@@ -2,6 +2,6 @@ export enum EcCurve {
   BrainpoolP512R1 = 'BrainpoolP512R1',
   BrainpoolP384R1 = 'BrainpoolP384R1',
   BrainpoolP256R1 = 'BrainpoolP256R1',
-  Secp256K1 = 'SECP256K1',
+  Secp256R1 = 'SECP256R1',
   Ed25519 = 'ed25519',
 }


### PR DESCRIPTION
First, this is consistent with the other two NIST curves in the codebase, which use the random ‘r’ variant of the curves, not the Koblitz ‘k' variants. Second, attempting to request a Lets Encrypt certificate with the previous type of secp256k1 fails, with the error message “Error parsing certificate request: x509: unsupported elliptic curve”. Third, the CAB forum says the 256-bit curve must be secp256r1; see section 7.1.3.1.2 of <https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.8.6.pdf>.