### PR TITLE
NAS-121296 / 23.10 / Implement better app status

### DIFF
--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -56,7 +56,9 @@ import {
   CertificateProfiles, CertificateUpdate,
   ExtendedKeyUsageChoices,
 } from 'app/interfaces/certificate.interface';
-import { ChartReleaseEvent, ChartRollbackParams, ChartScaleResult } from 'app/interfaces/chart-release-event.interface';
+import {
+  ChartReleaseEvent, ChartRollbackParams, ChartScaleQueryParams, ChartScaleResult,
+} from 'app/interfaces/chart-release-event.interface';
 import {
   ChartRelease,
   ChartReleaseCreate,
@@ -392,7 +394,7 @@ export type ApiDirectory = {
   'chart.release.upgrade': { params: [name: string, upgrade: ChartReleaseUpgrade]; response: ChartRelease };
   'chart.release.delete': { params: [string, { delete_unused_images: boolean }]; response: boolean };
   'chart.release.get_chart_releases_using_chart_release_images': { params: [name: string]; response: Choices };
-  'chart.release.scale': { params: [name: string, params: { replica_count: number }]; response: ChartScaleResult };
+  'chart.release.scale': { params: ChartScaleQueryParams; response: ChartScaleResult };
   'chart.release.pod_console_choices': { params: [string]; response: Record<string, string[]> };
   'chart.release.nic_choices': { params: void; response: Choices };
   'chart.release.events': { params: [name: string]; response: ChartReleaseEvent[] };

--- a/src/app/interfaces/chart-release-event.interface.ts
+++ b/src/app/interfaces/chart-release-event.interface.ts
@@ -33,6 +33,13 @@ export interface ChartReleaseEventObject {
   uid: string;
 }
 
+export type ChartScaleQueryParams = [
+  name: string,
+  params?: {
+    replica_count: number;
+  },
+];
+
 export interface ChartScaleResult {
   before_scale: number;
   after_scale: number;

--- a/src/app/pages/apps/apps.module.ts
+++ b/src/app/pages/apps/apps.module.ts
@@ -57,6 +57,7 @@ import { AppContainersCardComponent } from './components/installed-apps/app-cont
 import { AppDetailsPanelComponent } from './components/installed-apps/app-details-panel/app-details-panel.component';
 import { AppHistoryCardComponent } from './components/installed-apps/app-history-card/app-history-card.component';
 import { AppNotesCardComponent } from './components/installed-apps/app-notes-card/app-notes-card.component';
+import { AppStatusCellComponent } from './components/installed-apps/app-status-cell/app-status-cell.component';
 import { AppUpgradeDialogComponent } from './components/installed-apps/app-upgrade-dialog/app-upgrade-dialog.component';
 import { InstalledAppsComponent } from './components/installed-apps/installed-apps.component';
 
@@ -89,6 +90,7 @@ import { InstalledAppsComponent } from './components/installed-apps/installed-ap
     PodSelectLogsDialogComponent,
     AppUpgradeDialogComponent,
     AppsToolbarButtonsComponent,
+    AppStatusCellComponent,
   ],
   imports: [
     CommonModule,
@@ -121,5 +123,6 @@ import { InstalledAppsComponent } from './components/installed-apps/installed-ap
     MatTooltipModule,
     MatMenuModule,
   ],
+  exports: [],
 })
 export class AppsModule { }

--- a/src/app/pages/apps/apps.module.ts
+++ b/src/app/pages/apps/apps.module.ts
@@ -123,6 +123,5 @@ import { InstalledAppsComponent } from './components/installed-apps/installed-ap
     MatTooltipModule,
     MatMenuModule,
   ],
-  exports: [],
 })
 export class AppsModule { }

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
@@ -23,7 +23,8 @@
     <ix-app-status-cell
       [app]="app"
       [job]="job"
