### PR TITLE
NAS-120108 / 22.12.3 / Extract enclosure visualizations on new disk info

### DIFF
--- a/src/app/pages/system/view-enclosure/components/view-enclosure/view-enclosure.component.ts
+++ b/src/app/pages/system/view-enclosure/components/view-enclosure/view-enclosure.component.ts
@@ -274,6 +274,7 @@ export class ViewEnclosureComponent implements AfterViewInit, OnDestroy {
       this.system.pools = pools;
       this.events.next({ name: 'PoolsChanged', sender: this });
       this.addViews();
+      this.extractVisualizations();
     });
   }
 }


### PR DESCRIPTION
To Test this requires an enterprise server with an expansion shelf.

Try adding or removing a disk. In either case the visualizations in both the main  content card and the enclosure selector card on the right should reflect the changed state