### PR TITLE
NAS-121215 / 23.10 / Reduce memory leak in `ix-entity-table` component (by denysbutenko)

### DIFF
--- a/src/app/modules/entity/entity-table/entity-table.component.ts
+++ b/src/app/modules/entity/entity-table/entity-table.component.ts
@@ -151,7 +151,6 @@ export class EntityTableComponent<Row extends SomeRow = SomeRow> implements OnIn
     paging: true,
     sorting: { columns: this.columns },
   };
-  asyncView = false; // default table view is not async
   showDefaults = false;
   showSpinner = true;
   cardHeaderReady = false;
@@ -302,8 +301,6 @@ export class EntityTableComponent<Row extends SomeRow = SomeRow> implements OnIn
         this.conf.afterInit(this);
       }
     }
-
-    this.asyncView = this.conf.asyncView ? this.conf.asyncView : false;
 
     this.conf.columns.forEach((column) => {
       this.displayedColumns.push(column.prop);
@@ -543,16 +540,7 @@ export class EntityTableComponent<Row extends SomeRow = SomeRow> implements OnIn
       this.getFunction = EMPTY;
     }
 
-    if (this.asyncView && !this.interval) {
-      // One interval per table is enough
-      this.interval = setInterval(() => {
-        if (this.conf.callGetFunction) {
-          this.conf.callGetFunction(this);
-        } else {
-          this.callGetFunction(true);
-        }
-      }, 10000);
-    } else if (this.conf.callGetFunction) {
+    if (this.conf.callGetFunction) {
       this.conf.callGetFunction(this);
     } else {
       this.callGetFunction();
@@ -630,7 +618,7 @@ export class EntityTableComponent<Row extends SomeRow = SomeRow> implements OnIn
       this.paginationPageIndex = 0;
       this.showDefaults = true;
     }
-    if (this.expandedRows === 0 || !this.asyncView || this.excuteDeletion || this.needRefreshTable) {
+    if (this.expandedRows === 0 || this.excuteDeletion || this.needRefreshTable) {
       this.excuteDeletion = false;
       this.needRefreshTable = false;
 

--- a/src/app/modules/entity/entity-table/entity-table.component.ts
+++ b/src/app/modules/entity/entity-table/entity-table.component.ts
@@ -543,13 +543,8 @@ export class EntityTableComponent<Row extends SomeRow = SomeRow> implements OnIn
       this.getFunction = EMPTY;
     }
 
-    if (this.conf.callGetFunction) {
-      this.conf.callGetFunction(this);
-    } else {
-      this.callGetFunction();
-    }
-
-    if (this.asyncView) {
+    if (this.asyncView && !this.interval) {
+      // One interval per table is enough
       this.interval = setInterval(() => {
         if (this.conf.callGetFunction) {
           this.conf.callGetFunction(this);
@@ -557,6 +552,10 @@ export class EntityTableComponent<Row extends SomeRow = SomeRow> implements OnIn
           this.callGetFunction(true);
         }
       }, 10000);
+    } else if (this.conf.callGetFunction) {
+      this.conf.callGetFunction(this);
+    } else {
+      this.callGetFunction();
     }
   }
 

--- a/src/app/modules/entity/entity-table/entity-table.interface.ts
+++ b/src/app/modules/entity/entity-table/entity-table.interface.ts
@@ -38,7 +38,6 @@ export interface EntityTableConfig<Row extends SomeRow = SomeRow> {
   hasDetails?: boolean;
   rowDetailComponent?: Type<unknown>;
   cardHeaderComponent?: Type<unknown>;
-  asyncView?: boolean;
   wsDelete?: ApiMethod;
   wsMultiDelete?: ApiMethod;
   noAdd?: boolean;

--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -751,7 +751,7 @@ export class CloudsyncFormComponent {
     request$.pipe(untilDestroyed(this)).subscribe({
       next: () => {
         this.isLoading = false;
-        this.slideInService.close();
+        this.slideInService.close(null, true);
       },
       error: (error) => {
         this.isLoading = false;

--- a/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
@@ -6,7 +6,7 @@ import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { EMPTY } from 'rxjs';
 import {
-  catchError, filter, switchMap, tap,
+  catchError, filter, switchMap, take, tap,
 } from 'rxjs/operators';
 import { JobState } from 'app/enums/job-state.enum';
 import helptext from 'app/helptext/data-protection/cloudsync/cloudsync-form';
@@ -123,7 +123,7 @@ export class CloudsyncListComponent implements EntityTableConfig<CloudSyncTaskUi
       transformed.cron_schedule = task.enabled ? formattedCronSchedule : this.translate.instant('Disabled');
       transformed.frequency = this.taskService.getTaskCronDescription(formattedCronSchedule);
 
-      this.store$.select(selectTimezone).pipe(untilDestroyed(this)).subscribe((timezone) => {
+      this.store$.select(selectTimezone).pipe(take(1), untilDestroyed(this)).subscribe((timezone) => {
         transformed.next_run = task.enabled ? this.taskService.getTaskNextRun(formattedCronSchedule, timezone) : this.translate.instant('Disabled');
       });
 

--- a/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
@@ -51,7 +51,6 @@ export class CloudsyncListComponent implements EntityTableConfig<CloudSyncTaskUi
   routeEdit: string[] = ['tasks', 'cloudsync', 'edit'];
   wsDelete = 'cloudsync.delete' as const;
   entityList: EntityTableComponent<CloudSyncTaskUi>;
-  asyncView = true;
   filterValue = '';
 
   columns = [

--- a/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
@@ -133,6 +133,7 @@ export class CloudsyncListComponent implements EntityTableConfig<CloudSyncTaskUi
         transformed.state = { state: task.job.state };
         this.store$.select(selectJob(task.job.id)).pipe(
           filter(Boolean),
+          take(1),
           untilDestroyed(this),
         ).subscribe((job: Job) => {
           transformed.job = { ...job };

--- a/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
@@ -107,7 +107,10 @@ export class CloudsyncListComponent implements EntityTableConfig<CloudSyncTaskUi
 
   afterInit(entityList: EntityTableComponent<CloudSyncTaskUi>): void {
     this.entityList = entityList;
-    this.slideInService.onClose$.pipe(untilDestroyed(this)).subscribe(() => {
+    this.slideInService.onClose$.pipe(
+      filter((value) => !!value.response),
+      untilDestroyed(this),
+    ).subscribe(() => {
       this.entityList.getData();
     });
   }

--- a/src/app/pages/data-protection/replication/replication-list/replication-list.component.ts
+++ b/src/app/pages/data-protection/replication/replication-list/replication-list.component.ts
@@ -104,7 +104,10 @@ export class ReplicationListComponent implements EntityTableConfig {
 
   afterInit(entityList: EntityTableComponent): void {
     this.entityList = entityList;
-    this.modalService.onClose$.pipe(untilDestroyed(this)).subscribe(() => {
+    this.modalService.onClose$.pipe(
+      filter((value) => !!value.response),
+      untilDestroyed(this),
+    ).subscribe(() => {
       this.entityList.getData();
     });
 

--- a/src/app/pages/data-protection/replication/replication-list/replication-list.component.ts
+++ b/src/app/pages/data-protection/replication/replication-list/replication-list.component.ts
@@ -58,7 +58,6 @@ export class ReplicationListComponent implements EntityTableConfig {
   routeEdit: string[] = ['tasks', 'replication', 'edit'];
   routeSuccess: string[] = ['tasks', 'replication'];
   entityList: EntityTableComponent;
-  asyncView = true;
   filterValue = '';
 
   columns = [

--- a/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.ts
@@ -209,7 +209,7 @@ export class RsyncTaskFormComponent implements OnInit {
     request$.pipe(untilDestroyed(this)).subscribe({
       next: () => {
         this.isLoading = false;
-        this.slideInService.close();
+        this.slideInService.close(null, true);
       },
       error: (error) => {
         this.isLoading = false;

--- a/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
@@ -5,7 +5,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  catchError, EMPTY, filter, switchMap, tap,
+  catchError, EMPTY, filter, switchMap, take, tap,
 } from 'rxjs';
 import { JobState } from 'app/enums/job-state.enum';
 import globalHelptext from 'app/helptext/global-helptext';
@@ -165,7 +165,7 @@ export class RsyncTaskListComponent implements EntityTableConfig<RsyncTaskUi> {
       task.cron_schedule = `${task.schedule.minute} ${task.schedule.hour} ${task.schedule.dom} ${task.schedule.month} ${task.schedule.dow}`;
       task.frequency = this.taskService.getTaskCronDescription(task.cron_schedule);
 
-      this.store$.select(selectTimezone).pipe(untilDestroyed(this)).subscribe((timezone) => {
+      this.store$.select(selectTimezone).pipe(take(1), untilDestroyed(this)).subscribe((timezone) => {
         task.next_run = this.taskService.getTaskNextRun(task.cron_schedule, timezone);
       });
 

--- a/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
@@ -41,7 +41,6 @@ export class RsyncTaskListComponent implements EntityTableConfig<RsyncTaskUi> {
   routeAddTooltip = this.translate.instant('Add Rsync Task');
   routeEdit: string[] = ['tasks', 'rsync', 'edit'];
   entityList: EntityTableComponent<RsyncTaskUi>;
-  asyncView = true;
   filterValue = '';
 
   columns = [

--- a/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
@@ -97,7 +97,10 @@ export class RsyncTaskListComponent implements EntityTableConfig<RsyncTaskUi> {
 
   afterInit(entityList: EntityTableComponent<RsyncTaskUi>): void {
     this.entityList = entityList;
-    this.slideInService.onClose$.pipe(untilDestroyed(this)).subscribe(() => {
+    this.slideInService.onClose$.pipe(
+      filter((value) => !!value.response),
+      untilDestroyed(this),
+    ).subscribe(() => {
       this.entityList.getData();
     });
   }

--- a/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
@@ -175,6 +175,7 @@ export class RsyncTaskListComponent implements EntityTableConfig<RsyncTaskUi> {
         task.state = { state: task.job.state };
         this.store$.select(selectJob(task.job.id)).pipe(
           filter(Boolean),
+          take(1),
           untilDestroyed(this),
         ).subscribe((job: Job) => {
           task.state = { state: job.state };

--- a/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
+import { filter } from 'rxjs';
 import { JobState } from 'app/enums/job-state.enum';
 import {
   PeriodicSnapshotTask,
@@ -89,7 +90,10 @@ export class SnapshotListComponent implements EntityTableConfig<PeriodicSnapshot
 
   afterInit(entityList: EntityTableComponent<PeriodicSnapshotTaskUi>): void {
     this.entityList = entityList;
-    this.slideInService.onClose$.pipe(untilDestroyed(this)).subscribe(() => {
+    this.slideInService.onClose$.pipe(
+      filter((value) => !!value.response),
+      untilDestroyed(this),
+    ).subscribe(() => {
       this.entityList.getData();
     });
   }

--- a/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
@@ -38,7 +38,6 @@ export class SnapshotListComponent implements EntityTableConfig<PeriodicSnapshot
   routeAddTooltip = this.translate.instant('Add Periodic Snapshot Task');
   routeEdit: string[] = ['tasks', 'snapshot', 'edit'];
   entityList: EntityTableComponent<PeriodicSnapshotTaskUi>;
-  asyncView = true;
   filterValue = '';
 
   columns = [

--- a/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import { filter } from 'rxjs';
+import { filter, take } from 'rxjs';
 import { JobState } from 'app/enums/job-state.enum';
 import {
   PeriodicSnapshotTask,
@@ -112,7 +112,7 @@ export class SnapshotListComponent implements EntityTableConfig<PeriodicSnapshot
         frequency: this.taskService.getTaskCronDescription(transformedTask.cron_schedule),
       };
 
-      this.store$.select(selectTimezone).pipe(untilDestroyed(this)).subscribe((timezone) => {
+      this.store$.select(selectTimezone).pipe(take(1), untilDestroyed(this)).subscribe((timezone) => {
         transformedData.next_run = this.taskService.getTaskNextRun(transformedData.cron_schedule, timezone);
       });
 

--- a/src/app/pages/data-protection/snapshot/snapshot-task/snapshot-task.component.ts
+++ b/src/app/pages/data-protection/snapshot/snapshot-task/snapshot-task.component.ts
@@ -142,7 +142,7 @@ export class SnapshotTaskComponent {
     request$.pipe(untilDestroyed(this)).subscribe({
       next: () => {
         this.isLoading = false;
-        this.slideInService.close();
+        this.slideInService.close(null, true);
       },
       error: (error) => {
         this.isLoading = false;


### PR DESCRIPTION
**Description**
> Adding many cloud sync tasks causes the UI to become slower and slower. Eventually every click takes 30 seconds for the UI to recover. System is not under any load or shows any spike in CPU during this event.

**The Root Cause**

The Cloud Sync page uses the deprecated `ix-entity-table` component with the rare `asyncView` param. When a user interacts with the cloud sync form and when the form is closed, new data is fetched, creating an interval that invokes fetching data every 10 seconds. One form close - one new interval. After data fetching, it gathers transforming, which is a heavy operation if you have more than 15 entries. That causes the main thread to be locked, and UI is unresponsive until the page gets refreshed.

**How to reproduce the issue?**

1. Go to the full cloud sync list page (path `/data-protection/cloudsync`)
2. Click on the `Add` button
3. Press the `Escape` key or click the `Close` button. Alternatively, Create a new task.
4. Repeat step 3 at least five times or more.
5. Now you may notice that UI is unresponsive

**Testing** 
Please make sure the UI is still working smoothly after creating more than 5 cloud sync tasks.

Note: This is a fix for Bluefin. For Cobia, we need to get rid of `ix-entity-table` usage. For more context, please check the original ticket.


Original PR: https://github.com/truenas/webui/pull/8022
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121215