### PR TITLE
NAS-122385 / 23.10 / Process values ​​in kilobytes

### DIFF
--- a/src/app/pages/services/components/service-ftp/service-ftp.component.spec.ts
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.spec.ts
@@ -158,10 +158,10 @@ describe('ServiceFtpComponent', () => {
       'Masquerade Address': '192.168.1.110',
       'Display Login': 'Welcome',
       'Auxiliary Parameters': '--test=value',
-      'Local User Upload Bandwidth: (Examples: 500 KiB, 500M, 2 TB)': '1 MiB',
-      'Local User Download Bandwidth': '2 MiB',
-      'Anonymous User Upload Bandwidth': '3 MiB',
-      'Anonymous User Download Bandwidth': '5 KiB',
+      'Local User Upload Bandwidth: (Examples: 500 KiB, 500M, 2 TB)': '1 GiB',
+      'Local User Download Bandwidth': '2 GiB',
+      'Anonymous User Upload Bandwidth': '3 GiB',
+      'Anonymous User Download Bandwidth': '5 MiB',
     });
   });
 
@@ -180,7 +180,7 @@ describe('ServiceFtpComponent', () => {
     expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith('ftp.update', [{
       ...existingFtpConfig,
       tls_opt_ip_address_required: true,
-      anonuserdlbw: 5120,
+      anonuserdlbw: 5,
     }]);
   });
 

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.ts
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.ts
@@ -113,6 +113,10 @@ export class ServiceFtpComponent implements OnInit {
       ...this.form.value,
       filemask: invertUmask(this.form.value.filemask),
       dirmask: invertUmask(this.form.value.dirmask),
+      localuserbw: this.convertByteToKbyte(this.form.value.localuserbw),
+      localuserdlbw: this.convertByteToKbyte(this.form.value.localuserdlbw),
+      anonuserbw: this.convertByteToKbyte(this.form.value.anonuserbw),
+      anonuserdlbw: this.convertByteToKbyte(this.form.value.anonuserdlbw),
     };
 
     this.isFormLoading = true;
@@ -147,6 +151,10 @@ export class ServiceFtpComponent implements OnInit {
             ...config,
             filemask: invertUmask(config.filemask),
             dirmask: invertUmask(config.dirmask),
+            localuserbw: this.convertKbyteToByte(config.localuserbw),
+            localuserdlbw: this.convertKbyteToByte(config.localuserdlbw),
+            anonuserbw: this.convertKbyteToByte(config.anonuserbw),
+            anonuserdlbw: this.convertKbyteToByte(config.anonuserdlbw),
           });
           this.isFormLoading = false;
           this.setRootLoginWarning();
@@ -181,5 +189,13 @@ export class ServiceFtpComponent implements OnInit {
         rootlogin: false,
       });
     });
+  }
+
+  private convertByteToKbyte(bytes: number): number {
+    return bytes && bytes < 1024 ? 1 : bytes / 1024;
+  }
+
+  private convertKbyteToByte(value: number): number {
+    return value * 1024;
   }
 }


### PR DESCRIPTION
**Testing**

At FTP bandwidth limits,

for example, the **Anonymous User Download Bandwidth** field in the WebUI indicates 5 KiB, then the value for `anonuserdlbw` in `ftp.config` should be 5.

- **Expected result:** "5"