### PR TITLE
NAS-121440 / 23.10 / Sync cancel buttons in services

### DIFF
--- a/src/app/pages/services/components/service-dynamic-dns/service-dynamic-dns.component.html
+++ b/src/app/pages/services/components/service-dynamic-dns/service-dynamic-dns.component.html
@@ -94,7 +94,7 @@
           {{ 'Save' | translate }}
         </button>
 
-        <button mat-button type="button" ixTest="cancel" (click)="onCancel()">
+        <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
           {{ 'Cancel' | translate }}
         </button>
       </div>

--- a/src/app/pages/services/components/service-dynamic-dns/service-dynamic-dns.component.spec.ts
+++ b/src/app/pages/services/components/service-dynamic-dns/service-dynamic-dns.component.spec.ts
@@ -2,8 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { Router } from '@angular/router';
-import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { createRoutingFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { DynamicDnsConfig } from 'app/interfaces/dynamic-dns.interface';
 import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
@@ -18,7 +17,7 @@ describe('ServiceDynamicDnsComponent', () => {
   let spectator: Spectator<ServiceDynamicDnsComponent>;
   let loader: HarnessLoader;
   let ws: WebSocketService;
-  const createComponent = createComponentFactory({
+  const createComponent = createRoutingFactory({
     component: ServiceDynamicDnsComponent,
     imports: [
       IxFormsModule,
@@ -46,7 +45,6 @@ describe('ServiceDynamicDnsComponent', () => {
       mockProvider(IxSlideInService),
       mockProvider(FormErrorHandlerService),
       mockProvider(DialogService),
-      mockProvider(Router),
     ],
   });
 

--- a/src/app/pages/services/components/service-dynamic-dns/service-dynamic-dns.component.ts
+++ b/src/app/pages/services/components/service-dynamic-dns/service-dynamic-dns.component.ts
@@ -116,8 +116,4 @@ export class ServiceDynamicDnsComponent implements OnInit {
       },
     });
   }
-
-  onCancel(): void {
-    this.router.navigate(['/services']);
-  }
 }

--- a/src/app/pages/services/components/service-lldp/service-lldp.component.html
+++ b/src/app/pages/services/components/service-lldp/service-lldp.component.html
@@ -38,7 +38,7 @@
           {{ 'Save' | translate }}
         </button>
 
-        <button mat-button type="button" ixTest="cancel" (click)="onCancel()">
+        <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
           {{ 'Cancel' | translate }}
         </button>
       </div>

--- a/src/app/pages/services/components/service-lldp/service-lldp.component.ts
+++ b/src/app/pages/services/components/service-lldp/service-lldp.component.ts
@@ -111,8 +111,4 @@ export class ServiceLldpComponent implements OnInit {
         },
       });
   }
-
-  onCancel(): void {
-    this.router.navigate(['/services']);
-  }
 }

--- a/src/app/pages/services/components/service-nfs/service-nfs.component.html
+++ b/src/app/pages/services/components/service-nfs/service-nfs.component.html
@@ -102,7 +102,7 @@
             {{ 'Save' | translate }}
           </button>
 
-          <button mat-button color="accent" ixTest="cancel" (click)="onCancel()">
+          <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
             {{ 'Cancel' | translate }}
           </button>
         </div>

--- a/src/app/pages/services/components/service-nfs/service-nfs.component.spec.ts
+++ b/src/app/pages/services/components/service-nfs/service-nfs.component.spec.ts
@@ -3,8 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialog } from '@angular/material/dialog';
-import { Router } from '@angular/router';
-import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { createRoutingFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { DirectoryServiceState } from 'app/enums/directory-service-state.enum';
@@ -24,7 +23,7 @@ describe('ServiceNfsComponent', () => {
   let spectator: Spectator<ServiceNfsComponent>;
   let loader: HarnessLoader;
   let ws: WebSocketService;
-  const createComponent = createComponentFactory({
+  const createComponent = createRoutingFactory({
     component: ServiceNfsComponent,
     imports: [
       IxFormsModule,
@@ -67,7 +66,6 @@ describe('ServiceNfsComponent', () => {
           afterClosed: () => of(),
         })),
       }),
-      mockProvider(Router),
     ],
   });
 

--- a/src/app/pages/services/components/service-nfs/service-nfs.component.ts
+++ b/src/app/pages/services/components/service-nfs/service-nfs.component.ts
@@ -99,10 +99,6 @@ export class ServiceNfsComponent implements OnInit {
       });
   }
 
