### PR TITLE
NAS-120182 / 23.10 / Fixed error throwing my new ws2

### DIFF
--- a/src/app/modules/layout/components/topbar/topbar.component.ts
+++ b/src/app/modules/layout/components/topbar/topbar.component.ts
@@ -184,7 +184,7 @@ export class TopbarComponent implements OnInit, OnDestroy {
       this.hostname = sysInfo.hostname;
     });
 
-    this.wsManager.websocketSubject$.pipe(
+    this.wsManager.websocket$.pipe(
       finalize(() => {
         this.modalService.closeSlideIn();
       }),

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -66,7 +66,7 @@ export class AuthService {
   }
 
   getFilteredWebsocketResponse<T>(uuid: string): Observable<T> {
-    return this.wsManager.websocketSubject$.pipe(
+    return this.wsManager.websocket$.pipe(
       filter((data: IncomingWebsocketMessage) => data.msg === IncomingApiMessageType.Result && data.id === uuid),
       map((data: ResultMessage<T>) => data.result),
       take(1),

--- a/src/app/services/system-general.service.ts
+++ b/src/app/services/system-general.service.ts
@@ -82,7 +82,9 @@ export class SystemGeneralService {
     protected ws: WebSocketService2,
     @Inject(WINDOW) private window: Window,
     private store$: Store<AppState>,
-  ) {}
+  ) {
+    this.getProductType$.subscribe();
+  }
 
   getCertificateAuthorities(): Observable<CertificateAuthority[]> {
     return this.ws.call(this.caList, []);

--- a/src/app/services/websocket-connection.service.ts
+++ b/src/app/services/websocket-connection.service.ts
@@ -5,7 +5,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { UUID } from 'angular2-uuid';
 import { environment } from 'environments/environment';
 import {
-  BehaviorSubject, EMPTY, interval, Observable, of, switchMap, tap, throwError, timer,
+  BehaviorSubject, EMPTY, interval, Observable, of, switchMap, tap, timer,
 } from 'rxjs';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { IncomingApiMessageType, OutgoingApiMessageType } from 'app/enums/api-message-type.enum';
@@ -61,10 +61,6 @@ export class WebsocketConnectionService {
         if (this.hasAuthError(data)) {
           this.ws$.complete();
           return EMPTY;
-        }
-        if ('error' in data && data.error) {
-          console.error('Error: ', data.id, data.error);
-          return throwError(() => data.error);
         }
         return of(data);
       }),

--- a/src/app/services/websocket-connection.service.ts
+++ b/src/app/services/websocket-connection.service.ts
@@ -5,7 +5,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { UUID } from 'angular2-uuid';
 import { environment } from 'environments/environment';
 import {
-  BehaviorSubject, EMPTY, interval, Observable, of, switchMap, tap, timer,
+  BehaviorSubject, EMPTY, interval, Observable, of, switchMap, tap, throwError, timer,
 } from 'rxjs';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 import { IncomingApiMessageType, OutgoingApiMessageType } from 'app/enums/api-message-type.enum';
@@ -28,17 +28,10 @@ export class WebsocketConnectionService {
 
   private isConnectionReady = false;
   private isConnectionReady$ = new BehaviorSubject(false);
+  private wsAsObservable$: Observable<unknown>;
 
-  get websocketSubject$(): Observable<unknown> {
-    return this.ws$.asObservable().pipe(
-      switchMap((data: IncomingWebsocketMessage) => {
-        if (this.hasAuthError(data)) {
-          this.ws$.complete();
-          return EMPTY;
-        }
-        return of(data);
-      }),
-    );
+  get websocket$(): Observable<unknown> {
+    return this.wsAsObservable$;
   }
 
   get isConnected$(): Observable<boolean> {
@@ -63,7 +56,19 @@ export class WebsocketConnectionService {
         next: this.onClose.bind(this),
       },
     });
-
+    this.wsAsObservable$ = this.ws$.asObservable().pipe(
+      switchMap((data: IncomingWebsocketMessage) => {
+        if (this.hasAuthError(data)) {
+          this.ws$.complete();
+          return EMPTY;
+        }
+        if ('error' in data && data.error) {
+          console.error('Error: ', data.id, data.error);
+          return throwError(() => data.error);
+        }
+        return of(data);
+      }),
+    );
     // Atleast one explicit subscription required to keep the connection open
     this.ws$.pipe(
       tap((response: IncomingWebsocketMessage) => {

--- a/src/app/services/ws2.service.ts
+++ b/src/app/services/ws2.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { UUID } from 'angular2-uuid';
-import { Observable } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import {
   filter, map, share, switchMap, take,
 } from 'rxjs/operators';
@@ -37,6 +37,13 @@ export class WebSocketService2 {
     });
     return this.ws$.pipe(
       filter((data: IncomingWebsocketMessage) => data.msg === IncomingApiMessageType.Result && data.id === uuid),
+      switchMap((data: IncomingWebsocketMessage) => {
+        if ('error' in data && data.error) {
+          console.error('Error: ', data.error);
+          return throwError(() => data.error);
+        }
+        return of(data);
+      }),
       map((data: ResultMessage<ApiDirectory[K]['response']>) => data.result),
       take(1),
     );

--- a/src/app/services/ws2.service.ts
+++ b/src/app/services/ws2.service.ts
@@ -27,7 +27,7 @@ export class WebSocketService2 {
   ) { }
 
   private get ws$(): Observable<unknown> {
-    return this.wsManager.websocketSubject$;
+    return this.wsManager.websocket$;
   }
 
   call<K extends ApiMethod>(method: K, params?: ApiDirectory[K]['params']): Observable<ApiDirectory[K]['response']> {

--- a/src/app/views/sessions/signin/store/signin.store.spec.ts
+++ b/src/app/views/sessions/signin/store/signin.store.spec.ts
@@ -33,7 +33,7 @@ describe('SigninStore', () => {
       ]),
       mockProvider(WebsocketConnectionService, {
         isConnected$: of(true),
-        websocketSubject$: of(),
+        websocket$: of(),
       }),
       mockProvider(Router),
       mockProvider(SnackbarService),

--- a/src/app/views/sessions/signin/store/signin.store.ts
+++ b/src/app/views/sessions/signin/store/signin.store.ts
@@ -251,7 +251,7 @@ export class SigninStore extends ComponentStore<SigninState> {
    * If websocket connection is lost because of failover event, we need to resubscribe to updates.
    */
   private updateFailoverStatusOnDisconnect(): void {
-    this.wsManager.websocketSubject$.pipe(
+    this.wsManager.websocket$.pipe(
       finalize(() => {
         this.wsManager.isConnected$.pipe(
           filter(Boolean),


### PR DESCRIPTION
The new `WebsocketConnectionService` wasn't throwing errors properly. It should do that now.

Also, the new method called in the constructor of `SystemGeneralService` is there because not putting it there is causing a race condition of some sort where the signin page keeps loading indefinitely and you can't login. Refreshing the signin page a few times should reproduce that bug.