### PR TITLE
NAS-121176 / 23.10 / Do not allow to terminate current session

### DIFF
--- a/src/app/modules/entity/table/table.component.html
+++ b/src/app/modules/entity/table/table.component.html
@@ -209,7 +209,7 @@
                     <button
                       mat-icon-button
                       [ixTest]="['row-action', _tableConf.name, rowAction.name]"
-                      [disabled]="rowAction.disabled"
+                      [disabled]="rowAction.disabled || rowAction.disabledCondition"
                       (click)="$event.stopPropagation(); rowAction.onClick(element)"
                     >
                       <ix-icon

--- a/src/app/modules/entity/table/table.component.ts
+++ b/src/app/modules/entity/table/table.component.ts
@@ -17,6 +17,7 @@ export interface AppTableAction<Row = unknown> {
   matTooltip?: string;
   onChanging?: boolean;
   disabled?: boolean;
+  disabledCondition?: (row: Row) => boolean;
   onClick: (row: Row) => void;
 }
 

--- a/src/app/pages/system/advanced/sessions/sessions-card/sessions-card.component.ts
+++ b/src/app/pages/system/advanced/sessions/sessions-card/sessions-card.component.ts
@@ -58,26 +58,22 @@ export class SessionsCardComponent implements OnInit {
           name: 'terminate',
           icon: 'exit_to_app',
           matTooltip: this.translate.instant('Terminate session'),
+          disabledCondition: (row: AuthSessionRow): boolean => {
+            return row.current;
+          },
           onClick: (row: AuthSessionRow): void => {
-            if (!row.current) {
-              this.dialog
-                .confirm({
-                  title: this.translate.instant('Terminate session'),
-                  message: this.translate.instant('Are you sure you want to terminate the session?'),
-                })
-                .pipe(
-                  filter(Boolean),
-                  untilDestroyed(this),
-                ).subscribe({
-                  next: () => this.terminateSession(row.id),
-                  error: (err: WebsocketError) => new EntityUtils().handleError(this, err),
-                });
-            } else {
-              this.dialog.info(
-                this.translate.instant('Terminate session'),
-                this.translate.instant('This session is current and cannot be terminated'),
-              );
-            }
+            this.dialog
+              .confirm({
+                title: this.translate.instant('Terminate session'),
+                message: this.translate.instant('Are you sure you want to terminate the session?'),
+              })
+              .pipe(
+                filter(Boolean),
+                untilDestroyed(this),
+              ).subscribe({
+                next: () => this.terminateSession(row.id),
+                error: (err: WebsocketError) => new EntityUtils().handleError(this, err),
+              });
           },
         },
       ];

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -3198,7 +3198,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2435,7 +2435,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This type of VDEV requires at least {n, plural, one {# disk} other {# disks}}.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1115,7 +1115,6 @@
   "This operation will unset any certificates assigned to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assigned to OpenVPN Client configuration. Are you sure you want to proceed?": "",
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This type of VDEV requires at least {n, plural, one {# disk} other {# disks}}.": "",
   "Thread #": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3418,7 +3418,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -614,7 +614,6 @@
   "This node is currently processing a failover event.": "",
   "This operation will unset any certificates assigned to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assigned to OpenVPN Client configuration. Are you sure you want to proceed?": "",
-  "This session is current and cannot be terminated": "",
   "Thread #": "",
   "Thread:": "",
   "Threads": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3422,7 +3422,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3108,7 +3108,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3657,7 +3657,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -298,7 +298,6 @@
   "This node is currently processing a failover event.": "",
   "This operation will unset any certificates assigned to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assigned to OpenVPN Client configuration. Are you sure you want to proceed?": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "Thread #": "",
   "Thread responsible for syncing db transactions not running on other node.": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3565,7 +3565,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3589,7 +3589,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3466,7 +3466,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1741,7 +1741,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This type of VDEV requires at least {n, plural, one {# disk} other {# disks}}.": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -347,7 +347,6 @@
   "This node is currently processing a failover event.": "",
   "This operation will unset any certificates assigned to OpenVPN Server configuration. Are you sure you want to proceed?": "",
   "This operation will unset/unselect any certificates assigned to OpenVPN Client configuration. Are you sure you want to proceed?": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "Thread #": "",
   "Thread responsible for syncing db transactions not running on other node.": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3665,7 +3665,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -3738,7 +3738,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "此选项控制元数据和备用数据流如何读写磁盘。仅当共享配置从已弃用的Apple归档协议(AFP)迁移时才启用此功能。不要试图强制以前的AFP共享表现得像纯SMB共享，否则可能会发生文件损坏。",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "该池包含存储关键数据的系统数据集，例如调试核心文件、池的加密密钥以及Samba 4元数据（例如用户/组缓存和共享级别权限）。导出此池会将系统数据集传输到另一个可用池。如果唯一可用的池被加密，则该池将不再能够被锁定。当不存在其他池时，系统数据集传输回TrueNAS操作系统设备。",
   "This process continues in the background after closing this dialog.": "关闭此对话框后，此过程将在后台继续。",
-  "This session is current and cannot be terminated": "该会话目前无法终止",
   "This share is configured through TrueCommand": "该共享通过 TrueCommand 配置",
   "This system cannot communicate externally.": "该系统无法与外部通信。",
   "This system will restart when the update completes.": "更新完成后，该系统将重新启动。",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2778,7 +2778,6 @@
   "This option controls how metadata and alternate data streams read write to disks. Only enable this when the share configuration was migrated from the deprecated Apple Filing Protocol (AFP). Do not attempt to force a previous AFP share to behave like a pure SMB share or file corruption can occur.": "",
   "This pool contains the system dataset that stores critical data like debugging core files, encryption keys for pools, and Samba 4 metadata such as the user/group cache and share level permissions. Exporting this pool will transfer the system dataset to another available pool. If the only available pool is encrypted, that pool will no longer be able to be locked. When no other pools exist, the system dataset transfers back to the TrueNAS operating system device.": "",
   "This process continues in the background after closing this dialog.": "",
-  "This session is current and cannot be terminated": "",
   "This share is configured through TrueCommand": "",
   "This system cannot communicate externally.": "",
   "This system will restart when the update completes.": "",


### PR DESCRIPTION
**Description:**
> Now: 
> 1. I go to Advanced Settings.
> 2. Click terminate next to my current session.
> 3. Get a warning saying that current session cannot be terminated.
> 
> Instead we should communicate this to the user earlier. We should show Terminate icon for current session as disabled with a tooltip saying that current session cannot be terminated.

**Testing:**

Go to `Settings -> Advanced` take a look on the `Sessions` card and check if the button to terminate current session is disabled. Make sure others sessions can be terminated.