### PR TITLE
NAS-121675 / 23.10 / Adding User Auth key doesn't re-evaluate after home directory error - blanks Key on save, and doesn't close right panel

### DIFF
--- a/src/app/pages/account/users/user-form/user-form.component.spec.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.spec.ts
@@ -249,6 +249,10 @@ describe('UserFormComponent', () => {
       await saveButton.click();
 
       expect(ws.call).toHaveBeenCalledWith('user.update', [
+        69, { home: '/home/updated', home_create: true },
+      ]);
+
+      expect(ws.call).toHaveBeenCalledWith('user.update', [
         69,
         {
           email: null,
@@ -256,10 +260,8 @@ describe('UserFormComponent', () => {
           group: 102,
           groups: [102],
           home_mode: '755',
-          home: '/home/updated',
           locked: true,
           password_disabled: false,
-          home_create: true,
           shell: '/usr/bin/zsh',
           smb: false,
           ssh_password_enabled: true,

--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -272,7 +272,7 @@ export class UserFormComponent {
         this.isFormLoading = true;
         this.cdr.markForCheck();
 
-        let request$: Observable<unknown>;
+        let request$: Observable<number>;
         if (this.isNewUser) {
           request$ = this.ws.call('user.create', [{
             ...body,
@@ -289,6 +289,12 @@ export class UserFormComponent {
         }
 
         request$.pipe(
+          switchMap((id) => {
+            if (!this.isNewUser && body.home_create && body.sshpubkey) {
+              return this.ws.call('user.update', [id, { sshpubkey: body.sshpubkey }]);
+            }
+            return of(id);
+          }),
           switchMap((id) => this.ws.call('user.query', [[['id', '=', id]]])),
           map((users) => users[0]),
           untilDestroyed(this),

--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -273,6 +273,7 @@ export class UserFormComponent {
         this.cdr.markForCheck();
 
         let request$: Observable<number>;
+        let nextRequest$: Observable<number>;
         if (this.isNewUser) {
           request$ = this.ws.call('user.create', [{
             ...body,
@@ -285,16 +286,18 @@ export class UserFormComponent {
           if (passwordNotEmpty && !values.password_disabled) {
             body.password = values.password;
           }
-          request$ = this.ws.call('user.update', [this.editingUser.id, body]);
+          if (body.home_create) {
+            request$ = this.ws.call('user.update', [this.editingUser.id, { home_create: true, home: body.home }]);
+            delete body.home_create;
+            delete body.home;
+            nextRequest$ = this.ws.call('user.update', [this.editingUser.id, body]);
+          } else {
+            request$ = this.ws.call('user.update', [this.editingUser.id, body]);
+          }
         }
 
         request$.pipe(
-          switchMap((id) => {
-            if (!this.isNewUser && body.home_create && body.sshpubkey) {
-              return this.ws.call('user.update', [id, { sshpubkey: body.sshpubkey }]);
-            }
-            return of(id);
-          }),
+          switchMap((id) => nextRequest$ || of(id)),
           switchMap((id) => this.ws.call('user.query', [[['id', '=', id]]])),
           map((users) => users[0]),
           untilDestroyed(this),


### PR DESCRIPTION
**Summary**

Middleware does not support updating `home_create` simultaneously with any other property.
Make a separate `user.update` request for `home_create`.