### PR TITLE
NAS-119863: Load the "Available Apps" dashboard

### DIFF
--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -348,6 +348,9 @@ export type ApiDirectory = {
   'bootenv.delete': { params: [string]; response: boolean };
   'bootenv.query': { params: QueryParams<Bootenv>; response: Bootenv[] };
 
+  // App
+  'app.categories': { params: void; response: string[] };
+
   // Catalog
   'catalog.query': { params: CatalogQueryParams; response: Catalog[] };
   'catalog.update': { params: [id: string, update: CatalogUpdate]; response: Catalog };

--- a/src/app/interfaces/catalog.interface.ts
+++ b/src/app/interfaces/catalog.interface.ts
@@ -72,6 +72,8 @@ export interface CatalogApp {
   latest_app_version: string;
   latest_human_version: string;
   versions?: { [version: string]: CatalogAppVersion };
+  recommended?: boolean;
+  last_update?: string;
   catalog?: {
     id?: string;
     label?: string;

--- a/src/app/pages/apps/components/app-detail-view/app-detail-view.component.html
+++ b/src/app/pages/apps/components/app-detail-view/app-detail-view.component.html
@@ -12,7 +12,7 @@
         <a
           mat-button
           color="primary"
-          [ixTest]="[app.name, 'install']"
+          [ixTest]="[app?.name, 'install']"
           [disabled]="!app" (click)="onInstallButtonPressed()"
         >{{ 'Install' | translate }}</a>
       </div>

--- a/src/app/pages/apps/components/available-apps/available-apps.component.html
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.html
@@ -11,35 +11,28 @@
 
 <ix-available-apps-header></ix-available-apps-header>
 
-<div class="available-apps-list">
-  <ng-container *ngTemplateOutlet="appsSection; context: {
-    title: 'Recommended Apps',
-    apps: recommendedApps
-  }"></ng-container>
+<div *ngIf="apps.length" class="available-apps-list">
+  <ng-container *ngFor="let appSection of appSections; trackBy: trackByAppSectionTitle">
+    <section *ngIf="appSection.apps$ | async as apps">
+      <ng-container *ngIf="apps.length">
+        <h3 class="apps-section-title">
+          {{ appSection.title | translate }}
+        </h3>
 
-  <ng-container *ngTemplateOutlet="appsSection; context: {
-    title: 'New & Updated Apps',
-    apps: newAndUpdatedApps
-  }"></ng-container>
+        <div class="apps">
+          <ix-app-card
+            *ngFor="let app of apps; trackBy: trackByAppId"
+            [app]="app"
+            [routerLink]="['/apps', 'available', app.name]"
+          ></ix-app-card>
+        </div>
+
+        <p *ngIf="apps.length <= sliceAmount" class="view-all" (click)="appSection.onViewMore()">
+          <b>
+            {{ 'View All' | translate }} {{ appSection.title | translate }}
+          </b>
+        </p>
+      </ng-container>
+    </section>
+  </ng-container>
 </div>
-
-<ng-template #appsSection let-title="title" let-apps="apps">
-  <section *ngIf="apps.length">
-    <h3 class="apps-section-title">
-      {{ title | translate }}
-    </h3>
-    <div class="apps">
-      <ix-app-card
-        *ngFor="let app of apps; trackBy: trackByAppId"
-        [app]="app"
-        [routerLink]="['/apps', 'available', app.name]"
-      ></ix-app-card>
-    </div>
-    <p class="view-all">
-      <b>
-        {{ 'View All' | translate }}
-        {{ title | translate }}
-      </b>
-    </p>
-  </section>
-</ng-template>

--- a/src/app/pages/apps/components/available-apps/available-apps.component.html
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.html
@@ -11,10 +11,35 @@
 
 <ix-available-apps-header></ix-available-apps-header>
 
-<div class="apps">
-  <ix-app-card
-    *ngFor="let app of apps; trackBy: trackByAppId"
-    [app]="app"
-    [routerLink]="['/apps', 'available', app.name]"
-  ></ix-app-card>
+<div class="available-apps-list">
+  <ng-container *ngTemplateOutlet="appsSection; context: {
+    title: 'Recommended Apps',
+    apps: recommendedApps
+  }"></ng-container>
+
+  <ng-container *ngTemplateOutlet="appsSection; context: {
+    title: 'New & Updated Apps',
+    apps: newAndUpdatedApps
+  }"></ng-container>
 </div>
