### PR TITLE
NAS-121066 / 22.12.2 / add to LOC_FAILOVER_ONGOING HA disabled reasons (by yocalebo)

### DIFF
--- a/src/app/enums/failover-disabled-reason.enum.ts
+++ b/src/app/enums/failover-disabled-reason.enum.ts
@@ -13,6 +13,7 @@ export enum FailoverDisabledReason {
   NoJournalSync = 'NO_JOURNAL_SYNC',
   RemNoJournalSync = 'REM_NO_JOURNAL_SYNC',
   RemFailoverOngoing = 'REM_FAILOVER_ONGOING',
+  LocFailoverOngoing = 'LOC_FAILOVER_ONGOING',
   NoHeartbeatIface = 'NO_HEARTBEAT_IFACE',
   NoCarrierOnHeartbeat = 'NO_CARRIER_ON_HEARTBEAT',
 }

--- a/src/app/helptext/topbar.ts
+++ b/src/app/helptext/topbar.ts
@@ -22,6 +22,7 @@ export default {
     [FailoverDisabledReason.NoJournalSync]: T('Thread responsible for syncing db transactions not running on this node.'),
     [FailoverDisabledReason.RemNoJournalSync]: T('Thread responsible for syncing db transactions not running on other node.'),
     [FailoverDisabledReason.RemFailoverOngoing]: T('Other node is currently processing a failover event.'),
+    [FailoverDisabledReason.LocFailoverOngoing]: T('This node is currently processing a failover event.'),
     [FailoverDisabledReason.NoHeartbeatIface]: T('Local heartbeat interface does not exist.'),
     [FailoverDisabledReason.NoCarrierOnHeartbeat]: T('Local heartbeat interface is down.'),
   },


### PR DESCRIPTION
See https://github.com/truenas/middleware/pull/10877 for details. This should, hopefully, ease confusion when end-user initiates a manual failover and is presented the login page. Instead of showing all reasons why HA is unhealthy (which is expected since user initiated the failover process), it'll give a more concise message to the end-user.

Original PR: https://github.com/truenas/webui/pull/7919
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121066