### PR TITLE
NAS-119783 / 13.0 / NAS-119783 - Fixed error "[schedule] A dict was expected" for create a replication task

### DIFF
--- a/src/app/pages/task-calendar/replication/replication-form/replication-form.component.ts
+++ b/src/app/pages/task-calendar/replication/replication-form/replication-form.component.ts
@@ -818,6 +818,7 @@ export class ReplicationFormComponent {
           name: 'schedule',
           placeholder: helptext.schedule_placeholder,
           tooltip: helptext.schedule_tooltip,
+          value: false,
         }, {
           type: 'scheduler',
           name: 'schedule_picker',
@@ -1279,6 +1280,8 @@ export class ReplicationFormComponent {
       delete data['schedule_picker'];
       delete data['schedule_begin'];
       delete data['schedule_end'];
+    } else {
+      delete data['schedule'];
     }
     if (data['restrict_schedule']) {
       data['restrict_schedule'] = this.parsePickerTime(data['restrict_schedule_picker'], data['restrict_schedule_begin'], data['restrict_schedule_end']);


### PR DESCRIPTION
Create a replication task. 
Set the state to true for the Schedule checkbox.
Edit the task and change the Schedule state to false. 
There should be no errors after saving.


![image](https://user-images.githubusercontent.com/22006748/218077772-b54e73fa-061a-4f91-81f7-e3aad5dd3464.png)