+
+<ng-template #appsSection let-title="title" let-apps="apps">
+  <section *ngIf="apps.length">
+    <h3 class="apps-section-title">
+      {{ title | translate }}
+    </h3>
+    <div class="apps">
+      <ix-app-card
+        *ngFor="let app of apps; trackBy: trackByAppId"
+        [app]="app"
+        [routerLink]="['/apps', 'available', app.name]"
+      ></ix-app-card>
+    </div>
+    <p class="view-all">
+      <b>
+        {{ 'View All' | translate }}
+        {{ title | translate }}
+      </b>
+    </p>
+  </section>
+</ng-template>

--- a/src/app/pages/apps/components/available-apps/available-apps.component.html
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.html
@@ -27,7 +27,7 @@
           ></ix-app-card>
         </div>
 
-        <p *ngIf="apps.length <= sliceAmount" class="view-all" (click)="appSection.onViewMore()">
+        <p *ngIf="appSection.totalApps > sliceAmount" class="view-all" (click)="appSection.onViewMore()">
           <b>
             {{ 'View All' | translate }} {{ appSection.title | translate }}
           </b>

--- a/src/app/pages/apps/components/available-apps/available-apps.component.scss
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.scss
@@ -1,7 +1,29 @@
-.apps {
-  column-gap: 40px;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));
-  padding-top: 20px;
-  row-gap: 16px;
+.available-apps-list {
+  section {
+    .apps {
+      column-gap: 40px;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));
+      row-gap: 16px;
+    }
+
+    .apps-section-title {
+      background: var(--bg1);
+      color: var(--primary-txt);
+      margin: 0;
+      padding: 15px 0;
+      position: sticky;
+      top: -15px;
+      z-index: 1;
+    }
+
+    .view-all {
+      align-items: center;
+      color: var(--primary);
+      cursor: pointer;
+      display: flex;
+      justify-content: flex-end;
+      margin-bottom: 0;
+    }
+  }
 }

--- a/src/app/pages/apps/components/available-apps/available-apps.component.scss
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.scss
@@ -4,6 +4,7 @@
       column-gap: 40px;
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));
+      margin-bottom: 20px;
       row-gap: 16px;
     }
 
@@ -23,7 +24,7 @@
       cursor: pointer;
       display: flex;
       justify-content: flex-end;
-      margin-bottom: 0;
+      margin: 0;
     }
   }
 }

