### PR TITLE
NAS-120307 / 23.10 / Added tests for `AuthService`

### DIFF
--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -1,0 +1,59 @@
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator';
+import { of } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
+import { AuthService } from 'app/services/auth/auth.service';
+import { WebsocketConnectionService } from 'app/services/websocket-connection.service';
+
+describe('AuthService', () => {
+  let spectator: SpectatorService<AuthService>;
+  let websocketConnectionService: WebsocketConnectionService;
+  let testScheduler: TestScheduler;
+  const createService = createServiceFactory({
+    service: AuthService,
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+
+    jest.spyOn(spectator.service, 'authToken$', 'get').mockReturnValue(of('DUMMY_TOKEN'));
+
+    websocketConnectionService = spectator.inject(WebsocketConnectionService);
+    jest.spyOn(websocketConnectionService, 'isConnected$', 'get').mockImplementation(jest.fn(() => of(true)));
+
+    jest.spyOn(websocketConnectionService, 'send').mockImplementation(jest.fn());
+
+    testScheduler = new TestScheduler((actual, expected) => {
+      return expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('Login', () => {
+    it('logs user in with credentials', () => {
+      jest.spyOn(spectator.service, 'getFilteredWebsocketResponse').mockReturnValue(of(true));
+      jest.spyOn(websocketConnectionService, 'isConnected$', 'get').mockReturnValue(of(true));
+
+      const obs$ = spectator.service.login('dummy', 'dummy');
+      expect(websocketConnectionService.send).toHaveBeenCalledWith({
+        id: expect.anything(),
+        msg: IncomingApiMessageType.Method,
+        method: 'auth.login',
+        params: ['dummy', 'dummy'],
+      });
+      testScheduler.run(({ expectObservable }) => {
+        expectObservable(obs$).toBe(
+          '(a|)',
+          { a: true },
+        );
+        expectObservable(websocketConnectionService.isConnected$).toBe(
+          '(b|)',
+          { b: true },
+        );
+        // expectObservable(spectator.service.isAuthenticated$).toBe(
+        //   '---(c|)',
+        //   { c: true }
+        // );
+      });
+    });
+  });
+});

--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -9,7 +9,7 @@ import {
   StorageStrategyStub,
   STORAGE_STRATEGIES,
 } from 'ngx-webstorage';
-import { EMPTY, of } from 'rxjs';
+import { of } from 'rxjs';
 import * as rxjs from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
@@ -47,7 +47,6 @@ describe('AuthService', () => {
         useValue: {
           send: jest.fn(),
           isConnected$: of(true),
-          websocket$: of(EMPTY),
         },
       },
       {

--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -1,27 +1,67 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator';
-import { of } from 'rxjs';
+import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
+import { UUID } from 'angular2-uuid';
+import { when } from 'jest-when';
+import {
+  LocalStorageService,
+  LocalStorageStrategy,
+  NgxWebstorageModule,
+  StorageStrategy,
+  StorageStrategyStub,
+  STORAGE_STRATEGIES,
+} from 'ngx-webstorage';
+import { EMPTY, of } from 'rxjs';
+import * as rxjs from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
+import { DsUncachedUser, LoggedInUser } from 'app/interfaces/ds-cache.interface';
 import { AuthService } from 'app/services/auth/auth.service';
 import { WebsocketConnectionService } from 'app/services/websocket-connection.service';
 
+const uncachedUser: DsUncachedUser = {
+  pw_dir: 'dir',
+  pw_gecos: 'gecos',
+  pw_gid: 1,
+  pw_name: 'name',
+  pw_shell: 'shell',
+  pw_uid: 2,
+};
+
+const loggedInUser: LoggedInUser = {
+  ...uncachedUser,
+  id: 1,
+};
+
 describe('AuthService', () => {
   let spectator: SpectatorService<AuthService>;
-  let websocketConnectionService: WebsocketConnectionService;
   let testScheduler: TestScheduler;
+  let strategyStub: StorageStrategy<string>;
   const createService = createServiceFactory({
     service: AuthService,
+    imports: [
+      NgxWebstorageModule.forRoot(),
+    ],
+    providers: [
+      mockProvider(LocalStorageService),
+      {
+        provide: WebsocketConnectionService,
+        useValue: {
+          send: jest.fn(),
+          isConnected$: of(true),
+          websocket$: of(EMPTY),
+        },
+      },
+      {
+        provide: STORAGE_STRATEGIES,
+        useFactory: () => strategyStub,
+        multi: true,
+      },
+    ],
   });
 
   beforeEach(() => {
+    strategyStub = new StorageStrategyStub(LocalStorageStrategy.strategyName);
     spectator = createService();
-
     jest.spyOn(spectator.service, 'authToken$', 'get').mockReturnValue(of('DUMMY_TOKEN'));
-
-    websocketConnectionService = spectator.inject(WebsocketConnectionService);
-    jest.spyOn(websocketConnectionService, 'isConnected$', 'get').mockImplementation(jest.fn(() => of(true)));
-
-    jest.spyOn(websocketConnectionService, 'send').mockImplementation(jest.fn());
 
     testScheduler = new TestScheduler((actual, expected) => {
       return expect(actual).toEqual(expected);
@@ -30,12 +70,25 @@ describe('AuthService', () => {
 
   describe('Login', () => {
     it('logs user in with credentials', () => {
-      jest.spyOn(spectator.service, 'getFilteredWebsocketResponse').mockReturnValue(of(true));
-      jest.spyOn(websocketConnectionService, 'isConnected$', 'get').mockReturnValue(of(true));
+      jest.spyOn(spectator.service, 'authToken$', 'get').mockImplementation(jest.fn(() => of('DUMMY_TOKEN')));
+
+      jest.spyOn(rxjs, 'timer').mockReturnValue(of(0));
+
+      jest.spyOn(UUID, 'UUID')
+        .mockReturnValueOnce('login_uuid')
+        .mockReturnValueOnce('logged_in_user_uuid')
+        .mockReturnValueOnce('user_query_uuid')
+        .mockReturnValue('generate_token_uuid');
+
+      const getFilteredWebsocketResponse = jest.spyOn(spectator.service, 'getFilteredWebsocketResponse');
+      when(getFilteredWebsocketResponse).calledWith('login_uuid').mockReturnValue(of(true));
+      when(getFilteredWebsocketResponse).calledWith('logged_in_user_uuid').mockReturnValue(of(uncachedUser));
+      when(getFilteredWebsocketResponse).calledWith('user_query_uuid').mockReturnValue(of([loggedInUser]));
+      when(getFilteredWebsocketResponse).calledWith('generate_token_uuid').mockReturnValue(of('DUMMY_TOKEN'));
 
       const obs$ = spectator.service.login('dummy', 'dummy');
-      expect(websocketConnectionService.send).toHaveBeenCalledWith({
-        id: expect.anything(),
+      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
+        id: 'login_uuid',
         msg: IncomingApiMessageType.Method,
         method: 'auth.login',
         params: ['dummy', 'dummy'],
@@ -45,14 +98,34 @@ describe('AuthService', () => {
           '(a|)',
           { a: true },
         );
-        expectObservable(websocketConnectionService.isConnected$).toBe(
-          '(b|)',
-          { b: true },
+        expectObservable(spectator.service.isAuthenticated$).toBe(
+          'c',
+          { c: true },
         );
-        // expectObservable(spectator.service.isAuthenticated$).toBe(
-        //   '---(c|)',
-        //   { c: true }
-        // );
+        expectObservable(spectator.service.authToken$).toBe(
+          '(d|)',
+          { d: 'DUMMY_TOKEN' },
+        );
+        expectObservable(spectator.service.user$).toBe(
+          'e',
+          { e: { ...loggedInUser } },
+        );
+      });
+      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
+        id: 'logged_in_user_uuid',
+        msg: IncomingApiMessageType.Method,
+        method: 'auth.me',
+      });
+      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
+        id: 'user_query_uuid',
+        msg: IncomingApiMessageType.Method,
+        method: 'user.query',
+        params: [[['uid', '=', 2]]],
+      });
+      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
+        id: 'generate_token_uuid',
+        msg: IncomingApiMessageType.Method,
+        method: 'auth.generate_token',
       });
     });
   });

--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -34,7 +34,7 @@ const loggedInUser: LoggedInUser = {
 describe('AuthService', () => {
   let spectator: SpectatorService<AuthService>;
   let testScheduler: TestScheduler;
-  let strategyStub: StorageStrategy<string>;
+  let strategyStub: StorageStrategy<unknown>;
   const createService = createServiceFactory({
     service: AuthService,
     imports: [

--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -83,12 +83,7 @@ describe('AuthService', () => {
       when(getFilteredWebsocketResponse).calledWith('generate_token_uuid').mockReturnValue(of('DUMMY_TOKEN'));
 
       const obs$ = spectator.service.login('dummy', 'dummy');
-      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
-        id: 'login_uuid',
-        msg: IncomingApiMessageType.Method,
-        method: 'auth.login',
-        params: ['dummy', 'dummy'],
-      });
+
       testScheduler.run(({ expectObservable }) => {
         expectObservable(obs$).toBe(
           'a',
@@ -106,6 +101,12 @@ describe('AuthService', () => {
           'e',
           { e: { ...loggedInUser } },
         );
+      });
+      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
+        id: 'login_uuid',
+        msg: IncomingApiMessageType.Method,
+        method: 'auth.login',
+        params: ['dummy', 'dummy'],
       });
       expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
         id: 'logged_in_user_uuid',
@@ -141,12 +142,6 @@ describe('AuthService', () => {
 
       const obs$ = spectator.service.loginWithToken();
 
-      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
-        id: 'login_with_token_uuid',
-        msg: IncomingApiMessageType.Method,
-        method: 'auth.login_with_token',
-        params: ['DUMMY_TOKEN'],
-      });
       testScheduler.run(({ expectObservable }) => {
         expectObservable(obs$).toBe(
           '(a|)',
@@ -164,6 +159,12 @@ describe('AuthService', () => {
           'e',
           { e: { ...loggedInUser } },
         );
+      });
+      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
+        id: 'login_with_token_uuid',
+        msg: IncomingApiMessageType.Method,
+        method: 'auth.login_with_token',
+        params: ['DUMMY_TOKEN'],
       });
       expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
         id: 'logged_in_user_uuid',
@@ -190,11 +191,6 @@ describe('AuthService', () => {
       const getFilteredWebsocketResponse = jest.spyOn(spectator.service, 'getFilteredWebsocketResponse');
       when(getFilteredWebsocketResponse).calledWith('logout_uuid').mockReturnValue(of());
       const obs$ = spectator.service.logout();
-      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
-        id: 'logout_uuid',
-        msg: IncomingApiMessageType.Method,
-        method: 'auth.logout',
-      });
       testScheduler.run(({ expectObservable }) => {
         expectObservable(obs$).toBe(
           '|',
@@ -208,6 +204,11 @@ describe('AuthService', () => {
           'd',
           { d: null },
         );
+      });
+      expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({
+        id: 'logout_uuid',
+        msg: IncomingApiMessageType.Method,
+        method: 'auth.logout',
       });
     });
   });

--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -35,7 +35,6 @@ describe('AuthService', () => {
   let spectator: SpectatorService<AuthService>;
   let testScheduler: TestScheduler;
   let strategyStub: StorageStrategy<unknown>;
-  const normalizedAuthTokenKey = 'ngx-webstorage|token';
   const createService = createServiceFactory({
     service: AuthService,
     imports: [
@@ -127,8 +126,6 @@ describe('AuthService', () => {
     });
     it('initalizes auth session with triggers and token with token login', () => {
       jest.spyOn(rxjs, 'timer').mockReturnValueOnce(of(0));
-      const strategy: StorageStrategyStub = strategyStub as StorageStrategyStub;
-      strategy.store[normalizedAuthTokenKey] = 'DUMMY_TOKEN3';
 
       jest.spyOn(UUID, 'UUID')
         .mockReturnValueOnce('login_with_token_uuid')
@@ -148,7 +145,7 @@ describe('AuthService', () => {
         id: 'login_with_token_uuid',
         msg: IncomingApiMessageType.Method,
         method: 'auth.login_with_token',
-        params: ['DUMMY_TOKEN3'],
+        params: ['DUMMY_TOKEN'],
       });
       testScheduler.run(({ expectObservable }) => {
         expectObservable(obs$).toBe(

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -6,7 +6,6 @@ import {
   BehaviorSubject,
   combineLatest,
   filter,
-  first,
   map,
   Observable,
   of,
@@ -108,7 +107,7 @@ export class AuthService {
       requestTrigger$,
       uuidFilteredResponse$,
     ]).pipe(
-      first(),
+      take(1),
       map(([, data]) => data),
       switchMap((loginResponse) => {
         this.isLoggedIn$.next(loginResponse);
@@ -133,7 +132,7 @@ export class AuthService {
     const requestTrigger$ = new Observable((subscriber) => {
       this.wsManager.send(payload);
       subscriber.next();
-    }).pipe(first());
+    }).pipe(take(1));
 
     const uuidFilteredResponse$ = this.getFilteredWebsocketResponse<boolean>(uuid);
 
@@ -164,7 +163,7 @@ export class AuthService {
     return this.wsManager.websocket$.pipe(
       filter((data: IncomingWebsocketMessage) => data.msg === IncomingApiMessageType.Result && data.id === uuid),
       map((data: ResultMessage<T>) => data.result),
-      first(),
+      take(1),
     );
   }
 
@@ -179,7 +178,7 @@ export class AuthService {
     const requestTrigger$ = new Observable((subscriber) => {
       this.wsManager.send(payload);
       subscriber.next();
-    }).pipe(first());
+    }).pipe(take(1));
 
     const uuidFilteredResponse$ = this.getFilteredWebsocketResponse<string>(uuid);
 
@@ -201,7 +200,7 @@ export class AuthService {
       this.wsManager.send(payload);
       this.clearAuthToken();
       subscriber.next();
-    }).pipe(first());
+    }).pipe(take(1));
 
     const uuidFilteredResponse$ = this.getFilteredWebsocketResponse<void>(uuid);
 
@@ -228,7 +227,7 @@ export class AuthService {
     const requestTrigger$ = new Observable((subscriber) => {
       this.wsManager.send(payload);
       subscriber.next();
-    }).pipe(first());
+    }).pipe(take(1));
 
     combineLatest([
       requestTrigger$,
@@ -251,7 +250,7 @@ export class AuthService {
         const requestTriggerUserQuery$ = new Observable((subscriber) => {
           this.wsManager.send(userQueryPayload);
           subscriber.next();
-        }).pipe(first());
+        }).pipe(take(1));
 
         return combineLatest([
           requestTriggerUserQuery$,

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -121,7 +121,7 @@ export class AuthService {
     }));
   }
 
-  setupPeriodicTokenGeneration(): void {
+  private setupPeriodicTokenGeneration(): void {
     if (!this.generateTokenSubscription || this.generateTokenSubscription.closed) {
       this.generateTokenSubscription = timer(0, this.tokenRegenerationTimeMillis).pipe(
         switchMap(() => this.isAuthenticated$),
@@ -160,6 +160,7 @@ export class AuthService {
       method: 'auth.logout',
     };
     this.wsManager.send(payload);
+    this.clearAuthToken();
     return this.getFilteredWebsocketResponse<void>(uuid).pipe(tap(() => {
       this.isLoggedIn$.next(false);
     }));

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -46,7 +46,10 @@ export class AuthService {
 
   private generateTokenSubscription: Subscription;
 
-  readonly isAuthenticated$ = combineLatest([this.wsManager.isConnected$, this.isLoggedIn$.asObservable()]).pipe(
+  readonly isAuthenticated$ = combineLatest([
+    this.wsManager.isConnected$,
+    this.isLoggedIn$.asObservable(),
+  ]).pipe(
     switchMap(([isConnected, isLoggedIn]) => {
       return of(isConnected && isLoggedIn);
     }),

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -89,12 +89,13 @@ export class AuthService {
 
   login(username: string, password: string, otp: string = null): Observable<boolean> {
     const uuid = UUID.UUID();
-    this.wsManager.send({
+    const payload = {
       id: uuid,
       msg: IncomingApiMessageType.Method,
       method: 'auth.login',
       params: otp ? [username, password, otp] : [username, password],
-    });
+    };
+    this.wsManager.send(payload);
 
     return this.getFilteredWebsocketResponse<boolean>(uuid).pipe(
       switchMap((loginResponse) => {
@@ -110,12 +111,13 @@ export class AuthService {
 
   loginWithToken(): Observable<boolean> {
     const uuid = UUID.UUID();
-    this.wsManager.send({
+    const payload = {
       id: uuid,
       msg: IncomingApiMessageType.Method,
       method: 'auth.login_with_token',
       params: [this.token || ''],
-    });
+    };
+    this.wsManager.send(payload);
     return this.getFilteredWebsocketResponse<boolean>(uuid).pipe(tap((response) => {
       this.isLoggedIn$.next(response);
     }));

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -178,14 +178,15 @@ export class AuthService {
       filter((loggedInUser: DsUncachedUser) => !!loggedInUser?.pw_uid),
       switchMap((loggedInUser: DsUncachedUser) => {
         authenticatedUser = loggedInUser;
+        const userQueryUuid = UUID.UUID();
         const userQueryPayload = {
-          id: uuid,
+          id: userQueryUuid,
           msg: IncomingApiMessageType.Method,
           method: 'user.query',
           params: [[['uid', '=', authenticatedUser.pw_uid]]],
         };
         this.wsManager.send(userQueryPayload);
-        return this.getFilteredWebsocketResponse(uuid);
+        return this.getFilteredWebsocketResponse(userQueryUuid);
       }),
       tap((users: User[]) => {
         if (users?.[0]?.id) {

--- a/src/app/views/sessions/signin/store/signin.store.spec.ts
+++ b/src/app/views/sessions/signin/store/signin.store.spec.ts
@@ -60,11 +60,7 @@ describe('SigninStore', () => {
     spectator = createService();
     websocket2 = spectator.inject(MockWebsocketService);
     authService = spectator.inject(AuthService);
-    // This strips @LocalStorage() decorator from token.
-    // Object.defineProperty(authService, 'token2', {
-    //   value: '',
-    //   writable: true,
-    // });
+
     Object.defineProperty(authService, 'authToken$', {
       value: of('EXISTING_TOKEN'),
     });
@@ -144,8 +140,7 @@ describe('SigninStore', () => {
       });
     });
 
-    it('logs in with token if it is present in local storage (via AuthService.token2)', () => {
-      // authService.token2 = 'EXISTING_TOKEN';
+    it('logs in with token if it is present in local storage (via AuthService.token)', () => {
       spectator.service.init();
 
       expect(authService.loginWithToken).toHaveBeenCalled();


### PR DESCRIPTION
The tests check for all scenarios when you login via either username/password or with a token. Also checks scenarios for logout.

This PR also fixes the race condition potential in AuthService that was fixed in WebsocketService by https://github.com/truenas/webui/pull/7829