### PR TITLE
NAS-119591 / 23.10 / [SCALE/Apps]: `default` does not work in `list` types

### DIFF
--- a/src/app/interfaces/chart-release.interface.ts
+++ b/src/app/interfaces/chart-release.interface.ts
@@ -136,7 +136,7 @@ export interface ChartSchemaNodeConf {
   type: ChartSchemaType;
   attrs?: ChartSchemaNode[];
   items?: ChartSchemaNode[];
-  default?: unknown;
+  default?: unknown | unknown[];
   enum?: ChartSchemaEnum[];
   required?: boolean;
   value?: string;

--- a/src/app/interfaces/dynamic-form-schema.interface.ts
+++ b/src/app/interfaces/dynamic-form-schema.interface.ts
@@ -1,6 +1,7 @@
 import { UntypedFormArray } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { DynamicFormSchemaType } from 'app/enums/dynamic-form-schema-type.enum';
+import { ChartSchemaNode } from 'app/interfaces/chart-release.interface';
 import { Option } from 'app/interfaces/option.interface';
 import { TreeNodeProvider } from 'app/modules/ix-forms/components/ix-explorer/tree-node-provider.interface';
 
@@ -62,7 +63,8 @@ export interface DynamicFormSchemaIpaddr extends DynamicFormSchemaBase {
 export interface DynamicFormSchemaList extends DynamicFormSchemaBase {
   type: DynamicFormSchemaType.List;
   items?: DynamicFormSchemaNode[];
-  itemsSchema?: unknown[];
+  itemsSchema?: ChartSchemaNode[];
+  default?: unknown[];
 }
 
 export interface DynamicFormSchemaDict extends DynamicFormSchemaBase {

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
@@ -10,6 +10,7 @@
         *ngFor="let attr of dynamicSchema.attrs"
         [dynamicSchema]="attr"
         [dynamicForm]="dynamicForm.controls[dynamicSchema.controlName] | cast"
+        [isEditMode]="isEditMode"
         (addListItem)="addControlNext($event)"
         (deleteListItem)="removeControlNext($event)"
       ></ix-dynamic-form-item>
@@ -34,6 +35,7 @@
           class="list"
           [dynamicSchema]="item"
           [dynamicForm]="element | cast"
+          [isEditMode]="isEditMode"
           (addListItem)="addControlNext($event)"
           (deleteListItem)="removeControlNext($event)"
         ></ix-dynamic-form-item>

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
@@ -20,7 +20,9 @@
       [label]="dynamicSchema.title | translate"
       [empty]="getFormArray.controls.length === 0"
       [formArrayName]="dynamicSchema.controlName"
-      (add)="addControl()"
+      [default]="dynamicSchema.default"
+      [itemsSchema]="dynamicSchema.itemsSchema"
+      (add)="addControl($event)"
     >
       <ix-list-item *ngFor="let element of getFormArray.controls; let i = index" (delete)="removeControl(i)">
         <ix-dynamic-form-item

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
@@ -22,9 +22,13 @@
       [formArrayName]="dynamicSchema.controlName"
       [default]="dynamicSchema.default"
       [itemsSchema]="dynamicSchema.itemsSchema"
+      [isEditMode]="isEditMode"
       (add)="addControl($event)"
     >
-      <ix-list-item *ngFor="let element of getFormArray.controls; let i = index" (delete)="removeControl(i)">
+      <ix-list-item
+        *ngFor="let element of getFormArray.controls; let i = index"
+        (delete)="removeControl(i)"
+      >
         <ix-dynamic-form-item
           *ngFor="let item of dynamicSchema.items"
           class="list"

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.ts
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.ts
@@ -19,6 +19,7 @@ import { CustomUntypedFormField } from 'app/modules/ix-forms/components/ix-dynam
 export class IxDynamicFormItemComponent implements OnInit {
   @Input() dynamicForm: UntypedFormGroup;
   @Input() dynamicSchema: DynamicFormSchemaNode;
+  @Input() isEditMode: boolean;
 
   @Output() addListItem = new EventEmitter<AddListItemEvent>();
   @Output() deleteListItem = new EventEmitter<DeleteListItemEvent>();

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.ts
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.ts
@@ -65,11 +65,11 @@ export class IxDynamicFormItemComponent implements OnInit {
     return (this.dynamicForm.controls[this.dynamicSchema.controlName] as CustomUntypedFormField).hidden$;
   }
 
-  addControl(): void {
+  addControl(schema?: unknown[]): void {
     if (this.dynamicSchema.type === DynamicFormSchemaType.List) {
       this.addListItem.emit({
         array: this.getFormArray,
-        schema: this.dynamicSchema.itemsSchema,
+        schema: schema || this.dynamicSchema.itemsSchema,
       });
     }
   }

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.html
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.html
@@ -8,6 +8,7 @@
       <ix-dynamic-form-item
         [dynamicSchema]="schema"
         [dynamicForm]="dynamicForm"
+        [isEditMode]="isEditMode"
         (addListItem)="addControlNext($event)"
         (deleteListItem)="removeControlNext($event)"
       ></ix-dynamic-form-item>

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.ts
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.ts
@@ -16,7 +16,7 @@ import { AddListItemEvent, DeleteListItemEvent, DynamicFormSchema } from 'app/in
 export class IxDynamicFormComponent {
   @Input() dynamicForm: UntypedFormGroup;
   @Input() dynamicSection: DynamicFormSchema[];
-  @Input() isEditMode = false;
+  @Input() isEditMode: boolean;
 
   @Output() addListItem = new EventEmitter<AddListItemEvent>();
   @Output() deleteListItem = new EventEmitter<DeleteListItemEvent>();

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.ts
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.ts
@@ -16,6 +16,7 @@ import { AddListItemEvent, DeleteListItemEvent, DynamicFormSchema } from 'app/in
 export class IxDynamicFormComponent {
   @Input() dynamicForm: UntypedFormGroup;
   @Input() dynamicSection: DynamicFormSchema[];
+  @Input() isEditMode = false;
 
   @Output() addListItem = new EventEmitter<AddListItemEvent>();
   @Output() deleteListItem = new EventEmitter<DeleteListItemEvent>();

--- a/src/app/modules/ix-forms/components/ix-list/ix-list.component.html
+++ b/src/app/modules/ix-forms/components/ix-list/ix-list.component.html
@@ -21,7 +21,7 @@
   <div class="input-container" [class.disabled]="isDisabled">
     <ng-content></ng-content>
 
-    <span *ngIf="empty && !default.length" class="empty">
+    <span *ngIf="empty" class="empty">
       {{ 'No items have been added yet.' | translate }}
     </span>
   </div>

--- a/src/app/modules/ix-forms/components/ix-list/ix-list.component.html
+++ b/src/app/modules/ix-forms/components/ix-list/ix-list.component.html
@@ -21,7 +21,7 @@
   <div class="input-container" [class.disabled]="isDisabled">
     <ng-content></ng-content>
 
-    <span *ngIf="empty" class="empty">
+    <span *ngIf="empty && !default.length" class="empty">
       {{ 'No items have been added yet.' | translate }}
     </span>
   </div>

--- a/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
+++ b/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
@@ -20,7 +20,7 @@ export class IxListComponent implements OnInit {
   @Output() add = new EventEmitter<unknown[]>();
 
   ngOnInit(): void {
-    this.handleListDefaults();
+    setTimeout(() => this.handleListDefaults());
   }
 
   addItem(schema?: unknown[]): void {

--- a/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
+++ b/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
@@ -16,11 +16,14 @@ export class IxListComponent implements OnInit {
   @Input() canAdd = true;
   @Input() default: unknown[];
   @Input() itemsSchema: ChartSchemaNode[];
+  @Input() isEditMode: boolean;
 
   @Output() add = new EventEmitter<unknown[]>();
 
   ngOnInit(): void {
-    setTimeout(() => this.handleListDefaults());
+    if (!this.isEditMode && this.default?.length > 0) {
+      this.handleListDefaults();
+    }
   }
 
   addItem(schema?: unknown[]): void {
@@ -34,7 +37,7 @@ export class IxListComponent implements OnInit {
   }
 
   private handleListDefaults(): void {
-    if (this.default?.length > 0) {
+    setTimeout(() => {
       this.default.forEach((defaultValue: never) => {
         this.addItem(
           this.itemsSchema.map((item: ChartSchemaNode) => {
@@ -48,6 +51,6 @@ export class IxListComponent implements OnInit {
           }),
         );
       });
-    }
+    });
   }
 }

--- a/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
+++ b/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
@@ -1,28 +1,53 @@
 import {
-  Component, EventEmitter, Input, Output,
+  Component, EventEmitter, Input, OnInit, Output,
 } from '@angular/core';
+import { ChartSchemaNode } from 'app/interfaces/chart-release.interface';
 
 @Component({
   selector: 'ix-list',
   templateUrl: './ix-list.component.html',
   styleUrls: ['./ix-list.component.scss'],
 })
-export class IxListComponent {
+export class IxListComponent implements OnInit {
   @Input() label: string;
   @Input() tooltip: string;
   @Input() empty: boolean;
   @Input() required: boolean;
   @Input() canAdd = true;
+  @Input() default: unknown[];
+  @Input() itemsSchema: ChartSchemaNode[];
 
-  @Output() add = new EventEmitter<void>();
+  @Output() add = new EventEmitter<unknown[]>();
 
-  addItem(): void {
-    this.add.emit();
+  ngOnInit(): void {
+    this.handleListDefaults();
+  }
+
+  addItem(schema?: unknown[]): void {
+    this.add.emit(schema);
   }
 
   isDisabled = false;
 
   setDisabledState(isDisabled: boolean): void {
     this.isDisabled = isDisabled;
+  }
+
+  private handleListDefaults(): void {
+    if (this.default?.length > 0) {
+      this.default.forEach((defaultValue: never) => {
+        this.addItem(
+          this.itemsSchema.map((item: ChartSchemaNode) => {
+            return {
+              ...item,
+              schema: {
+                ...item.schema,
+                default: defaultValue?.[item.variable] ?? (typeof defaultValue !== 'object' ? defaultValue : item.schema.default),
+              },
+            };
+          }),
+        );
+      });
+    }
   }
 }

--- a/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
+++ b/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
@@ -1,5 +1,6 @@
 import {
-  Component, EventEmitter, Input, OnInit, Output,
+  AfterViewInit,
+  Component, EventEmitter, Input, Output,
 } from '@angular/core';
 import { ChartSchemaNode } from 'app/interfaces/chart-release.interface';
 
@@ -8,7 +9,7 @@ import { ChartSchemaNode } from 'app/interfaces/chart-release.interface';
   templateUrl: './ix-list.component.html',
   styleUrls: ['./ix-list.component.scss'],
 })
-export class IxListComponent implements OnInit {
+export class IxListComponent implements AfterViewInit {
   @Input() label: string;
   @Input() tooltip: string;
   @Input() empty: boolean;
@@ -20,7 +21,7 @@ export class IxListComponent implements OnInit {
 
   @Output() add = new EventEmitter<unknown[]>();
 
-  ngOnInit(): void {
+  ngAfterViewInit(): void {
     if (!this.isEditMode && this.default?.length > 0) {
       this.handleListDefaults();
     }

--- a/src/app/pages/apps-old/forms/chart-form/chart-form.component.html
+++ b/src/app/pages/apps-old/forms/chart-form/chart-form.component.html
@@ -5,6 +5,7 @@
       <ix-dynamic-form
         [dynamicSection]="dynamicSection"
         [dynamicForm]="form"
+        [isEditMode]="!isNew"
         (addListItem)="addItem($event)"
         (deleteListItem)="deleteItem($event)"
       ></ix-dynamic-form>

--- a/src/app/services/schema/app-schema.service.spec.ts
+++ b/src/app/services/schema/app-schema.service.spec.ts
@@ -240,7 +240,9 @@ const beforeList = [{
   label: 'Label List',
   schema: {
     type: 'list',
-    default: [],
+    default: [
+      { item_list_1: 'prefilled_1', item_list_2: 2 },
+    ],
     items: [
       {
         variable: 'item_list_1',
@@ -286,6 +288,9 @@ const afterList = [[{
     { label: '', schema: { type: 'int' }, variable: 'item_list_2' },
   ],
   title: 'Label List',
+  default: [
+    { item_list_1: 'prefilled_1', item_list_2: 2 },
+  ],
   type: 'list',
 }]] as DynamicFormSchemaList[][];
 

--- a/src/app/services/schema/app-shema.transformer.ts
+++ b/src/app/services/schema/app-shema.transformer.ts
@@ -174,6 +174,7 @@ export function transformListSchemaType(
     type: DynamicFormSchemaType.List,
     items,
     itemsSchema,
+    default: schema.default as unknown[],
     dependsOn: schema.show_if?.map((conditional) => conditional[0]),
   };
 }


### PR DESCRIPTION
Go to apps:
try to install `docspell`, there you should see pre-created array item:
`default: ["127.0.0.1"]`


<img width="812" alt="Screenshot 2023-01-13 at 13 10 09" src="https://user-images.githubusercontent.com/22980553/212306575-65d9c879-5fdb-4a67-8b39-2ac8440dc2b8.png">

This  block `label: IPs` has one element inside of a card.

So when middleware wants to pre-create element, it set's it as as `string[]` 
`default: ["127.0.0.1", "1.1.1.1"]` -> will result in 2 pre-created cards

![image](https://user-images.githubusercontent.com/22980553/212305253-275065fc-090a-4cdd-a896-326530ce5a88.png)

There might be multiple elements inside of a card.
In this case middleware sets it as `object[]`

<img width="825" alt="Screenshot 2023-01-13 at 13 12 32" src="https://user-images.githubusercontent.com/22980553/212307022-96139ff6-37ac-4421-a3dc-dc5572e3c4e5.png">

example:
```
[
  {
    name: 'preselected name 1',
    value: 'preselected value 1,
  },
  {
    name: 'preselected name 2',
    value: 'preselected value 2,
  }
]
```
In this case 2 cards will be created.
