### PR TITLE
NAS-121124 / 23.10 / Fixed the resizing on reload shell

### DIFF
--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -207,8 +207,8 @@ describe('AuthService', () => {
           { c: false },
         );
         expectObservable(spectator.service.authToken$).toBe(
-          'd',
-          { d: null },
+          '|',
+          {},
         );
       });
       expect(spectator.inject(WebsocketConnectionService).send).toHaveBeenCalledWith({

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -104,6 +104,9 @@ export class AuthService {
    */
   clearAuthToken(): void {
     this.latestTokenGenerated$.next(null);
+    this.latestTokenGenerated$.complete();
+    this.latestTokenGenerated$ = new ReplaySubject<string>(1);
+    this.setupTokenUpdate();
   }
 
   login(username: string, password: string, otp: string = null): Observable<boolean> {

--- a/src/app/services/dialog.service.ts
+++ b/src/app/services/dialog.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { UntilDestroy } from '@ngneat/until-destroy';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import {
   ConfirmOptions,
   ConfirmOptionsWithSecondaryCheckbox,
@@ -38,6 +38,7 @@ export class DialogService {
 
   error(error: ErrorReport | ErrorReport[]): Observable<boolean> {
     if (Array.isArray(error)) {
+      error = this.cleanErrors(error);
       if (error.length > 1) {
         const dialogRef = this.dialog.open(MultiErrorDialogComponent, {
           data: error,
@@ -45,6 +46,9 @@ export class DialogService {
         return dialogRef.afterClosed();
       }
       error = error[0];
+    }
+    if (!error.message) {
+      return of(false);
     }
     const dialogRef = this.dialog.open(ErrorDialogComponent, {
       data: error,
@@ -56,6 +60,16 @@ export class DialogService {
       dialogRef.componentInstance.logs = error.logs;
     }
     return dialogRef.afterClosed();
+  }
+
+  private cleanErrors(errorReports: ErrorReport[]): ErrorReport[] {
+    const newErrorReports = [];
+    for (const errorReport of errorReports) {
+      if (errorReport.message) {
+        newErrorReports.push({ ...errorReport });
+      }
+    }
+    return newErrorReports;
   }
 
   info(title: string, info: string, isHtml = false): Observable<boolean> {

--- a/src/app/services/error-handler.service.ts
+++ b/src/app/services/error-handler.service.ts
@@ -79,7 +79,7 @@ export class ErrorHandlerService implements ErrorHandler {
     return {
       title: error.type || error.trace.class,
       message: error.reason,
-      backtrace: error.trace.formatted,
+      backtrace: error.trace?.formatted || '',
     };
   }
 


### PR DESCRIPTION
See ticket for testing instructions.

The problem was that when we ran that command or generally on reload, the `ReplaySubject` `lastGeneratedAuthToken$` would remember the last token value, which was invalid at this point. When we went back to the shell, it loaded the wrong token the first couple of times and shell failed to authenticate so it loaded a couple of empty pages before actually loading the right one.

This problem was also partially caused by the missing `take(1)` in the generated auth token repeated action pipe. We only wanted that sequence to execute once every time the timer ticks. But because of that missing `take(1)` pipe, every time the `isAuthenticated$` observable emitted a value, the sequence ran again which caused token to reload without need.

Just test that authentication works as normal and no major authentication errors arise in the UI. Also, that shell loads without the empty blank pages.