### PR TITLE
NAS-122137 / 23.10 / Fix reporting dropdown menu

### DIFF
--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.html
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.html
@@ -1,4 +1,4 @@
-<form class="reports-toolbar" [formGroup]="form">
+<form *ngIf="allTabs.length" class="reports-toolbar" [formGroup]="form">
   <ng-container *ngIf="activeTab?.value === ReportType.Disk">
     <ix-select
       formControlName="devices"
@@ -39,7 +39,7 @@
         mat-menu-item
         [ixTest]="['category', tab.label]"
         [class.selected]="isActiveTab(tab)"
-        (click)="onNavigateToTab(tab)"
+        [routerLink]="['/reportsdashboard', tab.value]"
       >{{ tab.label | translate }}</button>
     </div>
   </mat-menu>

--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
@@ -63,9 +63,9 @@ export class ReportsGlobalControlsComponent implements OnInit {
   }
 
   private setupTabs(): void {
-    this.reportsService.getReportTabs().pipe(untilDestroyed(this)).subscribe((tabs) => {
-      this.allTabs = tabs;
-      this.activeTab = tabs.find((tab) => tab.value === this.route.routeConfig.path);
+    this.reportsService.getReportGraphs().pipe(untilDestroyed(this)).subscribe(() => {
+      this.allTabs = this.reportsService.getReportTabs();
+      this.activeTab = this.allTabs.find((tab) => tab.value === this.route.routeConfig.path);
       this.cdr.markForCheck();
     });
   }

--- a/src/app/pages/reports-dashboard/reports-dashboard.component.ts
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { combineLatest } from 'rxjs';
+import { combineLatest, of } from 'rxjs';
 import { ReportingGraphName } from 'app/enums/reporting-graph-name.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { Option } from 'app/interfaces/option.interface';
@@ -46,7 +46,7 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, AfterViewIn
 
     combineLatest([
       this.reportsService.getReportGraphs(),
-      this.reportsService.getReportTabs(),
+      of(this.reportsService.getReportTabs()),
     ])
       .pipe(untilDestroyed(this))
       .subscribe(([reports, tabs]) => {

--- a/src/app/pages/reports-dashboard/reports-dashboard.component.ts
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.ts
@@ -4,7 +4,6 @@ import {
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { combineLatest, of } from 'rxjs';
 import { ReportingGraphName } from 'app/enums/reporting-graph-name.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { Option } from 'app/interfaces/option.interface';
@@ -44,13 +43,10 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, AfterViewIn
     this.scrollContainer = this.layoutService.getContentContainer();
     this.scrollContainer.style.overflow = 'hidden';
 
-    combineLatest([
-      this.reportsService.getReportGraphs(),
-      of(this.reportsService.getReportTabs()),
-    ])
+    this.reportsService.getReportGraphs()
       .pipe(untilDestroyed(this))
-      .subscribe(([reports, tabs]) => {
-        this.allTabs = tabs;
+      .subscribe((reports) => {
+        this.allTabs = this.reportsService.getReportTabs();
         this.allReports = reports.map((report) => {
           const list = [];
           if (report.identifiers) {

--- a/src/app/pages/reports-dashboard/reports.service.ts
+++ b/src/app/pages/reports-dashboard/reports.service.ts
@@ -2,7 +2,7 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { addSeconds } from 'date-fns';
 import {
-  map, Observable, shareReplay, BehaviorSubject, switchMap, interval,
+  map, Observable, shareReplay, BehaviorSubject, switchMap, interval, of, withLatestFrom,
 } from 'rxjs';
 import { ReportingGraphName } from 'app/enums/reporting-graph-name.enum';
 import { CoreEvent } from 'app/interfaces/events';
@@ -40,10 +40,10 @@ export class ReportsService implements OnDestroy {
   serverTime: Date;
   private reportingGraphs$ = new BehaviorSubject<ReportingGraph[]>([]);
   private diskMetrics$ = new BehaviorSubject<Option[]>([]);
+  private hasUps$ = new BehaviorSubject<boolean>(false);
+  private hasDiskTemperature$ = new BehaviorSubject<boolean>(false);
+  private hasTarget$ = new BehaviorSubject<boolean>(false);
   private reportsUtils: Worker;
-  private hasUps = false;
-  private hasDiskTemperature = false;
-  private hasTarget = false;
 
   constructor(
     private ws: WebSocketService,
@@ -95,13 +95,13 @@ export class ReportsService implements OnDestroy {
     };
 
     this.ws.call('reporting.graphs').subscribe((reportingGraphs) => {
-      this.hasUps = reportingGraphs.some((graph) => graph.name === ReportingGraphName.Ups);
-      this.hasTarget = reportingGraphs.some((graph) => graph.name === ReportingGraphName.Target);
+      this.hasUps$.next(reportingGraphs.some((graph) => graph.name === ReportingGraphName.Ups));
+      this.hasTarget$.next(reportingGraphs.some((graph) => graph.name === ReportingGraphName.Target));
       this.reportingGraphs$.next(reportingGraphs);
     });
 
     this.ws.call('disk.temperatures').subscribe((values) => {
-      this.hasDiskTemperature = Boolean(Object.values(values).filter(Boolean).length);
+      this.hasDiskTemperature$.next(Boolean(Object.values(values).filter(Boolean).length));
     });
 
     this.store$
@@ -145,22 +145,23 @@ export class ReportsService implements OnDestroy {
     return data;
   }
 
-  getReportTabs(): ReportTab[] {
-    return Array.from(reportTypeLabels)
-      .filter(([value]) => {
-        if (value === ReportType.Ups && !this.hasUps) {
-          return false;
-        }
+  getReportTabs(): Observable<ReportTab[]> {
+    return of(Array.from(reportTypeLabels)).pipe(
+      withLatestFrom(this.hasUps$, this.hasTarget$, this.hasDiskTemperature$),
+      map(([tabs, hasUps, hasTarget]) => {
+        return tabs.filter(([value]) => {
+          if (value === ReportType.Ups && !hasUps) {
+            return false;
+          }
 
-        if (value === ReportType.Target && !this.hasTarget) {
-          return false;
-        }
+          if (value === ReportType.Target && !hasTarget) {
+            return false;
+          }
 
-        return true;
-      })
-      .map(([value, label]) => {
-        return { value, label } as ReportTab;
-      });
+          return true;
+        }).map(([value, label]) => ({ value, label }));
+      }),
+    );
   }
 
   getDiskDevices(): Observable<Option[]> {
@@ -188,7 +189,7 @@ export class ReportsService implements OnDestroy {
   getDiskMetrics(): Observable<Option[]> {
     return this.diskMetrics$.asObservable().pipe(
       map((options) => {
-        if (!this.hasDiskTemperature) {
+        if (!this.hasDiskTemperature$.value) {
           return options.filter((option) => option.value !== 'disktemp');
         }
 


### PR DESCRIPTION
The issue is missing menu items in the dropdown menu, such as UPS and Target, when reports are available.

For testing, find a system with UPS or mock it in the `reports.service.ts`.

```
this.ws.call('reporting.graphs').subscribe((reportingGraphs) => {
      reportingGraphs.push({
        name: 'ups',
        title: 'UPS',
        vertical_label: 'Requests',
        identifiers: [
          'demand_data',
          'demand_metadata',
          'prefetch_data',
          'prefetch_metadata',
        ],
        stacked: true,
        stacked_show_total: true,
      });
      reportingGraphs.push({
        name: 'ctl',
        title: 'Target',
        vertical_label: 'Requests',
        identifiers: [
          'demand_data',
          'demand_metadata',
          'prefetch_data',
          'prefetch_metadata',
        ],
        stacked: true,
        stacked_show_total: true,
      });
      this.hasUps$.next(reportingGraphs.some((graph) => graph.name === ReportingGraphName.Ups));
      this.hasTarget$.next(reportingGraphs.some((graph) => graph.name === ReportingGraphName.Target));
      this.reportingGraphs$.next(reportingGraphs);
    });
```