### PR TITLE
NAS-120387 / 22.12.2 / When loading currently running jobs for task manager, exclude the ones that have `transient: true` (by AlexKarpov98)

### DIFF
--- a/src/app/interfaces/job.interface.ts
+++ b/src/app/interfaces/job.interface.ts
@@ -6,6 +6,7 @@ import { ApiMethod } from 'app/interfaces/api-directory.interface';
 export interface Job<R = unknown, A = unknown[]> {
   abortable: boolean;
   arguments: A;
+  transient: boolean;
   description: string;
   error: string;
   extra?: Record<string, unknown>;

--- a/src/app/modules/jobs/store/job.selectors.ts
+++ b/src/app/modules/jobs/store/job.selectors.ts
@@ -29,7 +29,7 @@ export const selectIsJobPanelOpen = createSelector(
 
 export const selectRunningJobs = createSelector(
   selectJobs,
-  (jobs) => jobs.filter((job) => job.state === JobState.Running),
+  (jobs) => jobs.filter((job) => job.state === JobState.Running && !job.transient),
 );
 
 export const selectUpdateJob = createSelector(

--- a/src/app/pages/jobs/job-logs-row/job-logs-row.component.spec.ts
+++ b/src/app/pages/jobs/job-logs-row/job-logs-row.component.spec.ts
@@ -8,6 +8,7 @@ const fakeJob: Job = {
   abortable: true,
   arguments: [1],
   description: null,
+  transient: false,
   error: '[EFAULT] Transferred:   \t          0 / 0 Byte, -, 0 Byte/s, ETA',
   exc_info: {
     extra: null,


### PR DESCRIPTION
New **Boolean** field was added to the API.
Check this:
https://github.com/truenas/middleware/pull/10714/files

Original PR: https://github.com/truenas/webui/pull/7820
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120387