### PR TITLE
NAS-121848 / 23.10 / Fix missing mat-badges on topbar

### DIFF
--- a/src/app/modules/layout/components/topbar/jobs-indicator/jobs-indicator.component.html
+++ b/src/app/modules/layout/components/topbar/jobs-indicator/jobs-indicator.component.html
@@ -1,17 +1,15 @@
 <button
+  *appLet="jobBadgeCount$ | async as jobBadgeCount"
+  matBadgeSize="small"
+  matBadgeColor="warn"
   mat-icon-button
   id="task-manager"
   class="topbar-button-right"
   ixTest="jobs-manager"
+  [matBadge]="jobBadgeCount"
+  [matBadgeHidden]="jobBadgeCount === 0"
   [matTooltip]="tooltips.task_manager | translate"
   (click)="onIndicatorPressed()"
 >
-  <ix-icon
-    *appLet="jobBadgeCount$ | async as jobBadgeCount"
-    name="assignment"
-    matBadgeSize="small"
-    matBadgeColor="warn"
-    [matBadge]="jobBadgeCount"
-    [matBadgeHidden]="jobBadgeCount === 0"
-  ></ix-icon>
+  <ix-icon name="assignment"></ix-icon>
 </button>

--- a/src/app/modules/layout/components/topbar/jobs-indicator/jobs-indicator.component.spec.ts
+++ b/src/app/modules/layout/components/topbar/jobs-indicator/jobs-indicator.component.spec.ts
@@ -49,7 +49,7 @@ describe('JobsIndicatorComponent', () => {
     const icon = await iconButton.getHarness(MatIconHarness);
     expect(await icon.getName()).toMatch('assignment');
 
-    const badge = await iconButton.getHarness(MatBadgeHarness);
+    const badge = await loader.getHarness(MatBadgeHarness);
     expect(await badge.getText()).toBe('4');
   });
 

--- a/src/app/modules/layout/components/topbar/topbar.component.html
+++ b/src/app/modules/layout/components/topbar/topbar.component.html
@@ -122,20 +122,18 @@
 
       <!-- Alert toggle button -->
       <button
+        *appLet="alertBadgeCount$ | async as alertBadgeCount"
+        matBadgeSize="small"
+        matBadgeColor="warn"
         mat-icon-button
-        class="topbar-button-right overflow-visible"
+        class="topbar-button-right"
         ixTest="alerts-indicator"
+        [matBadge]="alertBadgeCount"
+        [matBadgeHidden]="alertBadgeCount === 0"
         [matTooltip]="tooltips.alerts | translate"
         (click)="onAlertIndicatorPressed()"
       >
-        <ix-icon
-          *appLet="alertBadgeCount$ | async as alertBadgeCount"
-          name="notifications"
-          matBadgeSize="small"
-          matBadgeColor="warn"
-          [matBadge]="alertBadgeCount"
-          [matBadgeHidden]="alertBadgeCount === 0"
-        ></ix-icon>
+        <ix-icon name="notifications"></ix-icon>
       </button>
 
       <ix-user-menu></ix-user-menu>

--- a/src/app/modules/layout/components/topbar/topbar.component.scss
+++ b/src/app/modules/layout/components/topbar/topbar.component.scss
@@ -47,9 +47,12 @@
   width: 50px;
 }
 
-.topbar-button-right {
-  &.overflow-visible {
-    overflow: visible;
+::ng-deep .topbar-button-right {
+  &.mat-badge.mat-badge-small.mat-badge-overlap.mat-badge-after {
+    .mat-badge-content {
+      right: 0;
+      top: 0;
+    }
   }
 }
 

--- a/src/app/modules/truecommand/truecommand-button.component.html
+++ b/src/app/modules/truecommand/truecommand-button.component.html
@@ -17,15 +17,13 @@
   *ngIf="tcStatus && tcStatus.status !== TrueCommandStatus.Connecting"
   mat-icon-button
   id="tc-status"
-  class="topbar-button-right"
+  class="topbar-button-right truecommand-button"
   ixTest="truecommand-indicator"
+  matBadgeSize="small"
   [matTooltip]="tooltips.tc_status | translate"
+  [matBadge]="tcsStatusMatBadge"
+  [ngClass]="[tcStatus.status]"
   (click)="handleClick()"
 >
-  <ix-icon
-    name="ix:logo_truecommand_white"
-    matBadgeSize="small"
-    [ngClass]="['truecommand-icon', tcStatus.status]"
-    [matBadge]="tcsStatusMatBadge"
-  ></ix-icon>
+  <ix-icon name="ix:logo_truecommand_white"></ix-icon>
 </button>

--- a/src/app/modules/truecommand/truecommand-button.component.scss
+++ b/src/app/modules/truecommand/truecommand-button.component.scss
@@ -17,14 +17,14 @@
   animation: nudge 3s infinite linear;
 }
 
-::ng-deep .ix-icon.truecommand-icon > span.mat-badge-content {
+::ng-deep .truecommand-button > span.mat-badge-content {
   font-family: 'Material Icons';
 }
 
-::ng-deep .ix-icon.truecommand-icon.CONNECTED > span.mat-badge-content {
+::ng-deep .truecommand-button.CONNECTED > span.mat-badge-content {
   background: var(--green);
 }
 
-::ng-deep .ix-icon.truecommand-icon.FAILED > span.mat-badge-content {
-  background: var(--warn);
+::ng-deep .truecommand-button.FAILED > span.mat-badge-content {
+  background: var(--red);
 }


### PR DESCRIPTION
A simple fix that moves badges to the upper level due to a bug in `ix-icon`. The issue with ix-icon will be resolved in another ticket - https://ixsystems.atlassian.net/browse/NAS-121890

For testing, check badges appear on the topbar (tc, jobs, alerts).