### PR TITLE
NAS-119844 / 22.12.1 / NVMe drives show "Enable S.M.A.R.T." checkbox unchecked even if `togglesmart` API field is true (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/disks/components/disk-form/disk-form.component.ts
+++ b/src/app/pages/storage/modules/disks/components/disk-form/disk-form.component.ts
@@ -15,7 +15,7 @@ import helptext from 'app/helptext/storage/disks/disks';
 import { Disk, DiskUpdate } from 'app/interfaces/storage.interface';
 import { FormErrorHandlerService } from 'app/modules/ix-forms/services/form-error-handler.service';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
-import { DialogService, WebSocketService } from 'app/services';
+import { WebSocketService } from 'app/services';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
 
 @UntilDestroy()
@@ -50,7 +50,6 @@ export class DiskFormComponent implements OnInit {
     private translate: TranslateService,
     private ws: WebSocketService,
     private fb: FormBuilder,
-    private dialogService: DialogService,
     private cdr: ChangeDetectorRef,
     private errorHandler: FormErrorHandlerService,
     private slideInService: IxSlideInService,
@@ -64,7 +63,11 @@ export class DiskFormComponent implements OnInit {
 
   setFormDisk(disk: Disk): void {
     this.existingDisk = disk;
-    this.form.patchValue({ ...disk });
+    this.form.patchValue({
+      ...disk,
+      togglesmart: disk.togglesmart || false,
+      smartoptions: disk.smartoptions || '',
+    });
   }
 
   private clearPasswordField(): void {

--- a/src/app/pages/storage/modules/disks/components/disk-form/disk-form.component.ts
+++ b/src/app/pages/storage/modules/disks/components/disk-form/disk-form.component.ts
@@ -63,11 +63,7 @@ export class DiskFormComponent implements OnInit {
 
   setFormDisk(disk: Disk): void {
     this.existingDisk = disk;
-    this.form.patchValue({
-      ...disk,
-      togglesmart: disk.togglesmart || false,
-      smartoptions: disk.smartoptions || '',
-    });
+    this.form.patchValue({ ...disk });
   }
 
   private clearPasswordField(): void {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 7dc806bb42ffa4169886fff25d4b49bc556127e0
    git cherry-pick -x 3a0b871f97d95386a568705085cac2ee26f9295d

main was merged here:
https://github.com/truenas/webui/pull/7591
now it's a cleanup PR

Original PR: https://github.com/truenas/webui/pull/7583
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119844