### PR TITLE
NAS-121738 / 23.10 / Snapshot Lifetime Unit Would Be Hidden If Custom ScheduleIs Too Long

### DIFF
--- a/src/app/modules/scheduler/components/scheduler/scheduler.component.scss
+++ b/src/app/modules/scheduler/components/scheduler/scheduler.component.scss
@@ -1,4 +1,4 @@
-host {
+:host {
   display: block;
   margin-bottom: 12px;
 }
@@ -25,6 +25,10 @@ host {
   ::ng-deep {
     mat-select .mat-mdc-select-value {
       padding: 5px 8px;
+    }
+
+    mat-select .mat-mdc-select-value-text {
+      white-space: initial;
     }
   }
 


### PR DESCRIPTION
Scheduler width & content is fixed like that:
<img width="814" alt="Screenshot 2023-05-05 at 14 11 52" src="https://user-images.githubusercontent.com/22980553/236443878-111f9fb9-70ac-42f2-8c91-3aec9272fb84.png">
