### PR TITLE
Revert "NAS-121402 / 23.10 / Upgrade node to hydrogen (18 LTS)"

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '16'
         cache: 'yarn'
     - name: Install packages
       shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ##NODE temporary builder image
-from node:18-buster as uibuilder
+from node:16-buster as uibuilder
 COPY ./ /src-ui
 WORKDIR /src-ui
 RUN yarn install --frozen-lockfile


### PR DESCRIPTION
Reverts truenas/webui#8054

Due to test failures:
```
TypeError: Cannot redefine property: window

    > 1 | import 'jest-canvas-mock';
```

The tests are passed in `18.15.x` and failed in `18.16.x`:
https://github.com/nodejs/node/issues/47563
https://github.com/nodejs/node/pull/46615