### PR TITLE
NAS-120348 / 23.10 / Refresh dashboard on pool changes

### DIFF
--- a/src/app/interfaces/api-event-directory.interface.ts
+++ b/src/app/interfaces/api-event-directory.interface.ts
@@ -6,6 +6,7 @@ import { DirectoryServicesState } from 'app/interfaces/directory-services-state.
 import { FailoverDisabledReasonEvent } from 'app/interfaces/failover-disabled-reasons.interface';
 import { Group } from 'app/interfaces/group.interface';
 import { Job } from 'app/interfaces/job.interface';
+import { Pool } from 'app/interfaces/pool.interface';
 import { ReportingRealtimeUpdate } from 'app/interfaces/reporting.interface';
 import { PoolScan } from 'app/interfaces/resilver-job.interface';
 import { Service } from 'app/interfaces/service.interface';
@@ -31,6 +32,7 @@ export type ApiEventDirectory = {
   'user.query': { response: User };
   'container.image.pull': { response: Job<PullContainerImageResponse, PullContainerImageParams> };
   'disk.query': { response: Disk };
+  'pool.query': { response: Pool };
   'group.query': { response: Group };
   'container.image.query': { response: ContainerImage };
   'reporting.realtime': { response: ReportingRealtimeUpdate };

--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
@@ -8,6 +8,7 @@ import { tween, styler } from 'popmotion';
 import { Subject } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 import { Styler } from 'stylefire';
+import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { NetworkInterfaceAliasType, NetworkInterfaceType } from 'app/enums/network-interface.enum';
 import { ScreenType } from 'app/enums/screen-type.enum';
@@ -255,6 +256,7 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
   startListeners(): void {
     this.getDisksData();
     this.getNetworkInterfaces();
+    this.getPoolsUpdate();
 
     this.ws2.subscribe('reporting.realtime').pipe(
       map((event) => event.fields),
@@ -674,5 +676,14 @@ export class DashboardComponent implements OnInit, AfterViewInit, OnDestroy {
     const startX = viewport.get('x') as number;
 
     return { carousel, vpw, startX };
+  }
+
+  private getPoolsUpdate(): void {
+    this.ws2.subscribe('pool.query').pipe(
+      filter((event) => !(event.msg === IncomingApiMessageType.Changed && event.cleared)),
+      untilDestroyed(this),
+    ).subscribe(() => {
+      this.loadPoolData();
+    });
   }
 }

--- a/src/app/pages/storage/stores/pools-dashboard-store.service.ts
+++ b/src/app/pages/storage/stores/pools-dashboard-store.service.ts
@@ -50,6 +50,7 @@ export class PoolsDashboardStore extends ComponentStore<PoolsDashboardState> {
     private sorter: StorageService,
   ) {
     super(initialState);
+    this.subscribeToPoolsUpdate();
   }
 
   readonly loadDashboard = this.effect((triggers$: Observable<void>) => {
@@ -106,6 +107,12 @@ export class PoolsDashboardStore extends ComponentStore<PoolsDashboardState> {
 
   getPools(): Observable<Pool[]> {
     return this.ws.call('pool.query', [[], { extra: { is_upgraded: true } }]);
+  }
+
+  subscribeToPoolsUpdate(): void {
+    this.ws.subscribe('pool.query').subscribe(() => {
+      this.loadDashboard();
+    });
   }
 
   getRootDatasets(): Observable<Dataset[]> {


### PR DESCRIPTION
For testing, open the main dashboard and focus on the Storage widget in the first tab, open the storage page in the second tab, and focus on pool status. Pick a pool with multiple disks, then make one disk offline in the third tab. Check if data is synced across tabs.