### PR TITLE
TE-117 / 23.10 / backport "Adding test cases to verify Alert, middleware logs and SMB permission on failover" from  (#7754)

### DIFF
--- a/tests/bdd/ha-bhyve02/test_NAS_T0951.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0951.py
@@ -103,9 +103,9 @@ def add_user_to_additional_groups_like_wheel_and_save_change(driver):
     assert wait_on_element(driver, 7, xpaths.add_User.auxiliary_Groups_Select, 'clickable')
 
     driver.find_element_by_xpath(xpaths.add_User.auxiliary_Groups_Select).click()
-    assert wait_on_element(driver, 7, xpaths.add_User.root_Group_Option, 'clickable')
-    driver.find_element_by_xpath(xpaths.add_User.root_Group_Option).click()
-    driver.find_element_by_xpath(xpaths.add_User.root_Group_Option).send_keys(Keys.TAB)
+    assert wait_on_element(driver, 7, xpaths.add_User.games_Group_Option, 'clickable')
+    driver.find_element_by_xpath(xpaths.add_User.games_Group_Option).click()
+    driver.find_element_by_xpath(xpaths.add_User.games_Group_Option).send_keys(Keys.TAB)
     wait_on_element(driver, 10, xpaths.button.save, 'clickable')
     driver.find_element_by_xpath(xpaths.button.save).click()
 
@@ -130,6 +130,6 @@ def reopen_the_user_edit_page_and_ensure_that_the_additional_group_was_saved(dri
 @then('Aux Group added should be visible')
 def aux_group_added_should_be_visible(driver):
     """Aux Group added should be visible."""
-    assert wait_on_element(driver, 7, '//mat-select[contains(.,"root,")]')
-    assert wait_on_element(driver, 7, '//ix-modal-header//mat-icon[contains(.,"cancel")]', 'clickable')
-    driver.find_element_by_xpath('//ix-modal-header//mat-icon[contains(.,"cancel")]').click()
+    assert wait_on_element(driver, 7, '//mat-select[contains(.,"games")]')
+    assert wait_on_element(driver, 7, xpaths.button.close_Icon, 'clickable')
+    driver.find_element_by_xpath(xpaths.button.close_Icon).click()

--- a/tests/bdd/ha-bhyve02/test_NAS_T0961.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0961.py
@@ -213,18 +213,15 @@ def verify_the_system_dataset_is_dozer_on_the_active_node(driver):
 @then('press Initiate Failover and confirm')
 def press_initiate_failover_and_confirm(driver):
     """press Initiate Failover and confirm."""
-    assert wait_on_element(driver, 10, xpaths.dashboard.system_Information_Standby_Title)
-    assert wait_on_element(driver, 20, xpaths.toolbar.ha_Enabled)
-    assert wait_on_element(driver, 10, xpaths.button.initiate_Failover, 'clickable')
-    driver.find_element_by_xpath(xpaths.button.initiate_Failover).click()
+    rsc.Trigger_Failover(driver)
+
     rsc.Confirm_Failover(driver)
 
 
 @then('wait for the login and the HA enabled status and login')
 def wait_for_the_login_and_the_HA_enabled_status_and_login(driver):
     """wait for the login and the HA enabled status and login."""
-    assert wait_on_element(driver, 180, xpaths.login.user_Input)
-    assert wait_on_element(driver, 180, xpaths.login.ha_Status_Enable)
+    rsc.HA_Login_Status_Enable(driver)
 
     rsc.Login(driver, admin_User, root_Password)
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0962.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0962.py
@@ -204,10 +204,8 @@ def after_go_to_the_dashboard(driver):
 @then('click INITIATE FAILOVER, click the confirm checkbox, and press FAILOVER')
 def click_initiate_failover_click_the_confirm_checkbox_and_press_failover(driver):
     """click INITIATE FAILOVER, click the confirm checkbox, and press FAILOVER."""
-    assert wait_on_element(driver, 60, xpaths.toolbar.ha_Enabled)
-    assert wait_on_element(driver, 10, xpaths.dashboard.system_Information_Standby_Title)
-    assert wait_on_element(driver, 10, xpaths.button.initiate_Failover, 'clickable')
-    driver.find_element_by_xpath(xpaths.button.initiate_Failover).click()
+    rsc.Trigger_Failover(driver)
+
     rsc.Confirm_Failover(driver)
 
 
@@ -215,8 +213,7 @@ def click_initiate_failover_click_the_confirm_checkbox_and_press_failover(driver
 def wait_for_the_login_page_to_appear(driver):
     """Wait for the login page to appear."""
     # to make sure the UI is refresh for the login page
-    assert wait_on_element(driver, 180, xpaths.login.user_Input)
-    assert wait_on_element(driver, 180, xpaths.login.ha_Status_Enable)
+    rsc.HA_Login_Status_Enable(driver)
 
 
 @then(parsers.parse('at the login page, enter "{user}" and "{password}"'))
@@ -252,9 +249,9 @@ def after_click_dataset_on_the_left_sidebar(driver):
 def on_the_dataset_page_click_on_the_dozer_tree_and_click_add_dataset(driver):
     """on the Dataset page, click on the dozer tree and click Add Dataset."""
     assert wait_on_element(driver, 7, xpaths.dataset.title)
-    assert wait_on_element(driver, 7, '//span[text()=" dozer " and contains(@class,"name")]')
-    driver.find_element_by_xpath('//ix-dataset-node[contains(.,"dozer")]/div').click()
-    assert wait_on_element(driver, 7, '//span[text()="dozer" and contains(@class,"own-name")]')
+    assert wait_on_element(driver, 7, xpaths.dataset.pool_Tree_Name('dozer'))
+    driver.find_element_by_xpath(xpaths.dataset.pool_Tree('dozer')).click()
+    assert wait_on_element(driver, 7, xpaths.dataset.pool_Selected('dozer'))
     assert wait_on_element(driver, 5, xpaths.dataset.add_Dataset_Button, 'clickable')
     driver.find_element_by_xpath(xpaths.dataset.add_Dataset_Button).click()
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0964.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0964.py
@@ -96,9 +96,8 @@ def input_my_active_directory_smb_share_as_the_description_click_save(driver, de
 @then('if Restart SMB Service box appears, click Restart Service')
 def if_restart_smb_service_box_appears_click_restart_service(driver):
     """if Restart SMB Service box appears, click Restart Service."""
-    assert wait_on_element(driver, 7, xpaths.popup.smb_Restart_Title)
-    assert wait_on_element(driver, 5, xpaths.popup.smb_Restart_Button, 'clickable')
-    driver.find_element_by_xpath(xpaths.popup.smb_Restart_Button).click()
+    rsc.Restart_SMB_Service(driver)
+
     assert wait_on_element_disappear(driver, 30, xpaths.progress.progressbar)
 
 
@@ -145,17 +144,15 @@ def verify_that_the_file_is_on_host(driver, nas_hostname):
     file = f'{dataset}/testfile.txt'
     results = post(nas_hostname, '/filesystem/stat/', ('root', root_password), file)
     assert results.status_code == 200, results.text
-
+    time.sleep(5)
 
 @then('go to the Dashboard and click Initiate Failover on the System Information standby controller')
 def go_to_the_dashboard_and_click_initiate_failover_on_the_system_information_standby_controller(driver):
     """go to the Dashboard and click Initiate Failover on the System Information standby controller."""
     driver.find_element_by_xpath(xpaths.side_Menu.dashboard).click()
     assert wait_on_element(driver, 10, xpaths.dashboard.title)
-    assert wait_on_element(driver, 60, xpaths.toolbar.ha_Enabled)
-    assert wait_on_element(driver, 10, xpaths.dashboard.system_Information_Standby_Title)
-    assert wait_on_element(driver, 10, xpaths.button.initiate_Failover, 'clickable')
-    driver.find_element_by_xpath(xpaths.button.initiate_Failover).click()
+
+    rsc.Trigger_Failover(driver)
 
 
 @then('on the Initiate Failover box check the Confirm checkbox, then click Failover')
@@ -167,8 +164,7 @@ def on_the_initiate_failover_box_check_the_confirm_checkbox_then_click_failover(
 @then('wait for the login to appear and HA to be enable')
 def wait_for_the_login_to_appear_and_ha_to_be_enable(driver):
     """wait for the login to appear and HA to be enable."""
-    assert wait_on_element(driver, 180, xpaths.login.user_Input)
-    assert wait_on_element(driver, 180, xpaths.login.ha_Status_Enable)
+    rsc.HA_Login_Status_Enable(driver)
 
 
 @then(parsers.parse('at the login page, enter "{user}" and "{password}"'))

--- a/tests/bdd/ha-bhyve02/test_NAS_T1657_NFSv3_failover.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T1657_NFSv3_failover.py
@@ -304,10 +304,8 @@ def go_to_the_dashboard_and_click_initiate_failover_on_the_standby_controller(dr
     """go to the Dashboard and click Initiate Failover on the standby controller."""
     driver.find_element_by_xpath(xpaths.side_Menu.dashboard).click()
     assert wait_on_element(driver, 10, xpaths.dashboard.title)
-    assert wait_on_element(driver, 60, xpaths.toolbar.ha_Enabled)
-    assert wait_on_element(driver, 10, xpaths.dashboard.system_Information_Standby_Title)
-    assert wait_on_element(driver, 10, xpaths.button.initiate_Failover, 'clickable')
-    driver.find_element_by_xpath(xpaths.button.initiate_Failover).click()
+
+    rsc.Trigger_Failover(driver)
 
 
 @then('on the Initiate Failover box, check the Confirm checkbox, then click Failover')
@@ -319,8 +317,7 @@ def on_the_initiate_failover_box_check_the_confirm_checkbox_then_click_failover(
 @then(parsers.parse('wait for the login to appear and HA to be enabled, login with {user} and {password}'))
 def wait_for_the_login_to_appear_and_ha_to_be_enabled_login_with_user_and_password(driver, user, password):
     """wait for the login to appear and HA to be enabled, login with <user> and <password>."""
-    assert wait_on_element(driver, 180, xpaths.login.user_Input)
-    assert wait_on_element(driver, 180, xpaths.login.ha_Status_Enable)
+    rsc.HA_Login_Status_Enable(driver)
 
     rsc.Login(driver, user, password)
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T1658_alert_on_failover.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T1658_alert_on_failover.py
@@ -1,0 +1,148 @@
+"""SCALE High Availability (tn-bhyve06) feature tests."""
+
+import pytest
+import reusableSeleniumCode as rsc
+import xpaths
+from function import (
+    wait_on_element,
+    wait_on_element_disappear,
+    ssh_cmd,
+    get
+)
+from pytest_dependency import depends
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+    parsers
+)
+
+
+@pytest.fixture(scope='module')
+def notification():
+    return {}
+
+
+@scenario('features/NAS-T1658.feature', 'Verify that a degraded pool alert is kept after failover')
+def test_verify_that_a_degraded_pool_alert_is_kept_after_failover():
+    """Verify that a degraded pool alert is kept after failover."""
+
+
+@given(parsers.parse('the browser is open to {nas_hostname} login with {user} and {password}'))
+def the_browser_is_open_to_nas_hostname_login_with_user_and_password(driver, nas_hostname, user, password, request):
+    """the browser is open to <nas_hostname> login with <user> and <password>."""
+    depends(request, ["Setup_HA"], scope='session')
+    global nas_Hostname, admin_User, admin_Password
+    nas_Hostname = nas_hostname
+    admin_User = user
+    admin_Password = password
+    if nas_hostname not in driver.current_url:
+        driver.get(f"http://{nas_hostname}/ui/sessions/signin")
+
+    rsc.Login_If_Not_On_Dashboard(driver, user, password)
+
+
+@when('on the Dashboard, look at the number of alerts')
+def on_the_dashboard_look_at_the_number_of_alerts(driver, notification):
+    """on the Dashboard, look at the number of alerts."""
+    rsc.Verify_The_Dashboard(driver)
+    element_text = driver.find_element_by_xpath(xpaths.toolbar.notification_Text).text
+    notification['before'] = element_text
+
+
+@then('degraded the tank pool to create an alert and verify that the pool is degraded')
+def degraded_the_tank_pool_to_create_an_alert_and_verify_that_the_pool_is_degraded():
+    """degraded the tank pool to create an alert and verify that the pool is degraded."""
+    global gptid
+    get_pool = get(nas_Hostname, "/pool/?name=tank", (admin_User, admin_Password)).json()[0]
+
+    id_path = '/dev/disk/by-partuuid/'
+    gptid = get_pool['topology']['data'][0]['path'].replace(id_path, '')
+    cmd = f'zinject -d {gptid} -A fault tank'
+    results = ssh_cmd(cmd, admin_User, admin_Password, nas_Hostname)
+    assert results['result'] is True, results['output']
+
+    cmd = f'zpool status tank | grep {gptid}'
+    results = ssh_cmd(cmd, admin_User, admin_Password, nas_Hostname)
+    assert results['result'] is True, results['output']
+    assert 'DEGRADED' in results['output'], results['output']
+
+
+@then('wait for the alert to appear and verify the volume and the state is degraded')
+def wait_for_the_alert_to_appear_and_verify_the_volume_and_the_state_is_degraded(driver, notification):
+    """wait for the alert to appear and verify the volume and the state is degraded."""
+    assert wait_on_element(driver, 7, xpaths.toolbar.notification)
+    assert wait_on_element_disappear(driver, 180, xpaths.toolbar.notification_Count(notification["before"]))
+
+    rsc.Verify_Degraded_Alert(driver)
+
+    element_text = driver.find_element_by_xpath(xpaths.toolbar.notification_Text).text
+    notification['after'] = element_text
+
+
+@then('on the Dashboard, click Initiate Failover on the standby controller')
+def on_the_dashboard_click_initiate_failover_on_the_standby_controller(driver):
+    """on the Dashboard, click Initiate Failover on the standby controller."""
+    rsc.Verify_The_Dashboard(driver)
+
+    rsc.Trigger_Failover(driver)
+
+
+
+@then('on the Initiate Failover box, check the Confirm checkbox, then click Failover')
+def on_the_initiate_failover_box_check_the_confirm_checkbox_then_click_failover(driver):
+    """on the Initiate Failover box, check the Confirm checkbox, then click Failover."""
+    rsc.Confirm_Failover(driver)
+
+
+@then(parsers.parse('wait for the login to appear and HA to be enabled, login with {user} and {password}'))
+def wait_for_the_login_to_appear_and_ha_to_be_enabled_login_with_user_and_password(driver, user, password):
+    """wait for the login to appear and HA to be enabled, login with <user> and <password>."""
+    rsc.HA_Login_Status_Enable(driver)
+
+    rsc.Login(driver, user, password)
+
+
+@then('on the Dashboard, verify the alert exists after failover with the right volume and state')
+def on_the_dashboard_verify_the_alert_exists_after_failover_with_the_right_volume_and_state(driver, notification):
+    """on the Dashboard, verify the alert exists after failover with the right volume and state."""
+    rsc.Verify_The_Dashboard(driver)
+
+    assert wait_on_element(driver, 7, xpaths.toolbar.notification)
+    assert wait_on_element(driver, 7, xpaths.toolbar.notification_Count(notification["after"]))
+
+    rsc.Verify_Degraded_Alert(driver)
+
+
+@then('fix the degraded pool and verify that the pool is fixed')
+def fix_the_degraded_pool_and_verify_that_the_pool_is_fixed():
+    """fix the degraded pool and verify that the pool is fixed."""
+    cmd = 'zpool clear tank'
+    results = ssh_cmd(cmd, admin_User, admin_Password, nas_Hostname)
+    assert results['result'] is True, results['output']
+
+    cmd = f'zpool status tank | grep {gptid}'
+    results = ssh_cmd(cmd, admin_User, admin_Password, nas_Hostname)
+    assert results['result'] is True, results['output']
+    assert 'DEGRADED' not in results['output'], results['output']
+
+
+@then('then wait for the alert to disappear and trigger failover again')
+def then_wait_for_the_alert_to_disappear_and_trigger_failover_again(driver, notification):
+    """then wait for the alert to disappear and trigger failover again."""
+    assert wait_on_element(driver, 180, xpaths.toolbar.notification_Count(notification["before"]))
+
+    rsc.Verify_Degraded_Alert_Is_Gone(driver)
+
+    rsc.Trigger_Failover(driver)
+
+    rsc.Confirm_Failover(driver)
+
+
+@then('on the Dashboard, verify that there is no degraded pool alert')
+def on_the_dashboard_verify_that_there_is_no_degraded_pool_alert(driver):
+    """on the Dashboard, verify that there is no degraded pool alert."""
+    assert wait_on_element(driver, 7, xpaths.toolbar.notification)
+
+    rsc.Verify_Degraded_Alert_Is_Gone(driver)

--- a/tests/bdd/ha-bhyve02/test_NAS_T1660_smb_permision_on_failover.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T1660_smb_permision_on_failover.py
@@ -1,0 +1,298 @@
+"""SCALE High Availability (tn-bhyve06) feature tests."""
+
+import pytest
+import reusableSeleniumCode as rsc
+import time
+import xpaths
+from function import (
+    wait_on_element,
+    wait_on_element_disappear,
+    attribute_value_exist,
+    run_cmd,
+    ssh_cmd,
+    post
+)
+from pytest_bdd import (
+    given,
+    scenario,
+    then,
+    when,
+    parsers
+)
+from pytest_dependency import depends
+
+
+@pytest.fixture(scope='module')
+def acl_Permission_Data():
+    return {}
+
+
+@pytest.fixture(scope='module')
+def share_Dataset_Data():
+    return {}
+
+
+@scenario('features/NAS-T1660.feature', 'Verify host sharing permissions on failover')
+def test_verify_host_sharing_permissions_on_failover():
+    """Verify host sharing permissions on failover."""
+
+
+@given(parsers.parse('the browser is open to {nas_hostname} login with {user} and {password}'))
+def the_browser_is_open_to_nas_hostname_login_with_user_and_password(driver, nas_hostname, user, password, request):
+    """the browser is open to <nas_hostname> login with <user> and <password>."""
+    depends(request, ["Setup_HA"], scope='session')
+    global nas_Hostname, admin_User, admin_Password
+    nas_Hostname = nas_hostname
+    admin_User = user
+    admin_Password = password
+    if nas_hostname not in driver.current_url:
+        driver.get(f"http://{nas_hostname}/ui/sessions/signin")
+
+    rsc.Login_If_Not_On_Dashboard(driver, user, password)
+
+
+@when('on the Dashboard, click on Datasets on the left side menu')
+def on_the_dashboard_click_on_datasets_on_the_left_side_menu(driver):
+    """on the Dashboard, click on Datasets on the left side menu."""
+    rsc.Verify_The_Dashboard(driver)
+
+    assert wait_on_element(driver, 5, xpaths.side_Menu.datasets, 'clickable')
+    driver.find_element_by_xpath(xpaths.side_Menu.datasets).click()
+
+
+@then('on the Datasets page, select the dozer dataset and click Add Dataset')
+def on_the_datasets_page_select_the_dozer_dataset_and_click_add_dataset(driver):
+    """on the Datasets page, select the dozer dataset and click Add Dataset."""
+    assert wait_on_element(driver, 7, xpaths.dataset.title)
+    assert wait_on_element(driver, 7, xpaths.dataset.pool_Tree_Name('dozer'))
+    driver.find_element_by_xpath(xpaths.dataset.pool_Tree('dozer')).click()
+    assert wait_on_element(driver, 7, xpaths.dataset.pool_Selected('dozer'))
+    assert wait_on_element(driver, 5, xpaths.dataset.add_Dataset_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.dataset.add_Dataset_Button).click()
+
+
+@then('input smb1 for dataset name, select SMB for Share Type and click save')
+def input_smb1_for_dataset_name_select_smb_for_share_type_and_click_save(driver):
+    """input smb1 for dataset name, select SMB for Share Type and click save."""
+    assert wait_on_element(driver, 5, xpaths.add_Dataset.title)
+    assert wait_on_element(driver, 5, xpaths.add_Dataset.name_Textarea, 'inputable')
+    driver.find_element_by_xpath(xpaths.add_Dataset.name_Textarea).clear()
+    driver.find_element_by_xpath(xpaths.add_Dataset.name_Textarea).send_keys('smb1')
+    assert wait_on_element(driver, 5, xpaths.add_Dataset.share_Type_Select)
+    driver.find_element_by_xpath(xpaths.add_Dataset.share_Type_Select).click()
+    assert wait_on_element(driver, 5, xpaths.add_Dataset.share_Type_SMB_Option, 'clickable')
+    driver.find_element_by_xpath(xpaths.add_Dataset.share_Type_SMB_Option).click()
+    assert wait_on_element(driver, 5, xpaths.button.save, 'clickable')
+    driver.find_element_by_xpath(xpaths.button.save).click()
+
+
+@then('when the new dataset is created click Add Dataset again')
+def when_the_new_dataset_is_created_click_add_dataset_again(driver):
+    """when the new dataset is created click Add Dataset again."""
+    assert wait_on_element_disappear(driver, 20, xpaths.popup.please_Wait)
+    assert wait_on_element(driver, 10, xpaths.dataset.dataset_Name('smb1'))
+
+    assert wait_on_element(driver, 5, xpaths.dataset.add_Dataset_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.dataset.add_Dataset_Button).click()
+
+
+@then('input smb2 for dataset name, select SMB for Share Type and click save')
+def input_smb2_for_dataset_name_select_smb_for_share_type_and_click_save(driver):
+    """input smb2 for dataset name, select SMB for Share Type and click save."""
+    assert wait_on_element(driver, 5, xpaths.add_Dataset.title)
+    assert wait_on_element(driver, 5, xpaths.add_Dataset.name_Textarea, 'inputable')
+    driver.find_element_by_xpath(xpaths.add_Dataset.name_Textarea).clear()
+    driver.find_element_by_xpath(xpaths.add_Dataset.name_Textarea).send_keys('smb2')
+    assert wait_on_element(driver, 5, xpaths.add_Dataset.share_Type_Select)
+    driver.find_element_by_xpath(xpaths.add_Dataset.share_Type_Select).click()
+    assert wait_on_element(driver, 5, xpaths.add_Dataset.share_Type_SMB_Option, 'clickable')
+    driver.find_element_by_xpath(xpaths.add_Dataset.share_Type_SMB_Option).click()
+    assert wait_on_element(driver, 5, xpaths.button.save, 'clickable')
+    driver.find_element_by_xpath(xpaths.button.save).click()
+
+
+@then('when the new dataset is created select smb2 click Edit on Permission card')
+def when_the_new_dataset_is_created_select_smb2_click_edit_on_permission_card(driver):
+    """when the new dataset is created select smb2 click Edit on Permission card."""
+    assert wait_on_element_disappear(driver, 20, xpaths.popup.please_Wait)
+    assert wait_on_element(driver, 10, xpaths.dataset.dataset_Name('smb2'))
+    driver.find_element_by_xpath(xpaths.dataset.dataset_Tree('smb2')).click()
+    assert wait_on_element(driver, 5, xpaths.dataset.permission_Edit_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.dataset.permission_Edit_Button).click()
+
+
+@then('on the Edit ACL page set ericbsd to read only and click Save ACL')
+def on_the_edit_acl_page_set_ericbsd_to_read_only_and_save_acl(driver):
+    """on the Edit ACL page set ericbsd to read only and Save ACL."""
+    assert wait_on_element(driver, 5, xpaths.edit_Acl.title)
+    assert wait_on_element(driver, 5, xpaths.edit_Acl.add_Item_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.edit_Acl.add_Item_Button).click()
+    assert wait_on_element(driver, 7, xpaths.edit_Acl.who_Select, 'clickable')
+    driver.find_element_by_xpath(xpaths.edit_Acl.who_Select).click()
+    assert wait_on_element(driver, 5, xpaths.edit_Acl.who_User_Option, 'clickable')
+    driver.find_element_by_xpath(xpaths.edit_Acl.who_User_Option).click()
+    assert wait_on_element(driver, 7, xpaths.edit_Acl.user_Combobox, 'inputable')
+    driver.find_element_by_xpath(xpaths.edit_Acl.user_Combobox).send_keys('ericbsd')
+
+    driver.find_element_by_xpath(xpaths.edit_Acl.permission_Select).click()
+    assert wait_on_element(driver, 5, xpaths.edit_Acl.permission_Read_Option, 'clickable')
+    driver.find_element_by_xpath(xpaths.edit_Acl.permission_Read_Option).click()
+
+    driver.find_element_by_xpath(xpaths.edit_Acl.builtin_Users_Cancel).click()
+    driver.find_element_by_xpath(xpaths.edit_Acl.builtin_Administrators_Cancel).click()
+
+    assert wait_on_element(driver, 5, xpaths.edit_Acl.save_Acl_Buttonox, 'clickable')
+    driver.find_element_by_xpath(xpaths.edit_Acl.save_Acl_Buttonox).click()
+
+
+@then('when the ACL Permission is save, click Shares on the left side menu')
+def when_the_acl_permision_is_save_click_shares_on_the_left_side_menu(driver):
+    """when the ACL Permission is save, click Shares on the left side menu."""
+    assert wait_on_element_disappear(driver, 60, xpaths.popup.updatin_Acl)
+    assert wait_on_element(driver, 5, xpaths.dataset.permission_Title)
+
+    assert wait_on_element(driver, 5, xpaths.side_Menu.shares, 'clickable')
+    driver.find_element_by_xpath(xpaths.side_Menu.shares).click()
+
+
+@then('on the Sharing page, click the Add button on Windows (SMB) Shares card')
+def on_the_sharing_page_click_the_add_button_on_windows_smb_shares_card(driver):
+    """on the Sharing page, click the Add button on Windows (SMB) Shares card."""
+    assert wait_on_element(driver, 7, xpaths.sharing.title)
+    assert wait_on_element(driver, 5, xpaths.sharing.smb_Panel_Title)
+    assert wait_on_element(driver, 5, xpaths.sharing.smb_Add_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.sharing.smb_Add_Button).click()
+
+
+@then(parsers.parse('set the Path to "{dataset_path}" and input the "{share_name}" as name, then click to enable'))
+def set_the_path_to_mntdozersmb1_and_input_the_smbtest1_as_name_then_click_to_enable(driver, dataset_path, share_name, share_Dataset_Data):
+    """set the Path to "/mnt/dozer/smb1" and input the "smbtest1" as name, then click to enable."""
+    share_Dataset_Data[share_name] = dataset_path
+    assert wait_on_element(driver, 7, xpaths.smb.addTitle)
+    assert wait_on_element(driver, 5, xpaths.smb.path_Input, 'inputable')
+    driver.find_element_by_xpath(xpaths.smb.path_Input).send_keys(dataset_path)
+
+    rsc.Click_Clear_Input(driver, xpaths.smb.name_Input, share_name)
+
+    assert wait_on_element(driver, 5, xpaths.checkbox.enabled, 'clickable')
+    if not attribute_value_exist(driver, xpaths.checkbox.enabled, 'class', 'mat-checkbox-checked'):
+        driver.find_element_by_xpath(xpaths.checkbox.enable).click()
+
+
+@then('click Save if Restart SMB Service box appears, click Restart Service')
+def click_save_if_restart_smb_service_box_appears_click_restart_service(driver):
+    """click Save if Restart SMB Service box appears, click Restart Service."""
+    assert wait_on_element(driver, 5, xpaths.button.save, 'clickable')
+    driver.find_element_by_xpath(xpaths.button.save).click()
+
+    rsc.Restart_SMB_Service(driver)
+
+    assert wait_on_element_disappear(driver, 30, xpaths.progress.progressbar)
+
+
+@then(parsers.parse('send a file to the {share_name} share and verify the file exist and get the acl permission of smbtest1'))
+def send_a_file_to_the_smbtest1_share_and_verify_the_file_exist_and_get_the_acl_permission_of_smbtest1(driver, acl_Permission_Data, share_name, share_Dataset_Data):
+    """send a file to the smbtest1 share and verify the file exist and get the acl permission of smbtest1."""
+    run_cmd('touch testfile.txt')
+    results = run_cmd(f'smbclient //{nas_Hostname}/{share_name} -U ericbsd%testing1 -c "put testfile.txt testfile.txt"')
+    assert results['result'], results['output']
+
+    results = post(nas_Hostname, '/filesystem/stat/', (admin_User, admin_Password), f'{share_Dataset_Data[share_name]}/testfile.txt')
+    assert results.status_code == 200, results.text
+
+    results = post(nas_Hostname, '/filesystem/getacl/', (admin_User, admin_Password), {'path': share_Dataset_Data[share_name]})
+    assert results.status_code == 200, results.text
+
+    acl_Permission_Data[share_name] = results.json()['acl']
+
+
+@then(parsers.parse('try to send a file to the {share_name} share and verify it failed and get the acl permission of smbtest2'))
+def try_to_send_a_file_to_the_smbtest2_share_and_verify_it_failed_and_get_the_acl_permission_of_smbtest2(driver, acl_Permission_Data, share_name, share_Dataset_Data):
+    """try to send a file to the smbtest2 share and verify it failed and get the acl permission of smbtest2."""
+    results = run_cmd(f'smbclient //{nas_Hostname}/{share_name} -U ericbsd%testing1 -c "put testfile.txt testfile.txt"')
+    assert results['result'] is False, results['output']
+    assert 'NT_STATUS_ACCESS_DENIED' in results['output']
+    run_cmd('rm testfile.txt')
+
+    results = post(nas_Hostname, '/filesystem/getacl/', (admin_User, admin_Password), {'path': share_Dataset_Data[share_name]})
+    assert results.status_code == 200, results.text
+
+    acl_Permission_Data[share_name] = results.json()['acl']
+
+
+@then(parsers.parse('create a file with root in "/mnt/dozer/smb2" get the file from the {share_name} share'))
+def create_a_file_with_root_in_mntdozersmb2_get_the_file_from_the_smbtest2_share(driver, share_name, share_Dataset_Data):
+    """create a file with root in "/mnt/dozer/smb2" get the file from the smbtest2 share."""
+    cmd = 'echo "some text" > /mnt/dozer/smb2/testfile.txt'
+    middlewared_log = ssh_cmd(cmd, admin_User, admin_Password, nas_Hostname)
+    assert middlewared_log['result'] is True, str(middlewared_log)
+
+    results = run_cmd(f'smbclient //{nas_Hostname}/{share_name} -U ericbsd%testing1 -c "get testfile.txt testfile.txt"')
+    assert results['result'], results['output']
+
+    print('past smbclient')
+    results = post(nas_Hostname, '/filesystem/stat/', (admin_User, admin_Password), f'{share_Dataset_Data[share_name]}/testfile.txt')
+    assert results.status_code == 200, results.text
+    time.sleep(5)
+
+
+@then('on the Dashboard, click Initiate Failover on the standby controller')
+def on_the_dashboard_click_initiate_failover_on_the_standby_controller(driver):
+    """on the Dashboard, click Initiate Failover on the standby controller."""
+    driver.find_element_by_xpath(xpaths.side_Menu.dashboard).click()
+    assert wait_on_element(driver, 10, xpaths.dashboard.title)
+
+    rsc.Trigger_Failover(driver)
+
+
+@then('on the Initiate Failover box, check the Confirm checkbox, then click Failover')
+def on_the_initiate_failover_box_check_the_confirm_checkbox_then_click_failover(driver):
+    """on the Initiate Failover box, check the Confirm checkbox, then click Failover."""
+    rsc.Confirm_Failover(driver)
+
+
+@then(parsers.parse('wait for the login to appear and HA to be enabled, login with {user} and {password}'))
+def wait_for_the_login_to_appear_and_ha_to_be_enabled_login_with_user_and_password(driver, user, password):
+    """wait for the login to appear and HA to be enabled, login with <user> and <password>."""
+    rsc.HA_Login_Status_Enable(driver)
+
+    rsc.Login(driver, user, password)
+
+
+@then(parsers.parse('verify the first file still exist in {share_name} dataset'))
+def verify_the_first_file_still_exist_in_smbtest1_dataset(share_name, share_Dataset_Data):
+    """verify the first file still exist in smbtest1 dataset."""
+    results = post(nas_Hostname, '/filesystem/stat/', (admin_User, admin_Password), f'{share_Dataset_Data[share_name]}/testfile.txt')
+    assert results.status_code == 200, results.text
+
+
+@then(parsers.parse('verify you still can write on {share_name} and verify the permission'))
+def verify_you_still_can_write_on_smbtest1_and_verify_the_permission(driver, acl_Permission_Data, share_name, share_Dataset_Data):
+    """verify you still can write on smbtest1 and verify the permission."""
+    run_cmd('touch testfile2.txt')
+    results = run_cmd(f'smbclient //{nas_Hostname}/{share_name} -U ericbsd%testing1 -c "put testfile2.txt testfile2.txt"')
+    assert results['result'], results['output']
+
+    results = post(nas_Hostname, '/filesystem/getacl/', (admin_User, admin_Password), {'path': share_Dataset_Data[share_name]})
+    assert results.status_code == 200, results.text
+    assert acl_Permission_Data[share_name] == results.json()['acl']
+
+
+@then(parsers.parse('verify the root created file still exist in {share_name} dataset'))
+def verify_the_test_file_still_exist_in_smbtest2_dataset(share_name, share_Dataset_Data):
+    """verify the test file still exist in smbtest2 dataset."""
+    results = post(nas_Hostname, '/filesystem/stat/', (admin_User, admin_Password), f'{share_Dataset_Data[share_name]}/testfile.txt')
+    assert results.status_code == 200, results.text
+
+
+@then(parsers.parse('verify you still cant write on {share_name} and verify the permission is still read only for ericbsd'))
+def verify_you_still_cant_write_on_smbtest2_and_verify_the_permission_is_still_read_only_for_ericbsd(driver, acl_Permission_Data, share_name, share_Dataset_Data):
+    """verify you still cant write on smbtest2 and verify the permission is still read only for ericbsd."""
+    results = run_cmd(f'smbclient //{nas_Hostname}/{share_name} -U ericbsd%testing1 -c "put testfile2.txt testfile2.txt"')
+    assert results['result'] is False, results['output']
+    assert 'NT_STATUS_ACCESS_DENIED' in results['output']
+    run_cmd('rm testfile2.txt')
+
+    results = post(nas_Hostname, '/filesystem/getacl/', (admin_User, admin_Password), {'path': share_Dataset_Data[share_name]})
+    assert results.status_code == 200, results.text
+    assert acl_Permission_Data[share_name] == results.json()['acl']

--- a/tests/bdd/reusableSeleniumCode.py
+++ b/tests/bdd/reusableSeleniumCode.py
@@ -9,6 +9,12 @@ from function import (
 )
 
 
+def Click_Clear_Input(driver, xpath, value):
+    driver.find_element_by_xpath(xpath).click()
+    driver.find_element_by_xpath(xpath).clear()
+    driver.find_element_by_xpath(xpath).send_keys(value)
+
+
 def Close_Common_Warning(driver):
     assert wait_on_element(driver, 5, xpaths.popup.warning)
     assert wait_on_element(driver, 5, xpaths.button.close, 'clickable')
@@ -48,10 +54,31 @@ def Confirm_Single_Disk(driver):
     driver.find_element_by_xpath(xpaths.button.Continue).click()
 
 
+def Dismiss_All_Alerts(driver):
+    if wait_on_element(driver, 5, '//span[contains(.,"notifications")]//span[not(contains(text(),"0"))]'):
+        assert wait_on_element(driver, 7, xpaths.toolbar.notification_Button, 'clickable')
+        driver.find_element_by_xpath(xpaths.toolbar.notification_Button).click()
+        assert wait_on_element(driver, 7, xpaths.alert.title)
+        assert wait_on_element(driver, 7, '//button[contains(text(),"Dismiss All Alerts")]', 'clickable')
+        driver.find_element_by_xpath('//button[contains(text(),"Dismiss All Alerts")]').click()
+        assert wait_on_element(driver, 7, '//mat-icon[contains(.,"clear")]', 'clickable')
+        driver.find_element_by_xpath('//mat-icon[contains(.,"clear")]').click()
+
+
 def Go_To_Service(driver):
     driver.find_element_by_xpath(xpaths.side_Menu.system_Setting).click()
     assert wait_on_element(driver, 5, xpaths.side_Menu.services, 'clickable')
     driver.find_element_by_xpath(xpaths.side_Menu.services).click()
+
+
+def HA_Login_Status_Enable(driver):
+    assert wait_on_element(driver, 180, xpaths.login.user_Input)
+    assert wait_on_element(driver, 240, xpaths.login.ha_Status_Enable)
+
+
+def Input_Value(driver, xpath, value):
+    driver.find_element_by_xpath(xpath).clear()
+    driver.find_element_by_xpath(xpath).send_keys(value)
 
 
 def Login(driver, user, password):
@@ -87,16 +114,42 @@ def Leave_Domain(driver, user, password):
     assert wait_on_element_disappear(driver, 120, xpaths.popup.please_Wait)
 
 
-def Input_Value(driver, xpath, value):
-    driver.find_element_by_xpath(xpaths.add_Dataset.name_Textarea).clear()
-    driver.find_element_by_xpath(xpaths.add_Dataset.name_Textarea).send_keys(value)
-    assert wait_on_element(driver, 5, xpaths.add_Dataset.share_Type_Select)
+def Restart_SMB_Service(driver):
+    assert wait_on_element(driver, 7, xpaths.popup.smb_Restart_Title)
+    assert wait_on_element(driver, 5, xpaths.popup.smb_Restart_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.popup.smb_Restart_Button).click()
 
 
-def Wait_For_Inputable_And_Input_Value(driver, xpath, value):
-    assert wait_on_element(driver, 5, xpath, 'inputable')
-    driver.find_element_by_xpath(xpath).clear()
-    driver.find_element_by_xpath(xpath).send_keys(value)
+def Trigger_Failover(driver):
+    assert wait_on_element(driver, 60, xpaths.toolbar.ha_Enabled)
+    assert wait_on_element(driver, 10, xpaths.dashboard.system_Information_Standby_Title)
+    assert wait_on_element(driver, 10, xpaths.button.initiate_Failover, 'clickable')
+    driver.find_element_by_xpath(xpaths.button.initiate_Failover).click()
+
+
+def Verify_Degraded_Alert(driver):
+    assert wait_on_element(driver, 7, xpaths.toolbar.notification_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.toolbar.notification_Button).click()
+    assert wait_on_element(driver, 7, xpaths.alert.title)
+    assert wait_on_element(driver, 7, xpaths.alert.degraded_Critical_Level)
+    assert wait_on_element(driver, 7, xpaths.alert.degraded_Pool_Text)
+    assert wait_on_element(driver, 7, xpaths.alert.close_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.alert.close_Button).click()
+    time.sleep(0.5)
+
+
+def Verify_Degraded_Alert_Is_Gone(driver):
+    driver.find_element_by_xpath(xpaths.toolbar.notification_Button).click()
+    assert wait_on_element(driver, 7, xpaths.alert.title)
+    assert is_element_present(driver, xpaths.alert.degraded_Critical_Level) is False
+    assert wait_on_element(driver, 7, xpaths.alert.close_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.alert.close_Button).click()
+    time.sleep(0.5)
+
+
+def Verify_Element_Text(driver, xpath, value):
+    element_text = driver.find_element_by_xpath(xpath).text
+    assert element_text == value
 
 
 def Verify_The_Dashboard(driver):
@@ -104,6 +157,7 @@ def Verify_The_Dashboard(driver):
     assert wait_on_element(driver, 10, xpaths.dashboard.system_Info_Card_Title)
 
 
-def Verify_Element_Text(driver, xpath, value):
-    element_text = driver.find_element_by_xpath(xpath).text
-    assert element_text == value
+def Wait_For_Inputable_And_Input_Value(driver, xpath, value):
+    assert wait_on_element(driver, 5, xpath, 'inputable')
+    driver.find_element_by_xpath(xpath).clear()
+    driver.find_element_by_xpath(xpath).send_keys(value)

--- a/tests/bdd/scale/test_NAS_T1223.py
+++ b/tests/bdd/scale/test_NAS_T1223.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """SCALE UI feature tests."""
 
+import reusableSeleniumCode as rsc
 import time
 import xpaths
 from function import (
@@ -47,17 +48,9 @@ def the_browser_is_open_on_the_truenas_url_and_logged_in(driver, nas_ip, root_pa
 @when('on the dashboard, if there is dismiss all notification')
 def on_the_dashboard_if_there_is_dismiss_all_notification(driver):
     """on the dashboard, if there is dismiss all notification."""
-    assert wait_on_element(driver, 7, xpaths.dashboard.title)
-    assert wait_on_element(driver, 7, xpaths.dashboard.system_Info_Card_Title)
-    assert wait_on_element(driver, 7, '//mat-icon[normalize-space(text())="notifications"]')
-    if wait_on_element(driver, 5, '//span[contains(.,"notifications")]//span[not(contains(text(),"0"))]'):
-        assert wait_on_element(driver, 7, '//button[contains(.,"notifications")]', 'clickable')
-        driver.find_element_by_xpath('//button[contains(.,"notifications")]').click()
-        assert wait_on_element(driver, 7, '//h3[text()="Alerts"]')
-        assert wait_on_element(driver, 7, '//button[contains(text(),"Dismiss All Alerts")]', 'clickable')
-        driver.find_element_by_xpath('//button[contains(text(),"Dismiss All Alerts")]').click()
-        assert wait_on_element(driver, 7, '//mat-icon[contains(.,"clear")]', 'clickable')
-        driver.find_element_by_xpath('//mat-icon[contains(.,"clear")]').click()
+    rsc.Verify_The_Dashboard(driver)
+
+    rsc.Dismiss_All_Alerts(driver)
 
 
 @then('kill a python process with ssh to trigger core files alert')
@@ -72,11 +65,11 @@ def kill_a_python_process_with_ssh_to_trigger_core_files_alert(driver, nas_ip, r
 @then('wait for the alert and verify the core files warning alert')
 def wait_for_the_alert_and_verify_the_core_files_warning_alert(driver):
     """wait for the alert and verify the core files warning alert."""
-    assert wait_on_element(driver, 7, '//mat-icon[normalize-space(text())="notifications"]')
+    assert wait_on_element(driver, 7, xpaths.toolbar.notification)
     assert wait_on_element(driver, 180, '//span[contains(.,"notifications")]//span[contains(text(),"1")]')
-    assert wait_on_element(driver, 7, '//button[contains(.,"notifications")]', 'clickable')
-    driver.find_element_by_xpath('//button[contains(.,"notifications")]').click()
-    assert wait_on_element(driver, 7, '//h3[text()="Alerts"]')
+    assert wait_on_element(driver, 7, xpaths.toolbar.notification_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.toolbar.notification_Button).click()
+    assert wait_on_element(driver, 7, xpaths.alert.title)
     assert wait_on_element(driver, 7, '//ix-alert[contains(.,"Core files")]//h3[contains(.,"Warning")]')
     assert wait_on_element(driver, 7, '//h4[contains(.,"Core files for the following executables were found: /usr/bin/python")]')
     assert wait_on_element(driver, 7, '//ix-alert[contains(.,"Core files")]//mat-icon[normalize-space(text())="error"]')
@@ -97,8 +90,8 @@ def click_on_the_core_files_warning_reopen_and_verify_the_alert_is_back(driver):
     driver.find_element_by_xpath('//ix-alert[contains(.,"Core files")]//a[normalize-space(text())="Re-Open"]').click()
     assert wait_on_element(driver, 7, '//ix-alert[contains(.,"Core files")]//h3[contains(.,"Warning")]')
     assert wait_on_element(driver, 7, '//ix-alert[contains(.,"Core files")]//mat-icon[normalize-space(text())="error"]')
-    assert wait_on_element(driver, 7, '//button[contains(.,"clear")]', 'clickable')
-    driver.find_element_by_xpath('//button[contains(.,"clear")]').click()
+    assert wait_on_element(driver, 7, xpaths.alert.close_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.alert.close_Button).click()
 
 
 @then('after remove the core files in "/var/db/system/cores"')
@@ -113,9 +106,9 @@ def after_remove_the_core_files_in_vardbsystemcores(driver, nas_ip, root_passwor
 def verify_that_the_core_file_alert_disappear(driver):
     """verify that the core file alert disappear."""
     assert wait_on_element_disappear(driver, 180, '//span[contains(.,"notifications")]//span[contains(text(),"1")]')
-    driver.find_element_by_xpath('//button[contains(.,"notifications")]').click()
-    assert wait_on_element(driver, 7, '//h3[text()="Alerts"]')
+    driver.find_element_by_xpath(xpaths.toolbar.notification_Button).click()
+    assert wait_on_element(driver, 7, xpaths.alert.title)
     assert not is_element_present(driver, '//ix-alert[contains(.,"Core files")]//h3[contains(.,"Warning")]')
-    assert wait_on_element(driver, 7, '//button[contains(.,"clear")]', 'clickable')
-    driver.find_element_by_xpath('//button[contains(.,"clear")]').click()
+    assert wait_on_element(driver, 7, xpaths.alert.close_Button, 'clickable')
+    driver.find_element_by_xpath(xpaths.alert.close_Button).click()
     time.sleep(0.5)

--- a/tests/bdd/xpaths.py
+++ b/tests/bdd/xpaths.py
@@ -61,6 +61,7 @@ class add_User:
     root_Group_Option = '//mat-option[contains(.,"root")]'
     wheel_Group_Option = '//mat-option[contains(.,"wheel")]'
     qatest_Group_Option = '//mat-option[contains(.,"qatest")]'
+    games_Group_Option = '//mat-option[contains(.,"games")]'
     home_Input = '//ix-explorer[@formcontrolname="home"]//input'
     password_Disabled_Slide = '//ix-slide-toggle[@formcontrolname="password_disabled"]//mat-slide-toggle'
     home_Mode_Owner_Write_Checkbox = '(//tr[contains(.,"User")]//mat-checkbox)[1]'
@@ -88,6 +89,13 @@ class advanced:
 
     def system_Dataset_Pool_Pool(pool_name):
         return f'//div[contains(.,"System Dataset Pool:")]//span[contains(text(),"{pool_name}")]'
+
+
+class alert():
+    title = '//h3[text()="Alerts"]'
+    degraded_Critical_Level = '//ix-alert[contains(.,"DEGRADED")]//h3[contains(.,"Critical")]'
+    degraded_Pool_Text = '//h4[contains(.,"Pool tank state is DEGRADED")]'
+    close_Button = '//button[contains(.,"clear")]'
 
 
 class applications:
@@ -272,6 +280,8 @@ class edit_Acl:
     builtin_Administrators_Cancel = '//div[contains(.,"Group - builtin_administrators") and contains(@class,"ace")]//mat-icon[text()="cancel"]'
     recursive_Checkbox = '//ix-checkbox[@formcontrolname="recursive"]//mat-checkbox'
     traverse_Checkbox = '//ix-checkbox[@formcontrolname="traverse"]//mat-checkbox'
+    permission_Select = '//ix-select[@formcontrolname="basicPermission"]//mat-select'
+    permission_Read_Option = '//mat-option[contains(.,"Read")]'
 
     def combobox_Option(option):
         return f'//mat-option[contains(.,"{option}")]'
@@ -486,6 +496,12 @@ class systemDataset:
 class toolbar:
     ha_Disabled = '//mat-icon[@data-mat-icon-name="ha_disabled"]'
     ha_Enabled = '//mat-icon[@data-mat-icon-name="ha_enabled"]'
+    notification = '//mat-icon[normalize-space(text())="notifications"]'
+    notification_Button = '//button[contains(.,"notifications")]'
+    notification_Text = '//button[contains(.,"notifications")]//mat-icon/span'
+
+    def notification_Count(text):
+        return f'//span[contains(.,"notifications")]//span[contains(text(),"{text}")]'
 
 
 class unlock_Dataset:


### PR DESCRIPTION

* Adding test cases to test Alert and failover with a degraded pool.

* Adding HA_Login_Status_Enable and Trigger_Failover in HA test

* Adding Test Case to verify middleware logs is available after failover

* Fixed missing notifications and added more time to wait for HA status

* Adding test cases to test SMB permission is kept after failover

* Adding sleep before failover in our SMB test cases.

* Fixed mat-select with games in T951

* restore old step in T951