### PR TITLE
NAS-119591 / 22.12.1 / [SCALE/Apps]: `default` does not work in `list` types (by AlexKarpov98)

### DIFF
--- a/src/app/interfaces/chart-release.interface.ts
+++ b/src/app/interfaces/chart-release.interface.ts
@@ -136,7 +136,7 @@ export interface ChartSchemaNodeConf {
   type: ChartSchemaType;
   attrs?: ChartSchemaNode[];
   items?: ChartSchemaNode[];
-  default?: unknown;
+  default?: unknown | unknown[];
   enum?: ChartSchemaEnum[];
   required?: boolean;
   value?: string;

--- a/src/app/interfaces/dynamic-form-schema.interface.ts
+++ b/src/app/interfaces/dynamic-form-schema.interface.ts
@@ -1,6 +1,7 @@
 import { UntypedFormArray } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { DynamicFormSchemaType } from 'app/enums/dynamic-form-schema-type.enum';
+import { ChartSchemaNode } from 'app/interfaces/chart-release.interface';
 import { Option } from 'app/interfaces/option.interface';
 import { TreeNodeProvider } from 'app/modules/ix-forms/components/ix-explorer/tree-node-provider.interface';
 
@@ -62,7 +63,8 @@ export interface DynamicFormSchemaIpaddr extends DynamicFormSchemaBase {
 export interface DynamicFormSchemaList extends DynamicFormSchemaBase {
   type: DynamicFormSchemaType.List;
   items?: DynamicFormSchemaNode[];
-  itemsSchema?: unknown[];
+  itemsSchema?: ChartSchemaNode[];
+  default?: unknown[];
 }
 
 export interface DynamicFormSchemaDict extends DynamicFormSchemaBase {

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
@@ -10,6 +10,7 @@
         *ngFor="let attr of dynamicSchema.attrs"
         [dynamicSchema]="attr"
         [dynamicForm]="dynamicForm.controls[dynamicSchema.controlName] | cast"
+        [isEditMode]="isEditMode"
         (addListItem)="addControlNext($event)"
         (deleteListItem)="removeControlNext($event)"
       ></ix-dynamic-form-item>
@@ -20,9 +21,15 @@
       [label]="dynamicSchema.title | translate"
       [empty]="getFormArray.controls.length === 0"
       [formArrayName]="dynamicSchema.controlName"
-      (add)="addControl()"
+      [default]="dynamicSchema.default"
+      [itemsSchema]="dynamicSchema.itemsSchema"
+      [isEditMode]="isEditMode"
+      (add)="addControl($event)"
     >
-      <ix-list-item *ngFor="let element of getFormArray.controls; let i = index" (delete)="removeControl(i)">
+      <ix-list-item
+        *ngFor="let element of getFormArray.controls; let i = index"
+        (delete)="removeControl(i)"
+      >
         <ix-dynamic-form-item
           *ngFor="let item of dynamicSchema.items"
           class="list"

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.ts
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.ts
@@ -19,6 +19,7 @@ import { CustomUntypedFormField } from 'app/modules/ix-forms/components/ix-dynam
 export class IxDynamicFormItemComponent implements OnInit {
   @Input() dynamicForm: UntypedFormGroup;
   @Input() dynamicSchema: DynamicFormSchemaNode;
+  @Input() isEditMode: boolean;
 
   @Output() addListItem = new EventEmitter<AddListItemEvent>();
   @Output() deleteListItem = new EventEmitter<DeleteListItemEvent>();
@@ -65,11 +66,11 @@ export class IxDynamicFormItemComponent implements OnInit {
     return (this.dynamicForm.controls[this.dynamicSchema.controlName] as CustomUntypedFormField).hidden$;
   }
 
-  addControl(): void {
+  addControl(schema?: unknown[]): void {
     if (this.dynamicSchema.type === DynamicFormSchemaType.List) {
       this.addListItem.emit({
         array: this.getFormArray,
-        schema: this.dynamicSchema.itemsSchema,
+        schema: schema || this.dynamicSchema.itemsSchema,
       });
     }
   }

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.html
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.html
@@ -8,6 +8,7 @@
       <ix-dynamic-form-item
         [dynamicSchema]="schema"
         [dynamicForm]="dynamicForm"
+        [isEditMode]="isEditMode"
         (addListItem)="addControlNext($event)"
         (deleteListItem)="removeControlNext($event)"
       ></ix-dynamic-form-item>

--- a/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.ts
+++ b/src/app/modules/ix-forms/components/ix-dynamic-form/ix-dynamic-form.component.ts
@@ -16,6 +16,7 @@ import { AddListItemEvent, DeleteListItemEvent, DynamicFormSchema } from 'app/in
 export class IxDynamicFormComponent {
   @Input() dynamicForm: UntypedFormGroup;
   @Input() dynamicSection: DynamicFormSchema[];
+  @Input() isEditMode: boolean;
 
   @Output() addListItem = new EventEmitter<AddListItemEvent>();
   @Output() deleteListItem = new EventEmitter<DeleteListItemEvent>();

--- a/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
+++ b/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
@@ -1,28 +1,57 @@
 import {
+  AfterViewInit,
   Component, EventEmitter, Input, Output,
 } from '@angular/core';
+import { ChartSchemaNode } from 'app/interfaces/chart-release.interface';
 
 @Component({
   selector: 'ix-list',
   templateUrl: './ix-list.component.html',
   styleUrls: ['./ix-list.component.scss'],
 })
-export class IxListComponent {
+export class IxListComponent implements AfterViewInit {
   @Input() label: string;
   @Input() tooltip: string;
   @Input() empty: boolean;
   @Input() required: boolean;
   @Input() canAdd = true;
+  @Input() default: unknown[];
+  @Input() itemsSchema: ChartSchemaNode[];
+  @Input() isEditMode: boolean;
 
-  @Output() add = new EventEmitter<void>();
+  @Output() add = new EventEmitter<unknown[]>();
 
-  addItem(): void {
-    this.add.emit();
+  ngAfterViewInit(): void {
+    if (!this.isEditMode && this.default?.length > 0) {
+      this.handleListDefaults();
+    }
+  }
+
+  addItem(schema?: unknown[]): void {
+    this.add.emit(schema);
   }
 
   isDisabled = false;
 
   setDisabledState(isDisabled: boolean): void {
     this.isDisabled = isDisabled;
+  }
+
+  private handleListDefaults(): void {
+    setTimeout(() => {
+      this.default.forEach((defaultValue: never) => {
+        this.addItem(
+          this.itemsSchema.map((item: ChartSchemaNode) => {
+            return {
+              ...item,
+              schema: {
+                ...item.schema,
+                default: defaultValue?.[item.variable] ?? (typeof defaultValue !== 'object' ? defaultValue : item.schema.default),
+              },
+            };
+          }),
+        );
+      });
+    });
   }
 }

--- a/src/app/pages/applications/forms/chart-form/chart-form.component.html
+++ b/src/app/pages/applications/forms/chart-form/chart-form.component.html
@@ -5,6 +5,7 @@
       <ix-dynamic-form
         [dynamicSection]="dynamicSection"
         [dynamicForm]="form"
+        [isEditMode]="!isNew"
         (addListItem)="addItem($event)"
         (deleteListItem)="deleteItem($event)"
       ></ix-dynamic-form>

--- a/src/app/services/app-schema.service.spec.ts
+++ b/src/app/services/app-schema.service.spec.ts
@@ -240,7 +240,9 @@ const beforeList = [{
   label: 'Label List',
   schema: {
     type: 'list',
-    default: [],
+    default: [
+      { item_list_1: 'prefilled_1', item_list_2: 2 },
+    ],
     items: [
       {
         variable: 'item_list_1',
@@ -286,6 +288,9 @@ const afterList = [[{
     { label: '', schema: { type: 'int' }, variable: 'item_list_2' },
   ],
   title: 'Label List',
+  default: [
+    { item_list_1: 'prefilled_1', item_list_2: 2 },
+  ],
   type: 'list',
 }]] as DynamicFormSchemaList[][];
 

--- a/src/app/services/app-schema.service.ts
+++ b/src/app/services/app-schema.service.ts
@@ -244,6 +244,7 @@ export class AppSchemaService {
         itemsSchema,
         editable: schema.editable,
         dependsOn: schema.show_if?.map((conditional) => conditional[0]),
+        default: schema.default as unknown[],
       };
       if (!isNew && (!!schema.immutable || isParentImmutable)) {
         inputSchema.editable = false;


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e6383470550f86527268e9202624181ba874e697
    git cherry-pick -x 62b7b46070e9ae7369667354f25ddbe613d099f4
    git cherry-pick -x 1a362a87bef43095043b7826694d18472510099e
    git cherry-pick -x acb81c0d5fcbc44f5c69659837f37888aaa40865
    git cherry-pick -x 976096ba85f1fa1b60fd54754c5646ce9bee1dc8

Go to apps:
try to install `docspell`, there you should see pre-created array item:
`default: ["127.0.0.1"]`


<img width="812" alt="Screenshot 2023-01-13 at 13 10 09" src="https://user-images.githubusercontent.com/22980553/212306575-65d9c879-5fdb-4a67-8b39-2ac8440dc2b8.png">

This  block `label: IPs` has one element inside of a card.

So when middleware wants to pre-create element, it set's it as as `string[]` 
`default: ["127.0.0.1", "1.1.1.1"]` -> will result in 2 pre-created cards

![image](https://user-images.githubusercontent.com/22980553/212305253-275065fc-090a-4cdd-a896-326530ce5a88.png)

There might be multiple elements inside of a card.
In this case middleware sets it as `object[]`

<img width="825" alt="Screenshot 2023-01-13 at 13 12 32" src="https://user-images.githubusercontent.com/22980553/212307022-96139ff6-37ac-4421-a3dc-dc5572e3c4e5.png">

example:
```
[
  {
    name: 'preselected name 1',
    value: 'preselected value 1,
  },
  {
    name: 'preselected name 2',
    value: 'preselected value 2,
  }
]
```
In this case 2 cards will be created.


Original PR: https://github.com/truenas/webui/pull/7573
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119591