### PR TITLE
NAS-118894 / 23.10 / WebUI changes in Data Protection Section

### DIFF
--- a/src/app/modules/entity/table/table.component.html
+++ b/src/app/modules/entity/table/table.component.html
@@ -123,6 +123,7 @@
                   <button
                     *ngSwitchCase="'state-button'"
                     mat-stroked-button
+                    class="state-button"
                     [ixTest]="[element[column.prop], 'state']"
                     [ngClass]="getButtonClass(element[column.prop])"
                     (click)="$event.stopPropagation(); onButtonClick(element)"

--- a/src/app/modules/entity/table/table.component.scss
+++ b/src/app/modules/entity/table/table.component.scss
@@ -19,6 +19,10 @@ mat-card-content.table-container {
   cursor: pointer;
 }
 
+.state-button {
+  line-height: initial;
+}
+
 .mat-header-cell,
 .mat-cell {
   &:not(:first-child):not(:last-child) {

--- a/src/app/modules/entity/table/table.component.ts
+++ b/src/app/modules/entity/table/table.component.ts
@@ -334,7 +334,6 @@ implements OnInit, AfterViewInit, AfterViewChecked {
 
     switch (state) {
       case JobState.Pending:
-      case JobState.Running:
       case JobState.Aborted:
         return 'fn-theme-orange';
       case JobState.Finished:
@@ -346,6 +345,7 @@ implements OnInit, AfterViewInit, AfterViewChecked {
       case JobState.Locked:
       case JobState.Hold:
         return 'fn-theme-yellow';
+      case JobState.Running:
       default:
         return 'fn-theme-primary';
     }

--- a/src/app/pages/data-protection/data-protection-dashboard.component.ts
+++ b/src/app/pages/data-protection/data-protection-dashboard.component.ts
@@ -151,8 +151,10 @@ export class DataProtectionDashboardComponent implements OnInit {
           dataSourceHelper: (data: ScrubTaskUi[]) => this.scrubDataSourceHelper(data),
           emptyEntityLarge: false,
           columns: [
-            { name: this.translate.instant('Pool'), prop: 'pool_name' },
-            { name: this.translate.instant('Description'), prop: 'description', hiddenIfEmpty: true },
+            { name: this.translate.instant('Pool'), prop: 'pool_name', enableMatTooltip: true },
+            {
+              name: this.translate.instant('Description'), prop: 'description', hiddenIfEmpty: true, enableMatTooltip: true,
+            },
             { name: this.translate.instant('Frequency'), prop: 'frequency', enableMatTooltip: true },
             { name: this.translate.instant('Next Run'), prop: 'next_run', enableMatTooltip: true },
             {
@@ -256,7 +258,7 @@ export class DataProtectionDashboardComponent implements OnInit {
           getActions: this.getReplicationActions.bind(this),
           isActionVisible: this.isActionVisible,
           columns: [
-            { name: this.translate.instant('Name'), prop: 'name' },
+            { name: this.translate.instant('Name'), prop: 'name', enableMatTooltip: true },
             { name: this.translate.instant('Last Snapshot'), prop: 'task_last_snapshot', enableMatTooltip: true },
             {
               name: this.translate.instant('Enabled'),
@@ -296,7 +298,7 @@ export class DataProtectionDashboardComponent implements OnInit {
           getActions: this.getCloudsyncActions.bind(this),
           isActionVisible: this.isActionVisible,
           columns: [
-            { name: this.translate.instant('Description'), prop: 'description' },
+            { name: this.translate.instant('Description'), prop: 'description', enableMatTooltip: true },
             { name: this.translate.instant('Frequency'), prop: 'frequency', enableMatTooltip: true },
             { name: this.translate.instant('Next Run'), prop: 'next_run', enableMatTooltip: true },
             {
@@ -334,8 +336,8 @@ export class DataProtectionDashboardComponent implements OnInit {
             key_props: ['remotehost', 'remotemodule'],
           },
           columns: [
-            { name: this.translate.instant('Path'), prop: 'path' },
-            { name: this.translate.instant('Remote Host'), prop: 'remotehost' },
+            { name: this.translate.instant('Path'), prop: 'path', enableMatTooltip: true },
+            { name: this.translate.instant('Remote Host'), prop: 'remotehost', enableMatTooltip: true },
             { name: this.translate.instant('Frequency'), prop: 'frequency', enableMatTooltip: true },
             { name: this.translate.instant('Next Run'), prop: 'next_run', enableMatTooltip: true },
             {
@@ -378,8 +380,8 @@ export class DataProtectionDashboardComponent implements OnInit {
           dataSourceHelper: (data: SmartTestTaskUi[]) => this.smartTestsDataSourceHelper(data),
           parent: this,
           columns: [
-            { name: helptext_smart.smartlist_column_disks, prop: 'disksLabel' },
-            { name: helptext_smart.smartlist_column_type, prop: 'type' },
+            { name: helptext_smart.smartlist_column_disks, prop: 'disksLabel', enableMatTooltip: true },
+            { name: helptext_smart.smartlist_column_type, prop: 'type', enableMatTooltip: true },
             { name: helptext_smart.smartlist_column_description, prop: 'desc', hiddenIfEmpty: true },
             { name: helptext_smart.smartlist_column_frequency, prop: 'frequency', enableMatTooltip: true },
             { name: helptext_smart.smartlist_column_next_run, prop: 'next_run', enableMatTooltip: true },

--- a/src/app/pages/data-protection/data-protection-dashboard.component.ts
+++ b/src/app/pages/data-protection/data-protection-dashboard.component.ts
@@ -154,7 +154,7 @@ export class DataProtectionDashboardComponent implements OnInit {
             { name: this.translate.instant('Pool'), prop: 'pool_name' },
             { name: this.translate.instant('Description'), prop: 'description', hiddenIfEmpty: true },
             { name: this.translate.instant('Frequency'), prop: 'frequency', enableMatTooltip: true },
-            { name: this.translate.instant('Next Run'), prop: 'next_run', width: '110px' },
+            { name: this.translate.instant('Next Run'), prop: 'next_run', enableMatTooltip: true },
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
@@ -198,10 +198,10 @@ export class DataProtectionDashboardComponent implements OnInit {
             key_props: ['dataset', 'naming_schema', 'keepfor'],
           },
           columns: [
-            { name: this.translate.instant('Pool/Dataset'), prop: 'dataset' },
-            { name: this.translate.instant('Keep for'), prop: 'keepfor' },
+            { name: this.translate.instant('Pool/Dataset'), prop: 'dataset', enableMatTooltip: true },
+            { name: this.translate.instant('Keep for'), prop: 'keepfor', enableMatTooltip: true },
             { name: this.translate.instant('Frequency'), prop: 'frequency', enableMatTooltip: true },
-            { name: this.translate.instant('Next Run'), prop: 'next_run' },
+            { name: this.translate.instant('Next Run'), prop: 'next_run', enableMatTooltip: true },
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
@@ -209,11 +209,7 @@ export class DataProtectionDashboardComponent implements OnInit {
               checkbox: true,
               onChange: (row: PeriodicSnapshotTaskUi) => this.onCheckboxToggle(TaskCardId.Snapshot, row, 'enabled'),
             },
-            {
-              name: this.translate.instant('State'),
-              prop: 'state',
-              button: true,
-            },
+            { name: this.translate.instant('State'), prop: 'state', button: true },
           ],
           dataSourceHelper: (data: PeriodicSnapshotTaskUi[]) => this.snapshotDataSourceHelper(data),
           isActionVisible: this.isActionVisible,
@@ -261,7 +257,7 @@ export class DataProtectionDashboardComponent implements OnInit {
           isActionVisible: this.isActionVisible,
           columns: [
             { name: this.translate.instant('Name'), prop: 'name' },
-            { name: this.translate.instant('Last Snapshot'), prop: 'task_last_snapshot' },
+            { name: this.translate.instant('Last Snapshot'), prop: 'task_last_snapshot', enableMatTooltip: true },
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
@@ -269,11 +265,7 @@ export class DataProtectionDashboardComponent implements OnInit {
               checkbox: true,
               onChange: (row: ReplicationTaskUi) => this.onCheckboxToggle(TaskCardId.Replication, row as TaskTableRow, 'enabled'),
             },
-            {
-              name: this.translate.instant('State'),
-              prop: 'state',
-              button: true,
-            },
+            { name: this.translate.instant('State'), prop: 'state', button: true },
           ],
           parent: this,
           add: () => {
@@ -306,23 +298,15 @@ export class DataProtectionDashboardComponent implements OnInit {
           columns: [
             { name: this.translate.instant('Description'), prop: 'description' },
             { name: this.translate.instant('Frequency'), prop: 'frequency', enableMatTooltip: true },
-            {
-              name: this.translate.instant('Next Run'),
-              prop: 'next_run',
-              width: '80px',
-            },
+            { name: this.translate.instant('Next Run'), prop: 'next_run', enableMatTooltip: true },
             {
               name: this.translate.instant('Enabled'),
-              width: '80px',
               prop: 'enabled',
               checkbox: true,
+              width: '80px',
               onChange: (row: CloudSyncTaskUi) => this.onCheckboxToggle(TaskCardId.CloudSync, row, 'enabled'),
             },
-            {
-              name: this.translate.instant('State'),
-              prop: 'state',
-              button: true,
-            },
+            { name: this.translate.instant('State'), prop: 'state', button: true },
           ],
           parent: this,
           add: () => {
@@ -353,7 +337,7 @@ export class DataProtectionDashboardComponent implements OnInit {
             { name: this.translate.instant('Path'), prop: 'path' },
             { name: this.translate.instant('Remote Host'), prop: 'remotehost' },
             { name: this.translate.instant('Frequency'), prop: 'frequency', enableMatTooltip: true },
-            { name: this.translate.instant('Next Run'), prop: 'next_run' },
+            { name: this.translate.instant('Next Run'), prop: 'next_run', enableMatTooltip: true },
             {
               name: this.translate.instant('Enabled'),
               prop: 'enabled',
@@ -361,11 +345,7 @@ export class DataProtectionDashboardComponent implements OnInit {
               checkbox: true,
               onChange: (row: RsyncTaskUi) => this.onCheckboxToggle(TaskCardId.Rsync, row as TaskTableRow, 'enabled'),
             },
-            {
-              name: this.translate.instant('State'),
-              prop: 'state',
-              button: true,
-            },
+            { name: this.translate.instant('State'), prop: 'state', button: true },
           ],
           dataSourceHelper: (data: RsyncTaskUi[]) => this.rsyncDataSourceHelper(data),
           getActions: this.getRsyncActions.bind(this),
@@ -398,24 +378,11 @@ export class DataProtectionDashboardComponent implements OnInit {
           dataSourceHelper: (data: SmartTestTaskUi[]) => this.smartTestsDataSourceHelper(data),
           parent: this,
           columns: [
-            {
-              name: helptext_smart.smartlist_column_disks,
-              prop: 'disksLabel',
-            },
-            {
-              name: helptext_smart.smartlist_column_type,
-              prop: 'type',
-            },
+            { name: helptext_smart.smartlist_column_disks, prop: 'disksLabel' },
+            { name: helptext_smart.smartlist_column_type, prop: 'type' },
             { name: helptext_smart.smartlist_column_description, prop: 'desc', hiddenIfEmpty: true },
-            {
-              name: helptext_smart.smartlist_column_frequency,
-              prop: 'frequency',
-              enableMatTooltip: true,
-            },
-            {
-              name: helptext_smart.smartlist_column_next_run,
-              prop: 'next_run',
-            },
+            { name: helptext_smart.smartlist_column_frequency, prop: 'frequency', enableMatTooltip: true },
+            { name: helptext_smart.smartlist_column_next_run, prop: 'next_run', enableMatTooltip: true },
           ],
           add: () => {
             const slideInRef = this.slideInService.open(SmartTaskFormComponent);


### PR DESCRIPTION
Added more tooltips for easier reading of data.
<img width="1727" alt="Screenshot 2023-05-30 at 15 54 30" src="https://github.com/truenas/webui/assets/22980553/e003c4cf-5016-48a8-9fe7-75d7078253e6">

Running button colour updated (instead of orange):
<img width="727" alt="Screenshot 2023-05-30 at 15 55 58" src="https://github.com/truenas/webui/assets/22980553/16ca3b4a-140a-41ce-bfdd-a4a072f09a01">
