### PR TITLE
NAS-120492 / 22.12.2 / [SCALE/Apps]: Initial value of a dropdown is null, but after picking something and reverting to empty is no longer null (by AlexKarpov98)

### DIFF
--- a/src/app/services/app-schema.service.ts
+++ b/src/app/services/app-schema.service.ts
@@ -518,7 +518,7 @@ export class AppSchemaService {
         }
 
         parentControl.hidden$.pipe(take(1)).subscribe((isParentHidden) => {
-          if (value !== null && !isParentHidden) {
+          if (!isParentHidden) {
             const formField = (formGroup.controls[chartSchemaNode.variable] as CustomUntypedFormField);
             if (!formField.hidden$) {
               formField.hidden$ = new BehaviorSubject<boolean>(false);
@@ -562,7 +562,7 @@ export class AppSchemaService {
         }
 
         parentControl.hidden$.pipe(take(1)).subscribe((isParentHidden) => {
-          if (value !== null && !isParentHidden) {
+          if (!isParentHidden) {
             const formField = (formGroup.controls[chartSchemaNode.variable] as CustomUntypedFormField);
             if (!formField.hidden$) {
               formField.hidden$ = new BehaviorSubject<boolean>(false);


### PR DESCRIPTION
For testing you can use machine from ticket.

Go to apps -> Available Apps -> search for **minio**
click **Install** 

Under **Minio Configuration** configuration there is:

Test Certificate. 
Once you select a certificate, there should appear `Test cert` string field.
And if you select `No certificate` then `Test cert` string input field should disappear.

<img width="809" alt="Screenshot 2023-03-03 at 11 29 13" src="https://user-images.githubusercontent.com/22980553/222683857-d49e7bb6-3d3e-47e9-9788-9dc6edede50a.png">


Or contact @stavros-k (he knows how to setup on any machine)


Original PR: https://github.com/truenas/webui/pull/7859
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120492