### PR TITLE
NAS-120655 / 22.12.3 / Errors in authorized hosts are not displayed in Web UI during NFS share create or edit (by AlexKarpov98)

### DIFF
--- a/src/app/enums/default-validation-error.enum.ts
+++ b/src/app/enums/default-validation-error.enum.ts
@@ -10,4 +10,5 @@ export enum DefaultValidationError {
   Forbidden = 'forbidden',
   Number = 'number',
   Cron = 'cron',
+  Ip2 = 'ip2',
 }

--- a/src/app/modules/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -48,6 +48,7 @@ export class IxErrorsComponent implements OnChanges {
     ),
     number: () => this.translate.instant('Value must be a number'),
     cron: () => this.translate.instant('Invalid cron expression'),
+    ip2: () => this.translate.instant('Invalid IP address'),
   };
 
   constructor(
@@ -67,7 +68,8 @@ export class IxErrorsComponent implements OnChanges {
 
           return this.getDefaultError(error as DefaultValidationError);
         });
-        this.messages = newErrors;
+
+        this.messages = newErrors.filter((message) => !!message);
 
         this.cdr.markForCheck();
       });
@@ -104,6 +106,8 @@ export class IxErrorsComponent implements OnChanges {
         return this.defaultErrMessages.number();
       case DefaultValidationError.Cron:
         return this.defaultErrMessages.cron();
+      case DefaultValidationError.Ip2:
+        return this.defaultErrMessages.ip2();
       default:
         return undefined;
     }

--- a/src/app/modules/ix-forms/services/form-error-handler.service.ts
+++ b/src/app/modules/ix-forms/services/form-error-handler.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { AbstractControl, UntypedFormGroup } from '@angular/forms';
+import { AbstractControl, UntypedFormArray, UntypedFormGroup } from '@angular/forms';
 import { ResponseErrorType } from 'app/enums/response-error-type.enum';
 import { Job } from 'app/interfaces/job.interface';
 import { WebsocketError } from 'app/interfaces/websocket-error.interface';
@@ -46,7 +46,8 @@ export class FormErrorHandlerService {
       const field = extraItem[0].split('.')[1];
       const errorMessage = extraItem[1];
 
-      const control = this.getFormField(formGroup, field, fieldsMap);
+      let control = this.getFormField(formGroup, field, fieldsMap);
+
       if (!control) {
         console.error(`Could not find control ${field}.`);
         // Fallback to default modal error message.
@@ -54,11 +55,19 @@ export class FormErrorHandlerService {
         return;
       }
 
+      if ((control as UntypedFormArray).controls?.length) {
+        const isExactMatch = (text: string, match: string): boolean => new RegExp(`\\b${match}\\b`).test(text);
+
+        control = (control as UntypedFormArray).controls
+          .find((controlOfArray) => isExactMatch(errorMessage, controlOfArray.value));
+      }
+
       control.setErrors({
         manualValidateError: true,
         manualValidateErrorMsg: errorMessage,
         ixManualValidateError: { message: errorMessage },
       });
+
       control.markAsTouched();
     }
   }

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
@@ -158,7 +158,7 @@ export class NfsFormComponent implements OnInit {
     this.ws.call('nfs.config')
       .pipe(untilDestroyed(this))
       .subscribe((nfsConfig) => {
-        this.hasNfsSecurityField = nfsConfig.v4;
+        this.hasNfsSecurityField = nfsConfig.v4 || nfsConfig.protocols?.includes(NfsProtocol.V4);
       });
   }
 

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
@@ -158,7 +158,7 @@ export class NfsFormComponent implements OnInit {
     this.ws.call('nfs.config')
       .pipe(untilDestroyed(this))
       .subscribe((nfsConfig) => {
-        this.hasNfsSecurityField = nfsConfig.v4 || nfsConfig.protocols?.includes(NfsProtocol.V4);
+        this.hasNfsSecurityField = nfsConfig.v4;
       });
   }
 

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -3199,6 +3199,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2392,6 +2392,7 @@
   "This is a one way action and cannot be reversed. Are you sure you want to revoke this Certificate?": "",
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1005,6 +1005,7 @@
   "This is a one way action and cannot be reversed. Are you sure you want to revoke this Certificate?": "",
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3430,6 +3430,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -482,6 +482,7 @@
   "The following { n, plural, one {docker image} other {# docker images} } will be deleted. Are you sure you want to proceed?": "",
   "The following { n, plural, one {docker image} other {# docker images} } will be updated. Are you sure you want to proceed?": "",
   "These disks do not support S.M.A.R.T. tests:": "",
