### PR TITLE
NAS-120580 / 23.10 / Apps cron input with type "string" no validation on cron field

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "chart.js": "~2.9.4",
     "core-js": "~3.6.4",
     "cron-parser": "~4.2.1",
-    "cron-validator": "~1.3.1",
     "croner": "~4.2.3",
     "cronstrue": "~1.113.0",
     "d3": "~5.16.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "chart.js": "~2.9.4",
     "core-js": "~3.6.4",
     "cron-parser": "~4.2.1",
+    "cron-validator": "~1.3.1",
     "croner": "~4.2.3",
     "cronstrue": "~1.113.0",
     "d3": "~5.16.0",

--- a/src/app/enums/default-validation-error.enum.ts
+++ b/src/app/enums/default-validation-error.enum.ts
@@ -9,4 +9,5 @@ export enum DefaultValidationError {
   Pattern = 'pattern',
   Forbidden = 'forbidden',
   Number = 'number',
+  Cron = 'cron',
 }

--- a/src/app/modules/entity/entity-form/components/form-errors/form-errors.component.html
+++ b/src/app/modules/entity/entity-form/components/form-errors/form-errors.component.html
@@ -83,4 +83,8 @@
   <mat-error *ngIf="control.hasError('email')">
     {{ 'Value must be a valid email address' | translate }}
   </mat-error>
+
+  <mat-error *ngIf="control.hasError('cron')">
+    {{ 'Invalid cron expression' | translate }}
+  </mat-error>
 </div>

--- a/src/app/modules/entity/entity-form/validators/cron-validation.ts
+++ b/src/app/modules/entity/entity-form/validators/cron-validation.ts
@@ -1,0 +1,12 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { isValidCron } from 'cron-validator';
+
+export function cronValidator(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (!control.value || control.value === '' || control.value === undefined) {
+      return null;
+    }
+
+    return !isValidCron(control.value) ? { cron: true } : null;
+  };
+}

--- a/src/app/modules/entity/entity-form/validators/cron-validation.ts
+++ b/src/app/modules/entity/entity-form/validators/cron-validation.ts
@@ -1,12 +1,12 @@
 import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
