### PR TITLE
NAS-121043 / 23.10 / webUI is showing incorrect warning

### DIFF
--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -31,6 +31,8 @@ import { StorageService } from 'app/services/storage.service';
 import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
 
+const defaultHomePath = '/nonexistent';
+
 @UntilDestroy({ arrayName: 'subscriptions' })
 @Component({
   templateUrl: './user-form.component.html',
@@ -77,7 +79,7 @@ export class UserFormComponent {
     group: [null as number],
     group_create: [true],
     groups: [[] as number[]],
-    home: ['/nonexistent', []],
+    home: [defaultHomePath, []],
     home_mode: ['755'],
     home_create: [false],
     sshpubkey: [null as string],
@@ -126,14 +128,14 @@ export class UserFormComponent {
     const home = this.form.value.home;
     const homeMode = this.form.value.home_mode;
     if (this.isNewUser) {
-      if (!homeCreate && home !== '/nonexistent') {
+      if (!homeCreate && home !== defaultHomePath) {
         return this.translate.instant(
           'With this configuration, the existing directory {path} will be used a home directory without creating a new directory for the user.',
           { path: '\'' + this.form.value.home + '\'' },
         );
       }
     } else {
-      if (this.editingUser.immutable) {
+      if (this.editingUser.immutable || home === defaultHomePath) {
         return '';
       }
       if (!homeCreate && this.editingUser.home !== home) {
@@ -188,7 +190,7 @@ export class UserFormComponent {
       ),
     );
 
-    if (user?.home && user.home !== '/nonexistent') {
+    if (user?.home && user.home !== defaultHomePath) {
       this.storageService.filesystemStat(user.home).pipe(untilDestroyed(this)).subscribe((stat) => {
         this.form.patchValue({ home_mode: stat.mode.toString(8).substring(2, 5) });
         this.homeModeOldValue = stat.mode.toString(8).substring(2, 5);


### PR DESCRIPTION
Testing:
Credentials -> Local Users:
Try to update user 
IF Home Directory is `/nonexistent` we don't need to show warning modal and simply update user. 

<img width="1727" alt="Screenshot 2023-03-16 at 12 26 25" src="https://user-images.githubusercontent.com/22980553/225588750-3ad8ef5e-dd13-4e9d-852f-b86311eb7897.png">

<img width="435" alt="Screenshot 2023-03-16 at 12 28 31" src="https://user-images.githubusercontent.com/22980553/225589331-415ed63d-2a3e-4b77-9a5c-dde6a8daea4b.png">

Once we changed it (Home Directory) -> Modal should warn us.
<img width="748" alt="Screenshot 2023-03-16 at 12 27 44" src="https://user-images.githubusercontent.com/22980553/225589099-a4816bc1-1785-4eab-902c-8bc7701d40de.png">
