### PR TITLE
NAS-122215 / 23.10 / Handling resumable errors during updates (by undsoft)

### DIFF
--- a/src/app/helptext/system/update.ts
+++ b/src/app/helptext/system/update.ts
@@ -33,6 +33,9 @@ export const helptextSystemUpdate = {
     message: T('Error submitting file'),
   },
 
+  continueDialogTitle: T('Warning'),
+  continueDialogAction: T('Continue with the upgrade'),
+
   clickForInformationLink: T('Click for information on\
     <a href="https://www.truenas.com/docs/truenasupgrades/" target="_blank">TrueNAS SCALE Migration, Nightly trains\
     and other upgrade options.</a>'),

--- a/src/app/interfaces/api-directory.interface.ts
+++ b/src/app/interfaces/api-directory.interface.ts
@@ -111,7 +111,12 @@ import {
 } from 'app/interfaces/dns-authenticator.interface';
 import { DsUncachedGroup, DsUncachedUser } from 'app/interfaces/ds-cache.interface';
 import { Enclosure } from 'app/interfaces/enclosure.interface';
-import { FailoverConfig, FailoverRemoteCall, FailoverUpdate } from 'app/interfaces/failover.interface';
+import {
+  FailoverConfig,
+  FailoverRemoteCall,
+  FailoverUpdate,
+  FailoverUpgradeParams,
+} from 'app/interfaces/failover.interface';
 import { FileRecord, ListdirQueryParams } from 'app/interfaces/file-record.interface';
 import { FilesystemPutParams, FileSystemStat, Statfs } from 'app/interfaces/filesystem-stat.interface';
 import { FtpConfig, FtpConfigUpdate } from 'app/interfaces/ftp-config.interface';