+  "This node is currently processing a failover event.": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",
   "This session is current and cannot be terminated": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3431,6 +3431,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3096,6 +3096,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3673,6 +3673,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -156,6 +156,7 @@
   "This disk is part of the exported pool {pool}. Reusing this disk will make {pool} unable to import. You will lose any and all data in {pool}. Please make sure any sensitive data in {pool} is backed up before reusing/repusposing this disk.": "",
   "This disk is part of the exported pool {pool}. Wiping this disk will make {pool} unable\n  to import. You will lose any and all data in {pool}. Please make sure that any sensitive data in {pool} is backed up before wiping this disk.": "",
   "This disk is part of the exported pool {pool}. Wiping this disk will make {pool} unable        to import. You will lose any and all data in {pool}. Please make sure that any sensitive data in {pool} is backed up before reusing/repurposing this disk.": "",
+  "This node is currently processing a failover event.": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",
   "This session is current and cannot be terminated": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3578,6 +3578,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3601,6 +3601,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3478,6 +3478,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1690,6 +1690,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -206,6 +206,7 @@
   "This disk is part of the exported pool {pool}. Reusing this disk will make {pool} unable to import. You will lose any and all data in {pool}. Please make sure any sensitive data in {pool} is backed up before reusing/repusposing this disk.": "",
   "This disk is part of the exported pool {pool}. Wiping this disk will make {pool} unable\n  to import. You will lose any and all data in {pool}. Please make sure that any sensitive data in {pool} is backed up before wiping this disk.": "",
   "This disk is part of the exported pool {pool}. Wiping this disk will make {pool} unable        to import. You will lose any and all data in {pool}. Please make sure that any sensitive data in {pool} is backed up before reusing/repurposing this disk.": "",
+  "This node is currently processing a failover event.": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",
   "This session is current and cannot be terminated": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3682,6 +3682,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -26,6 +26,7 @@
   "Set new password:": "",
   "Sign in": "",
   "Sudo Enabled": "",
+  "This node is currently processing a failover event.": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",
   "Unset Certificates": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2757,6 +2757,7 @@
   "This is the only time the key is shown.": "",
   "This job is scheduled to run again {nextRun}.": "",
   "This job will not run again until it is enabled.": "",
+  "This node is currently processing a failover event.": "",
   "This operation might take a long time. It cannot be aborted once started. Proceed?": "",
   "This operation will unset any certificates assgined to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assgined to OpenVPN Client configuration. Are you sure you want to proceed?": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x fb869a54f93993c6c34a2fcb16f826f23b030ef0

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 2bc12bdf0bd12346fdd24d220511b5d9c4149564

Check `/sharing/nfs` route.

Click ADD 

And add invalid hosts -> submit.

You should see validation message.

<img width="498" alt="Screenshot 2023-03-20 at 14 39 32" src="https://user-images.githubusercontent.com/22980553/226342300-8e40b316-13bb-480d-9222-d1ef37141669.png">

As well I fixed network input: 

<img width="476" alt="Screenshot 2023-03-20 at 14 45 51" src="https://user-images.githubusercontent.com/22980553/226342651-c2e298f6-f11f-4468-9c5e-2e6c3c947573.png">


Original PR: https://github.com/truenas/webui/pull/7950
Jira URL: https://ixsystems.atlassian.net/browse/NAS-120655