### PR TITLE
NAS-122262 / 22.12.4 / iSCSI "Associated Targets" UI does not refresh after saving "Edits".  User must change UI focus for updates to appear

### DIFF
--- a/src/app/pages/sharing/iscsi/associated-target/associated-target-list/associated-target-list.component.ts
+++ b/src/app/pages/sharing/iscsi/associated-target/associated-target-list/associated-target-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import * as _ from 'lodash';
@@ -63,14 +63,11 @@ export class AssociatedTargetListComponent implements EntityTableConfig {
     private ws: WebSocketService,
     private translate: TranslateService,
     private slideInService: IxSlideInService,
-    private cdr: ChangeDetectorRef,
   ) {}
 
   afterInit(entityList: EntityTableComponent): void {
-    this.entityList = entityList;
-
     this.slideInService.onClose$.pipe(untilDestroyed(this)).subscribe(() => {
-      this.entityList.getData();
+      entityList.getData();
     });
   }
 

--- a/src/app/pages/sharing/iscsi/authorized-access/authorized-access-list/authorized-access-list.component.ts
+++ b/src/app/pages/sharing/iscsi/authorized-access/authorized-access-list/authorized-access-list.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { IscsiAuthAccess } from 'app/interfaces/iscsi.interface';
@@ -47,7 +46,6 @@ export class AuthorizedAccessListComponent implements EntityTableConfig<IscsiAut
   };
 
   constructor(
-    private router: Router,
     private translate: TranslateService,
     private slideInService: IxSlideInService,
   ) {}


### PR DESCRIPTION
Issue appears only for Bluefin.

Testing: 

Go to `Shares` --> `Associated Target` tab http://10.234.27.211/ui/sharing/iscsi/associatedtarget

Try to edit on of the items and it should be updated instantly on the list.