-      (statusChanged)="appStatusChanged($event)"
+      (click)="statusPressed(); $event.stopPropagation()"
+      (statusChanged)="statusChanged($event)"
     ></ix-app-status-cell>
   </div>
   <div class="cell cell-cpu">

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
@@ -20,18 +20,7 @@
     </div>
   </div>
   <div class="cell cell-status">
-    <ng-container [ngSwitch]="app.status">
-      <div *ngSwitchCase="chartReleaseStatus.Active" class="status active">
-        {{ 'Running' | translate }}
-      </div>
-      <div *ngSwitchCase="chartReleaseStatus.Deploying" class="status deploying">
-        <mat-spinner [diameter]="20"></mat-spinner>
-        {{ 'Deploying' | translate }}
-      </div>
-      <div *ngSwitchCase="chartReleaseStatus.Stopped" class="status stopped">
-        {{ 'Stopped' | translate }}
-      </div>
-    </ng-container>
+    <ix-app-status-cell [app]="app"></ix-app-status-cell>
   </div>
   <div class="cell cell-cpu">
     <span [ngTemplateOutlet]="notAvailable"></span>

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
@@ -20,7 +20,11 @@
     </div>
   </div>
   <div class="cell cell-status">
-    <ix-app-status-cell [app]="app"></ix-app-status-cell>
+    <ix-app-status-cell
+      [app]="app"
+      [job]="job"
+      (statusChanged)="appStatusChanged($event)"
+    ></ix-app-status-cell>
   </div>
   <div class="cell cell-cpu">
     <span [ngTemplateOutlet]="notAvailable"></span>
@@ -43,7 +47,7 @@
   </div>
   <div class="cell cell-action">
     <button
-      *ngIf="isAppStopped"
+      *ngIf="isAppStopped && !inProgress"
       mat-icon-button
       matTooltipPosition="above"
       [ixTest]="[app.name, 'start']"
@@ -53,7 +57,7 @@
       <ix-icon name="mdi-play"></ix-icon>
     </button>
     <button
-      *ngIf="!isAppStopped"
+      *ngIf="!isAppStopped && !inProgress"
       mat-icon-button
       matTooltipPosition="above"
       [ixTest]="[app.name, 'stop']"

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.scss
@@ -67,7 +67,7 @@
   align-items: center;
   display: grid;
   grid-gap: 8px;
-  grid-template-columns: auto 130px 40px 40px 40px 115px 60px;
+  grid-template-columns: minmax(200px, auto) minmax(100px, 130px) 40px 40px 40px minmax(100px, 115px) 60px;
   min-width: fit-content;
   width: 100%;
 

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.scss
@@ -108,36 +108,6 @@
     }
   }
 
