### PR TITLE
NAS-120266 / 23.10 / Dont unsub when dialog is destroyed

### DIFF
--- a/src/app/pages/vm/vm-list/stop-vm-dialog/stop-vm-dialog.component.html
+++ b/src/app/pages/vm/vm-list/stop-vm-dialog/stop-vm-dialog.component.html
@@ -1,4 +1,4 @@
-<h1 mat-dialog-title>{{ 'Stop {vmName}?' | translate: { vmName: vm.name } }}</h1>
+<h1 mat-dialog-title>{{ 'Stop {vmName}?' | translate: { vmName: data.vm.name } }}</h1>
 <div mat-dialog-content>
   <ix-checkbox
     [formControl]="forceAfterTimeoutCheckbox"

--- a/src/app/pages/vm/vm-list/stop-vm-dialog/stop-vm-dialog.component.spec.ts
+++ b/src/app/pages/vm/vm-list/stop-vm-dialog/stop-vm-dialog.component.spec.ts
@@ -6,14 +6,23 @@ import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dial
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { mockEntityJobComponentRef } from 'app/core/testing/utils/mock-entity-job-component-ref.utils';
 import { VirtualMachine } from 'app/interfaces/virtual-machine.interface';
+import { EntityModule } from 'app/modules/entity/entity.module';
 import { IxCheckboxHarness } from 'app/modules/ix-forms/components/ix-checkbox/ix-checkbox.harness';
 import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
 import { StopVmDialogComponent } from 'app/pages/vm/vm-list/stop-vm-dialog/stop-vm-dialog.component';
+import { VmListComponent } from 'app/pages/vm/vm-list/vm-list.component';
 import { DialogService } from 'app/services';
 
 describe('StopVmDialogComponent', () => {
   let spectator: Spectator<StopVmDialogComponent>;
   let loader: HarnessLoader;
+
+  const createVmListComponent = createComponentFactory({
+    component: VmListComponent,
+    imports: [
+      EntityModule,
+    ],
+  });
   const createComponent = createComponentFactory({
     component: StopVmDialogComponent,
     imports: [
@@ -29,15 +38,22 @@ describe('StopVmDialogComponent', () => {
       {
         provide: MAT_DIALOG_DATA,
         useValue: {
-          id: 1,
-          name: 'test',
-        } as VirtualMachine,
+          vm: {
+            id: 1,
+            name: 'test',
+          } as VirtualMachine,
+        },
       },
     ],
   });
 
   beforeEach(() => {
     spectator = createComponent();
+    const mockedVmListComponent = createVmListComponent();
+
+    Object.defineProperty(spectator.component.data, 'parent', {
+      value: mockedVmListComponent.component,
+    });
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   });
 

--- a/src/app/pages/vm/vm-list/stop-vm-dialog/stop-vm-dialog.component.ts
+++ b/src/app/pages/vm/vm-list/stop-vm-dialog/stop-vm-dialog.component.ts
@@ -8,6 +8,7 @@ import { TranslateService } from '@ngx-translate/core';
 import helptext from 'app/helptext/vm/vm-list';
 import { VirtualMachine } from 'app/interfaces/virtual-machine.interface';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
+import { VmListComponent } from 'app/pages/vm/vm-list/vm-list.component';
 import { DialogService } from 'app/services';
 
 @UntilDestroy()
@@ -23,7 +24,7 @@ export class StopVmDialogComponent {
 
   constructor(
     private dialogRef: MatDialogRef<StopVmDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public vm: VirtualMachine,
+    @Inject(MAT_DIALOG_DATA) public data: { vm: VirtualMachine; parent: VmListComponent },
     private dialog: MatDialog,
     private dialogService: DialogService,
     private translate: TranslateService,
@@ -34,20 +35,20 @@ export class StopVmDialogComponent {
       EntityJobComponent,
       {
         data: {
-          title: this.translate.instant('Stopping {rowName}', { rowName: this.vm.name }),
+          title: this.translate.instant('Stopping {rowName}', { rowName: this.data.vm.name }),
         },
       },
     );
-    jobDialogRef.componentInstance.setCall('vm.stop', [this.vm.id, {
+    jobDialogRef.componentInstance.setCall('vm.stop', [this.data.vm.id, {
       force: false,
       force_after_timeout: this.forceAfterTimeoutCheckbox.value,
     }]);
     jobDialogRef.componentInstance.submit();
-    jobDialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
+    jobDialogRef.componentInstance.success.pipe(untilDestroyed(this.data.parent)).subscribe(() => {
       jobDialogRef.close(false);
       this.dialogService.info(
         this.translate.instant('Finished'),
-        this.translate.instant(helptext.stop_dialog.successMessage, { vmName: this.vm.name }),
+        this.translate.instant(helptext.stop_dialog.successMessage, { vmName: this.data.vm.name }),
         true,
       );
     });

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -481,7 +481,7 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow>, On
 
   private openStopDialog(vm: VirtualMachineRow): void {
     this.dialog.open(StopVmDialogComponent, {
-      data: vm,
+      data: { vm, parent: this },
     })
       .afterClosed()
       .pipe(untilDestroyed(this))


### PR DESCRIPTION
The issue was that we open `StopVmDialogComponent` with `MatDialog` and when the call is made to middleware, all of the subscriptions are set to be destroyed when `StopVmDialogComponent` is destroyed which happens immediately because we are done with that dialog and now we only need the job dialog. So, updated the code to keep the subscriptions alive until the parent component is destroyed.