### PR TITLE
(NAS-120533) UI does not allow for EXTEND operations on single-device special VDEVs

### DIFF
--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
@@ -47,7 +47,7 @@ export class ZfsInfoCardComponent {
   get canExtendDisk(): boolean {
     return this.topologyParentItem.type !== TopologyItemType.Mirror
       && this.topologyItem.type === TopologyItemType.Disk
-      && this.topologyCategory === PoolTopologyCategory.Data
+      && ( this.topologyCategory === PoolTopologyCategory.Data || this.topologyCategory === PoolTopologyCategory.Dedup || this.topologyCategory === PoolTopologyCategory.Special )
       && this.topologyItem.status !== TopologyItemStatus.Unavail;
   }
 


### PR DESCRIPTION
added OR conditions for canExtendDisk function to present Extend option for single-disk Dedup and Special VDEVs