### PR TITLE
NAS-122198 / 23.10 / Fix active state for Reporting menu item

### DIFF
--- a/src/app/services/navigation/navigation.service.ts
+++ b/src/app/services/navigation/navigation.service.ts
@@ -117,7 +117,7 @@ export class NavigationService {
       type: MenuItemType.Link,
       tooltip: T('Reports'),
       icon: 'insert_chart',
-      state: 'reportsdashboard/cpu',
+      state: 'reportsdashboard',
     },
     {
       name: T('System Settings'),


### PR DESCRIPTION
For more context, follow the original ticket.

For testing, go to Reporting and check if the side nav menu item is active, then change the report type using the dropdown menu and check it again.