### PR TITLE
NAS-121107 / 23.10 / Remove high CPU usage indicator

### DIFF
--- a/src/app/pages/dashboard/components/widget-cpu/widget-cpu.component.html
+++ b/src/app/pages/dashboard/components/widget-cpu/widget-cpu.component.html
@@ -91,13 +91,6 @@
                 </span>
               </mat-list-item>
               <mat-list-item>
-                <div
-                  *ngIf="usageMax >= 70"
-                  class="label-icon"
-                  [ngClass]="{ warn: usageMax < 90, danger: usageMax > 89 }"
-                >
-                  <ix-icon name="error"></ix-icon>
-                </div>
                 <span class="label">
                   <strong> {{ 'Highest Usage' | translate }}: </strong>
                 </span>


### PR DESCRIPTION
Some people complained about it and to be fair high CPU usage is not an error.