### PR TITLE
NAS-122219 / 23.10 / Update FTP form options

### DIFF
--- a/src/app/modules/ix-forms/components/ix-input/ix-input.component.ts
+++ b/src/app/modules/ix-forms/components/ix-input/ix-input.component.ts
@@ -36,6 +36,7 @@ export class IxInputComponent implements ControlValueAccessor, OnChanges {
   @Input() type: string;
   @Input() autocomplete = 'off';
   @Input() autocompleteOptions: Option[];
+  @Input() postfix?: string;
 
   /**
    * @deprecated Avoid using. Use valueChanges.
@@ -45,7 +46,7 @@ export class IxInputComponent implements ControlValueAccessor, OnChanges {
   /** If formatted value returned by parseAndFormatInput has non-numeric letters
    * and input 'type' is a number, the input will stay empty on the form */
   @Input() format: (value: string | number) => string;
-  @Input() parse: (value: string | number) => string | number;
+  @Input() parse: (value: string | number, postfix?: string) => string | number;
 
   @ViewChild('ixInput') inputElementRef: ElementRef<HTMLInputElement>;
 
@@ -101,7 +102,7 @@ export class IxInputComponent implements ControlValueAccessor, OnChanges {
     this.value = value;
     this.formatted = value;
     if (value && this.parse) {
-      this.value = this.parse(value);
+      this.value = this.parse(value, this.postfix);
     }
     this.onChange(this.value);
     this.filterOptions();
@@ -169,7 +170,7 @@ export class IxInputComponent implements ControlValueAccessor, OnChanges {
     this.onTouch();
     if (this.formatted) {
       if (this.parse) {
-        this.value = this.parse(this.formatted);
+        this.value = this.parse(this.formatted, this.postfix);
         this.formatted = this.value;
       }
       if (this.format) {

--- a/src/app/modules/ix-forms/services/ix-formatter.service.ts
+++ b/src/app/modules/ix-forms/services/ix-formatter.service.ts
@@ -27,13 +27,16 @@ export class IxFormatterService {
    * @param value The value to be parsed
    * @returns The parsed value
    */
-  memorySizeParsing: (val: string) => number = (value: string) => {
+  memorySizeParsing: (val: string, postfixValue?: string) => number = (value: string, postfix: string) => {
     if (!value) {
       return null;
     }
-    const humanStringToNum = this.convertHumanStringToNum(value, true);
+
+    const finalValue = `${value} ${!Number(value) ? '' : postfix || ''}`.trim();
+    const humanStringToNum = this.convertHumanStringToNum(finalValue, true);
+
     // Default unit is MiB so if the user passed in no unit, we assume unit is MiB
-    return (humanStringToNum !== Number(value)) ? humanStringToNum : this.convertHumanStringToNum(value + 'mb', true);
+    return (humanStringToNum !== Number(finalValue)) ? humanStringToNum : this.convertHumanStringToNum(finalValue + 'mb', true);
   };
 
   /**
@@ -43,8 +46,6 @@ export class IxFormatterService {
    * @param minUnits If no unit is provided, what minimum base unit should be assumed
    * @param hideBytes If the value is in bytes, should the 'B' sign be added
    * @returns A human readable string with appropriate units
-  /**
-   * @deprecated Use Filesize pipe
    */
   convertBytesToHumanReadable = (
     rawBytes: number | string,

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.html
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.html
@@ -267,6 +267,7 @@
           <ix-fieldset [title]="'Bandwidth' | translate">
             <ix-input
               formControlName="localuserbw"
+              postfix="KiB"
               [label]="helptext.localuserbw_placeholder | translate"
               [tooltip]="helptext.userbw_tooltip | translate"
               [format]="iecFormatter.memorySizeFormatting"
@@ -275,6 +276,7 @@
 
             <ix-input
               formControlName="localuserdlbw"
+              postfix="KiB"
               [label]="'Local User Download Bandwidth' | translate"
               [tooltip]="helptext.userbw_tooltip | translate"
               [format]="iecFormatter.memorySizeFormatting"
@@ -283,6 +285,7 @@
 
             <ix-input
               formControlName="anonuserbw"
+              postfix="KiB"
               [label]="'Anonymous User Upload Bandwidth' | translate"
               [tooltip]="helptext.userbw_tooltip | translate"
               [format]="iecFormatter.memorySizeFormatting"
@@ -291,6 +294,7 @@
 
             <ix-input
               formControlName="anonuserdlbw"
+              postfix="KiB"
               [label]="'Anonymous User Download Bandwidth' | translate"
               [tooltip]="helptext.userbw_tooltip | translate"
               [format]="iecFormatter.memorySizeFormatting"

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.spec.ts
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.spec.ts
@@ -158,7 +158,6 @@ describe('ServiceFtpComponent', () => {
       'Masquerade Address': '192.168.1.110',
       'Display Login': 'Welcome',
       'Auxiliary Parameters': '--test=value',
-
       'Local User Upload Bandwidth: (Examples: 500 KiB, 500M, 2 TB)': '1 MiB',
       'Local User Download Bandwidth': '2 MiB',
       'Anonymous User Upload Bandwidth': '3 MiB',

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.spec.ts
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.spec.ts
@@ -20,7 +20,7 @@ describe('ServiceFtpComponent', () => {
   const existingFtpConfig = {
     anonpath: '/mnt/x',
     anonuserbw: 3145728,
-    anonuserdlbw: 4194304,
+    anonuserdlbw: 5120,
     banner: 'Welcome',
     clients: 5,
     defaultroot: true,
@@ -162,7 +162,7 @@ describe('ServiceFtpComponent', () => {
       'Local User Upload Bandwidth: (Examples: 500 KiB, 500M, 2 TB)': '1 MiB',
       'Local User Download Bandwidth': '2 MiB',
       'Anonymous User Upload Bandwidth': '3 MiB',
-      'Anonymous User Download Bandwidth': '4 MiB',
+      'Anonymous User Download Bandwidth': '5 KiB',
     });
   });
 
@@ -181,7 +181,7 @@ describe('ServiceFtpComponent', () => {
     expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith('ftp.update', [{
       ...existingFtpConfig,
       tls_opt_ip_address_required: true,
-      anonuserdlbw: 5242880,
+      anonuserdlbw: 5120,
     }]);
   });
 


### PR DESCRIPTION
For testing use http://localhost:4200/services/ftp

Advanced options (input now defaults to KiB instead of MiB if no unit specified manually)

<img width="497" alt="Screenshot 2023-06-07 at 18 37 48" src="https://github.com/truenas/webui/assets/22980553/ae0d2e96-e939-45f1-8706-df7ebc117ad4">
