### PR TITLE
NAS-122002 / 23.10 / ManualDiskSelectionStore cleanup

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-disks/manual-selection-disks.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-disks/manual-selection-disks.component.html
@@ -5,7 +5,7 @@
 <div 
   class="dnd-wrapper"
   dndDropzone
-  [ngClass]="{'drag-active': (store$.dragActive$ | async)}"
+  [ngClass]="{'drag-active': (dragToggleStore$.dragActive$ | async)}"
   (dndDrop)="onDrop($event)">
   <div
     class="tree-container"
@@ -21,7 +21,7 @@
       >
         <div
           class="unused-disk drag-handle"
-          [ngClass]="{ 'grabbed': store$.dragActive$ | async }"
+          [ngClass]="{ 'grabbed': dragToggleStore$.dragActive$ | async }"
           [dndDraggable]="asDisk(disk)"
           [dndEffectAllowed]="'move'"
           (dndStart)="onDragStart()"

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-disks/manual-selection-disks.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-disks/manual-selection-disks.component.ts
@@ -16,6 +16,7 @@ import {
 import {
   ManualSelectionDisk,
 } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/interfaces/manual-disk-selection.interface';
+import { ManualDiskDragToggleStore } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-drag-toggle.store';
 import { ManualDiskSelectionStore } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-selection.store';
 
 interface EnclosureDisk extends Disk {
@@ -53,7 +54,8 @@ export class ManualSelectionDisksComponent implements OnInit {
   constructor(
     private filesizePipe: FileSizePipe,
     private translate: TranslateService,
-    public store$: ManualDiskSelectionStore,
+    protected store$: ManualDiskSelectionStore,
+    protected dragToggleStore$: ManualDiskDragToggleStore,
   ) {}
 
   readonly isGroup = (i: number, node: DiskOrGroup): node is EnclosureGroup => 'group' in node;
@@ -152,19 +154,19 @@ export class ManualSelectionDisksComponent implements OnInit {
 
   onDrop(event: DndDropEvent): void {
     const disk = event.data as ManualSelectionDisk;
-    this.store$.toggleActivateDrag(false);
+    this.dragToggleStore$.toggleActivateDrag(false);
     this.store$.removeDiskFromVdev(disk);
   }
 
   onDragStart(): void {
-    this.store$.toggleActivateDrag(true);
+    this.dragToggleStore$.toggleActivateDrag(true);
   }
 
   onDragEnd(): void {
-    this.store$.toggleActivateDrag(false);
+    this.dragToggleStore$.toggleActivateDrag(false);
   }
 
   onDragCanceled(): void {
-    this.store$.toggleActivateDrag(false);
+    this.dragToggleStore$.toggleActivateDrag(false);
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-vdev/manual-selection-vdev.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-vdev/manual-selection-vdev.component.html
@@ -54,9 +54,9 @@
         </div>
       </div>
       <ix-label class="drag-hint" [label]="'Drag & drop disks to add or remove them' | translate"></ix-label>
-      <ix-label *ngIf="vdev.errorMsg" class="error" [label]="vdev.errorMsg"></ix-label>
+      <ix-label *ngIf="vdevErrMsg" class="error" [label]="vdevErrMsg"></ix-label>
       <ix-label
-        *ngIf="vdev.showDiskSizeError"
+        *ngIf="showDiskSizeError"
         class="error"
         [label]="'Mixing disks of different sizes in a vdev is not recommended.' | translate"
       ></ix-label>

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-vdev/manual-selection-vdev.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-vdev/manual-selection-vdev.component.html
@@ -3,7 +3,7 @@
     <div
       dndDropzone
       class="drag-container"
-      [ngClass]="{'drag-active': (store$.dragActive$ | async)}"
+      [ngClass]="{'drag-active': (dragToggleStore$.dragActive$ | async)}"
       (dndDrop)="onDrop($event)"
     >
       <div class="outer-container">
@@ -25,7 +25,7 @@
             <div class="disk-icons">
               <ix-disk-icon *ngFor="let disk of enclosureDisks.value"
                 class="disk-icon drag-handle"
-                [ngClass]="{ 'grabbed': store$.dragActive$ | async }"
+                [ngClass]="{ 'grabbed': dragToggleStore$.dragActive$ | async }"
                 [dndDraggable]="getMovableDisk(disk)"
                 [dndEffectAllowed]="'move'"
                 [disk]="disk"
@@ -38,7 +38,7 @@
           <div class="disk-icons no-enclosure">
             <ix-disk-icon *ngFor="let disk of nonEnclosureDisks"
               class="disk-icon drag-handle"
-              [ngClass]="{ 'grabbed': store$.dragActive$ | async }"
+              [ngClass]="{ 'grabbed': dragToggleStore$.dragActive$ | async }"
               [dndDraggable]="getMovableDisk(disk)"
               [dndEffectAllowed]="'move'"
               [disk]="disk"

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-vdev/manual-selection-vdev.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-vdev/manual-selection-vdev.component.ts
@@ -10,6 +10,7 @@ import {
   ManualSelectionDisk,
   ManualSelectionVdev,
 } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/interfaces/manual-disk-selection.interface';
+import { ManualDiskDragToggleStore as ManualDiskSelectionDragToggleStore } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-drag-toggle.store';
 import { ManualDiskSelectionStore } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-selection.store';
 import { minDisksPerLayout } from 'app/pages/storage/modules/pool-manager/utils/min-disks-per-layout.constant';
 
@@ -38,8 +39,9 @@ export class ManualSelectionVdevComponent implements OnChanges {
   }
   constructor(
     private cdr: ChangeDetectorRef,
-    public store$: ManualDiskSelectionStore,
+    protected store$: ManualDiskSelectionStore,
     private translate: TranslateService,
+    protected dragToggleStore$: ManualDiskSelectionDragToggleStore,
   ) { }
 
   ngOnChanges(): void {
@@ -124,15 +126,15 @@ export class ManualSelectionVdevComponent implements OnChanges {
   }
 
   onDragStart(): void {
-    this.store$.toggleActivateDrag(true);
+    this.dragToggleStore$.toggleActivateDrag(true);
   }
 
   onDragEnd(): void {
-    this.store$.toggleActivateDrag(false);
+    this.dragToggleStore$.toggleActivateDrag(false);
   }
 
   onDragCanceled(): void {
-    this.store$.toggleActivateDrag(false);
+    this.dragToggleStore$.toggleActivateDrag(false);
   }
 
   deleteVdev(): void {
@@ -148,7 +150,7 @@ export class ManualSelectionVdevComponent implements OnChanges {
       this.store$.removeDiskFromVdev(disk);
     }
     this.store$.addDiskToVdev({ disk, vdev: this.vdev });
-    this.store$.toggleActivateDrag(false);
+    this.dragToggleStore$.toggleActivateDrag(false);
     this.cdr.markForCheck();
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-vdev/manual-selection-vdev.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-vdev/manual-selection-vdev.component.ts
@@ -1,7 +1,8 @@
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges,
 } from '@angular/core';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { UntilDestroy } from '@ngneat/until-destroy';
+import { TranslateService } from '@ngx-translate/core';
 import { DndDropEvent } from 'ngx-drag-drop';
 import { GiB, MiB } from 'app/constants/bytes.constant';
 import { CreateVdevLayout } from 'app/enums/v-dev-type.enum';
@@ -19,10 +20,12 @@ import { minDisksPerLayout } from 'app/pages/storage/modules/pool-manager/utils/
   styleUrls: ['./manual-selection-vdev.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ManualSelectionVdevComponent implements OnInit {
+export class ManualSelectionVdevComponent implements OnChanges {
   @Input() vdev: ManualSelectionVdev;
   @Input() layout: CreateVdevLayout;
   @Input() swapondrive = 2;
+  vdevErrMsg = '';
+  showDiskSizeError = false;
 
   enclosuresDisks = new Map<number, ManualSelectionDisk[]>();
   nonEnclosureDisks: ManualSelectionDisk[] = [];
@@ -36,26 +39,36 @@ export class ManualSelectionVdevComponent implements OnInit {
   constructor(
     private cdr: ChangeDetectorRef,
     public store$: ManualDiskSelectionStore,
+    private translate: TranslateService,
   ) { }
 
-  ngOnInit(): void {
-    this.store$.vdevs$.pipe(untilDestroyed(this)).subscribe(() => {
-      this.enclosuresDisks = new Map();
-      this.nonEnclosureDisks = [];
-      for (const disk of this.vdev?.disks) {
-        if (disk.enclosure?.number || disk.enclosure?.number === 0) {
-          let enclosureDisks = this.enclosuresDisks.get(disk.enclosure.number);
-          if (!enclosureDisks) {
-            enclosureDisks = [];
-          }
-          this.enclosuresDisks.set(disk.enclosure.number, [...enclosureDisks, disk]);
-        } else {
-          this.nonEnclosureDisks.push(disk);
+  ngOnChanges(): void {
+    let vdevErrorMsg: string = null;
+    if (this.vdev.disks?.length < this.minDisks[this.layout]) {
+      const typeKey = Object.entries(CreateVdevLayout).filter(
+        ([, value]) => value === this.layout,
+      ).map(([key]) => key)[0];
+      vdevErrorMsg = this.translate.instant(
+        'Atleast {min} disk(s) are required for {vdevType} vdevs',
+        { min: this.minDisks[this.layout], vdevType: typeKey },
+      );
+    }
+    this.vdevErrMsg = vdevErrorMsg;
+
+    this.enclosuresDisks = new Map();
+    this.nonEnclosureDisks = [];
+    for (const disk of this.vdev?.disks) {
+      if (disk.enclosure?.number || disk.enclosure?.number === 0) {
+        let enclosureDisks = this.enclosuresDisks.get(disk.enclosure.number);
+        if (!enclosureDisks) {
+          enclosureDisks = [];
         }
+        this.enclosuresDisks.set(disk.enclosure.number, [...enclosureDisks, disk]);
+      } else {
+        this.nonEnclosureDisks.push(disk);
       }
-      this.estimateSize(this.vdev);
-      this.cdr.markForCheck();
-    });
+    }
+    this.estimateSize(this.vdev);
   }
 
   getMovableDisk(disk: ManualSelectionDisk): ManualSelectionDisk {
@@ -71,18 +84,18 @@ export class ManualSelectionVdevComponent implements OnInit {
     let smallestdisk = 0;
     let estimate = 0;
     const swapsize = this.swapondrive * GiB;
-    vdev.showDiskSizeError = false;
+    this.showDiskSizeError = false;
     for (let i = 0; i < vdev.disks.length; i++) {
-      const size = vdev.disks[i].real_capacity - swapsize;
+      const size = vdev.disks[i].size - swapsize;
       stripeSize += size;
       if (i === 0) {
         smallestdisk = size;
       }
       const tenMib = 10 * MiB;
       if (size > smallestdisk + tenMib || size < smallestdisk - tenMib) {
-        vdev.showDiskSizeError = true;
+        this.showDiskSizeError = true;
       }
-      if (vdev.disks[i].real_capacity < smallestdisk) {
+      if (vdev.disks[i].size < smallestdisk) {
         smallestdisk = size;
       }
     }

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/interfaces/manual-disk-selection.interface.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/interfaces/manual-disk-selection.interface.ts
@@ -3,14 +3,10 @@ import { UnusedDisk } from 'app/interfaces/storage.interface';
 // TODO: Clear out unused properties
 export interface ManualSelectionDisk extends UnusedDisk {
   vdevUuid: string;
-  real_capacity: number;
 }
 
 export interface ManualSelectionVdev {
   disks: ManualSelectionDisk[];
   uuid?: string;
-  showDiskSizeError: boolean;
   rawSize: number;
-  vdevDisksError: boolean;
-  errorMsg: string;
 }

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-drag-toggle.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-drag-toggle.store.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { ComponentStore } from '@ngrx/component-store';
+
+export interface ManualDiskDragToggleState {
+  dragActive: boolean;
+}
+
+const initialState: ManualDiskDragToggleState = {
+  dragActive: false,
+};
+
+@Injectable()
+export class ManualDiskDragToggleStore extends ComponentStore<ManualDiskDragToggleState> {
+  readonly dragActive$ = this.select((state) => state.dragActive);
+
+  constructor() {
+    super(initialState);
+  }
+
+  toggleActivateDrag = this.updater((state: ManualDiskDragToggleState, activateDrag: boolean) => {
+    return {
+      dragActive: activateDrag,
+    };
+  });
+}

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-selection.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-selection.store.ts
@@ -120,10 +120,7 @@ export class ManualDiskSelectionStore extends ComponentStore<ManualDiskSelection
     const vdevs = _.cloneDeep(state.vdevs).filter((vdev) => vdev.uuid !== vdevToRemove.uuid);
     const inventory = _.cloneDeep(state.inventory);
     for (const disk of vdevToRemove.disks) {
-      const diskAlreadyExists = inventory.some(
-        (unusedDisk) => unusedDisk.identifier === disk.identifier,
-      );
-      if (!diskAlreadyExists) {
+      if (!inventory.some((unusedDisk) => unusedDisk.identifier === disk.identifier)) {
         inventory.push(_.cloneDeep(disk));
       }
     }

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-selection.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-selection.store.ts
@@ -86,11 +86,12 @@ export class ManualDiskSelectionStore extends ComponentStore<ManualDiskSelection
 
       return newVdev;
     });
-    const newDisk = _.cloneDeep(disk);
-    newDisk.vdevUuid = null;
 
     const inventory = _.cloneDeep(state.inventory);
-    if (!inventory.some((unusedDisk) => unusedDisk.identifier === newDisk.identifier)) {
+    const isDiskAlreadyInInventory = inventory.some((unusedDisk) => unusedDisk.identifier === disk.identifier);
+    if (!isDiskAlreadyInInventory) {
+      const newDisk = _.cloneDeep(disk);
+      newDisk.vdevUuid = null;
       inventory.push(newDisk);
     }
     return {
@@ -120,8 +121,11 @@ export class ManualDiskSelectionStore extends ComponentStore<ManualDiskSelection
     const vdevs = _.cloneDeep(state.vdevs).filter((vdev) => vdev.uuid !== vdevToRemove.uuid);
     const inventory = _.cloneDeep(state.inventory);
     for (const disk of vdevToRemove.disks) {
-      if (!inventory.some((unusedDisk) => unusedDisk.identifier === disk.identifier)) {
-        inventory.push(_.cloneDeep(disk));
+      const isDiskAlreadyInInventory = inventory.some((unusedDisk) => unusedDisk.identifier === disk.identifier);
+      if (!isDiskAlreadyInInventory) {
+        const newDisk = _.cloneDeep(disk);
+        newDisk.vdevUuid = null;
+        inventory.push(newDisk);
       }
     }
     return {

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/utils/vdevs-to-manual-selection-vdevs.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/utils/vdevs-to-manual-selection-vdevs.utils.ts
@@ -16,10 +16,7 @@ export function vdevsToManualSelectionVdevs(vdevs: UnusedDisk[][]): ManualSelect
         };
       }),
       uuid: vdevId,
-      showDiskSizeError: false,
       rawSize: 0,
-      vdevDisksError: false,
-      errorMsg: '',
     };
   });
 }

--- a/src/app/pages/storage/modules/pool-manager/pool-manager.module.ts
+++ b/src/app/pages/storage/modules/pool-manager/pool-manager.module.ts
@@ -25,6 +25,7 @@ import { DiskInfoComponent } from 'app/pages/storage/modules/pool-manager/compon
 import { EnclosureWrapperComponent } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/enclosure-wrapper/enclosure-wrapper.component';
 import { ManualSelectionVdevComponent } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-vdev/manual-selection-vdev.component';
 import { ManualDiskSelectionComponent } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/manual-disk-selection.component';
+import { ManualDiskDragToggleStore } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-drag-toggle.store';
 import { ManualDiskSelectionStore } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/store/manual-disk-selection.store';
 import { PoolManagerWizardComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component';
 import { GeneralWizardStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/1-general-wizard-step/general-wizard-step.component';
@@ -88,6 +89,7 @@ import { DataWizardStepComponent } from './components/pool-manager-wizard/steps/
   providers: [
     PoolManagerStore,
     ManualDiskSelectionStore,
+    ManualDiskDragToggleStore,
     GenerateVdevsService,
   ],
 })


### PR DESCRIPTION
See ticket for details

ManualDiskSelectionDragToggleStore exists because if it is part of the old store, when updating the toggle boolean, as we update the state (because of the immutable patterns, we can't just update one boolean. The whole state has to be a new object), the vdevs gets cloned, which means they are considered updated and get re-rendered on the dom and the dragging can't work because the view we were trying to drag got destroyed in the process. So, drag toggle has to exist in a separate store.

Will add tests in a separate PR.