### PR TITLE
NAS-117906 / 23.10 / Cannot clear optional integer value - nodePort

### DIFF
--- a/src/app/interfaces/chart-release.interface.ts
+++ b/src/app/interfaces/chart-release.interface.ts
@@ -135,6 +135,7 @@ export interface ChartSchemaEnum {
 export interface ChartSchemaNodeConf {
   type: ChartSchemaType;
   attrs?: ChartSchemaNode[];
+  null?: boolean;
   items?: ChartSchemaNode[];
   default?: unknown | unknown[];
   enum?: ChartSchemaEnum[];

--- a/src/app/pages/apps-old/forms/chart-form/chart-form.component.ts
+++ b/src/app/pages/apps-old/forms/chart-form/chart-form.component.ts
@@ -36,6 +36,7 @@ export class ChartFormComponent implements OnDestroy {
   title: string;
   config: { [key: string]: ChartFormValue };
   catalogApp: CatalogApp;
+  chartSchema: ChartSchema['schema'];
 
   isLoading = false;
   isNew = true;
@@ -142,6 +143,7 @@ export class ChartFormComponent implements OnDestroy {
   }
 
   buildDynamicForm(schema: ChartSchema['schema']): void {
+    this.chartSchema = schema;
     try {
       schema.groups.forEach((group) => {
         this.dynamicSection.push({ ...group, schema: [] });
@@ -227,7 +229,8 @@ export class ChartFormComponent implements OnDestroy {
   }
 
   onSubmit(): void {
-    const data = this.appSchemaService.serializeFormValue(this.form.getRawValue()) as ChartFormValues;
+    const data = this.appSchemaService.serializeFormValue(this.form.getRawValue(), this.chartSchema) as ChartFormValues;
+
     const deleteField$ = new Subject<string>();
     deleteField$.pipe(untilDestroyed(this)).subscribe({
       next: (fieldToBeDeleted) => {

--- a/src/app/pages/apps/components/chart-form/chart-form.component.ts
+++ b/src/app/pages/apps/components/chart-form/chart-form.component.ts
@@ -42,6 +42,7 @@ export class ChartFormComponent implements OnDestroy {
   dynamicSection: DynamicFormSchema[] = [];
   dialogRef: MatDialogRef<EntityJobComponent>;
   subscription = new Subscription();
+  chartSchema: ChartSchema['schema'];
 
   form = this.formBuilder.group<ChartFormValues>({
     release_name: '',
@@ -142,6 +143,7 @@ export class ChartFormComponent implements OnDestroy {
   }
 
   buildDynamicForm(schema: ChartSchema['schema']): void {
+    this.chartSchema = schema;
     try {
       schema.groups.forEach((group) => {
         this.dynamicSection.push({ ...group, schema: [] });
@@ -227,7 +229,7 @@ export class ChartFormComponent implements OnDestroy {
   }
 
   onSubmit(): void {
-    const data = this.appSchemaService.serializeFormValue(this.form.getRawValue()) as ChartFormValues;
+    const data = this.appSchemaService.serializeFormValue(this.form.getRawValue(), this.chartSchema) as ChartFormValues;
     const deleteField$ = new Subject<string>();
     deleteField$.pipe(untilDestroyed(this)).subscribe({
       next: (fieldToBeDeleted) => {

--- a/src/app/services/schema/app-schema.service.spec.ts
+++ b/src/app/services/schema/app-schema.service.spec.ts
@@ -1,5 +1,6 @@
 import { FormArray, FormControl, UntypedFormGroup } from '@angular/forms';
 import { FormGroup } from '@ngneat/reactive-forms';
+import { ChartSchemaType } from 'app/enums/chart-schema-type.enum';
 import { ChartSchemaNode } from 'app/interfaces/chart-release.interface';
 import {
   DynamicFormSchemaCheckbox,
@@ -537,21 +538,43 @@ describe('AppSchemaService', () => {
   });
   describe('serializeFormValue()', () => {
     it('serialization validation', () => {
-      expect(service.serializeFormValue(undefined)).toBeUndefined();
-      expect(service.serializeFormValue(true)).toBe(true);
-      expect(service.serializeFormValue(1)).toBe(1);
-      expect(service.serializeFormValue('1')).toBe('1');
-      expect(service.serializeFormValue('')).toBe('');
-      expect(service.serializeFormValue('test')).toBe('test');
-      expect(service.serializeFormValue(12)).toBe(12);
-      expect(service.serializeFormValue({})).toEqual({});
-      expect(service.serializeFormValue([])).toEqual([]);
-      expect(service.serializeFormValue([{ a: 1 }, { a: 2 }, { a: 3 }])).toEqual([1, 2, 3]);
-      expect(service.serializeFormValue({ a: 1 })).toEqual({ a: 1 });
-      expect(service.serializeFormValue({ a: { b: 1 } })).toEqual({ a: { b: 1 } });
-      expect(service.serializeFormValue({ a: { b: [{ c: 'test' }] } })).toEqual({ a: { b: ['test'] } });
-      expect(service.serializeFormValue({ a: { c: null, d: 'test' }, b: null })).toEqual({ a: { d: 'test' } });
-      expect(service.serializeFormValue('* * * * *')).toEqual({
+      expect(service.serializeFormValue(undefined, null)).toBeUndefined();
+      expect(service.serializeFormValue(true, null)).toBe(true);
+      expect(service.serializeFormValue(1, null)).toBe(1);
+      expect(service.serializeFormValue('1', null)).toBe('1');
+      expect(service.serializeFormValue('', null)).toBe('');
+      expect(service.serializeFormValue('test', null)).toBe('test');
+      expect(service.serializeFormValue(12, null)).toBe(12);
+      expect(service.serializeFormValue({}, null)).toEqual({});
+      expect(service.serializeFormValue([], null)).toEqual([]);
+      expect(service.serializeFormValue([{ a: 1 }, { a: 2 }, { a: 3 }], null)).toEqual([1, 2, 3]);
+      expect(service.serializeFormValue({ a: 1 }, null)).toEqual({ a: 1 });
+      expect(service.serializeFormValue({ a: { b: 1 } }, null)).toEqual({ a: { b: 1 } });
+      expect(service.serializeFormValue({ a: { b: [{ c: 'test' }] } }, null)).toEqual({ a: { b: ['test'] } });
+      expect(service.serializeFormValue({ a: { c: null, d: 'test' }, b: null }, null)).toEqual({ a: { d: 'test' } });
+      expect(service.serializeFormValue({ a: { c: null, d: 'test' }, b: null }, {
+        questions: [
+          {
+            schema: {
+              type: ChartSchemaType.Int,
+              null: true,
+            },
+            label: 'c',
+            variable: 'c',
+          },
+          {
+            schema: {
+              type: ChartSchemaType.Int,
+              null: false,
+            },
+            label: 'b',
+            variable: 'b',
+          },
+        ],
+        groups: [],
+        portals: {},
+      })).toEqual({ a: { c: null, d: 'test' } });
+      expect(service.serializeFormValue('* * * * *', null)).toEqual({
         hour: '*',
         minute: '*',
         month: '*',

--- a/src/app/services/schema/app-schema.service.ts
+++ b/src/app/services/schema/app-schema.service.ts
@@ -237,7 +237,7 @@ export class AppSchemaService {
     Object.keys(groupValue).forEach((key) => {
       result[key] = this.serializeFormValue(groupValue[key], schema) as HierarchicalObjectMap<ChartFormValue>;
       if (result[key] === null) {
-        const fieldSchema = _.find(schema.questions, { variable: key });
+        const fieldSchema = _.find(schema?.questions, { variable: key });
 
         if (fieldSchema?.schema?.null) {
           return null;

--- a/src/app/services/schema/app-schema.service.ts
+++ b/src/app/services/schema/app-schema.service.ts
@@ -13,7 +13,7 @@ import {
   KeysRestoredFromFormGroup,
   SerializeFormValue,
 } from 'app/interfaces/app-schema.interface';
-import { ChartFormValue, ChartSchemaNode } from 'app/interfaces/chart-release.interface';
+import { ChartFormValue, ChartSchema, ChartSchemaNode } from 'app/interfaces/chart-release.interface';
 import { DeleteListItemEvent, DynamicFormSchemaNode } from 'app/interfaces/dynamic-form-schema.interface';
 import { HierarchicalObjectMap } from 'app/interfaces/hierarhical-object-map.interface';
 import { Schedule } from 'app/interfaces/schedule.interface';
@@ -213,7 +213,7 @@ export class AppSchemaService {
     return !!(schedule.month && schedule.hour && schedule.minute && schedule.dom && schedule.dow);
   }
 
-  serializeFormValue(data: SerializeFormValue): SerializeFormValue {
+  serializeFormValue(data: SerializeFormValue, schema: ChartSchema['schema']): SerializeFormValue {
     if (data == null) {
       return data;
     }
@@ -221,19 +221,28 @@ export class AppSchemaService {
       return crontabToSchedule(data) as SerializeFormValue;
     }
     if (Array.isArray(data)) {
-      return this.serializeFormList(data);
+      return this.serializeFormList(data, schema);
     }
     if (typeof data === 'object') {
-      return this.serializeFormGroup(data as HierarchicalObjectMap<ChartFormValue>);
+      return this.serializeFormGroup(data as HierarchicalObjectMap<ChartFormValue>, schema);
     }
     return data;
   }
 
-  serializeFormGroup(groupValue: HierarchicalObjectMap<ChartFormValue>): HierarchicalObjectMap<ChartFormValue> {
+  serializeFormGroup(
+    groupValue: HierarchicalObjectMap<ChartFormValue>,
+    schema: ChartSchema['schema'],
+  ): HierarchicalObjectMap<ChartFormValue> {
     const result = {} as HierarchicalObjectMap<ChartFormValue>;
     Object.keys(groupValue).forEach((key) => {
-      result[key] = this.serializeFormValue(groupValue[key]) as HierarchicalObjectMap<ChartFormValue>;
+      result[key] = this.serializeFormValue(groupValue[key], schema) as HierarchicalObjectMap<ChartFormValue>;
       if (result[key] === null) {
+        const fieldSchema = _.find(schema.questions, { variable: key });
+
+        if (fieldSchema?.schema?.null) {
+          return null;
+        }
+
         delete result[key];
       }
     });
@@ -242,12 +251,13 @@ export class AppSchemaService {
 
   serializeFormList(
     list: HierarchicalObjectMap<ChartFormValue>[] | ChartFormValue[],
+    schema: ChartSchema['schema'],
   ): HierarchicalObjectMap<ChartFormValue>[] {
     return list.map((listItem: HierarchicalObjectMap<ChartFormValue>) => {
       if (Object.keys(listItem).length > 1) {
-        return this.serializeFormValue(listItem);
+        return this.serializeFormValue(listItem, schema);
       }
-      return this.serializeFormValue(listItem[Object.keys(listItem)[0]]);
+      return this.serializeFormValue(listItem[Object.keys(listItem)[0]], schema);
     }) as HierarchicalObjectMap<ChartFormValue>[];
   }
 


### PR DESCRIPTION
Write to @stavros-k  to set up app according to this comment:
https://ixsystems.atlassian.net/browse/NAS-117906?focusedCommentId=179172 

Check app new fields

![image](https://user-images.githubusercontent.com/22980553/218501394-7f644b9f-8777-48bb-a6fc-dbd07abea5e8.png)

![image](https://user-images.githubusercontent.com/22980553/218501523-694e82fa-63c8-48bd-991b-42da08dc0712.png)

AND in the end check `onSubmit(): void {` method in **chart-form.component.ts**

**const data = this.appSchemaService.serializeFormValue(this.form.getRawValue(), this.chartSchema) as ChartFormValues;**

fill all the required fields, then submit and:

console.log(data) and see that field where:
-- **NULL_FALSE is not in the object**
-- **NULL_TRUE is in the object as null** 