### PR TITLE
NAS-121738 / 22.12.3 / Snapshot Lifetime Unit Would Be Hidden If Custom ScheduleIs Too Long (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-forms/services/ix-formatter.service.ts
+++ b/src/app/modules/ix-forms/services/ix-formatter.service.ts
@@ -14,7 +14,7 @@ export class IxFormatterService {
       return '';
     }
     value = value.toString();
-    return !value || Number.isNaN(Number(value)) ? '' : this.convertBytesToHumanReadable(value, 0);
+    return !value || Number.isNaN(Number(value)) ? '' : this.convertBytesToHumanReadable(value, 2);
   };
 
   /**
@@ -27,9 +27,9 @@ export class IxFormatterService {
     if (!value) {
       return null;
     }
-    const humanStringToNum = this.convertHumanStringToNum(value);
+    const humanStringToNum = this.convertHumanStringToNum(value, true);
     // Default unit is MiB so if the user passed in no unit, we assume unit is MiB
-    return (humanStringToNum !== Number(value)) ? humanStringToNum : this.convertHumanStringToNum(value + 'mb');
+    return (humanStringToNum !== Number(value)) ? humanStringToNum : this.convertHumanStringToNum(value + 'mb', true);
   };
 
   /**
@@ -62,7 +62,7 @@ export class IxFormatterService {
     } else {
       units = hideBytes ? '' : 'B';
     }
-    return `${bytes.toFixed(dec)} ${units}`;
+    return `${parseFloat(bytes.toFixed(dec))} ${units}`;
   };
 
   /**

--- a/src/app/modules/scheduler/components/scheduler/scheduler.component.scss
+++ b/src/app/modules/scheduler/components/scheduler/scheduler.component.scss
@@ -1,4 +1,4 @@
-host {
+:host {
   display: block;
   margin-bottom: 12px;
 }
@@ -23,6 +23,16 @@ host {
   font-size: 12px;
   padding: 7px;
   position: relative;
+
+  ::ng-deep {
+    mat-select .mat-mdc-select-value {
+      padding: 5px 8px;
+    }
+
+    mat-select .mat-mdc-select-value-text {
+      white-space: initial;
+    }
+  }
 
   &:focus-within {
     border-color: var(--primary);


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 440027a2993263003b6f584c8db9cde4ce5c2d40

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 63c1fe7adfa52ceff3f8f6e99399f0cd6bbaf2da

Scheduler width & content is fixed like that:
<img width="814" alt="Screenshot 2023-05-05 at 14 11 52" src="https://user-images.githubusercontent.com/22980553/236443878-111f9fb9-70ac-42f2-8c91-3aec9272fb84.png">


Original PR: https://github.com/truenas/webui/pull/8154
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121738