### PR TITLE
NAS-122503 / 23.10 / Redirect to installed apps after deletion

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -15,6 +15,7 @@ import { AppCardLogoComponent } from 'app/pages/apps/components/app-card-logo/ap
 import { AppInfoCardComponent } from 'app/pages/apps/components/installed-apps/app-info-card/app-info-card.component';
 import { AppUpgradeDialogComponent } from 'app/pages/apps/components/installed-apps/app-upgrade-dialog/app-upgrade-dialog.component';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
+import { AppsStore } from 'app/pages/apps/store/apps-store.service';
 import { AppLoaderService, DialogService, RedirectService } from 'app/services';
 
 describe('AppInfoCardComponent', () => {
@@ -63,6 +64,9 @@ describe('AppInfoCardComponent', () => {
     providers: [
       mockProvider(ApplicationsService, {
         getChartUpgradeSummary: jest.fn(() => of(upgradeSummary)),
+      }),
+      mockProvider(AppsStore, {
+        installedApps$: of([]),
       }),
       mockProvider(DialogService, {
         confirm: jest.fn(() => of(true)),

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { startCase } from 'lodash';
-import { filter } from 'rxjs';
+import { filter, map, take } from 'rxjs';
 import helptext from 'app/helptext/apps/apps';
 import { UpgradeSummary } from 'app/interfaces/application.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
@@ -13,6 +13,7 @@ import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.com
 import { ChartUpgradeDialogConfig } from 'app/pages/apps-old/interfaces/chart-upgrade-dialog-config.interface';
 import { AppUpgradeDialogComponent } from 'app/pages/apps/components/installed-apps/app-upgrade-dialog/app-upgrade-dialog.component';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
+import { AppsStore } from 'app/pages/apps/store/apps-store.service';
 import { getCleanLink } from 'app/pages/apps/utils/get-clean-link';
 import { RedirectService, AppLoaderService, DialogService } from 'app/services';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
@@ -37,6 +38,7 @@ export class AppInfoCardComponent {
     private dialogService: DialogService,
     private translate: TranslateService,
     private router: Router,
+    private store: AppsStore,
   ) {}
 
   get hasUpdates(): boolean {
@@ -108,12 +110,8 @@ export class AppInfoCardComponent {
       secondaryCheckbox: true,
       secondaryCheckboxText: this.translate.instant('Delete docker images used by the app'),
     })
-      .pipe(untilDestroyed(this))
+      .pipe(filter((result) => result.confirmed), untilDestroyed(this))
       .subscribe((result) => {
-        if (!result.confirmed) {
-          return;
-        }
-
         const deleteUnusedImages = result.secondaryCheckbox;
         if (result.secondaryCheckbox) {
           this.appLoaderService.open();
@@ -155,7 +153,16 @@ export class AppInfoCardComponent {
     dialogRef.componentInstance.setCall('chart.release.delete', [name, { delete_unused_images: deleteUnusedImages }]);
     dialogRef.componentInstance.submit();
     dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
-      this.dialogService.closeAllDialogs();
+      this.store.installedApps$.pipe(
+        map((apps) => !apps.length),
+        take(1),
+        untilDestroyed(this),
+      ).subscribe((noApps) => {
+        if (noApps) {
+          this.router.navigate(['/apps', 'installed'], { state: { hideMobileDetails: true } });
+        }
+        this.dialogService.closeAllDialogs();
+      });
     });
   }
 }

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -138,6 +138,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit, OnDestroy 
         if (this.router.getCurrentNavigation()?.extras?.state?.hideMobileDetails) {
           this.closeMobileDetails();
           this.selectedApp = undefined;
+          this.cdr.markForCheck();
         }
       });
   }
@@ -377,6 +378,9 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit, OnDestroy 
       dialogRef.componentInstance.submit();
       dialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(
         (job: Job<CoreBulkResponse[]>) => {
+          if (!this.dataSource.length) {
+            this.router.navigate(['/apps', 'installed'], { state: { hideMobileDetails: true } });
+          }
           this.dialogService.closeAllDialogs();
           let message = '';
           job.result.forEach((item) => {


### PR DESCRIPTION
For testing, delete the last app and check if the URL was changed and the details panel is closed. When multiple apps are installed, it should keep the existing behavior - redirect to the first app in the list and the details panel is there.