### PR TITLE
NAS-121054 / 22.12.2 / Hide identify button for R30

### DIFF
--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
@@ -160,7 +160,15 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
 
   get hideIdentifyDrive(): boolean {
     const selectedEnclosure = this.getSelectedEnclosure();
-    return this.system.enclosures[selectedEnclosure.enclosureKey].model === 'TRUENAS-MINI-R';
+    let hideButton = false;
+    if (
+      selectedEnclosure.model === 'TRUENAS-MINI-R'
+      || selectedEnclosure.model === 'TRUENAS-R30'
+      || selectedEnclosure.model === 'R30'
+    ) {
+      hideButton = true;
+    }
+    return hideButton;
   }
 
   selectedVdevDisks: string[];


### PR DESCRIPTION
To test go to enclosure UI and click on a disk. Underneath the drive icon there should not be an "Identify Drive" button under the disk icon. Look in the ticket comments for a test machine url