### PR TITLE
NAS-121035 / 22.12.3 / Fixed updating status of unused disks (by Raz-Dva)

### DIFF
--- a/src/app/pages/storage/modules/disks/components/disk-list/disk-list.component.ts
+++ b/src/app/pages/storage/modules/disks/components/disk-list/disk-list.component.ts
@@ -6,7 +6,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import * as filesize from 'filesize';
 import {
-  forkJoin, lastValueFrom, of, Subject,
+  forkJoin, lastValueFrom, of, Subject, switchMap,
 } from 'rxjs';
 import { catchError, debounceTime, map } from 'rxjs/operators';
 import { SmartTestResultPageType } from 'app/enums/smart-test-results-page-type.enum';
@@ -197,8 +197,10 @@ export class DiskListComponent implements EntityTableConfig<Disk>, OnDestroy {
     const disksUpdateTrigger$ = new Subject<ApiEvent<Disk>>();
     disksUpdateTrigger$.pipe(
       debounceTime(50),
+      switchMap(() => this.ws.call('disk.get_unused')),
       untilDestroyed(this),
-    ).subscribe(() => {
+    ).subscribe((unusedDisks) => {
+      this.unusedDisks = unusedDisks;
       entityList.getData();
     });
     this.diskUpdateSubscriptionId = this.disksUpdate.addSubscriber(disksUpdateTrigger$);

--- a/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.html
+++ b/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.html
@@ -1,5 +1,5 @@
 <h1 matDialogTitle>{{ title }}</h1>
-<div *ngIf="data.exportedPool">
+<div *ngIf="data.exportedPool" class="warning-wrapper">
   <ix-warning [message]="'This disk is part of the exported pool {pool}. Wiping this disk will make {pool} unable\
   to import. You will lose any and all data in {pool}. Please make sure that any sensitive data in {pool} is backed up before wiping this disk.' | translate: { pool: '\'' + data.exportedPool + '\'' }"></ix-warning>
 </div>

--- a/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.scss
+++ b/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.scss
@@ -11,5 +11,3 @@
     margin-left: 10px;
   }
 }
-
-

--- a/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.scss
+++ b/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.scss
@@ -11,3 +11,8 @@
     margin-left: 10px;
   }
 }
+
+.warning-wrapper {
+  padding: 0 24px;
+}
+

--- a/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.scss
+++ b/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.scss
@@ -12,7 +12,4 @@
   }
 }
 
-.warning-wrapper {
-  padding: 0 24px;
-}
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 0f3b666a3441b67b9ab061aeaa68a66a2560850a

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 36a1a26267adab95566889ead6f4dfd73c8c2c81

Go Storage -> Disks 
Execute wipe a disk that is part of an exported zpool.
The disk status should be updated in the Pool column after the wipe

Original PR: https://github.com/truenas/webui/pull/7974
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121035