### PR TITLE
NAS-120203 / 13.0 / Create/Edit Dataset > Fix Discrepancies between GUI and command line output of dataset checksum

### DIFF
--- a/src/app/pages/storage/volumes/datasets/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/storage/volumes/datasets/dataset-form/dataset-form.component.ts
@@ -1264,7 +1264,7 @@ export class DatasetFormComponent implements Formconfiguration {
               edit_deduplication_collection = [{ label: `Inherit (${this.parent_dataset.deduplication.rawvalue})`, value: 'INHERIT' }];
               edit_deduplication.options = edit_deduplication_collection.concat(edit_deduplication.options);
 
-              const edit_checksum_collection = [{ label: `Inherit (${this.parent_dataset.deduplication.rawvalue})`, value: 'INHERIT' }];
+              const edit_checksum_collection = [{ label: `Inherit (${this.parent_dataset.checksum.rawvalue})`, value: 'INHERIT' }];
               edit_checksum.options = edit_checksum_collection.concat(edit_checksum.options);
 
               edit_exec_collection = [{ label: `Inherit (${this.parent_dataset.exec.rawvalue})`, value: 'INHERIT' }];


### PR DESCRIPTION
**Testing**

On the **Create/Edit Dataset** form,

1. Create a pool `tank1` with the default options and a child dataset `tank1/test1` also with the default options. When creating the `tank1/test1` dataset, make sure that the GUI indicated "Checksum: inherit (on)" 
2. Go back to the “Edit Options” for the `tank1/test1` 

**Expected result:**

The value displayed in the WebUI should match the value returned by the call 
```
zfs get checksum tank1/test1
```

For more details please see ticket.