### PR TITLE
NAS-121183 / 22.12.3 / Hide `Enable Atime` for Zvol (by denysbutenko)

### DIFF
--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
@@ -38,7 +38,7 @@
           </ng-container>
         </span>
       </div>
-      <div class="details-item">
+      <div *ngIf="!isZvol" class="details-item">
         <span class="label">{{ 'Enable Atime' | translate }}:</span>
         <span class="value">
           {{ (dataset.atime ? OnOff.On : OnOff.Off) | translate }}


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 63687a26ba54879463daf7eb1290bd239ae1fc09

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 1806a3b62357bc0e6e769407ef78dd7b004d1040

From the original ticket:
> Since Enable Atime does not really apply to Zvol datasets, that line should be removed from the "Zvol Details" section of the following TrueNAS SCALE page

For testing, go to the datasets page and check if it does meet requirements

Original PR: https://github.com/truenas/webui/pull/7999
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121183