@@ -502,7 +507,7 @@ export type ApiDirectory = {
   'failover.config': { params: void; response: FailoverConfig };
   'failover.sync_to_peer': { params: [{ reboot?: boolean }]; response: void };
   'failover.upgrade_finish': { params: void; response: boolean };
-  'failover.upgrade': { params: void; response: boolean };
+  'failover.upgrade': { params: [FailoverUpgradeParams]; response: boolean };
 
   // Keychain Credential
   'keychaincredential.create': { params: [KeychainCredentialCreate]; response: KeychainCredential };
@@ -962,6 +967,7 @@ export type ApiDirectory = {
   'update.set_train': { params: [train: string]; response: void };
   'update.download': { params: void; response: boolean };
   'update.update': { params: [UpdateParams]; response: void };
+  'update.file': { params: [{ resume: boolean }?]; response: void };
 
   // ZFS
   'zfs.snapshot.create': { params: [CreateZfsSnapshot]; response: ZfsSnapshot };

--- a/src/app/interfaces/failover.interface.ts
+++ b/src/app/interfaces/failover.interface.ts
@@ -19,3 +19,8 @@ export interface FailoverRemoteCallParams {
   job_return?: boolean;
   callback?: unknown;
 }
+
+export interface FailoverUpgradeParams {
+  resume?: boolean;
+  resume_manual?: boolean;
+}

--- a/src/app/interfaces/system-update.interface.ts
+++ b/src/app/interfaces/system-update.interface.ts
@@ -40,4 +40,5 @@ export interface SystemUpdateTrain {
 
 export interface UpdateParams {
   reboot: boolean;
+  resume?: boolean;
 }

--- a/src/app/pages/system/update/update-again-code.constant.ts
+++ b/src/app/pages/system/update/update-again-code.constant.ts
@@ -1,0 +1,4 @@
+/**
+ * Indicates presence of a resumable error during the update.
+ */
+export const updateAgainCode = '[EAGAIN]';

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -719,6 +719,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -527,6 +527,7 @@
   "Content Commitment": "",
   "Contents of the uploaded Service Account JSON file.": "",
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
+  "Continue with the upgrade": "",
   "Control": "",
   "Controller Type": "",
   "Controls whether the user used for SSH/SSH+NETCAT replication will have passwordless sudo enabled to execute zfs commands on the remote host.    If not checked, <i>zfs allow</i> must be used to grant non-user permissions to perform ZFS tasks. Mounting ZFS filesystems by non-root still would not be possible due to Linux restrictions.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -197,6 +197,7 @@
   "Connect": "",
   "Connect using:": "",
   "Connecting to TrueNAS": "",
+  "Continue with the upgrade": "",
   "Control": "",
   "Controller Type": "",
   "Controls whether the user used for SSH/SSH+NETCAT replication will have passwordless sudo enabled to execute zfs commands on the remote host.    If not checked, <i>zfs allow</i> must be used to grant non-user permissions to perform ZFS tasks. Mounting ZFS filesystems by non-root still would not be possible due to Linux restrictions.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -697,6 +697,7 @@
   "Contents of the uploaded Service Account JSON file.": "",
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -34,6 +34,7 @@
   "Choose <i>Master</i> if the UPS is plugged directly      into the system serial port. The UPS will remain the      last item to shut down. Choose <i>Slave</i> to have      this system shut down before <i>Master</i>. See the      <a href=\"{url}\"      target=\"_blank\">Network UPS Tools Overview</a>.": "",
   "Click for information on    <a href=\"https://www.truenas.com/docs/truenasupgrades/\" target=\"_blank\">TrueNAS SCALE Migration, Nightly trains    and other upgrade options.</a>": "",
   "Commits in the last 60 days": "",
+  "Continue with the upgrade": "",
   "Controls whether the user used for SSH/SSH+NETCAT replication will have passwordless sudo enabled to execute zfs commands on the remote host.    If not checked, <i>zfs allow</i> must be used to grant non-user permissions to perform ZFS tasks. Mounting ZFS filesystems by non-root still would not be possible due to Linux restrictions.": "",
   "Cron job created": "",
   "Cron job updated": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -637,6 +637,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -587,6 +587,7 @@
   "Containers": "",
   "Content Commitment": "",
   "Contents of the uploaded Service Account JSON file.": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -263,6 +263,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -776,6 +776,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -6,6 +6,7 @@
   "Bucket Name": "",
   "Capabilities": "",
   "Choose <i>Master</i> if the UPS is plugged directly      into the system serial port. The UPS will remain the      last item to shut down. Choose <i>Slave</i> to have      this system shut down before <i>Master</i>. See the      <a href=\"{url}\"      target=\"_blank\">Network UPS Tools Overview</a>.": "",
+  "Continue with the upgrade": "",
   "Discover": "",
   "Discover Apps": "",
   "Enclosure Options": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -725,6 +725,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -714,6 +714,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -728,6 +728,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -330,6 +330,7 @@
   "Container Name": "",
   "Containers": "",
   "Content Commitment": "",
+  "Continue with the upgrade": "",
   "Controller Type": "",
   "Controls whether the user used for SSH/SSH+NETCAT replication will have passwordless sudo enabled to execute zfs commands on the remote host.    If not checked, <i>zfs allow</i> must be used to grant non-user permissions to perform ZFS tasks. Mounting ZFS filesystems by non-root still would not be possible due to Linux restrictions.": "",
   "Controls whether the volume snapshot devices under /dev/zvol/⟨pool⟩  are hidden or visible. The default value is hidden.": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -16,6 +16,7 @@
   "Catalog is being added. This may take some time. You can minimize this dialog and process will continue in background": "",
   "Certificate request signed": "",
   "Choose <i>Master</i> if the UPS is plugged directly      into the system serial port. The UPS will remain the      last item to shut down. Choose <i>Slave</i> to have      this system shut down before <i>Master</i>. See the      <a href=\"{url}\"      target=\"_blank\">Network UPS Tools Overview</a>.": "",
+  "Continue with the upgrade": "",
   "Cron job created": "",
   "Cron job updated": "",
   "Dashboard settings saved": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -782,6 +782,7 @@
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Continue": "",
   "Continue with download?": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -38,6 +38,7 @@
   "Choose a path to the user's home directory. If the directory exists and matches the username, it is set as the user's home directory. When the path does not end with a subdirectory matching the username, a new subdirectory is created only if the 'Create Home Directory' field is marked checked. The full path to the user's home directory is shown here when editing a user.": "",
   "Commits in the last 60 days": "",
   "Configuration Preview": "",
+  "Continue with the upgrade": "",
   "Create Home Directory": "",
   "Create a new home directory for user within the selected path.": "",
   "Custom ({customTransfers})": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -561,6 +561,7 @@
   "Content Commitment": "",
   "Contents of the uploaded Service Account JSON file.": "",
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
+  "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
   "Controller Type": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 948933021b0f3f7319c5150122ca4cfbdc208970

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x a8f624fa610cbe034f4be7a43d66969310973c6e

Testing:
1. Have a Bluefin machine with latest nightly.
2. In services enable auto start for DynamicDNS.
3. Update to Cobia nightly using manual update file.

Original PR: https://github.com/truenas/webui/pull/8258
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122215