### PR TITLE
NAS-121914 / 13.0 / Fixed Expect Enter an option instead of https:// in boot.exp

### DIFF
--- a/tests/boot.exp
+++ b/tests/boot.exp
@@ -8,18 +8,7 @@ set PID [spawn vm console "$vm"]
 send_user "Spawned PID: $PID \n"
 
 expect {
-  "https://" {
-    sleep .5
-    exit 0
-  }
-
-  "login:" {
-    sleep .5
-  }
-}
-
-expect {
-  "https://" {
+  "Enter an option from 1-11:" {
     sleep .5
     exit 0
   }


### PR DESCRIPTION
This will fix the boot issue for 13.1. It should now affect the 13.0 boot since it is how it is set up for the 13.0 and 13.1 HA boot.