### PR TITLE
NAS-119431 / 22.12.2 / No special treatment for dictionary list items

### DIFF
--- a/src/app/services/app-shema.transformer.ts
+++ b/src/app/services/app-shema.transformer.ts
@@ -185,15 +185,8 @@ export function transformListSchemaType(
   let items: DynamicFormSchemaNode[] = [];
   let itemsSchema: ChartSchemaNode[] = [];
   schema.items.forEach((item) => {
-    if (item.schema.attrs) {
-      item.schema.attrs.forEach((attr) => {
-        items = items.concat(transformNode(attr, isNew, !!schema.immutable || isParentImmutable));
-        itemsSchema = itemsSchema.concat(attr);
-      });
-    } else {
-      items = items.concat(transformNode(item, isNew, !!schema.immutable || isParentImmutable));
-      itemsSchema = itemsSchema.concat(item);
-    }
+    items = items.concat(transformNode(item, isNew, !!schema.immutable || isParentImmutable));
+    itemsSchema = itemsSchema.concat(item);
   });
   return {
     ...buildCommonSchemaBase(payload),


### PR DESCRIPTION
The issue was caused because the logic in the addressed method skipped the item and went directly to its attributes and treated them as a direct child of the grand parent. Removing that special treatment fixes this error.

Click `Launch Docker Image` on the apps page. Enter `nginx` in the `Image Repository` field and add a couple of options `'/abc'`, `'/def'` in the `Memory Backed Volumes` field. When you submit, the data sent with the request payload should have the `emptyDirVolumes` field the following formatting `{ ..., emptyDirVolumes: [{ mouthPath: '/abc' }, { mountPath: '/def' }], ... }` instead of `{ ..., emptyDirVolumes: [ '/abc', '/def' ], ... }`

Also, check for regressions by trying to install some other apps.