### PR TITLE
NAS-119980 / 22.12.2 / Missing icon in dataset details header (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-icon/ix-icon.component.ts
+++ b/src/app/modules/ix-icon/ix-icon.component.ts
@@ -1,6 +1,15 @@
 import {
-  Attribute, ChangeDetectionStrategy, Component, ElementRef,
-  ErrorHandler, Inject, Input, OnChanges, OnInit, Optional, ViewEncapsulation,
+  AfterContentInit,
+  Attribute,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  ErrorHandler,
+  Inject,
+  Input,
+  OnInit,
+  Optional,
+  ViewEncapsulation,
 } from '@angular/core';
 import {
   MatIcon, MatIconDefaultOptions, MatIconLocation, MatIconRegistry, MAT_ICON_DEFAULT_OPTIONS, MAT_ICON_LOCATION,
@@ -29,7 +38,7 @@ import {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class IxIconComponent extends MatIcon implements OnInit, OnChanges {
+export class IxIconComponent extends MatIcon implements OnInit, AfterContentInit {
   @Input() name: string;
 
   private get iconName(): string {
@@ -61,10 +70,10 @@ export class IxIconComponent extends MatIcon implements OnInit, OnChanges {
 
   constructor(
     elementRef: ElementRef<HTMLElement>,
-    private iconRegistry: MatIconRegistry,
+    iconRegistry: MatIconRegistry,
     @Attribute('aria-hidden') ariaHidden: string,
-    @Inject(MAT_ICON_LOCATION) private location: MatIconLocation,
-    private readonly errorHandler: ErrorHandler,
+    @Inject(MAT_ICON_LOCATION) location: MatIconLocation,
+    readonly errorHandler: ErrorHandler,
     @Optional() @Inject(MAT_ICON_DEFAULT_OPTIONS)
     defaults?: MatIconDefaultOptions,
   ) {
@@ -76,7 +85,7 @@ export class IxIconComponent extends MatIcon implements OnInit, OnChanges {
     super.ngOnInit();
   }
 
-  ngOnChanges(): void {
+  ngAfterContentInit(): void {
     this.updateIcon(this.name);
   }
 

--- a/src/app/modules/ix-icon/ix-icon.component.ts
+++ b/src/app/modules/ix-icon/ix-icon.component.ts
@@ -7,6 +7,7 @@ import {
   ErrorHandler,
   Inject,
   Input,
+  OnChanges,
   OnInit,
   Optional,
   ViewEncapsulation,
@@ -38,7 +39,7 @@ import {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class IxIconComponent extends MatIcon implements OnInit, AfterContentInit {
+export class IxIconComponent extends MatIcon implements OnInit, OnChanges, AfterContentInit {
   @Input() name: string;
 
   private get iconName(): string {
@@ -83,6 +84,10 @@ export class IxIconComponent extends MatIcon implements OnInit, AfterContentInit
   ngOnInit(): void {
     this.updateIcon(this.iconName);
     super.ngOnInit();
+  }
+
+  ngOnChanges(): void {
+    this.updateIcon(this.name);
   }
 
   ngAfterContentInit(): void {

--- a/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.scss
+++ b/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.scss
@@ -129,6 +129,7 @@
 
     @media (max-width: $breakpoint-hidden) {
       display: inline-block;
+      left: 2px;
       position: relative;
       top: 1px;
     }

--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.html
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.html
@@ -149,7 +149,7 @@
       *ngIf="selectedNode"
       [topologyItem]="selectedNode | cast"
       [topologyParentItem]="selectedParentNode$ | async | cast"
-      [disk]="getDisk(selectedNode)"
+      [disk]="getDisk(selectedNode.children[0] || selectedNode)"
       [poolId]="poolId"
       [topologyCategory]="selectedTopologyCategory$ | async"
       (closeMobileDetails)="closeMobileDetails()"

--- a/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.scss
+++ b/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.scss
@@ -141,6 +141,7 @@
 
     @media (max-width: $breakpoint-hidden) {
       display: inline-block;
+      left: 2px;
       position: relative;
       top: 1px;
     }


### PR DESCRIPTION
Testing:
- Switch to mobile view
- Open dataset
<img width="161" alt="Screenshot 2023-01-24 at 15 21 15" src="https://user-images.githubusercontent.com/22980553/214305430-cc078563-542e-474b-8f41-466b4ab2b1ef.png">

- If icon is there, go to Storage and then go back.

- Open same dataset 

-- 
As well test devices for the same logic
<img width="1114" alt="Screenshot 2023-01-24 at 15 41 03" src="https://user-images.githubusercontent.com/22980553/214309983-dd533fb3-4cfe-4334-a453-2770b31501b5.png">


Original PR: https://github.com/truenas/webui/pull/7625
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119980