### PR TITLE
NAS-121985 / 23.10 / Add Feedback Module

### DIFF
--- a/src/app/modules/ix-feedback/feedback-dialog/feedback-dialog.component.scss
+++ b/src/app/modules/ix-feedback/feedback-dialog/feedback-dialog.component.scss
@@ -2,6 +2,16 @@
   display: block;
   max-width: 100%;
   width: 500px;
+
+  ::ng-deep {
+    ix-textarea {
+      textarea {
+        max-height: 40vh;
+        min-height: 7vh;
+        min-width: 96.5%;
+      }
+    }
+  }
 }
 
 .close-feedback-dialog {

--- a/src/app/modules/ix-feedback/feedback-dialog/feedback-dialog.component.scss
+++ b/src/app/modules/ix-feedback/feedback-dialog/feedback-dialog.component.scss
@@ -1,6 +1,7 @@
 :host {
   display: block;
-  min-width: 500px;
+  max-width: 100%;
+  width: 500px;
 }
 
 .close-feedback-dialog {

--- a/src/app/modules/ix-feedback/feedback-dialog/feedback-dialog.component.ts
+++ b/src/app/modules/ix-feedback/feedback-dialog/feedback-dialog.component.ts
@@ -73,6 +73,7 @@ export class FeedbackDialogComponent implements OnInit {
       user_agent: this.window.navigator.userAgent,
       environment: environment.production ? FeedbackEnvironment.Production : FeedbackEnvironment.Development,
       release: this.release,
+      extra: {},
     };
 
     this.feedbackService.addReview(values)

--- a/src/app/modules/ix-feedback/interfaces/feedback.interface.ts
+++ b/src/app/modules/ix-feedback/interfaces/feedback.interface.ts
@@ -25,7 +25,7 @@ export interface AddReview {
   environment: FeedbackEnvironment;
   host_u_id: string;
   message: string;
-  extra?: object;
+  extra: object;
 }
 
 export interface ReviewAddedResponse {


### PR DESCRIPTION
Making `extra` as required param. Fixes dialog width on narrow screens.

There is a known issue with CORS - it will be solved at https://github.com/truenas/feedback-service/pull/8. Until that, for testing, you'll need to set up `feedback-service` locally and expose it to some domain, using `ngrok` for example. Update `hostname` in `ix-feedback.service.ts` using the exposed domain, and test form submission in the dialog.