### PR TITLE
NAS-12035: fixed updating status of unused disks

### DIFF
--- a/src/app/pages/storage/modules/disks/components/disk-list/disk-list.component.ts
+++ b/src/app/pages/storage/modules/disks/components/disk-list/disk-list.component.ts
@@ -6,7 +6,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import * as filesize from 'filesize';
 import {
-  forkJoin, lastValueFrom, of, Subject,
+  forkJoin, lastValueFrom, of, Subject, switchMap,
 } from 'rxjs';
 import { catchError, debounceTime, map } from 'rxjs/operators';
 import { SmartTestResultPageType } from 'app/enums/smart-test-results-page-type.enum';
@@ -195,8 +195,10 @@ export class DiskListComponent implements EntityTableConfig<Disk>, OnDestroy {
     const disksUpdateTrigger$ = new Subject<ApiEvent<Disk>>();
     disksUpdateTrigger$.pipe(
       debounceTime(50),
+      switchMap(() => this.ws.call('disk.get_unused')),
       untilDestroyed(this),
-    ).subscribe(() => {
+    ).subscribe((unusedDisks) => {
+      this.unusedDisks = unusedDisks;
       entityList.getData();
     });
     this.diskUpdateSubscriptionId = this.disksUpdate.addSubscriber(disksUpdateTrigger$);


### PR DESCRIPTION
Go Storage -> Disks 
Execute wipe a disk that is part of an exported zpool.
The disk status should be updated in the Pool column after the wipe