### PR TITLE
NAS-119773: removed validation pattern for ssh keypair name

### DIFF
--- a/src/app/pages/credentials/backup-credentials/ssh-keypair-form/ssh-keypair-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/ssh-keypair-form/ssh-keypair-form.component.ts
@@ -11,7 +11,7 @@ import { atLeastOne } from 'app/modules/entity/entity-form/validators/at-least-o
 import { EntityUtils } from 'app/modules/entity/utils';
 import { FormErrorHandlerService } from 'app/modules/ix-forms/services/form-error-handler.service';
 import {
-  AppLoaderService, DialogService, StorageService, UserService,
+  AppLoaderService, DialogService, StorageService,
 } from 'app/services';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
 import { WebSocketService2 } from 'app/services/ws2.service';
@@ -31,7 +31,7 @@ export class SshKeypairFormComponent {
   isFormLoading = false;
 
   form = this.fb.group({
-    name: ['', [Validators.required, Validators.pattern(UserService.namePattern)]],
+    name: ['', Validators.required],
     private_key: [''],
     public_key: ['', atLeastOne('private_key', [helptext.private_key_placeholder, helptext.public_key_placeholder])],
   });


### PR DESCRIPTION
Go to Credentials -> Backup-credentials
Change name of existing SSH Keypairs. `Validators.pattern` for this field was removed.
Probably the validator was added by mistake during the refactoring of the component, because it was not in the old code