### PR TITLE
NAS-122137 / 22.12.3 / Fix reporting dropdown menu (by denysbutenko)

### DIFF
--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.html
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.html
@@ -1,4 +1,4 @@
-<form class="reports-toolbar" [formGroup]="form">
+<form *ngIf="allTabs.length" class="reports-toolbar" [formGroup]="form">
   <ng-container *ngIf="activeTab?.value === ReportType.Disk">
     <ix-select
       formControlName="devices"
@@ -43,7 +43,7 @@
         ix-auto-type="option"
         [ix-auto-identifier]="tab.label"
         [class.selected]="isActiveTab(tab)"
-        (click)="onNavigateToTab(tab)"
+        [routerLink]="['/reportsdashboard', tab.value]"
       >{{ tab.label | translate }}</button>
     </div>
   </mat-menu>

--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
@@ -1,5 +1,6 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component, EventEmitter, OnInit, Output,
 } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
@@ -30,7 +31,7 @@ export class ReportsGlobalControlsComponent implements OnInit {
   });
   activeTab: ReportTab;
   selectedDisks: string[];
-  allTabs: ReportTab[] = this.reportsService.getReportTabs();
+  allTabs: ReportTab[];
   diskDevices$ = this.reportsService.getDiskDevices();
   diskMetrics$ = this.reportsService.getDiskMetrics();
   @Output() diskOptionsChanged = new EventEmitter<{ devices: string[]; metrics: string[] }>();
@@ -44,10 +45,11 @@ export class ReportsGlobalControlsComponent implements OnInit {
     private store$: Store<AppState>,
     private reportsService: ReportsService,
     private slideIn: IxSlideInService,
+    private cdr: ChangeDetectorRef,
   ) {}
 
   ngOnInit(): void {
-    this.activeTab = this.allTabs.find((tab) => tab.value === this.route.routeConfig.path);
+    this.setupTabs();
     this.setAutoRefreshControl();
     this.setupDisksTab();
   }
@@ -56,12 +58,16 @@ export class ReportsGlobalControlsComponent implements OnInit {
     this.slideIn.open(ReportsConfigFormComponent);
   }
 
-  onNavigateToTab(tab: ReportTab): void {
-    this.router.navigate(['/reportsdashboard', tab.value]);
-  }
-
   isActiveTab(tab: ReportTab): boolean {
     return this.activeTab?.value === tab.value;
+  }
+
+  private setupTabs(): void {
+    this.reportsService.getReportGraphs().pipe(untilDestroyed(this)).subscribe(() => {
+      this.allTabs = this.reportsService.getReportTabs();
+      this.activeTab = this.allTabs.find((tab) => tab.value === this.route.routeConfig.path);
+      this.cdr.markForCheck();
+    });
   }
 
   private setupDisksTab(): void {

--- a/src/app/pages/reports-dashboard/reports-dashboard.component.ts
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.ts
@@ -111,10 +111,6 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, AfterViewIn
     }
   }
 
-  navigateToTab(tab: ReportTab): void {
-    this.router.navigate(['/reportsdashboard', tab.value]);
-  }
-
   activateTab(activeTab: ReportTab): void {
     const reportCategories = activeTab.value === ReportType.Disk ? this.diskReports : this.otherReports.filter(
       (report) => {

--- a/src/app/pages/reports-dashboard/reports-dashboard.component.ts
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.ts
@@ -2,9 +2,7 @@ import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import {
   Component, ElementRef, OnInit, OnDestroy, AfterViewInit, ViewChild, TemplateRef, Inject,
 } from '@angular/core';
-import {
-  Router, ActivatedRoute,
-} from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { format } from 'date-fns';
@@ -38,10 +36,9 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, AfterViewIn
   otherReports: Report[] = [];
   activeReports: Report[] = [];
   visibleReports: number[] = [];
-  allTabs: ReportTab[] = this.reportsService.getReportTabs();
+  allTabs: ReportTab[];
 
   constructor(
-    private router: Router,
     private route: ActivatedRoute,
     private translate: TranslateService,
     private layoutService: LayoutService,
@@ -67,6 +64,7 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, AfterViewIn
     this.reportsService.getReportGraphs()
       .pipe(untilDestroyed(this))
       .subscribe((reports) => {
+        this.allTabs = this.reportsService.getReportTabs();
         this.allReports = reports.map((report) => {
           const list = [];
           if (report.identifiers) {
@@ -96,7 +94,7 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy, AfterViewIn
   }
 
   activateTabFromUrl(): void {
-    const subpath = this.route.snapshot.url[0] && this.route.snapshot.url[0].path;
+    const subpath = this.route.snapshot?.url[0]?.path;
     const tabFound = this.allTabs.find((tab) => tab.value === subpath);
     this.updateActiveTab(tabFound || this.allTabs[0]);
   }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 2c65f59223cb939c2978d3d1cb57238e9d3eddce
    git cherry-pick -x 9dce31810b1ff421d672ab9a5f5360dfae66492f
    git cherry-pick -x 7a92aa09a22d9f0e788b7944a6f32a0a36e83386

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x f37076989e9dc15d101923d88beec106958ec744

The issue is missing menu items in the dropdown menu, such as UPS and Target, when reports are available.

For testing, find a system with UPS or mock it in the `reports.service.ts`.

```
this.ws.call('reporting.graphs').subscribe((reportingGraphs) => {
      reportingGraphs.push({
        name: 'ups',
        title: 'UPS',
        vertical_label: 'Requests',
        identifiers: [
          'demand_data',
          'demand_metadata',
          'prefetch_data',
          'prefetch_metadata',
        ],
        stacked: true,
        stacked_show_total: true,
      });
      reportingGraphs.push({
        name: 'ctl',
        title: 'Target',
        vertical_label: 'Requests',
        identifiers: [
          'demand_data',
          'demand_metadata',
          'prefetch_data',
          'prefetch_metadata',
        ],
        stacked: true,
        stacked_show_total: true,
      });
      this.hasUps$.next(reportingGraphs.some((graph) => graph.name === ReportingGraphName.Ups));
      this.hasTarget$.next(reportingGraphs.some((graph) => graph.name === ReportingGraphName.Target));
      this.reportingGraphs$.next(reportingGraphs);
    });
```

Original PR: https://github.com/truenas/webui/pull/8241
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122137