### PR TITLE
NAS-119689 / 23.10 / Update pool-usage-card.component.html (by RehanY147)

### DIFF
--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
@@ -66,7 +66,7 @@
       <a
         class="link"
         [ixTest]="[poolState.name, 'view-disk-space-reports']"
-        [routerLink]="['/reportsdashboard', 'disk']"
+        [routerLink]="['/reportsdashboard', 'partition']"
         [queryParams]="{ disks }"
       >
         {{ 'View Disk Space Reports' | translate }}

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
@@ -119,6 +119,6 @@ describe('PoolUsageCardComponent', () => {
 
   it('should pre-select disks when user click "View Disk Space Reports" link', () => {
     const href = spectator.query(byText('View Disk Space Reports')).getAttribute('href');
-    expect(href).toBe('/reportsdashboard/disk?disks=sda&disks=sdb');
+    expect(href).toBe('/reportsdashboard/partition?disks=sda&disks=sdb');
   });
 });


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 9e1603f28dc324a889e33b7d9fefc1ea053bce2e
    git cherry-pick -x d76353c31156aa0bf4465512d141e7af5bbded03

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x da66080489d2c0b26a6466531dccbaa128301f3a

Clicking on the "View Disk Space Reports" button on the pool's dashboard usage card should take you to the Partition/Space reports.

Original PR: https://github.com/truenas/webui/pull/7874
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119689