### PR TITLE
NAS-121773 / 23.10 / Show capacity for disks only on manage devices

### DIFF
--- a/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.spec.ts
+++ b/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.spec.ts
@@ -12,7 +12,7 @@ describe('TopologyItemNodeComponent', () => {
   let spectator: Spectator<TopologyItemNodeComponent>;
   const topologyDisk = {
     type: TopologyItemType.Disk,
-    path: null,
+    path: '/path/to/disk',
     guid: '123',
     status: TopologyItemStatus.Offline,
     stats: {

--- a/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.ts
+++ b/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.ts
@@ -5,7 +5,9 @@ import filesize from 'filesize';
 import { PoolStatus } from 'app/enums/pool-status.enum';
 import { TopologyItemType } from 'app/enums/v-dev-type.enum';
 import { TopologyItemStatus } from 'app/enums/vdev-status.enum';
-import { Disk, TopologyDisk, TopologyItem } from 'app/interfaces/storage.interface';
+import {
+  Disk, TopologyDisk, TopologyItem,
+} from 'app/interfaces/storage.interface';
 
 @UntilDestroy()
 @Component({
@@ -37,7 +39,7 @@ export class TopologyItemNodeComponent {
   }
 
   get capacity(): string {
-    return this.disk?.size ? filesize(this.disk.size, { standard: 'iec' }) : '';
+    return this.isDisk && this.disk?.size ? filesize(this.disk.size, { standard: 'iec' }) : '';
   }
 
   get errors(): string {


### PR DESCRIPTION
Remove the capacity value from VDEV items on the Manage Devices page.

An example
![image](https://github.com/truenas/webui/assets/351613/4cb496ea-1a63-4868-b7d2-804c265327c3)
