### PR TITLE
NAS-120621 / 22.12.2 / Leading whitespaces lost when displaying logs (by AlexKarpov98)

### DIFF
--- a/src/app/modules/common/dialog/show-logs-dialog/show-logs-dialog.component.html
+++ b/src/app/modules/common/dialog/show-logs-dialog/show-logs-dialog.component.html
@@ -1,6 +1,6 @@
 <h1 mat-dialog-title>{{ 'Logs' | translate }}</h1>
 
-<div class="logs" *ngIf="job?.logs_excerpt">
+<div *ngIf="job?.logs_excerpt" class="logs">
   <pre><code>{{ job.logs_excerpt }}</code></pre>
   <ix-copy-btn [text]="job.logs_excerpt"></ix-copy-btn>
 </div>
@@ -9,10 +9,15 @@
   <button
     mat-button
     matDialogClose
-  >{{ 'Close' | translate }}</button>
+    ixTest="close"
+  >
+    {{ 'Close' | translate }}
+  </button>
   <button
     mat-button
     color="primary"
     (click)="downloadLogs()"
-  >{{ 'Download Logs' | translate }}</button>
+  >
+    {{ 'Download Logs' | translate }}
+  </button>
 </div>

--- a/src/app/modules/common/dialog/show-logs-dialog/show-logs-dialog.component.scss
+++ b/src/app/modules/common/dialog/show-logs-dialog/show-logs-dialog.component.scss
@@ -18,7 +18,8 @@
       code {
         display: flex;
         overflow: auto;
-        white-space: pre-line;
+        padding: 20px;
+        white-space: pre-wrap;
       }
     }
 

--- a/src/app/pages/data-protection/components/data-protection-dashboard/data-protection-dashboard.component.ts
+++ b/src/app/pages/data-protection/components/data-protection-dashboard/data-protection-dashboard.component.ts
@@ -215,7 +215,7 @@ export class DataProtectionDashboardComponent implements OnInit {
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
-              width: '50px',
+              width: '80px',
               checkbox: true,
               onChange: (row: PeriodicSnapshotTaskUi) => this.onCheckboxToggle(TaskCardId.Snapshot, row, 'enabled'),
             },
@@ -274,7 +274,7 @@ export class DataProtectionDashboardComponent implements OnInit {
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
-              width: '50px',
+              width: '80px',
               checkbox: true,
               onChange: (row: ReplicationTaskUi) => this.onCheckboxToggle(TaskCardId.Replication, row as TaskTableRow, 'enabled'),
             },
@@ -320,7 +320,7 @@ export class DataProtectionDashboardComponent implements OnInit {
             },
             {
               name: this.translate.instant('Enabled'),
-              width: '50px',
+              width: '80px',
               prop: 'enabled',
               checkbox: true,
               onChange: (row: CloudSyncTaskUi) => this.onCheckboxToggle(TaskCardId.CloudSync, row, 'enabled'),
@@ -363,7 +363,7 @@ export class DataProtectionDashboardComponent implements OnInit {
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
-              width: '50px',
+              width: '80px',
               checkbox: true,
               onChange: (row: RsyncTaskUi) => this.onCheckboxToggle(TaskCardId.Rsync, row as TaskTableRow, 'enabled'),
             },


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b7d22d1d19e29ce9972074c168340e12ff2a142e
    git cherry-pick -x 57aa02f37dc340b69012a97e3ab2b0f4ddb2dfc7

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 2ff5ef3c87a1fa4d21af5c8bad7a2fdab17b6449



Original PR: https://github.com/truenas/webui/pull/7886
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120621