-  onCancel(): void {
-    this.router.navigate(['/services']);
-  }
-
   private loadConfig(): void {
     this.ws.call('nfs.config')
       .pipe(untilDestroyed(this))

--- a/src/app/pages/services/components/service-rsync/rsync-configure/rsync-configure.component.html
+++ b/src/app/pages/services/components/service-rsync/rsync-configure/rsync-configure.component.html
@@ -26,7 +26,7 @@
           {{ 'Save' | translate }}
         </button>
 
-        <button mat-button color="accent" ixTest="cancel" (click)="cancel()">
+        <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
           {{ 'Cancel' | translate }}
         </button>
       </div>

--- a/src/app/pages/services/components/service-rsync/rsync-configure/rsync-configure.component.ts
+++ b/src/app/pages/services/components/service-rsync/rsync-configure/rsync-configure.component.ts
@@ -81,8 +81,4 @@ export class RsyncConfigureComponent implements OnInit {
       },
     });
   }
-
-  cancel(): void {
-    this.router.navigate(['services']);
-  }
 }

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -85,7 +85,7 @@
           {{ 'Save' | translate }}
         </button>
 
-        <button mat-button type="button" ixTest="cancel" (click)="onCancel()">
+        <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
           {{ 'Cancel' | translate }}
         </button>
       </div>

