### PR TITLE
NAS-121844 / 23.10 / Make sure mock utility doesn't break UI

### DIFF
--- a/src/app/core/testing/utils/mock-enclosure.utils.ts
+++ b/src/app/core/testing/utils/mock-enclosure.utils.ts
@@ -23,10 +23,7 @@ export class MockEnclosureUtils {
 
   constructor() {
     const diskOptions = this.mockConfig?.diskOptions;
-
-    if (diskOptions?.mockPools) {
-      this.mockStorage = new MockStorageGenerator(diskOptions.mockPools);
-    }
+    this.mockStorage = new MockStorageGenerator(diskOptions.mockPools);
 
     // Add Pools and VDEVs
     if (diskOptions?.mockPools && diskOptions?.topologyOptions) {

--- a/src/app/services/ws.service.ts
+++ b/src/app/services/ws.service.ts
@@ -31,7 +31,7 @@ export class WebSocketService {
     protected router: Router,
     protected wsManager: WebsocketConnectionService,
   ) {
-    this.mockUtils = new MockEnclosureUtils();
+    if (environment.mockConfig && !environment?.production) this.mockUtils = new MockEnclosureUtils();
     this.wsManager.isConnected$?.pipe(untilDestroyed(this)).subscribe((isConnected) => {
       if (!isConnected) {
         this.clearSubscriptions();
@@ -60,10 +60,9 @@ export class WebSocketService {
         }
 
         if (
-          environment
-          && !environment.production
+          this.mockUtils
           && environment.mockConfig?.enabled
-          && this.mockUtils.canMock
+          && this.mockUtils?.canMock
           && data.msg === IncomingApiMessageType.Result
         ) {
           const mockResultMessage: ResultMessage = this.mockUtils.overrideMessage(data, method);

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,4 @@
 import { enableProdMode } from '@angular/core';
-import { MockEnclosureConfig } from 'app/core/testing/interfaces/mock-enclosure-utils.interface';
 import { WebUiEnvironment } from './environment.interface';
 import { environmentVersion } from './environment.version';
 
@@ -9,7 +8,6 @@ export const environment: WebUiEnvironment = {
   remote: document.location.host,
   production: true,
   sentryPublicDsn: 'https://7ac3e76fe2a94f77a58e1c38ea6b42d9@sentry.ixsystems.com/4',
-  mockConfig: {} as MockEnclosureConfig,
 };
 
 // Production


### PR DESCRIPTION
Removed a condition that broke UI if `mock-pool` was disabled

Try enabling/disabling `mock-enclosure` and `mock-disks` with and without `mock-pools` enabled
There should not be any combination that results in browser console error that breaks the UI