### PR TITLE
NAS-121183 / 23.10 / Hide `Enable Atime` for Zvol

### DIFF
--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
@@ -43,7 +43,7 @@
           </ng-container>
         </span>
       </div>
-      <div class="details-item">
+      <div *ngIf="!isZvol" class="details-item">
         <span class="label">{{ 'Enable Atime' | translate }}:</span>
         <span class="value">
           {{ (dataset.atime ? OnOff.On : OnOff.Off) | translate }}

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
@@ -28,11 +28,16 @@ const dataset = {
   type: DatasetType.Filesystem,
   sync: { value: 'STANDARD' },
   compression: { source: ZfsPropertySource.Inherited, value: 'LZ4' },
-  atime: false,
+  atime: true,
   deduplication: { value: 'OFF' },
   casesensitive: false,
   comments: { value: 'Test comment', source: ZfsPropertySource.Local },
   origin: null,
+} as DatasetDetails;
+
+const zvol = {
+  ...dataset,
+  type: DatasetType.Volume,
 } as DatasetDetails;
 
 describe('DatasetDetailsCardComponent', () => {
@@ -82,96 +87,109 @@ describe('DatasetDetailsCardComponent', () => {
     ],
   });
 
-  beforeEach(() => {
-    spectator = createComponent({
-      props: {
-        dataset,
-      },
-    });
+  function setupTest(props: Partial<DatasetDetailsCardComponent> = {}): void {
+    spectator = createComponent({ props });
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
-  });
+  }
+
+  function getDetails(): Record<string, string> {
+    return spectator.queryAll('.details-item').reduce((acc, item: HTMLElement) => {
+      const key = item.querySelector('.label').textContent;
+      const value = item.querySelector('.value').textContent;
+      acc[key] = value;
+      return acc;
+    }, {} as Record<string, string>);
+  }
 
   it('shows header', () => {
+    setupTest({ dataset });
+
     expect(spectator.query('mat-card-header h3')).toHaveText('Dataset Details');
     expect(spectator.query('mat-card-header button')).toHaveText('Edit');
   });
 
-  it('shows details', () => {
-    const details = spectator.queryAll('.details-item');
-    expect(details).toHaveLength(8);
+  describe('filesystem dataset', () => {
+    it('shows filesystem details', () => {
+      setupTest({ dataset });
 
-    expect(details[0].querySelector('.label')).toHaveText('Type:');
-    expect(details[0].querySelector('.value')).toHaveText('FILESYSTEM');
-
-    expect(details[1].querySelector('.label')).toHaveText('Sync:');
-    expect(details[1].querySelector('.value')).toHaveText('STANDARD');
-
-    expect(details[2].querySelector('.label')).toHaveText('Compression Level:');
-    expect(details[2].querySelector('.value')).toHaveText('Inherit (LZ4)');
-
-    expect(details[3].querySelector('.label')).toHaveText('Enable Atime:');
-    expect(details[3].querySelector('.value')).toHaveText('OFF');
-
-    expect(details[4].querySelector('.label')).toHaveText('ZFS Deduplication:');
-    expect(details[4].querySelector('.value')).toHaveText('OFF');
-
-    expect(details[5].querySelector('.label')).toHaveText('Case Sensitivity:');
-    expect(details[5].querySelector('.value')).toHaveText('OFF');
-
-    expect(details[6].querySelector('.label')).toHaveText('Path:');
-    expect(details[6].querySelector('.value')).toHaveText('pool/child');
-
-    expect(details[7].querySelector('.label')).toHaveText('Comments:');
-    expect(details[7].querySelector('.value')).toHaveText('Test comment');
-  });
-
-  it('opens edit dataset form when Edit button is clicked', async () => {
-    const editButton = await loader.getHarness(MatButtonHarness.with({ text: 'Edit' }));
-    await editButton.click();
-
-    expect(spectator.inject(ModalService).openInSlideIn).toHaveBeenCalledWith(DatasetFormComponent, dataset.id);
-    expect(fakeModalRef.setPk).toHaveBeenCalledWith('pool/child');
-    expect(fakeModalRef.setVolId).toHaveBeenCalledWith('pool');
-    expect(fakeModalRef.setTitle).toHaveBeenCalledWith('Edit Dataset');
-  });
-
-  it('opens edit zvol form when Edit Zvol button is clicked', async () => {
-    const zvolSpectator = createComponent({
-      props: {
-        dataset: {
-          ...dataset,
-          type: DatasetType.Volume,
-        },
-      },
+      const details = getDetails();
+      expect(details).toEqual({
+        'Type:': ' FILESYSTEM ',
+        'Sync:': ' STANDARD ',
+        'Compression Level:': ' Inherit (LZ4) ',
+        'Enable Atime:': ' ON ',
+        'ZFS Deduplication:': ' OFF ',
+        'Case Sensitivity:': ' OFF ',
+        'Path:': ' pool/child ',
+        'Comments:': 'Test comment',
+      });
     });
-    const zvolLoader = TestbedHarnessEnvironment.loader(zvolSpectator.fixture);
 
-    const editZvolButton = await zvolLoader.getHarness(MatButtonHarness.with({ text: 'Edit Zvol' }));
-    await editZvolButton.click();
-    expect(zvolSpectator.inject(IxSlideInService).open).toHaveBeenCalledWith(ZvolFormComponent);
-    expect(fakeSlideInRef.zvolFormInit).toHaveBeenCalledWith(false, 'pool/child');
+    it('opens edit dataset form when Edit button is clicked', async () => {
+      setupTest({ dataset });
+
+      const editButton = await loader.getHarness(MatButtonHarness.with({ text: 'Edit' }));
+      await editButton.click();
+
+      expect(spectator.inject(ModalService).openInSlideIn).toHaveBeenCalledWith(DatasetFormComponent, dataset.id);
+      expect(fakeModalRef.setPk).toHaveBeenCalledWith('pool/child');
+      expect(fakeModalRef.setVolId).toHaveBeenCalledWith('pool');
+      expect(fakeModalRef.setTitle).toHaveBeenCalledWith('Edit Dataset');
+    });
+
+    it('opens delete dataset dialog when Delete button is clicked', async () => {
+      setupTest({ dataset });
+
+      const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: 'Delete' }));
+      await deleteButton.click();
+
+      expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(DeleteDatasetDialogComponent, { data: dataset });
+    });
   });
 
-  it('opens delete dataset dialog when Delete button is clicked', async () => {
-    const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: 'Delete' }));
-    await deleteButton.click();
+  describe('volume dataset', () => {
+    it('shows zvol details', () => {
+      setupTest({ dataset: zvol });
 
-    expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(DeleteDatasetDialogComponent, { data: dataset });
+      const details = getDetails();
+      expect(details).toEqual({
+        'Type:': ' VOLUME ',
+        'Sync:': ' STANDARD ',
+        'Compression Level:': ' Inherit (LZ4) ',
+        'ZFS Deduplication:': ' OFF ',
+        'Case Sensitivity:': ' OFF ',
+        'Path:': ' pool/child ',
+        'Comments:': 'Test comment',
+      });
+    });
+
+    it('opens edit zvol form when Edit Zvol button is clicked', async () => {
+      setupTest({ dataset: zvol });
+
+      const editZvolButton = await loader.getHarness(MatButtonHarness.with({ text: 'Edit Zvol' }));
+      await editZvolButton.click();
+      expect(spectator.inject(IxSlideInService).open).toHaveBeenCalledWith(ZvolFormComponent);
+      expect(fakeSlideInRef.zvolFormInit).toHaveBeenCalledWith(false, 'pool/child');
+    });
   });
 
   describe('promoting dataset', () => {
     it('does not show a Promote Dataset button when dataset cannot be promoted', async () => {
+      setupTest({ dataset });
+
       const promoteButton = await loader.getHarnessOrNull(MatButtonHarness.with({ text: 'Promote' }));
       expect(promoteButton).toBeNull();
     });
 
     it('promotes dataset when dataset can be promoted and Promote Dataset button is pressed', async () => {
-      spectator.setInput('dataset', {
-        ...dataset,
-        origin: {
-          parsed: 'pool/origin',
-        },
-      } as DatasetDetails);
+      setupTest({
+        dataset: {
+          ...dataset,
+          origin: {
+            parsed: 'pool/origin',
+          },
+        } as DatasetDetails,
+      });
 
       const promoteButton = await loader.getHarnessOrNull(MatButtonHarness.with({ text: 'Promote' }));
       await promoteButton.click();


### PR DESCRIPTION
From the original ticket:
> Since Enable Atime does not really apply to Zvol datasets, that line should be removed from the "Zvol Details" section of the following TrueNAS SCALE page

For testing, go to the datasets page and check if it does meet requirements