-import { isValidCron } from 'cron-validator';
+import { parseString } from 'cron-parser';
 
 export function cronValidator(): ValidatorFn {
-  return (control: AbstractControl): ValidationErrors | null => {
+  return (control: AbstractControl<string>): ValidationErrors | null => {
     if (!control.value || control.value === '' || control.value === undefined) {
       return null;
     }
 
-    return !isValidCron(control.value) ? { cron: true } : null;
+    return Object.keys(parseString(control.value).errors).length ? { cron: true } : null;
   };
 }

--- a/src/app/modules/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -47,6 +47,7 @@ export class IxErrorsComponent implements OnChanges {
       { min, max },
     ),
     number: () => this.translate.instant('Value must be a number'),
+    cron: () => this.translate.instant('Invalid cron expression'),
   };
 
   constructor(
@@ -101,6 +102,8 @@ export class IxErrorsComponent implements OnChanges {
         return this.defaultErrMessages.forbidden(this.control.value);
       case DefaultValidationError.Number:
         return this.defaultErrMessages.number();
+      case DefaultValidationError.Cron:
+        return this.defaultErrMessages.cron();
       default:
         return undefined;
     }

--- a/src/app/services/schema/app-schema.service.spec.ts
+++ b/src/app/services/schema/app-schema.service.spec.ts
@@ -14,6 +14,7 @@ import {
 } from 'app/interfaces/dynamic-form-schema.interface';
 import { FilesystemService } from 'app/services/filesystem.service';
 import { AppSchemaService } from 'app/services/schema/app-schema.service';
+import { UrlValidationService } from 'app/services/url-validation.service';
 
 const beforeIntString = [{
   variable: 'variable_dict',
@@ -376,7 +377,7 @@ const afterHidden = [[]] as DynamicFormSchemaIpaddr[][];
 const dynamicForm = new FormGroup<Record<string, UntypedFormGroup>>({});
 
 describe('AppSchemaService', () => {
-  const service = new AppSchemaService({} as FilesystemService);
+  const service = new AppSchemaService({} as FilesystemService, {} as UrlValidationService);
   describe('transformNode()', () => {
     beforeIntString.forEach((item, idx) => {
       it('converts schema with "int" and "string" type', () => {

--- a/src/app/services/schema/app-schema.service.ts
+++ b/src/app/services/schema/app-schema.service.ts
@@ -353,7 +353,7 @@ export class AppSchemaService {
 
     const defaultValue = schema.default !== undefined ? schema.default : altDefault;
     const nullValidator = Validators.nullValidator;
-    const isCron = schema.type === ChartSchemaType.String && isValidCron(schema.default.toString());
+    const isCron = schema.type === ChartSchemaType.String && schema.default && isValidCron(schema.default.toString());
 
     const newFormControl = new CustomUntypedFormControl(defaultValue, [
       schema.required ? Validators.required : nullValidator,

--- a/src/app/services/schema/app-schema.service.ts
+++ b/src/app/services/schema/app-schema.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Validators, AbstractControl, FormGroup } from '@angular/forms';
 import { UntilDestroy } from '@ngneat/until-destroy';
+import { isValidCron } from 'cron-validator';
 import _ from 'lodash';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
@@ -18,6 +19,7 @@ import { DeleteListItemEvent, DynamicFormSchemaNode } from 'app/interfaces/dynam
 import { HierarchicalObjectMap } from 'app/interfaces/hierarhical-object-map.interface';
 import { Schedule } from 'app/interfaces/schedule.interface';
 import { Relation } from 'app/modules/entity/entity-form/models/field-relation.interface';
+import { cronValidator } from 'app/modules/entity/entity-form/validators/cron-validation';
 import {
   CustomUntypedFormArray,
 } from 'app/modules/ix-dynamic-form/components/ix-dynamic-form/classes/custom-untped-form-array';
@@ -45,15 +47,17 @@ import {
   transformStringSchemaType,
   transformUriSchemaType,
 } from 'app/services/schema/app-shema.transformer';
-
-const urlRegex = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/;
+import { UrlValidationService } from 'app/services/url-validation.service';
 
 @UntilDestroy()
 @Injectable({
   providedIn: 'root',
 })
 export class AppSchemaService {
-  constructor(protected filesystemService: FilesystemService) {}
+  constructor(
+    protected filesystemService: FilesystemService,
+    private urlValidationService: UrlValidationService,
+  ) {}
 
   transformNode(chartSchemaNode: ChartSchemaNode, isNew: boolean, isParentImmutable: boolean): DynamicFormSchemaNode[] {
     const schema = chartSchemaNode.schema;
@@ -205,10 +209,6 @@ export class AppSchemaService {
     event.array.removeAt(event.index);
   }
 
-  checkIsValidCronTab(crontab: string): boolean {
-    return !!crontab.match(/^((((\d+,)+\d+|(\d+(\/|-|#)\d+)|\d+L?|\*(\/\d+)?|L(-\d+)?|\?|[a-z]{3}(,[a-z]{3}){0,10}) ?){5})$/);
-  }
-
   checkIsValidSchedule(schedule: Schedule): boolean {
     return !!(schedule.month && schedule.hour && schedule.minute && schedule.dom && schedule.dow);
   }
@@ -221,7 +221,7 @@ export class AppSchemaService {
     if (data == null) {
       return data;
     }
-    if (fieldSchemaNode?.schema?.type === ChartSchemaType.Cron && this.checkIsValidCronTab(data.toString())) {
+    if (fieldSchemaNode?.schema?.type === ChartSchemaType.Cron && isValidCron(data.toString())) {
       return crontabToSchedule(data.toString()) as SerializeFormValue;
     }
     if (Array.isArray(data)) {
@@ -352,14 +352,17 @@ export class AppSchemaService {
     }
 
     const defaultValue = schema.default !== undefined ? schema.default : altDefault;
+    const nullValidator = Validators.nullValidator;
+    const isCron = schema.type === ChartSchemaType.String && isValidCron(schema.default.toString());
 
     const newFormControl = new CustomUntypedFormControl(defaultValue, [
-      schema.required ? Validators.required : Validators.nullValidator,
-      schema.max ? Validators.max(schema.max) : Validators.nullValidator,
-      schema.min ? Validators.min(schema.min) : Validators.nullValidator,
-      schema.max_length ? Validators.maxLength(schema.max_length) : Validators.nullValidator,
-      schema.min_length ? Validators.minLength(schema.min_length) : Validators.nullValidator,
-      schema.type === ChartSchemaType.Uri ? Validators.pattern(urlRegex) : Validators.nullValidator,
+      schema.required ? Validators.required : nullValidator,
+      schema.max ? Validators.max(schema.max) : nullValidator,
+      schema.min ? Validators.min(schema.min) : nullValidator,
+      schema.max_length ? Validators.maxLength(schema.max_length) : nullValidator,
+      schema.min_length ? Validators.minLength(schema.min_length) : nullValidator,
+      schema.type === ChartSchemaType.Uri ? Validators.pattern(this.urlValidationService.urlRegex) : nullValidator,
+      isCron ? cronValidator() : nullValidator,
     ]);
 
     this.handleSchemaSubQuestions(payload, newFormControl);

--- a/src/app/services/url-validation.service.ts
+++ b/src/app/services/url-validation.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class UrlValidationService {
+  urlRegex = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/;
+}

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1589,6 +1589,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1193,6 +1193,7 @@
   "Interval": "",
   "Invalid Format.": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid image": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -396,6 +396,7 @@
   "Installed Catalogs": "",
   "Interfaces": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid format or character": "",
   "Invalid image": "",
   "Invalid value. Must be greater than or equal to ": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1691,6 +1691,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -140,6 +140,7 @@
   "Installed": "",
   "Installed Apps": "",
   "Installed Catalogs": "",
+  "Invalid cron expression": "",
   "Inventory": "",
   "Jan": "",
   "KDC": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1619,6 +1619,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1501,6 +1501,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1854,6 +1854,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -62,6 +62,7 @@
   "Helm Chart Info": "",
   "Home Page": "",
   "Install Button Pressed": "",
+  "Invalid cron expression": "",
   "Keywords": "",
   "Logout": "",
   "Maintainer": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1790,6 +1790,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1785,6 +1785,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1746,6 +1746,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -723,6 +723,7 @@
   "Internetwork control": "",
   "Invalid Format.": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid image": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -131,6 +131,7 @@
   "Installed": "",
   "Installed Apps": "",
   "Installed Catalogs": "",
+  "Invalid cron expression": "",
   "Inventory": "",
   "Is planned to be automatically destroyed at {datetime}": "",
   "KDC": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1862,6 +1862,7 @@
   "Invalid Format.": "",
   "Invalid IP address": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -6,6 +6,7 @@
   "Deploying": "",
   "Filter by Disk Size": "",
   "Filter by Disk Type": "",
+  "Invalid cron expression": "",
   "Manual Disk Selection": "",
   "Maximize Enclosure Dispersal": "",
   "Minimize Enclosure Dispersal": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1335,6 +1335,7 @@
   "Internal identifier of the certificate. Only alphanumeric, \"_\" and \"-\" are allowed.": "",
   "Internetwork control": "",
   "Invalid Pod name": "",
+  "Invalid cron expression": "",
   "Invalid file": "",
   "Invalid format or character": "",
   "Invalid format or character.": "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6244,6 +6244,11 @@ cron-parser@~4.2.1:
   dependencies:
     luxon "^1.28.0"
 
+cron-validator@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/cron-validator/-/cron-validator-1.3.1.tgz#8f2fe430f92140df77f91178ae31fc1e3a48a20e"
+  integrity sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A==
+
 croner@~4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/croner/-/croner-4.2.3.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6244,11 +6244,6 @@ cron-parser@~4.2.1:
   dependencies:
     luxon "^1.28.0"
 
-cron-validator@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/cron-validator/-/cron-validator-1.3.1.tgz#8f2fe430f92140df77f91178ae31fc1e3a48a20e"
-  integrity sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A==
-
 croner@~4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/croner/-/croner-4.2.3.tgz"


### PR DESCRIPTION
For testing you can use: 
mini3xlp-101.dc1.ixsystems.net (machine)
creds: **root / abcd1234** 

Go to apps -> Available Apps -> search for **nextcloud**
click **Install** 

Under **CronJob configuration** configuration there is:

Schedule of a type string.
Try to put some invalid cron expression and you should see validation error.

<img width="504" alt="Screenshot 2023-03-03 at 12 37 54" src="https://user-images.githubusercontent.com/22980553/222701300-b9ae7a60-5832-4c27-b6aa-9b0abaac4bab.png">

Or contact @stavros-k (he knows how to setup on any machine)