### PR TITLE
NAS-121488 / 23.10 / Close unnecessary connection

### DIFF
--- a/src/app/services/websocket-connection.service.ts
+++ b/src/app/services/websocket-connection.service.ts
@@ -94,6 +94,10 @@ export class WebsocketConnectionService {
   }
 
   private onOpen(): void {
+    if (this.isTryingReconnect) {
+      this.closeWebsocketConnection();
+      return;
+    }
     this.shutDownInProgress = false;
     this.setupConnectionEvents();
   }


### PR DESCRIPTION
**Testing**

1. Login in one browser and open inspector.

1. Login in another browser and go to Advanced. Click Terminate Other Sessions.

1. Ensure that in first browser now has only 1 websocket connection with Pending status. (Previously it was 2 connections)

1. Wait for ~2 minutes.  You should not see "Trying to reconnect" message.