-  .cell-status {
-    .status {
-      border: 2px solid;
-      border-radius: 20px;
-      display: flex;
-      font-weight: bold;
-      gap: 6px;
-      padding: 3px 16px;
-    }
-
-    .active {
-      border-color: var(--green);
-      color: var(--green);
-    }
-
-    .deploying {
-      border-color: var(--yellow);
-      color: var(--yellow);
-
-      mat-spinner::ng-deep circle {
-        stroke: var(--yellow);
-      }
-    }
-
-    .stopped {
-      border-color: var(--red);
-      color: var(--red);
-    }
-  }
-
   .cell-update {
     gap: 4px;
 

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.spec.ts
@@ -1,9 +1,11 @@
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { MockComponents } from 'ng-mocks';
 import { ImgFallbackModule } from 'ngx-img-fallback';
 import { officialCatalog } from 'app/constants/catalog.constants';
 import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
 import { AppRowComponent } from 'app/pages/apps/components/installed-apps/app-row/app-row.component';
+import { AppStatusCellComponent } from 'app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component';
 
 describe('AppRowComponent', () => {
   let spectator: Spectator<AppRowComponent>;
@@ -17,6 +19,9 @@ describe('AppRowComponent', () => {
   const createComponent = createComponentFactory({
     component: AppRowComponent,
     imports: [ImgFallbackModule],
+    declarations: [
+      MockComponents(AppStatusCellComponent),
+    ],
   });
 
   beforeEach(() => {
@@ -32,7 +37,9 @@ describe('AppRowComponent', () => {
   });
 
   it('checks app status column', () => {
-    expect(spectator.query('.cell-status .status')).toHaveText('Running');
+    const statusCell = spectator.query(AppStatusCellComponent);
+    expect(statusCell).toBeTruthy();
+    expect(statusCell.app).toBe(app);
   });
 
   it('checks app update column', () => {

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
@@ -3,7 +3,10 @@ import {
 } from '@angular/core';
 import { appImagePlaceholder } from 'app/constants/catalog.constants';
 import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
+import { ChartScaleQueryParams, ChartScaleResult } from 'app/interfaces/chart-release-event.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
+import { Job } from 'app/interfaces/job.interface';
+import { AppStatus } from 'app/pages/apps/enum/app-status.enum';
 
 @Component({
   selector: 'ix-app-row',
@@ -12,8 +15,10 @@ import { ChartRelease } from 'app/interfaces/chart-release.interface';
 })
 export class AppRowComponent {
   @Input() app: ChartRelease;
+  @Input() job: Job<ChartScaleResult, ChartScaleQueryParams>;
   @Output() startApp = new EventEmitter<void>();
   @Output() stopApp = new EventEmitter<void>();
+  inProgress = false;
 
   readonly imagePlaceholder = appImagePlaceholder;
   readonly appStatus = ChartReleaseStatus;
@@ -24,6 +29,14 @@ export class AppRowComponent {
 
   get isAppStopped(): boolean {
     return this.app.status === ChartReleaseStatus.Stopped;
+  }
+
+  appStatusChanged(status: AppStatus): void {
+    this.inProgress = [
+      AppStatus.Deploying,
+      AppStatus.Starting,
+      AppStatus.Stopping,
+    ].includes(status);
   }
 
   toggleAppChecked(checked: boolean): void {

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
@@ -15,7 +15,7 @@ import { AppStatus } from 'app/pages/apps/enum/app-status.enum';
 })
 export class AppRowComponent {
   @Input() app: ChartRelease;
-  @Input() job: Job<ChartScaleResult, ChartScaleQueryParams>;
+  @Input() job?: Job<ChartScaleResult, ChartScaleQueryParams>;
   @Output() startApp = new EventEmitter<void>();
   @Output() stopApp = new EventEmitter<void>();
   @Output() clickStatus = new EventEmitter<void>();

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
@@ -22,7 +22,6 @@ export class AppRowComponent {
   inProgress = false;
 
   readonly imagePlaceholder = appImagePlaceholder;
-  readonly appStatus = ChartReleaseStatus;
 
   get hasUpdates(): boolean {
     return this.app.update_available || this.app.container_images_update_available;

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
@@ -16,7 +16,7 @@ export class AppRowComponent {
   @Output() stopApp = new EventEmitter<void>();
 
   readonly imagePlaceholder = appImagePlaceholder;
-  readonly chartReleaseStatus = ChartReleaseStatus;
+  readonly appStatus = ChartReleaseStatus;
 
   get hasUpdates(): boolean {
     return this.app.update_available || this.app.container_images_update_available;

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
@@ -18,6 +18,7 @@ export class AppRowComponent {
   @Input() job: Job<ChartScaleResult, ChartScaleQueryParams>;
   @Output() startApp = new EventEmitter<void>();
   @Output() stopApp = new EventEmitter<void>();
+  @Output() clickStatus = new EventEmitter<void>();
   inProgress = false;
 
   readonly imagePlaceholder = appImagePlaceholder;
@@ -31,14 +32,6 @@ export class AppRowComponent {
     return this.app.status === ChartReleaseStatus.Stopped;
   }
 
-  appStatusChanged(status: AppStatus): void {
-    this.inProgress = [
-      AppStatus.Deploying,
-      AppStatus.Starting,
-      AppStatus.Stopping,
-    ].includes(status);
-  }
-
   toggleAppChecked(checked: boolean): void {
     this.app.selected = checked;
   }
@@ -49,5 +42,17 @@ export class AppRowComponent {
 
   stop(): void {
     this.stopApp.emit();
+  }
+
+  statusChanged(status: AppStatus): void {
+    this.inProgress = [
+      AppStatus.Deploying,
+      AppStatus.Starting,
+      AppStatus.Stopping,
+    ].includes(status);
+  }
+
+  statusPressed(): void {
+    this.clickStatus.emit();
   }
 }

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
@@ -3,4 +3,4 @@
   [diameter]="20"
   [matTooltip]="job?.progress?.description"
 ></mat-spinner>
-{{ appStatus | mapValue: appStatusLabels | translate }}
+<span>{{ appStatus | mapValue: appStatusLabels | translate }}</span>

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
@@ -1,1 +1,8 @@
+<mat-spinner
+  *ngIf="inProgress"
+  [diameter]="20"
+  [mode]="job?.progress?.percent ? 'determinate' : 'indeterminate'"
+  [value]="job?.progress?.percent"
+  [matTooltip]="job?.progress?.description"
+></mat-spinner>
 {{ appStatus | mapValue: appStatusLabels | translate }}

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
@@ -1,0 +1,1 @@
+{{ appStatus | mapValue: appStatusLabels | translate }}

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
@@ -1,8 +1,6 @@
 <mat-spinner
   *ngIf="inProgress"
   [diameter]="20"
-  [mode]="job?.progress?.percent ? 'determinate' : 'indeterminate'"
-  [value]="job?.progress?.percent"
   [matTooltip]="job?.progress?.description"
 ></mat-spinner>
 {{ appStatus | mapValue: appStatusLabels | translate }}

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.scss
@@ -1,0 +1,30 @@
+:host {
+  border: 2px solid transparent;
+  border-radius: 20px;
+  box-sizing: border-box;
+  display: flex;
+  font-weight: bold;
+  gap: 6px;
+  padding: 3px 18px;
+
+  &.started {
+    border-color: var(--green);
+    color: var(--green);
+  }
+
+  &.starting,
+  &.deploying,
+  &.stopping {
+    border-color: var(--yellow);
+    color: var(--yellow);
+
+    mat-spinner::ng-deep circle {
+      stroke: var(--yellow);
+    }
+  }
+
+  &.stopped {
+    border-color: var(--red);
+    color: var(--red);
+  }
+}

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.spec.ts
@@ -1,0 +1,29 @@
+import { Spectator } from '@ngneat/spectator';
+import { createComponentFactory } from '@ngneat/spectator/jest';
+import { CoreComponents } from 'app/core/core-components.module';
+import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
+import { ChartRelease } from 'app/interfaces/chart-release.interface';
+import { AppStatusCellComponent } from 'app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component';
+
+describe('AppStatusCellComponent', () => {
+  let spectator: Spectator<AppStatusCellComponent>;
+
+  const createComponent = createComponentFactory({
+    component: AppStatusCellComponent,
+    imports: [CoreComponents],
+  });
+
+  function setupTest(app: ChartRelease): void {
+    spectator = createComponent({
+      props: {
+        app,
+      },
+    });
+  }
+
+  it('checks status for active app', () => {
+    setupTest({ status: ChartReleaseStatus.Active } as ChartRelease);
+
+    expect(spectator.query(AppStatusCellComponent)).toHaveText('Running');
+  });
+});

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.spec.ts
@@ -1,29 +1,71 @@
 import { Spectator } from '@ngneat/spectator';
-import { createComponentFactory } from '@ngneat/spectator/jest';
+import { createHostFactory } from '@ngneat/spectator/jest';
 import { CoreComponents } from 'app/core/core-components.module';
 import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
+import { JobState } from 'app/enums/job-state.enum';
+import { ChartScaleQueryParams, ChartScaleResult } from 'app/interfaces/chart-release-event.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
+import { Job } from 'app/interfaces/job.interface';
 import { AppStatusCellComponent } from 'app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component';
 
 describe('AppStatusCellComponent', () => {
   let spectator: Spectator<AppStatusCellComponent>;
 
-  const createComponent = createComponentFactory({
+  const createHost = createHostFactory({
     component: AppStatusCellComponent,
     imports: [CoreComponents],
   });
 
-  function setupTest(app: ChartRelease): void {
-    spectator = createComponent({
-      props: {
-        app,
-      },
+  function setupTest(app: ChartRelease, job?: Job<ChartScaleResult, ChartScaleQueryParams>): void {
+    spectator = createHost('<ix-app-status-cell [app]="app" [job]="job"></ix-app-status-cell>', {
+      hostProps: { app, job },
     });
   }
 
-  it('checks status for active app', () => {
+  it('checks status for running app', () => {
     setupTest({ status: ChartReleaseStatus.Active } as ChartRelease);
 
-    expect(spectator.query(AppStatusCellComponent)).toHaveText('Running');
+    expect(spectator.query('span')).toHaveText('Running');
+  });
+
+  it('checks status for stopped app', () => {
+    setupTest({ status: ChartReleaseStatus.Stopped } as ChartRelease);
+
+    expect(spectator.query('span')).toHaveText('Stopped');
+  });
+
+  it('checks status for deploying app', () => {
+    setupTest({ status: ChartReleaseStatus.Deploying } as ChartRelease);
+
+    expect(spectator.query('mat-spinner')).toBeTruthy();
+    expect(spectator.query('span')).toHaveText('Deploying');
+  });
+
+  it('checks status for starting app', () => {
+    setupTest(
+      { status: ChartReleaseStatus.Stopped } as ChartRelease,
+      {
+        arguments: ['fake-name', { replica_count: 1 }],
+        state: JobState.Running,
+        result: [],
+      } as unknown as Job<ChartScaleResult, ChartScaleQueryParams>,
+    );
+
+    expect(spectator.query('mat-spinner')).toBeTruthy();
+    expect(spectator.query('span')).toHaveText('Starting');
+  });
+
+  it('checks status for stopping app', () => {
+    setupTest(
+      { status: ChartReleaseStatus.Active } as ChartRelease,
+      {
+        arguments: ['fake-name', { replica_count: 0 }],
+        state: JobState.Running,
+        result: [],
+      } as unknown as Job<ChartScaleResult, ChartScaleQueryParams>,
+    );
+
+    expect(spectator.query('mat-spinner')).toBeTruthy();
+    expect(spectator.query('span')).toHaveText('Stopping');
   });
 });

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.ts
@@ -1,0 +1,38 @@
+import { Component, HostBinding, Input } from '@angular/core';
+import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
+import { ChartRelease } from 'app/interfaces/chart-release.interface';
+import { AppStatus, appStatusLabels } from 'app/pages/apps/enum/app-status.enum';
+
+@Component({
+  selector: 'ix-app-status-cell',
+  templateUrl: './app-status-cell.component.html',
+  styleUrls: ['./app-status-cell.component.scss'],
+})
+export class AppStatusCellComponent {
+  @Input() app: ChartRelease;
+  @HostBinding('class') get hostClasses(): string[] {
+    return ['status', this.appStatus.toLowerCase()];
+  }
+
+  protected appStatusLabels = appStatusLabels;
+
+  get appStatus(): AppStatus {
+    let status: AppStatus;
+
+    switch (this.app.status) {
+      case ChartReleaseStatus.Active:
+        status = AppStatus.Started;
+        break;
+      case ChartReleaseStatus.Deploying:
+        status = AppStatus.Deploying;
+        break;
+      case ChartReleaseStatus.Stopped:
+        status = AppStatus.Stopped;
+        break;
+      default:
+        console.info('Unknown app status');
+    }
+
+    return status;
+  }
+}

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component, EventEmitter, HostBinding, Input, Output,
 } from '@angular/core';
 import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
@@ -12,13 +13,14 @@ import { AppStatus, appStatusLabels } from 'app/pages/apps/enum/app-status.enum'
   selector: 'ix-app-status-cell',
   templateUrl: './app-status-cell.component.html',
   styleUrls: ['./app-status-cell.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppStatusCellComponent {
   @Input() app: ChartRelease;
   @Input() job: Job<ChartScaleResult, ChartScaleQueryParams>;
   @Output() statusChanged = new EventEmitter<AppStatus>();
   @HostBinding('class') get hostClasses(): string[] {
-    return ['status', this.appStatus.toLowerCase()];
+    return ['status', this.appStatus?.toLowerCase()];
   }
 
   protected appStatusLabels = appStatusLabels;

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.html
@@ -128,6 +128,7 @@
                 [routerLink]="['/apps/installed', app.id]"
                 (startApp)="start(app.name)"
                 (stopApp)="stop(app.name)"
+                (clickStatus)="openStatusDialog(app.name)"
                 (click)="selectApp(app)"
                 (keydown.enter)="selectApp(app)"
               ></ix-app-row>

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.html
@@ -124,6 +124,7 @@
               <ix-app-row
                 routerLinkActive="selected"
                 [app]="app"
+                [job]="appJobs.get(app.name)"
                 [routerLink]="['/apps/installed', app.id]"
                 (startApp)="start(app.name)"
                 (stopApp)="stop(app.name)"

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
@@ -115,7 +115,7 @@ $scrollbar-offset: 20px;
   color: var(--fg2);
   display: grid;
   grid-gap: 8px;
-  grid-template-columns: auto 130px 40px 40px 40px 115px 60px;
+  grid-template-columns: minmax(200px, auto) minmax(100px, 130px) 40px 40px 40px minmax(100px, 115px) 60px;
   min-height: 48px;
   min-width: fit-content;
   padding-left: 8px;

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -240,32 +240,22 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
     });
   }
 
-  syncAll(): void {
-    const dialogRef = this.matDialog.open(EntityJobComponent, {
-      data: { title: helptext.refreshing },
-    });
-    dialogRef.componentInstance.setCall('catalog.sync_all');
-    dialogRef.componentInstance.submit();
-    dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
-      this.dialogService.closeAllDialogs();
-      this.updateChartReleases();
-    });
-  }
-
   refreshStatus(name: string): void {
-    this.appService.getChartReleases(name).pipe(filter(Boolean), untilDestroyed(this)).subscribe((releases) => {
-      const item = this.dataSource.find((app) => app.name === name);
-      if (item) {
-        item.status = releases[0].status;
-        this.cdr.markForCheck();
-        if (item.status === ChartReleaseStatus.Deploying) {
-          setTimeout(() => {
-            this.refreshStatus(name);
-            this.cdr.markForCheck();
-          }, 3000);
+    this.appService.getChartReleases(name)
+      .pipe(filter(Boolean), untilDestroyed(this))
+      .subscribe((releases) => {
+        const item = this.dataSource.find((app) => app.name === name);
+        if (item) {
+          item.status = releases[0].status;
+          this.cdr.markForCheck();
+          if (item.status === ChartReleaseStatus.Deploying) {
+            setTimeout(() => {
+              this.refreshStatus(name);
+              this.cdr.markForCheck();
+            }, 3000);
+          }
         }
-      }
-    });
+      });
   }
 
   start(name: string): void {

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -256,7 +256,10 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
         item.status = releases[0].status;
         this.cdr.markForCheck();
         if (item.status === ChartReleaseStatus.Deploying) {
-          setTimeout(() => this.refreshStatus(name), 3000);
+          setTimeout(() => {
+            this.refreshStatus(name);
+            this.cdr.markForCheck();
+          }, 3000);
         }
       }
     });
@@ -274,8 +277,16 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
     const dialogRef = this.matDialog.open(EntityJobComponent, { data: { title } });
     dialogRef.componentInstance.setCall('chart.release.scale', [chartName, { replica_count: newReplicaCount }]);
     dialogRef.componentInstance.submit();
-    dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
+
+    dialogRef.componentInstance.progress.pipe(untilDestroyed(this)).subscribe((value) => {
+      console.info('progress', value);
       this.refreshStatus(chartName);
+      this.cdr.markForCheck();
+    });
+    dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe((value) => {
+      console.info('success', value);
+      this.refreshStatus(chartName);
+      this.cdr.markForCheck();
       dialogRef.close();
     });
     dialogRef.componentInstance.failure.pipe(untilDestroyed(this)).subscribe((error) => {

--- a/src/app/pages/apps/enum/app-status.enum.ts
+++ b/src/app/pages/apps/enum/app-status.enum.ts
@@ -1,0 +1,17 @@
+import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
+
+export enum AppStatus {
+  Started = 'STARTED',
+  Starting = 'STARTING',
+  Deploying = 'DEPLOYING',
+  Stopped = 'STOPPED',
+  Stopping = 'STOPPING',
+}
+
+export const appStatusLabels = new Map<AppStatus, string>([
+  [AppStatus.Started, T('Running')],
+  [AppStatus.Starting, T('Starting')],
+  [AppStatus.Deploying, T('Deploying')],
+  [AppStatus.Stopped, T('Stopped')],
+  [AppStatus.Stopping, T('Stopping')],
+]);

--- a/src/app/pages/apps/services/applications.service.ts
+++ b/src/app/pages/apps/services/applications.service.ts
@@ -7,9 +7,10 @@ import { UpgradeSummary } from 'app/interfaces/application.interface';
 import { AppsFiltersValues } from 'app/interfaces/apps-filters-values.interface';
 import { AvailableApp } from 'app/interfaces/available-app.interfase';
 import { CatalogApp } from 'app/interfaces/catalog.interface';
-import { ChartReleaseEvent } from 'app/interfaces/chart-release-event.interface';
+import { ChartReleaseEvent, ChartScaleResult } from 'app/interfaces/chart-release-event.interface';
 import { ChartRelease, ChartReleaseUpgradeParams } from 'app/interfaces/chart-release.interface';
 import { Choices } from 'app/interfaces/choices.interface';
+import { Job } from 'app/interfaces/job.interface';
 import { KubernetesConfig } from 'app/interfaces/kubernetes-config.interface';
 import { QueryFilter } from 'app/interfaces/query-api.interface';
 import { WebSocketService } from 'app/services';
@@ -98,5 +99,13 @@ export class ApplicationsService {
       'chart.release.get_chart_releases_using_chart_release_images',
       [name],
     );
+  }
+
+  startApplication(name: string): Observable<Job<ChartScaleResult>> {
+    return this.ws.job('chart.release.scale', [name, { replica_count: 1 }]);
+  }
+
+  stopApplication(name: string): Observable<Job<ChartScaleResult>> {
+    return this.ws.job('chart.release.scale', [name, { replica_count: 0 }]);
   }
 }


### PR DESCRIPTION
**Description**

> On the installed apps page, when you click to start a stopped app, the starting process is shown as a progress in a dialog. Instead use the state tiles in the row to show that the app is starting. Clicking on that tile can bring up this dialog that’s showing now.

**Testing**

- Open the Installed Apps page
- Make a test of the app status

