### PR TITLE
Revert "NAS-121686 / 23.10 / Add usableUnusedDisks stream"

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/inventory/inventory.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/inventory/inventory.component.ts
@@ -25,7 +25,7 @@ export class InventoryComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.poolManagerStore.usableUnusedDisks$.pipe(untilDestroyed(this)).subscribe((unusedDisks) => {
+    this.poolManagerStore.unusedDisks$.pipe(untilDestroyed(this)).subscribe((unusedDisks) => {
       this.sizeDisksMap = {
         [DiskType.Hdd]: getSizeDisksMap(unusedDisks.filter((disk) => disk.type === DiskType.Hdd)),
         [DiskType.Ssd]: getSizeDisksMap(unusedDisks.filter((disk) => disk.type === DiskType.Ssd)),

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/create-data-wizard-step/create-data-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/create-data-wizard-step/create-data-wizard-step.component.ts
@@ -9,13 +9,13 @@ import _ from 'lodash';
 import {
   Observable,
   filter,
-  of, skipUntil, switchMap, take,
+  of, switchMap, take, takeWhile,
 } from 'rxjs';
 import { DiskType } from 'app/enums/disk-type.enum';
 import { CreateVdevLayout } from 'app/enums/v-dev-type.enum';
 import helptext from 'app/helptext/storage/volumes/manager/manager';
-import { RadioOption, SelectOption } from 'app/interfaces/option.interface';
-import { ManagerDisk } from 'app/pages/storage/components/manager/manager-disk.interface';
+import { SelectOption } from 'app/interfaces/option.interface';
+import { UnusedDisk } from 'app/interfaces/storage.interface';
 import {
   ManualDiskSelectionComponent, ManualDiskSelectionLayout,
 } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/manual-disk-selection.component';
@@ -37,7 +37,7 @@ export class CreateDataWizardStepComponent implements OnInit {
   @Input() form: PoolManagerWizardComponent['form']['controls']['data'];
 
   readonly manualDiskSelectionMessage = helptext.manual_disk_selection_message;
-  unusedDisks: ManagerDisk[] = [];
+  unusedDisks: UnusedDisk[] = [];
   sizeDisksMap: SizeDisksMap = { [DiskType.Hdd]: {}, [DiskType.Ssd]: {} };
 
   selectedDiskType: DiskType = null;
@@ -45,7 +45,7 @@ export class CreateDataWizardStepComponent implements OnInit {
   selectedWidth: number = null;
   selectedVdevsCount: number = null;
 
-  vdevLayoutOptions$: Observable<SelectOption<CreateVdevLayout>[]> = of([
+  vdevLayoutOptions$ = of([
     { label: 'Stripe', value: CreateVdevLayout.Stripe },
   ]);
 
@@ -54,7 +54,7 @@ export class CreateDataWizardStepComponent implements OnInit {
   numberOptions$: Observable<SelectOption[]> = of([]);
 
   readonly totalUsableCapacity$ = this.poolManagerStore.totalUsableCapacity$;
-  readonly dispersalOptions$: Observable<RadioOption[]> = of([
+  readonly dispersalOptions$ = of([
     {
       label: this.translate.instant('Minimize Enclosure Dispersal'),
       value: true,
@@ -74,9 +74,10 @@ export class CreateDataWizardStepComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.poolManagerStore.usableUnusedDisks$.pipe(
-      skipUntil(this.poolManagerStore.isLoading$),
-      take(1),
+    this.poolManagerStore.unusedDisks$.pipe(
+      takeWhile((unusedDisks) => {
+        return !unusedDisks?.length;
+      }, true),
       untilDestroyed(this),
     ).subscribe((disks) => {
       this.unusedDisks = disks;

--- a/src/app/pages/storage/modules/pool-manager/store/manual-disk-selection-store.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/manual-disk-selection-store.service.ts
@@ -53,7 +53,7 @@ export class ManualDiskSelectionStore extends ComponentStore<ManualDiskSelection
       }),
       switchMap(() => combineLatest([
         this.poolManagerStore$.select((state: PoolManagerState) => state.allUnusedDisks),
-        this.poolManagerStore$.usableUnusedDisks$,
+        this.poolManagerStore$.unusedDisks$,
         this.poolManagerStore$.enclosures$,
       ])),
       tap(([allUnusedDisks, unusedDisks, enclosures]) => {

--- a/src/app/pages/storage/modules/pool-manager/store/pools-manager-store.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pools-manager-store.service.ts
@@ -2,10 +2,7 @@ import { Injectable } from '@angular/core';
 import { ComponentStore, tapResponse } from '@ngrx/component-store';
 import { TranslateService } from '@ngx-translate/core';
 import filesize from 'filesize';
-import _ from 'lodash';
-import {
-  forkJoin, Observable, tap,
-} from 'rxjs';
+import { forkJoin, Observable, tap } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { PoolManagerDisk } from 'app/classes/pool-manager-disk.class';
 import { PoolManagerVdev } from 'app/classes/pool-manager-vdev.class';
@@ -65,36 +62,6 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
         .filter((disk) => !!disk.exported_zpool)
         .map((disk) => disk.exported_zpool)
         .filter((value, index, self) => self.indexOf(value) === index);
-    }),
-  );
-  readonly usableUnusedDisks$ = this.state$.pipe(
-    map((state) => {
-      const unusedDisks = [...state.unusedDisks];
-      const allowNonUniqueSerialDisks = state?.formValue?.general?.allowNonUniqueSerialDisks === 'true';
-      const allowUsageExportedPoolDisks = state?.formValue?.general?.allowDisksFromExportedPools?.length;
-      let usableDisks = unusedDisks.filter((disk) => !disk.duplicate_serial.length && !disk.exported_zpool);
-      if (allowNonUniqueSerialDisks) {
-        usableDisks = [
-          ...usableDisks,
-          ...unusedDisks
-            .filter((disk) => allowUsageExportedPoolDisks || !!disk.exported_zpool)
-            .filter((disk) => disk.duplicate_serial.length),
-        ];
-      }
-      if (allowUsageExportedPoolDisks) {
-        state.formValue.general.allowDisksFromExportedPools.forEach((poolName) => {
-          const exportedPoolDisks = unusedDisks
-            .filter((disk) => allowNonUniqueSerialDisks || !disk.duplicate_serial.length)
-            .filter((disk) => disk.exported_zpool === poolName);
-          if (exportedPoolDisks.length) {
-            usableDisks = _.uniq([
-              ...usableDisks,
-              ...exportedPoolDisks,
-            ]);
-          }
-        });
-      }
-      return usableDisks;
     }),
   );
 


### PR DESCRIPTION
Reverts truenas/webui#8141

The original PR leaves a couple of bugs that need to be addressed. Even if I do nothing and have a couple of disks in the inventory, they don't show up in the drop downs on the second step. Also, if I go back to the first step and mark some checkboxes, the second step options don't update.
Furthermore, the `take(1)` for `usableUnusedDisks$` from the store needs to be removed so when disks update the options can update. But removing that causes infinite emits from the selector because in that subscription we are updating form values which triggers state update which triggers `usableUnusedDisks$` update in an infinite loop.