### PR TITLE
NAS-120250 / 13.0 / Fixing incorrect rsync module being edited

### DIFF
--- a/src/app/pages/services/components/service-rsync/rsyncconfiguration/rsyncmodule/rsyncconfiguration-form.component.ts
+++ b/src/app/pages/services/components/service-rsync/rsyncconfiguration/rsyncmodule/rsyncconfiguration-form.component.ts
@@ -18,6 +18,7 @@ export class RYSNCConfigurationFormComponent {
   protected isEntity = true;
   formGroup: FormGroup;
   protected pk: any;
+  protected queryKey = 'id';
   protected addCall = 'rsyncmod.create';
   protected isNew: boolean;
   fieldConfig: FieldConfig[] = [];


### PR DESCRIPTION
Testing: see ticket. Original issue didn't happen every time, you had to open rsync module several times.

Note to self: do not merge before u4 release.