### PR TITLE
NAS-121681 / 23.10 / Shares cards (2 per row) bad visualization

### DIFF
--- a/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.ts
@@ -219,7 +219,7 @@ export class SharesDashboardComponent implements AfterViewInit {
             {
               name: helptextSharingNfs.column_enabled,
               prop: 'enabled',
-              width: '60px',
+              width: '100px',
               slideToggle: true,
               onChange: (row: NfsShare) => this.onSlideToggle(ShareType.Nfs, row, 'enabled'),
             },
@@ -324,7 +324,7 @@ export class SharesDashboardComponent implements AfterViewInit {
             {
               prop: 'enabled',
               name: helptextSharingWebdav.column_enabled,
-              width: '60px',
+              width: '100px',
               slideToggle: true,
               onChange: (row: WebDavShare) => this.onSlideToggle(ShareType.WebDav, row, 'enabled'),
             },
@@ -370,7 +370,7 @@ export class SharesDashboardComponent implements AfterViewInit {
             {
               name: helptextSharingSmb.column_enabled,
               prop: 'enabled',
-              width: '60px',
+              width: '100px',
               slideToggle: true,
               onChange: (row: SmbShare) => this.onSlideToggle(ShareType.Smb, row, 'enabled'),
             },


### PR DESCRIPTION
Before:
<img width="1728" alt="Screenshot 2023-04-26 at 10 43 48" src="https://user-images.githubusercontent.com/22980553/234513066-1b5ed6fd-4f45-44e3-a987-3e8a3bcf97ba.png">

After:
<img width="1728" alt="Screenshot 2023-04-26 at 10 54 20" src="https://user-images.githubusercontent.com/22980553/234513125-433f197e-ff13-4184-9dc5-53326660851c.png">
