### PR TITLE
NAS-121308: Resolve issues with old-style timeFormat

### DIFF
--- a/src/app/core/pipes/format-datetime.pipe.spec.ts
+++ b/src/app/core/pipes/format-datetime.pipe.spec.ts
@@ -87,4 +87,13 @@ describe('FormatDateTimePipe', () => {
     });
     expect(spectator.element).toHaveExactText('2021-09-28 15:22');
   });
+
+  it('converts date using custom time format with old style " A" format', () => {
+    spectator = createPipe('{{ inputDateValue | formatDateTime:"Europe/Kiev":"":"hh:mm A" }}', {
+      hostProps: {
+        inputDateValue: new Date(inputValue),
+      },
+    });
+    expect(spectator.element).toHaveExactText('2021-09-28 03:22 PM');
+  });
 });

--- a/src/app/core/pipes/format-datetime.pipe.ts
+++ b/src/app/core/pipes/format-datetime.pipe.ts
@@ -63,6 +63,9 @@ export class FormatDateTimePipe implements PipeTransform {
       .replace('DD', 'dd')
       .replace('D', 'd')
       .replace(' A', ' aa');
+    if (this.timeFormat) {
+      this.timeFormat = this.timeFormat.replace(' A', ' aa');
+    }
     return format(localDate, `${this.dateFormat} ${this.timeFormat}`);
   }
 }


### PR DESCRIPTION
`timeFormat` in local storage may have an old-style format escape `A` that needs to be converted to `aa`. If not converted, the UI does not work reliably, creating hundreds of RangeError messages in the console and potentially freezing the screen.