### PR TITLE
NAS-119950 / 23.10 / No scroll-bar on traceback screens in webUI

### DIFF
--- a/src/app/modules/common/dialog/error-dialog/error-dialog.component.scss
+++ b/src/app/modules/common/dialog/error-dialog/error-dialog.component.scss
@@ -1,3 +1,5 @@
+$opened-scroll-container-height: calc(80vh - 48px - 240px); // Viewport - topbar - sum of sibling elements
+
 .mat-mdc-dialog-actions {
   display: block;
   min-height: unset;
@@ -13,7 +15,7 @@
 
   &.open {
     margin-bottom: 24px;
-    max-height: calc(80vh - 48px - 240px); // Viewport - topbar - sum of sibling elements
+    max-height: $opened-scroll-container-height;
     padding: 2px;
   }
 
@@ -22,7 +24,7 @@
     border: 1px solid var(--lines);
     color: var(--fg2);
     font-family: 'Droid Sans Mono', 'Courier New', Courier, monospace;
-    height: 100%;
+    max-height: $opened-scroll-container-height;
     min-height: 100px;
     overflow: auto;
     padding: 1rem;


### PR DESCRIPTION
<img width="824" alt="Screenshot 2023-01-23 at 01 21 19" src="https://user-images.githubusercontent.com/22980553/213945943-60430213-d3c0-4084-8e6e-a5fddfb4234a.png">
