### PR TITLE
NAS-120187 / 23.10 / Unable to set static IP address on secondary interface

### DIFF
--- a/src/app/pages/network/components/interface-form/interface-form.component.html
+++ b/src/app/pages/network/components/interface-form/interface-form.component.html
@@ -180,6 +180,8 @@
                   [tooltip]="helptext.failover_virtual_alias_address_tooltip | translate"
                 ></ix-input>
               </ng-container>
+
+              <ix-errors [control]="network"></ix-errors>
             </div>
           </ix-list-item>
         </ix-list>

--- a/src/app/pages/network/components/interface-form/interface-form.component.scss
+++ b/src/app/pages/network/components/interface-form/interface-form.component.scss
@@ -2,6 +2,11 @@
   margin-left: 12px;
   margin-right: 12px;
 
+  ix-errors {
+    display: block;
+    margin-bottom: 15px;
+  }
+
   .alias-ip {
     margin-top: 0;
   }


### PR DESCRIPTION
error is shown now:
<img width="484" alt="Screenshot 2023-05-31 at 17 19 55" src="https://github.com/truenas/webui/assets/22980553/7d7bfbd5-9263-4662-b75d-7f70b5e14d2e">
