### PR TITLE
NAS-120381 / 23.10 / Calculate slot when no disk is present (by dszidi)

### DIFF
--- a/src/app/pages/system/view-enclosure/classes/chassis-view.ts
+++ b/src/app/pages/system/view-enclosure/classes/chassis-view.ts
@@ -288,16 +288,19 @@ export class ChassisView {
   }
 
   colorDriveTray(options: ChangeDriveTrayOptions): void {
-    if (!options.slot) return; // TODO: find out why we get undefined options.slot
+    // if there is no disk in slot we can't get a slot number, so we use id instead
+    const slot = !options.slot ? Number(options.id) : options.slot;
+    const driveIndex = slot - this.slotRange.start;
 
-    const driveIndex = options.slot - this.slotRange.start;
     if (driveIndex < 0 || driveIndex >= this.totalDriveTrays) {
       console.warn(`IGNORING DRIVE AT INDEX ${driveIndex} SLOT ${options.slot} IS OUT OF RANGE`);
       return;
     }
+
     const dt = this.driveTrayObjects[driveIndex];
 
-    dt.color = options.color.toLowerCase();
+    if (dt) dt.color = options.color.toLowerCase();
+
     if (dt && this.initialized) {
       dt.handle.alpha = options.color === 'none' ? this.disabledOpacity : 1;
     }


### PR DESCRIPTION
Testing requires physical access to hardware
- Enclosure UI visualization should update when disk is added or removed (could take up to 10 seconds or so)
- Verify that the color coding on drivetrays is correct and matches physical location of disk

Do this on both MINI products as well as Enterprise models

Original PR: https://github.com/truenas/webui/pull/7839
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120381