### PR TITLE
NAS-121342 / 22.12.2 / Fix rear NVME drives on M Series (by dszidi)

### DIFF
--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
@@ -1006,7 +1006,7 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
         : (this.system.enclosures[disk.enclosure.number].elements[0] as EnclosureElementsGroup).elements;
       const slot = elements.find((element) => element.slot === disk.enclosure.slot);
 
-      if (!failed && slot.fault) {
+      if (!failed && slot?.fault) {
         failed = true;
       }
 


### PR DESCRIPTION
Test against an M Series machine with the following conditions:

- Rear drives are NVME
- Rear drives are not assigned to a pool
- no console errors when switching to rear view

Check ticket description for an M Series url

Original PR: https://github.com/truenas/webui/pull/8034
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121342