### PR TITLE
NAS-122282 / 22.12.4 / "Failed to export RRD data: ERROR" appear when navigate to the furthest position/time, left, in Reporting graphs (by AlexKarpov98)

### DIFF
--- a/src/app/pages/reports-dashboard/components/report/report.component.html
+++ b/src/app/pages/reports-dashboard/components/report/report.component.html
@@ -27,6 +27,7 @@
                 ix-auto
                 ix-auto-type="button"
                 ix-auto-identifier="{{ reportTitle }}_stepBack"
+                [disabled]="stepBackDisabled"
                 [matTooltip]="'Step Back' | translate"
                 [matTooltipShowDelay]="1000"
                 (click)="stepBack()"

--- a/src/app/pages/reports-dashboard/components/report/report.component.ts
+++ b/src/app/pages/reports-dashboard/components/report/report.component.ts
@@ -69,6 +69,7 @@ export class ReportComponent extends WidgetComponent implements OnInit, OnChange
   subtitle: string = this.translate.instant('% of all cores');
   isActive = true;
   stepForwardDisabled = true;
+  stepBackDisabled = false;
   timezone: string;
   currentStartDate: number;
   currentEndDate: number;
@@ -268,6 +269,10 @@ export class ReportComponent extends WidgetComponent implements OnInit, OnChange
   }
 
   stepBack(): void {
+    if (this.stepBackDisabled) {
+      return;
+    }
+
     const rrdOptions = this.convertTimespan(
       this.currentZoomLevel,
       ReportStepDirection.Backward,
@@ -281,6 +286,10 @@ export class ReportComponent extends WidgetComponent implements OnInit, OnChange
   }
 
   stepForward(): void {
+    if (this.stepForwardDisabled) {
+      return;
+    }
+
     const rrdOptions = this.convertTimespan(
       this.currentZoomLevel,
       ReportStepDirection.Forward,
@@ -354,6 +363,12 @@ export class ReportComponent extends WidgetComponent implements OnInit, OnChange
       this.stepForwardDisabled = true;
     } else {
       this.stepForwardDisabled = false;
+    }
+
+    if (startDate.getFullYear() <= 1999) {
+      this.stepBackDisabled = true;
+    } else {
+      this.stepBackDisabled = false;
     }
 
     return {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 0c553cde7c07e377547b744667c45b91ed3c0853

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 5f3e43fcae448ce7148f7682d45917ce3a8c28af

Testing: 
Go to reports page and try to rewind to 2000 year.
You should not be able to rewind further - this fixes the bug.
http://localhost:4200/reportsdashboard/network

<img width="1728" alt="Screenshot 2023-06-14 at 13 00 18" src="https://github.com/truenas/webui/assets/22980553/67c95cb7-706a-42fe-8f1a-11c0abce41a2">

<img width="553" alt="Screenshot 2023-06-14 at 13 01 55" src="https://github.com/truenas/webui/assets/22980553/4bf87699-8313-4add-a7a8-1d1f6b707235">


Original PR: https://github.com/truenas/webui/pull/8304
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122282