### PR TITLE
NAS-121222 / 22.12.3 / Update `shell` field (by bvasilenko)

### DIFF
--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -989,7 +989,7 @@ export type ApiDirectory = {
   'user.setup_local_administrator': { params: [userName: string, password: string, ec2?: { instance_id: string }]; response: void };
   'user.delete': { params: DeleteUserParams; response: number };
   'user.get_user_obj': { params: [{ username?: string; uid?: number }]; response: DsUncachedUser };
-  'user.shell_choices': { params: [userId?: number]; response: Choices };
+  'user.shell_choices': { params: [ids: number[]]; response: Choices };
   'user.set_attribute': { params: [id: number, key: string, value: unknown]; response: boolean };
   'user.get_next_uid': { params: void; response: number };
   'user.has_local_administrator_set_up': { params: void; response: boolean };

--- a/src/app/pages/account/users/user-form/user-form.component.html
+++ b/src/app/pages/account/users/user-form/user-form.component.html
@@ -130,12 +130,13 @@
           [label]="'Upload SSH Key' | translate"
         ></ix-file-input>
 
-        <ix-combobox
+        <ix-select
           formControlName="shell"
           [label]="'Shell' | translate"
           [tooltip]="tooltips.shell | translate"
-          [provider]="shellProvider"
-        ></ix-combobox>
+          [options]="shellOptions$"
+          [required]="true"
+        ></ix-select>
 
         <ix-checkbox
           formControlName="locked"

--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -11,11 +11,12 @@ import {
   combineLatest, from, Observable, of, Subscription,
 } from 'rxjs';
 import {
-  filter, map, switchMap,
+  debounceTime, filter, map, switchMap, take,
 } from 'rxjs/operators';
 import { allCommands } from 'app/constants/all-commands.constant';
 import { choicesToOptions } from 'app/helpers/options.helper';
 import helptext from 'app/helptext/account/user-form';
+import { Option } from 'app/interfaces/option.interface';
 import { User, UserUpdate } from 'app/interfaces/user.interface';
 import { forbiddenValues } from 'app/modules/entity/entity-form/validators/forbidden-values-validation';
 import { matchOtherValidator } from 'app/modules/entity/entity-form/validators/password-validation/password-validation';
@@ -117,9 +118,8 @@ export class UserFormComponent {
   readonly groupOptions$ = this.ws.call('group.query').pipe(
     map((groups) => groups.map((group) => ({ label: group.group, value: group.id }))),
   );
-  readonly shellOptions$ = this.ws.call('user.shell_choices').pipe(choicesToOptions());
+  shellOptions$: Observable<Option[]>;
   readonly treeNodeProvider = this.filesystemService.getFilesystemNodeProvider();
-  readonly shellProvider = new SimpleAsyncComboboxProvider(this.shellOptions$);
   readonly groupProvider = new SimpleAsyncComboboxProvider(this.groupOptions$);
 
   get homeCreateWarning(): string {
@@ -190,6 +190,14 @@ export class UserFormComponent {
       untilDestroyed(this),
     ).subscribe((key) => {
       this.form.controls.sshpubkey.setValue(key);
+    });
+
+    this.form.controls.group.valueChanges.pipe(debounceTime(300), untilDestroyed(this)).subscribe((group) => {
+      this.updateShellOptions(group, this.form.value.groups);
+    });
+
+    this.form.controls.groups.valueChanges.pipe(debounceTime(300), untilDestroyed(this)).subscribe((groups) => {
+      this.updateShellOptions(this.form.value.group, groups);
     });
 
     this.form.get('password_conf').addValidators(
@@ -401,7 +409,8 @@ export class UserFormComponent {
   }
 
   private setFirstShellOption(): void {
-    this.shellOptions$.pipe(
+    this.ws.call('user.shell_choices', [this.form.value.groups]).pipe(
+      choicesToOptions(),
       filter((shells) => !!shells.length),
       map((shells) => shells[0].value),
       untilDestroyed(this),
@@ -433,5 +442,19 @@ export class UserFormComponent {
     }
 
     return username.toLocaleLowerCase();
+  }
+
+  private updateShellOptions(group: number, groups: number[]): void {
+    const ids = new Set<number>(groups);
+    if (group) {
+      ids.add(group);
+    }
+
+    this.ws.call('user.shell_choices', [Array.from(ids)])
+      .pipe(choicesToOptions(), take(1), untilDestroyed(this))
+      .subscribe((options) => {
+        this.shellOptions$ = of(options);
+        this.cdr.markForCheck();
+      });
   }
 }


### PR DESCRIPTION


## **Testing**

At the **Credentials > Users > Add User** and **Edit User**, 

On the **Add/Edit user** form, 

When value of **Primary Groups** or **Auxiliary Groups** is changed

**Expected result:**

In the **Shell** dropdown input box, the list of options is should be refreshed from the API call `user.shell_choices`

Original PR: https://github.com/truenas/webui/pull/8023
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121222