--- a/src/app/pages/apps/components/available-apps/available-apps.component.ts
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.ts
@@ -22,6 +22,15 @@ export class AvailableAppsComponent implements OnInit, AfterViewInit {
 
   apps: CatalogApp[] = [];
 
+  get recommendedApps(): CatalogApp[] {
+    // return this.apps.filter((app) => app.recommended).slice(0, 6);
+    return this.apps.slice(0, 6);
+  }
+
+  get newAndUpdatedApps(): CatalogApp[] {
+    return this.apps.slice(0, 6).sort((a, b) => new Date(a.last_update).getTime() - new Date(b.last_update).getTime());
+  }
+
   constructor(
     private layoutService: LayoutService,
     private loader: AppLoaderService,

--- a/src/app/pages/apps/components/available-apps/available-apps.component.ts
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.ts
@@ -14,6 +14,7 @@ import { LayoutService } from 'app/services/layout.service';
 
 interface AppSection {
   title: string;
+  totalApps: number;
   apps$: BehaviorSubject<CatalogApp[]>;
   onViewMore: () => void;
 }
@@ -28,27 +29,13 @@ export class AvailableAppsComponent implements OnInit, AfterViewInit {
   @ViewChild('pageHeader') pageHeader: TemplateRef<unknown>;
 
   apps: CatalogApp[] = [];
-
   allRecommendedApps: CatalogApp[] = [];
   allNewAndUpdatedApps: CatalogApp[] = [];
+  sliceAmount = 6;
+  appSections: AppSection[] = [];
 
   recommendedApps$ = new BehaviorSubject<CatalogApp[]>([]);
   newAndUpdatedApps$ = new BehaviorSubject<CatalogApp[]>([]);
-
-  sliceAmount = 6;
-
-  appSections: AppSection[] = [
-    {
-      title: 'Recommended Apps',
-      apps$: this.recommendedApps$,
-      onViewMore: () => this.recommendedApps$.next(this.allRecommendedApps),
-    },
-    {
-      title: 'New & Updated Apps',
-      apps$: this.newAndUpdatedApps$,
-      onViewMore: () => this.newAndUpdatedApps$.next(this.allNewAndUpdatedApps),
-    },
-  ];
 
   constructor(
     private layoutService: LayoutService,
@@ -125,13 +112,29 @@ export class AvailableAppsComponent implements OnInit, AfterViewInit {
     this.recommendedApps$.next(this.allRecommendedApps.slice(0, this.sliceAmount));
     this.newAndUpdatedApps$.next(this.allNewAndUpdatedApps.slice(0, this.sliceAmount));
 
+    this.appSections.push(
+      {
+        title: 'Recommended Apps',
+        apps$: this.recommendedApps$,
+        totalApps: this.allNewAndUpdatedApps.length,
+        onViewMore: () => this.recommendedApps$.next(this.allRecommendedApps),
+      },
+      {
+        title: 'New & Updated Apps',
+        apps$: this.newAndUpdatedApps$,
+        totalApps: this.allNewAndUpdatedApps.length,
+        onViewMore: () => this.newAndUpdatedApps$.next(this.allNewAndUpdatedApps),
+      },
+    );
+
     appCategories.forEach((category) => {
+      const categorizedApps = this.apps.filter((app) => app.categories.some((appCategory) => appCategory === category));
+
       this.appSections.push(
         {
           title: category,
-          apps$: new BehaviorSubject(
-            this.apps.filter((app) => app.categories.some((appCategory) => appCategory === category)),
-          ),
+          apps$: new BehaviorSubject(categorizedApps.slice(0, this.sliceAmount)),
+          totalApps: categorizedApps.length,
           onViewMore: () => {},
         },
       );

--- a/src/app/pages/apps/services/applications.service.ts
+++ b/src/app/pages/apps/services/applications.service.ts
@@ -26,6 +26,10 @@ export class ApplicationsService {
     return this.ws.call('catalog.query', [[], { extra: { cache: true, item_details: true } }]);
   }
 
+  getAllAppCategories(): Observable<string[]> {
+    return this.ws.call('app.categories');
+  }
+
   getChartReleases(name?: string): Observable<ChartRelease[]> {
     const secondOption = { extra: { history: true } };
 

--- a/src/app/pages/data-protection/components/data-protection-dashboard/data-protection-dashboard.component.ts
+++ b/src/app/pages/data-protection/components/data-protection-dashboard/data-protection-dashboard.component.ts
@@ -215,7 +215,7 @@ export class DataProtectionDashboardComponent implements OnInit {
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
-              width: '50px',
+              width: '80px',
               checkbox: true,
               onChange: (row: PeriodicSnapshotTaskUi) => this.onCheckboxToggle(TaskCardId.Snapshot, row, 'enabled'),
             },
@@ -274,7 +274,7 @@ export class DataProtectionDashboardComponent implements OnInit {
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
-              width: '50px',
+              width: '80px',
               checkbox: true,
               onChange: (row: ReplicationTaskUi) => this.onCheckboxToggle(TaskCardId.Replication, row as TaskTableRow, 'enabled'),
             },
@@ -363,7 +363,7 @@ export class DataProtectionDashboardComponent implements OnInit {
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
-              width: '50px',
+              width: '80px',
               checkbox: true,
               onChange: (row: RsyncTaskUi) => this.onCheckboxToggle(TaskCardId.Rsync, row as TaskTableRow, 'enabled'),
             },


### PR DESCRIPTION
In order to check this you need to connect to one of the latest nightlies.
like this `10.238.238.172` machine.

Go Apps WIP -> Available 

<img width="1728" alt="Screenshot 2023-03-09 at 14 02 42" src="https://user-images.githubusercontent.com/22980553/224017477-1758da7f-607a-463c-9083-29a285f5a2c1.png">

You gonna see apps split by category.
Regarding the designs we have: 
`Recommended Apps` and `New & Updated Apps`
And we should show Recommented apps only if there are so (flagged with `recommended: true`)

We should show max 6 elements and by clicking view more for these 2 categories -> show all items.

If we are watching custom category and there are more then 6 items, View should trigger form filtering and submit to such categories page.
Currently this logic is not implemented and out of scope of this task.

<img width="1514" alt="Screenshot 2023-03-09 at 14 04 58" src="https://user-images.githubusercontent.com/22980553/224018001-65cc60d5-b22f-4d1b-a4ff-e48361b8f601.png">
