### PR TITLE
NAS-119945 / 22.12.3 / Save input decimals (by bvasilenko)

### DIFF
--- a/src/app/modules/ix-forms/services/ix-formatter.service.ts
+++ b/src/app/modules/ix-forms/services/ix-formatter.service.ts
@@ -14,7 +14,7 @@ export class IxFormatterService {
       return '';
     }
     value = value.toString();
-    return !value || Number.isNaN(Number(value)) ? '' : this.convertBytesToHumanReadable(value, 0);
+    return !value || Number.isNaN(Number(value)) ? '' : this.convertBytesToHumanReadable(value, 2);
   };
 
   /**
@@ -27,9 +27,9 @@ export class IxFormatterService {
     if (!value) {
       return null;
     }
-    const humanStringToNum = this.convertHumanStringToNum(value);
+    const humanStringToNum = this.convertHumanStringToNum(value, true);
     // Default unit is MiB so if the user passed in no unit, we assume unit is MiB
-    return (humanStringToNum !== Number(value)) ? humanStringToNum : this.convertHumanStringToNum(value + 'mb');
+    return (humanStringToNum !== Number(value)) ? humanStringToNum : this.convertHumanStringToNum(value + 'mb', true);
   };
 
   /**
@@ -62,7 +62,7 @@ export class IxFormatterService {
     } else {
       units = hideBytes ? '' : 'B';
     }
-    return `${bytes.toFixed(dec)} ${units}`;
+    return `${parseFloat(bytes.toFixed(dec))} ${units}`;
   };
 
   /**


### PR DESCRIPTION
**Testing**

At the **Capacity Settings** block,

Test using a decimal in the **Quota** and **Reserved** fields

Original PR: https://github.com/truenas/webui/pull/7643
Jira URL: https://ixsystems.atlassian.net/browse/NAS-119945