### PR TITLE
NAS-121679 / 23.10 / Update FirstUse state on Installed Apps

### DIFF
--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -19,7 +19,6 @@ import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.com
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ChartBulkUpgradeComponent } from 'app/pages/apps-old/dialogs/chart-bulk-upgrade/chart-bulk-upgrade.component';
 import { KubernetesSettingsComponent } from 'app/pages/apps-old/kubernetes-settings/kubernetes-settings.component';
-import { SelectPoolDialogComponent } from 'app/pages/apps-old/select-pool-dialog/select-pool-dialog.component';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
 import { DialogService } from 'app/services';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
@@ -159,13 +158,6 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
         this.entityEmptyConf.button = undefined;
         break;
       case EmptyType.FirstUse:
-        this.entityEmptyConf.title = helptext.message.not_configured;
-        this.entityEmptyConf.message = undefined;
-        this.entityEmptyConf.button = {
-          label: this.translate.instant('Choose Pool'),
-          action: () => this.choosePool(),
-        };
-        break;
       case EmptyType.NoPageData:
         this.entityEmptyConf.title = helptext.message.no_installed;
         this.entityEmptyConf.message = this.translate.instant('Applications you install will automatically appear here. Click below and browse available apps to get started.');
@@ -385,12 +377,5 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
 
   private redirectToAvailableApps(): void {
     this.router.navigate(['/apps', 'available']);
-  }
-
-  private choosePool(): void {
-    const dialog = this.matDialog.open(SelectPoolDialogComponent);
-    dialog.afterClosed().pipe(untilDestroyed(this)).subscribe(() => {
-      this.updateChartReleases();
-    });
   }
 }

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -19,6 +19,7 @@ import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.com
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ChartBulkUpgradeComponent } from 'app/pages/apps-old/dialogs/chart-bulk-upgrade/chart-bulk-upgrade.component';
 import { KubernetesSettingsComponent } from 'app/pages/apps-old/kubernetes-settings/kubernetes-settings.component';
+import { SelectPoolDialogComponent } from 'app/pages/apps-old/select-pool-dialog/select-pool-dialog.component';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
 import { DialogService } from 'app/services';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
@@ -160,8 +161,10 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
       case EmptyType.FirstUse:
         this.entityEmptyConf.title = helptext.message.not_configured;
         this.entityEmptyConf.message = undefined;
-        this.entityEmptyConf.button = undefined;
-        // TODO: Button to check available apps or open advanced settings?
+        this.entityEmptyConf.button = {
+          label: this.translate.instant('Choose Pool'),
+          action: () => this.choosePool(),
+        };
         break;
       case EmptyType.NoPageData:
         this.entityEmptyConf.title = helptext.message.no_installed;
@@ -382,5 +385,12 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
 
   private redirectToAvailableApps(): void {
     this.router.navigate(['/apps', 'available']);
+  }
+
+  private choosePool(): void {
+    const dialog = this.matDialog.open(SelectPoolDialogComponent);
+    dialog.afterClosed().pipe(untilDestroyed(this)).subscribe(() => {
+      this.updateChartReleases();
+    });
   }
 }


### PR DESCRIPTION
Add the `Choose Pool` button on the Installed Apps table on first use.

For testing, use a fresh system or `unset pool` to see the needed state.

![image](https://user-images.githubusercontent.com/351613/234471904-3e9da711-aa09-46d4-9728-8fd6dd2a8e1b.png)

After the pool is selected, you'll see the next state:
![image](https://user-images.githubusercontent.com/351613/234471959-71c58316-0b81-45ab-ac10-e6d5e1657df4.png)
