### PR TITLE
Validate iSCSI Target Name field

### DIFF
--- a/src/app/helptext/sharing/iscsi/iscsi.ts
+++ b/src/app/helptext/sharing/iscsi/iscsi.ts
@@ -322,8 +322,10 @@ export const helptext_sharing_iscsi = {
   // wizard
   step1_label: T('Create or Choose Block Device'),
 
-  name_placeholder: T('Name'),
-  name_tooltip: T('Keep the name short. Using a name longer than 63 characters can prevent accessing the block device.'),
+  name: {
+    placeholder: T('Name'),
+    tooltip: T('Keep the name short. Using a name longer than 63 characters can prevent accessing the block device. Allowed characters: letters, numbers, period (.), dash (-), and colon (:).'),
+  },
 
   disk_placeholder: T('Device'),
   disk_tooltip: T('Select the unformatted disk, controller, zvol, or zvol snapshot. Select\

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
@@ -55,12 +55,14 @@ export class IscsiWizardComponent {
         {
           type: 'input',
           name: 'name',
-          placeholder: helptext_sharing_iscsi.name_placeholder,
-          tooltip: helptext_sharing_iscsi.name_tooltip,
+          placeholder: helptext_sharing_iscsi.name.placeholder,
+          tooltip: helptext_sharing_iscsi.name.tooltip,
           required: true,
           validation: [
             Validators.required,
             forbiddenValues(this.namesInUse),
+            // Allowed characters: letters, numbers, period, hyphen, colon
+            Validators.pattern(/^[a-z0-9\\.\-\\:]+$/),
           ],
         },
         {


### PR DESCRIPTION
When creating a new iSCSI target the name field has some rules that aren't reflected until you reach the end of the wizard at which point you may find that the name was invalid. While these rules are probably known by someone familiar with iSCSI, it's not necessarily user-friendly as-is.

I was trying to find a way to show a more helpful validation error when the validation rule was violated, but gave up and instead added the specificity to the tooltip. Also, happy to port this to the latest!

![Screenshot 2023-03-02 at 10 07 54 PM](https://user-images.githubusercontent.com/1728260/222636529-b8a5806d-729c-45a5-9943-d762cb61880a.png)
