### PR TITLE
NAS-120602 / 13.0 / Uncommanded reboot from logging into the web interface

### DIFF
--- a/src/app/components/common/topbar/topbar.component.ts
+++ b/src/app/components/common/topbar/topbar.component.ts
@@ -146,7 +146,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
           if (res && res.fields && res.fields.arguments[0] && res.fields.arguments[0].reboot) {
             this.systemWillRestart = true;
             if (res.fields.state === 'SUCCESS') {
-              this.router.navigate(['/others/reboot']);
+              this.router.navigate(['/others/reboot'], { skipLocationChange: true });
             }
           }
         }
@@ -320,7 +320,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
           buttonMsg: T('Shut Down'),
         }).subscribe((res) => {
           if (res) {
-            this.router.navigate(['/others/shutdown']);
+            this.router.navigate(['/others/shutdown'], { skipLocationChange: true });
           }
         });
       });
@@ -332,7 +332,7 @@ export class TopbarComponent extends ViewControllerComponent implements OnInit, 
       this.translate.get('Restart the system?').subscribe((reboot_prompt: string) => {
         this.dialogService.confirm(reboot, reboot_prompt, false, T('Restart')).subscribe((res) => {
           if (res) {
-            this.router.navigate(['/others/reboot']);
+            this.router.navigate(['/others/reboot'], { skipLocationChange: true });
           }
         });
       });

--- a/src/app/pages/system/general/general.component.ts
+++ b/src/app/pages/system/general/general.component.ts
@@ -620,7 +620,7 @@ export class GeneralComponent implements OnDestroy {
     dialogRef.componentInstance.wspost(parent.subs.apiEndPoint, formData);
     dialogRef.componentInstance.success.subscribe((res) => {
       dialogRef.close();
-      parent.router.navigate(['/others/reboot']);
+      parent.router.navigate(['/others/reboot'], { skipLocationChange: true });
     });
     dialogRef.componentInstance.failure.subscribe((res) => {
       dialogRef.componentInstance.setDescription(res.error);
@@ -629,7 +629,7 @@ export class GeneralComponent implements OnDestroy {
 
   resetConfigSubmit(entityDialog) {
     const parent = entityDialog.parent;
-    parent.router.navigate(new Array('').concat(['others', 'config-reset']));
+    parent.router.navigate(['others', 'config-reset'], { skipLocationChange: true });
   }
 
   customSubmit(body) {

--- a/src/app/pages/system/update/manualupdate/manualupdate.component.ts
+++ b/src/app/pages/system/update/manualupdate/manualupdate.component.ts
@@ -165,14 +165,14 @@ export class ManualUpdateComponent extends ViewControllerComponent {
         if (!this.isHA) {
           if (ures[0].attributes.preferences['rebootAfterManualUpdate']) {
             this.updateService.setForHardRefresh();
-            this.router.navigate(['/others/reboot']);
+            this.router.navigate(['/others/reboot'], { skipLocationChange: true });
           } else {
             this.translate.get('Restart').subscribe((reboot: string) => {
               this.translate.get(helptext.rebootAfterManualUpdate.manual_reboot_msg).subscribe((reboot_prompt: string) => {
                 this.dialogService.confirm(reboot, reboot_prompt).subscribe((reboot_res) => {
                   if (reboot_res) {
                     this.updateService.setForHardRefresh();
-                    this.router.navigate(['/others/reboot']);
+                    this.router.navigate(['/others/reboot'], { skipLocationChange: true });
                   }
                 });
               });
@@ -245,7 +245,7 @@ export class ManualUpdateComponent extends ViewControllerComponent {
     this.dialogRef.componentInstance.jobId = jobId;
     this.dialogRef.componentInstance.wsshow();
     this.dialogRef.componentInstance.success.subscribe((res) => {
-      this.router.navigate(['/others/reboot']);
+      this.router.navigate(['/others/reboot'], { skipLocationChange: true });
     });
     this.dialogRef.componentInstance.failure.subscribe((err) => {
       new EntityUtils().handleWSError(this, err, this.dialogService);

--- a/src/app/pages/system/update/update.component.ts
+++ b/src/app/pages/system/update/update.component.ts
@@ -401,7 +401,7 @@ export class UpdateComponent implements OnInit, OnDestroy {
     this.dialogRef.componentInstance.wsshow();
     this.dialogRef.componentInstance.success.subscribe((res) => {
       this.updateService.setForHardRefresh();
-      this.router.navigate(['/others/reboot']);
+      this.router.navigate(['/others/reboot'], { skipLocationChange: true });
     });
     this.dialogRef.componentInstance.failure.subscribe((err) => {
       new EntityUtils().handleWSError(this, err, this.dialogService);


### PR DESCRIPTION
To reproduce previous issue.
1. In `reboot.component.ts` replace add:
```
console.log('rebooted');
return;
```
before
```
this.ws.call('system.reboot', {})
```

2. Remove `{ skipLocationChange: true }` in `topbar.component.ts`.
3. Press reboot in UI.
4. Change address in browser to `http://localhost` and press Enter.
Observe that you are at reboot page again.