--- a/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
@@ -2,8 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { Router } from '@angular/router';
-import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { createRoutingFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
@@ -26,7 +25,7 @@ describe('ServiceS3Component', () => {
   let spectator: Spectator<ServiceS3Component>;
   let loader: HarnessLoader;
   let ws: WebSocketService;
-  const createComponent = createComponentFactory({
+  const createComponent = createRoutingFactory({
     component: ServiceS3Component,
     imports: [
       IxFormsModule,
@@ -59,7 +58,6 @@ describe('ServiceS3Component', () => {
       mockProvider(DialogService, {
         confirm: jest.fn(() => of(true)),
       }),
-      mockProvider(Router),
       mockProvider(SystemGeneralService, {
         getCertificates: jest.fn(() => of([
           { name: 'Default', id: 1 },

--- a/src/app/pages/services/components/service-s3/service-s3.component.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.ts
@@ -170,8 +170,4 @@ export class ServiceS3Component implements OnInit {
         },
       });
   }
-
-  onCancel(): void {
-    this.router.navigate(['/services']);
-  }
 }

--- a/src/app/pages/services/components/service-smb/service-smb.component.html
+++ b/src/app/pages/services/components/service-smb/service-smb.component.html
@@ -130,7 +130,7 @@
           {{ 'Save' | translate }}
         </button>
 
-        <button mat-button type="button" ixTest="cancel" (click)="onCancel()">
+        <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
           {{ 'Cancel' | translate }}
         </button>
 

--- a/src/app/pages/services/components/service-smb/service-smb.component.spec.ts
+++ b/src/app/pages/services/components/service-smb/service-smb.component.spec.ts
@@ -3,7 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { Router } from '@angular/router';
-import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { createRoutingFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { SmbConfig } from 'app/interfaces/smb-config.interface';
@@ -22,7 +22,7 @@ describe('ServiceSmbComponent', () => {
   let loader: HarnessLoader;
   let ws: WebSocketService;
 
-  const createComponent = createComponentFactory({
+  const createComponent = createRoutingFactory({
     component: ServiceSmbComponent,
     imports: [
       IxFormsModule,

--- a/src/app/pages/services/components/service-smb/service-smb.component.ts
+++ b/src/app/pages/services/components/service-smb/service-smb.component.ts
@@ -152,8 +152,4 @@ export class ServiceSmbComponent implements OnInit {
         },
       });
   }
-
-  onCancel(): void {
-    this.router.navigate(['/services']);
-  }
 }

--- a/src/app/pages/services/components/service-snmp/service-snmp.component.html
+++ b/src/app/pages/services/components/service-snmp/service-snmp.component.html
@@ -106,9 +106,9 @@
           {{ 'Save' | translate }}
         </button>
 
-        <a mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
+        <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
           {{ 'Cancel' | translate }}
-        </a>
+        </button>
       </div>
     </form>
   </mat-card-content>

--- a/src/app/pages/services/components/service-ssh/service-ssh.component.html
+++ b/src/app/pages/services/components/service-ssh/service-ssh.component.html
@@ -96,7 +96,7 @@
           {{ 'Save' | translate }}
         </button>
 
-        <button mat-button type="button" ixTest="cancel" (click)="onCancel()">
+        <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
           {{ 'Cancel' | translate }}
         </button>
 

--- a/src/app/pages/services/components/service-ssh/service-ssh.component.spec.ts
+++ b/src/app/pages/services/components/service-ssh/service-ssh.component.spec.ts
@@ -2,8 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { Router } from '@angular/router';
-import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { createRoutingFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { SshSftpLogFacility, SshSftpLogLevel, SshWeakCipher } from 'app/enums/ssh.enum';
 import { Group } from 'app/interfaces/group.interface';
@@ -29,7 +28,7 @@ describe('ServiceSshComponent', () => {
   let spectator: Spectator<ServiceSshComponent>;
   let loader: HarnessLoader;
   let ws: WebSocketService;
-  const createComponent = createComponentFactory({
+  const createComponent = createRoutingFactory({
     component: ServiceSshComponent,
     imports: [
       IxFormsModule,
@@ -59,7 +58,6 @@ describe('ServiceSshComponent', () => {
       ]),
       mockProvider(IxSlideInService),
       mockProvider(FormErrorHandlerService),
-      mockProvider(Router),
       mockProvider(DialogService),
     ],
   });

--- a/src/app/pages/services/components/service-ssh/service-ssh.component.ts
+++ b/src/app/pages/services/components/service-ssh/service-ssh.component.ts
@@ -115,8 +115,4 @@ export class ServiceSshComponent implements OnInit {
         },
       });
   }
-
-  onCancel(): void {
-    this.router.navigate(['/services']);
-  }
 }

--- a/src/app/pages/services/components/service-ups/service-ups.component.html
+++ b/src/app/pages/services/components/service-ups/service-ups.component.html
@@ -165,7 +165,7 @@
           {{ 'Save' | translate }}
         </button>
 
-        <button mat-button color="accent" ixTest="cancel" (click)="onCancel()">
+        <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
           {{ 'Cancel' | translate }}
         </button>
       </div>

--- a/src/app/pages/services/components/service-ups/service-ups.component.spec.ts
+++ b/src/app/pages/services/components/service-ups/service-ups.component.spec.ts
@@ -2,8 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { Router } from '@angular/router';
-import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { createRoutingFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { UpsConfig, UpsConfigUpdate } from 'app/interfaces/ups-config.interface';
 import { IxComboboxHarness } from 'app/modules/ix-forms/components/ix-combobox/ix-combobox.harness';
@@ -18,7 +17,7 @@ describe('ServiceUpsComponent', () => {
   let spectator: Spectator<ServiceUpsComponent>;
   let loader: HarnessLoader;
   let ws: WebSocketService;
-  const createComponent = createComponentFactory({
+  const createComponent = createRoutingFactory({
     component: ServiceUpsComponent,
     imports: [
       IxFormsModule,
@@ -63,7 +62,6 @@ describe('ServiceUpsComponent', () => {
       ]),
       mockProvider(FormErrorHandlerService),
       mockProvider(DialogService),
-      mockProvider(Router),
     ],
   });
 

--- a/src/app/pages/services/components/service-ups/service-ups.component.ts
+++ b/src/app/pages/services/components/service-ups/service-ups.component.ts
@@ -177,8 +177,4 @@ export class ServiceUpsComponent implements OnInit {
         },
       });
   }
-
-  onCancel(): void {
-    this.router.navigate(['/services']);
-  }
 }

--- a/src/app/pages/services/components/service-webdav/service-webdav.component.html
+++ b/src/app/pages/services/components/service-webdav/service-webdav.component.html
@@ -70,7 +70,7 @@
             {{ 'Save' | translate }}
           </button>
 
-          <button mat-button color="accent" ixTest="cancel" (click)="cancel()">
+          <button mat-button type="button" ixTest="cancel" [routerLink]="['/services']">
             {{ 'Cancel' | translate }}
           </button>
         </ix-form-actions>

--- a/src/app/pages/services/components/service-webdav/service-webdav.component.ts
+++ b/src/app/pages/services/components/service-webdav/service-webdav.component.ts
@@ -177,8 +177,4 @@ export class ServiceWebdavComponent implements OnInit {
       },
     });
   }
-
-  cancel(): void {
-    this.router.navigate(['/', 'services']);
-  }
 }


### PR DESCRIPTION
**Description**
> When identifying the SNMP service edit page cancel button, the data-test tag is defined differently than other service cancel buttons.  This should be consistent.

For testing, the cancel button on the `Services -> SNMP` page should have `data-test="button-cancel"` value.