### PR TITLE
TE-274 / 22.12.2 / Added wait for inputable for ldap share name

### DIFF
--- a/tests/bdd/scale/test_NAS_T1120.py
+++ b/tests/bdd/scale/test_NAS_T1120.py
@@ -24,6 +24,7 @@ from pytest_bdd import (
 from pytest_dependency import depends
 
 
+
 @pytest.mark.dependency(name='AD_SMB')
 @scenario('features/NAS-T1120.feature', 'Verify an smb share with  AD dataset from a system pool works')
 def test_verify_an_smb_share_with__ad_dataset_from_a_system_pool_works(driver):

--- a/tests/bdd/scale/test_NAS_T1125.py
+++ b/tests/bdd/scale/test_NAS_T1125.py
@@ -18,6 +18,10 @@ from pytest_bdd import (
     parsers
 )
 
+from pytest_dependency import depends
+
+pytestmark = [pytest.mark.debug_test]
+
 
 @pytest.mark.dependency(name='LDAP_SETUP')
 @scenario('features/NAS-T1125.feature', 'Setting up LDAP and verify that it is setup on the NAS')
@@ -26,8 +30,9 @@ def test_scale_ui_setting_up_ldap_and_verify_that_it_is_setup_on_the_nas():
 
 
 @given('the browser is open, the TrueNAS URL and logged in')
-def the_browser_is_open_the_truenas_url_and_logged_in(driver, nas_ip, root_password):
+def the_browser_is_open_the_truenas_url_and_logged_in(driver, nas_ip, root_password, request):
     """the browser is open, the TrueNAS URL and logged in."""
+    depends(request, ['AD_Setup', 'AD_SMB'], scope='session')
     if nas_ip not in driver.current_url:
         driver.get(f"http://{nas_ip}")
         assert wait_on_element(driver, 10, xpaths.login.user_Input)

--- a/tests/bdd/scale/test_NAS_T1129.py
+++ b/tests/bdd/scale/test_NAS_T1129.py
@@ -85,7 +85,7 @@ def on_the_smb_add_set_path_to_mnttankmy_ldap_dataset(driver, path):
     global dataset_path
     dataset_path = path
     assert wait_on_element(driver, 5, xpaths.smb.addTitle)
-    assert wait_on_element(driver, 5, xpaths.smb.path_Input)
+    assert wait_on_element(driver, 5, xpaths.smb.path_Input, 'inputable')
     driver.find_element_by_xpath(xpaths.smb.path_Input).clear()
     driver.find_element_by_xpath(xpaths.smb.path_Input).send_keys(path)
 
@@ -93,7 +93,7 @@ def on_the_smb_add_set_path_to_mnttankmy_ldap_dataset(driver, path):
 @then(parsers.parse('input "{name}" as name and click enable'))
 def input_ldapsmbshare_as_name_and_click_enable(driver, name):
     """input "ldapsmbshare" as name and click enable."""
-    assert wait_on_element(driver, 5, xpaths.smb.name_Input)
+    assert wait_on_element(driver, 5, xpaths.smb.name_Input, 'inputable')
     driver.find_element_by_xpath(xpaths.smb.name_Input).click()
     driver.find_element_by_xpath(xpaths.smb.name_Input).clear()
     driver.find_element_by_xpath(xpaths.smb.name_Input).send_keys(name)
@@ -130,7 +130,7 @@ def the_ldapsmbshare_should_be_added_to_the_shares_list(driver, share_name):
     """the ldapsmbshare should be added to the Shares list."""
     assert wait_on_element(driver, 5, xpaths.sharing.smb_Share_Name(share_name))
     assert wait_on_element(driver, 5, xpaths.sharing.smb_Service_Status)
-    time.sleep(5)
+    time.sleep(1)
 
 
 @then(parsers.parse('send a file to the share with ip/"{smb_share}" and "{ldap_user}" and "{ldap_password}"'))

--- a/tests/bdd/scale/test_NAS_T1129.py
+++ b/tests/bdd/scale/test_NAS_T1129.py
@@ -21,6 +21,7 @@ from pytest_bdd import (
 from pytest_dependency import depends
 
 
+@pytest.mark.dependency(name='LDAP_SMB')
 @scenario('features/NAS-T1129.feature', 'Create an smb share with the LDAP dataset and verify the connection')
 def test_create_an_smb_share_with_the_ldap_dataset_and_verify_the_connection(driver):
     """Create an smb share with the LDAP dataset and verify the connection."""

--- a/tests/bdd/scale/test_NAS_T1133.py
+++ b/tests/bdd/scale/test_NAS_T1133.py
@@ -29,7 +29,7 @@ def test_create_a_wheel_group_smb_share_and_verify_only_wheel_group_can_send_fil
 @given('the browser is open, the TrueNAS URL and logged in')
 def the_browser_is_open_the_truenas_url_and_logged_in(driver, nas_ip, root_password, request):
     """the browser is open, the TrueNAS URL and logged in."""
-    depends(request, ['755_dataset'], scope='session')
+    depends(request, ['755_dataset', 'LDAP_SMB'], scope='session')
     if nas_ip not in driver.current_url:
         driver.get(f"http://{nas_ip}")
         assert wait_on_element(driver, 10, xpaths.login.user_Input)

--- a/tests/bdd/scale/test_NAS_T1137.py
+++ b/tests/bdd/scale/test_NAS_T1137.py
@@ -28,7 +28,7 @@ def test_create_smb_share_for_ericbsd_verify_only_ericbsd_can_access_it():
 @given('the browser is open, the TrueNAS URL and logged in')
 def the_browser_is_open_the_truenas_url_and_logged_in(driver, nas_ip, root_password, request):
     """the browser is open, the TrueNAS URL and logged in."""
-    depends(request, ['ericbsd_dataset'], scope='session')
+    depends(request, ['ericbsd_dataset', 'LDAP_SMB'], scope='session')
     if nas_ip not in driver.current_url:
         driver.get(f"http://{nas_ip}")
         assert wait_on_element(driver, 10, xpaths.login.user_Input)

--- a/tests/bdd/xpaths.py
+++ b/tests/bdd/xpaths.py
@@ -505,7 +505,7 @@ class sharing:
     turn_On_Service_Button = '//button[contains(.,"Turn On Service")]'
 
     def smb_Share_Name(share_name):
-        return f'//div[contains(text(),"{share_name}")]'
+        return f'//div[normalize-space(text())="{share_name}"]'
 
 
 class side_Menu:


### PR DESCRIPTION
Fixed the smb_Share_Name xpath to verify the share name is proper.

Improved SMB test dependencies since All SMB tests will fail if AD or LDAP are not correctly disabled.