### PR TITLE
NAS-121244 / 22.12.3 / The Custom Schedule window displays partially off screen When viewing the Periodic Snapshots Custom Schedule window on the Data Protection Page. (by AlexKarpov98)

### DIFF
--- a/src/app/modules/scheduler/components/scheduler-modal/scheduler-modal.component.scss
+++ b/src/app/modules/scheduler/components/scheduler-modal/scheduler-modal.component.scss
@@ -4,8 +4,7 @@
 
 :host {
   display: flex;
-  // TODO: Make mixin
-  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  font-family: var(--mdc-dialog-subhead-font);
 }
 
 .settings-column {
@@ -107,4 +106,10 @@
   .days-of-week-header {
     font-size: x-small;
   }
+}
+
+.settings-column,
+ix-scheduler-preview-column {
+  max-height: 90vh;
+  overflow: hidden auto;
 }

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -586,6 +586,7 @@ button.mat-menu-trigger.menu-toggle.mat-button {
 /* Material Cards*/
 .mat-card {
   border: solid 1px var(--contrast-lighter);
+  font-family: var(--mdc-dialog-subhead-font);
   padding: 0 !important;
   position: relative;
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 6240458ded73049ae1bc142c9716c1590249d45d

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4fa124542956fbf021bd7b2c52e12a179caaf334

For testing please check the ticket details.

Original PR: https://github.com/truenas/webui/pull/8024
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121244