### PR TITLE
NAS-120083 / 22.12.2 / Fixed calls wherever token is used

### DIFF
--- a/src/app/interfaces/subs.interface.ts
+++ b/src/app/interfaces/subs.interface.ts
@@ -1,5 +1,0 @@
-// TODO: Unclear what it is and why it's called Subs
-export interface Subs {
-  apiEndPoint: string;
-  file: File;
-}

--- a/src/app/pages/system/file-ticket/file-ticket-form/file-ticket-form.component.spec.ts
+++ b/src/app/pages/system/file-ticket/file-ticket-form/file-ticket-form.component.spec.ts
@@ -69,6 +69,8 @@ describe('FileTicketFormComponent', () => {
                 API: '11008',
                 WebUI: '10004',
               });
+            case 'auth.generate_token':
+              return of('AUTH_TOKEN');
           }
         }),
       }),

--- a/src/app/pages/system/file-ticket/file-ticket-form/file-ticket-form.component.ts
+++ b/src/app/pages/system/file-ticket/file-ticket-form/file-ticket-form.component.ts
@@ -192,13 +192,22 @@ export class FileTicketFormComponent implements OnInit {
               this.openSuccessDialog(job.result);
             },
           });
-          this.screenshots.forEach((file) => {
-            this.fileUpload.upload(file, 'support.attach_ticket', [{
-              ticket: job.result.ticket,
-              filename: file.name,
-              token: payload.token,
-            }]);
-          });
+          this.ws.call('auth.generate_token').pipe(
+            tap((token) => {
+              this.screenshots.forEach((file) => {
+                this.fileUpload.upload(file, 'support.attach_ticket', [{
+                  ticket: job.result.ticket,
+                  filename: file.name,
+                  token: payload.token,
+                }], '/_upload?auth_token=' + token);
+              });
+            }),
+            catchError((error) => {
+              this.dialog.errorReportMiddleware(error);
+              return EMPTY;
+            }),
+            untilDestroyed(this),
+          ).subscribe();
         } else {
           this.isFormLoading$.next(false);
           this.openSuccessDialog(job.result);

--- a/src/app/pages/system/file-ticket/file-ticket-licensed-form/file-ticket-licensed-form.component.spec.ts
+++ b/src/app/pages/system/file-ticket/file-ticket-licensed-form/file-ticket-licensed-form.component.spec.ts
@@ -61,6 +61,7 @@ describe('FileTicketLicensedFormComponent', () => {
         }),
         mockJob('support.new_ticket', fakeSuccessfulJob(mockNewTicketResponse as NewTicketResponse)),
         mockJob('support.attach_ticket', fakeSuccessfulJob()),
+        mockCall('auth.generate_token', 'AUTH_TOKEN'),
       ]),
       mockProvider(IxSlideInService),
       mockProvider(FormErrorHandlerService),

--- a/src/app/pages/system/file-ticket/file-ticket-licensed-form/file-ticket-licensed-form.component.ts
+++ b/src/app/pages/system/file-ticket/file-ticket-licensed-form/file-ticket-licensed-form.component.ts
@@ -165,12 +165,17 @@ export class FileTicketLicensedFormComponent implements OnInit {
               this.openSuccessDialog(job.result);
             },
           });
-          this.screenshots.forEach((file) => {
-            this.fileUpload.upload(file, 'support.attach_ticket', [{
-              ticket: job.result.ticket,
-              filename: file.name,
-            }]);
-          });
+          this.ws.call('auth.generate_token').pipe(
+            tap((token) => {
+              this.screenshots.forEach((file) => {
+                this.fileUpload.upload(file, 'support.attach_ticket', [{
+                  ticket: job.result.ticket,
+                  filename: file.name,
+                }], '/_upload?auth_token=' + token);
+              });
+            }),
+            untilDestroyed(this),
+          ).subscribe();
         } else {
           this.isFormLoading = false;
           this.openSuccessDialog(job.result);

--- a/src/app/pages/system/general-settings/upload-config-dialog/upload-config-dialog.component.ts
+++ b/src/app/pages/system/general-settings/upload-config-dialog/upload-config-dialog.component.ts
@@ -5,8 +5,9 @@ import { Router } from '@angular/router';
 import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { helptextSystemGeneral as helptext } from 'app/helptext/system/general';
+import { WebsocketError } from 'app/interfaces/websocket-error.interface';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
-import { WebSocketService } from 'app/services';
+import { AppLoaderService, DialogService, WebSocketService } from 'app/services';
 
 @UntilDestroy()
 @Component({
@@ -26,6 +27,8 @@ export class UploadConfigDialogComponent {
     private router: Router,
     private mdDialog: MatDialog,
     private ws: WebSocketService,
+    private appLoader: AppLoaderService,
+    private dialogService: DialogService,
   ) {}
 
   onSubmit(): void {
@@ -45,6 +48,16 @@ export class UploadConfigDialogComponent {
     dialogRef.componentInstance.failure.pipe(untilDestroyed(this)).subscribe((res) => {
       dialogRef.componentInstance.setDescription(res.error);
     });
-    dialogRef.componentInstance.wspost('/_upload?auth_token=' + this.ws.token, formData);
+    this.appLoader.open();
+    this.ws.call('auth.generate_token').pipe(untilDestroyed(this)).subscribe({
+      next: (token) => {
+        this.appLoader.close();
+        dialogRef.componentInstance.wspost('/_upload?auth_token=' + token, formData);
+      },
+      error: (error: WebsocketError) => {
+        this.appLoader.close();
+        this.dialogService.errorReportMiddleware(error);
+      },
+    });
   }
 }

--- a/src/app/services/ix-file-upload.service.ts
+++ b/src/app/services/ix-file-upload.service.ts
@@ -23,10 +23,6 @@ export class IxFileUploadService {
   private fileUploadProgress$ = new Subject<HttpProgressEvent>();
   private fileUploadSuccess$ = new Subject<HttpResponse<unknown>>();
 
-  get defaultUploadEndpoint(): string {
-    return '/_upload?auth_token=' + this.ws.token;
-  }
-
   constructor(
     protected http: HttpClient,
     private translate: TranslateService,
@@ -37,7 +33,7 @@ export class IxFileUploadService {
     file: File,
     method: ApiMethod,
     params: unknown[] = [],
-    apiEndPoint = this.defaultUploadEndpoint,
+    apiEndPoint: string,
   ): void {
     const formData: FormData = new FormData();
     formData.append('data', JSON.stringify({


### PR DESCRIPTION
The ticket bug was caused by the fact that the token generated by the call `auth.generate_token` expires after 300 seconds. So, at the time of using that token, if it has expired, middleware will give a 403 error.

This PR aims to call `auth.generate_token` to generate a fresh token every time it is used in such a way.