### PR TITLE
NAS-122116 / 23.10 / No Error/notification of duplicate CSR when trying to save

### DIFF
--- a/src/app/services/error-handler.service.ts
+++ b/src/app/services/error-handler.service.ts
@@ -77,8 +77,8 @@ export class ErrorHandlerService implements ErrorHandler {
 
   parseWsError(error: WebsocketError): ErrorReport {
     return {
-      title: error.type || error.trace.class,
-      message: error.reason,
+      title: error.type || error.trace?.class,
+      message: error.reason || error?.error.toString(),
       backtrace: error.trace?.formatted || '',
     };
   }


### PR DESCRIPTION
For current fix it's okay to show modal, but in future we need to fix this TODO:

// TODO: Need to update error handler to open step with an error.
**src/app/pages/credentials/certificates-dash/csr-add/csr-add.component.ts**

<img width="626" alt="Screenshot 2023-05-31 at 18 24 58" src="https://github.com/truenas/webui/assets/22980553/e2e7d3ea-1e52-4360-9a64-aff1801ffd18">


<img width="1728" alt="Screenshot 2023-05-31 at 18 21 27" src="https://github.com/truenas/webui/assets/22980553/1bba874f-d537-4d17-b9e6-8d26957301be">
