### PR TITLE
NAS-122601: "Custom App" button disabled with no explanation

### DIFF
--- a/src/app/pages/apps/apps.module.ts
+++ b/src/app/pages/apps/apps.module.ts
@@ -70,6 +70,7 @@ import { AppCardComponent } from './components/available-apps/app-card/app-card.
 import { AvailableAppsHeaderComponent } from './components/available-apps/available-apps-header/available-apps-header.component';
 import { AvailableAppsComponent } from './components/available-apps/available-apps.component';
 import { CategoryViewComponent } from './components/available-apps/category-view/category-view.component';
+import { CustomAppButtonComponent } from './components/available-apps/custom-app-button/custom-app-button.component';
 import { AppContainersCardComponent } from './components/installed-apps/app-containers-card/app-containers-card.component';
 import { AppDetailsPanelComponent } from './components/installed-apps/app-details-panel/app-details-panel.component';
 import { AppHistoryCardComponent } from './components/installed-apps/app-history-card/app-history-card.component';
@@ -114,6 +115,7 @@ import { InstalledAppsComponent } from './components/installed-apps/installed-ap
     AppMetadataCardComponent,
     AppSectionExpandCollapseComponent,
     CategoryViewComponent,
+    CustomAppButtonComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/pages/apps/components/available-apps/available-apps.component.html
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.html
@@ -1,14 +1,6 @@
 <ng-template #pageHeader>
   <ix-page-title-header [pageTitle]="'Discover' | translate" [loading]="isLoading$ | async">
-    <a
-      mat-button
-      color="primary"
-      ixTest="custom-app"
-      [disabled]="customAppDisabled$ | async"
-      [routerLink]="['/apps', 'available', officialCatalog, chartsTrain, customIxChartApp, 'install']"
-    >
-      {{ 'Custom App' | translate }}
-    </a>
+    <ix-custom-app-button></ix-custom-app-button>
   </ix-page-title-header>
 </ng-template>
 

--- a/src/app/pages/apps/components/available-apps/available-apps.component.ts
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.ts
@@ -8,11 +8,9 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import {
   Observable, combineLatest, filter, map,
 } from 'rxjs';
-import { ixChartApp, chartsTrain, officialCatalog } from 'app/constants/catalog.constants';
 import { AvailableApp } from 'app/interfaces/available-app.interface';
 import { AppsFilterStore } from 'app/pages/apps/store/apps-filter-store.service';
 import { AppsByCategory, AppsStore } from 'app/pages/apps/store/apps-store.service';
-import { KubernetesStore } from 'app/pages/apps/store/kubernetes-store.service';
 import { LayoutService } from 'app/services/layout.service';
 
 @UntilDestroy()
@@ -38,21 +36,13 @@ export class AvailableAppsComponent implements AfterViewInit, OnInit {
       return !!searchQuery || isFilterApplied;
     }),
   );
-  customAppDisabled$ = this.kubernetesStore.selectedPool$.pipe(
-    map((pool) => !pool),
-  );
   isLoading$ = this.applicationsStore.isLoading$;
-
-  readonly customIxChartApp = ixChartApp;
-  readonly chartsTrain = chartsTrain;
-  readonly officialCatalog = officialCatalog;
 
   constructor(
     private layoutService: LayoutService,
     protected applicationsStore: AppsStore,
     protected appsFilterStore: AppsFilterStore,
     private router: Router,
-    protected kubernetesStore: KubernetesStore,
   ) { }
 
   ngOnInit(): void {

--- a/src/app/pages/apps/components/available-apps/category-view/category-view.component.html
+++ b/src/app/pages/apps/components/available-apps/category-view/category-view.component.html
@@ -3,15 +3,7 @@
     [pageTitle]="pageTitle$ | async | titlecase | translate"
     [loading]="isLoading$ | async"
   >
-    <a
-      mat-button
-      color="primary"
-      ixTest="custom-app"
-      [disabled]="customAppDisabled$ | async"
-      [routerLink]="['/apps', 'available', officialCatalog, chartsTrain, customIxChartApp, 'install']"
-    >
-      {{ 'Custom App' | translate }}
-    </a>
+    <ix-custom-app-button></ix-custom-app-button>
   </ix-page-title-header>
 </ng-template>
 

--- a/src/app/pages/apps/components/available-apps/category-view/category-view.component.ts
+++ b/src/app/pages/apps/components/available-apps/category-view/category-view.component.ts
@@ -7,13 +7,11 @@ import {
 } from '@angular/router';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import {
-  BehaviorSubject, map,
+  BehaviorSubject,
 } from 'rxjs';
-import { ixChartApp, chartsTrain, officialCatalog } from 'app/constants/catalog.constants';
 import { AvailableApp } from 'app/interfaces/available-app.interface';
 import { AppsFilterStore } from 'app/pages/apps/store/apps-filter-store.service';
 import { AppsStore } from 'app/pages/apps/store/apps-store.service';
-import { KubernetesStore } from 'app/pages/apps/store/kubernetes-store.service';
 import { LayoutService } from 'app/services/layout.service';
 
 @UntilDestroy()
@@ -28,18 +26,12 @@ export class CategoryViewComponent implements OnInit, OnDestroy, AfterViewInit {
   pageTitle$ = new BehaviorSubject('Category');
   apps$ = this.appsFilterStore.filteredApps$;
   isLoading$ = this.applicationsStore.isLoading$;
-  customAppDisabled$ = this.kubernetesStore.selectedPool$.pipe(map((pool) => !pool));
-
-  readonly customIxChartApp = ixChartApp;
-  readonly chartsTrain = chartsTrain;
-  readonly officialCatalog = officialCatalog;
 
   constructor(
     private layoutService: LayoutService,
     private applicationsStore: AppsStore,
     private route: ActivatedRoute,
     private appsFilterStore: AppsFilterStore,
-    private kubernetesStore: KubernetesStore,
   ) {}
 
   ngOnInit(): void {

--- a/src/app/pages/apps/components/available-apps/custom-app-button/custom-app-button.component.html
+++ b/src/app/pages/apps/components/available-apps/custom-app-button/custom-app-button.component.html
@@ -1,0 +1,14 @@
+<div
+  [matTooltip]="'Setup Pool To Create Custom App' | translate"
+  [matTooltipDisabled]="!(customAppDisabled$ | async)"
+>
+  <a
+    mat-button
+    color="primary"
+    ixTest="custom-app"
+    [disabled]="customAppDisabled$ | async"
+    (click)="navigateToCustomAppCreation()"
+  >
+    {{ 'Custom App' | translate }}
+  </a>
+</div>

--- a/src/app/pages/apps/components/available-apps/custom-app-button/custom-app-button.component.spec.ts
+++ b/src/app/pages/apps/components/available-apps/custom-app-button/custom-app-button.component.spec.ts
@@ -1,0 +1,60 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { Router } from '@angular/router';
+import { SpectatorRouting } from '@ngneat/spectator';
+import { createRoutingFactory, mockProvider } from '@ngneat/spectator/jest';
+import { MockComponent } from 'ng-mocks';
+import { of } from 'rxjs';
+import { chartsTrain, ixChartApp, officialCatalog } from 'app/constants/catalog.constants';
+import { AppCardComponent } from 'app/pages/apps/components/available-apps/app-card/app-card.component';
+import { CustomAppButtonComponent } from 'app/pages/apps/components/available-apps/custom-app-button/custom-app-button.component';
+import { KubernetesStore } from 'app/pages/apps/store/kubernetes-store.service';
+
+describe('CustomAppButtonComponent', () => {
+  let spectator: SpectatorRouting<CustomAppButtonComponent>;
+  let loader: HarnessLoader;
+
+  const createComponent = createRoutingFactory({
+    component: CustomAppButtonComponent,
+    imports: [],
+    declarations: [MockComponent(AppCardComponent)],
+    providers: [
+      mockProvider(KubernetesStore, {
+        selectedPool$: of('selected pool'),
+      }),
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createComponent();
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+  });
+
+  it('renders Custom App Button', async () => {
+    const button = await loader.getHarness(MatButtonHarness.with({ text: 'Custom App' }));
+    expect(button).toExist();
+  });
+
+  it('navigates to create custom app page', async () => {
+    const button = await loader.getHarness(MatButtonHarness.with({ text: 'Custom App' }));
+
+    await button.click();
+
+    const router = spectator.inject(Router);
+    jest.spyOn(router, 'navigate').mockImplementation();
+
+    expect(router.navigate).toHaveBeenCalledWith([
+      '/apps', 'available', officialCatalog, chartsTrain, ixChartApp, 'install',
+    ]);
+  });
+
+  it('disables Custom App button if pool is not set', async () => {
+    const button = await loader.getHarness(MatButtonHarness.with({ text: 'Custom App' }));
+
+    const store = spectator.inject(KubernetesStore);
+    Object.defineProperty(store, 'selectedPool$', { value: of(undefined) });
+
+    expect(button.isDisabled()).toBeTruthy();
+  });
+});

--- a/src/app/pages/apps/components/available-apps/custom-app-button/custom-app-button.component.ts
+++ b/src/app/pages/apps/components/available-apps/custom-app-button/custom-app-button.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { map } from 'rxjs';
+import { chartsTrain, ixChartApp, officialCatalog } from 'app/constants/catalog.constants';
+import { KubernetesStore } from 'app/pages/apps/store/kubernetes-store.service';
+
+@Component({
+  selector: 'ix-custom-app-button',
+  templateUrl: './custom-app-button.component.html',
+  styleUrls: ['./custom-app-button.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CustomAppButtonComponent {
+  customAppDisabled$ = this.kubernetesStore.selectedPool$.pipe(
+    map((pool) => !pool),
+  );
+
+  constructor(private kubernetesStore: KubernetesStore, private router: Router) {}
+
+  navigateToCustomAppCreation(): void {
+    this.router.navigate(['/apps', 'available', officialCatalog, chartsTrain, ixChartApp, 'install']);
+  }
+}

--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.spec.ts
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.spec.ts
@@ -19,7 +19,7 @@ import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
 import { IxFormHarness } from 'app/modules/ix-forms/testing/ix-form.harness';
 import { ChartWizardComponent } from 'app/pages/apps/components/chart-wizard/chart-wizard.component';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
-import { AppsStore } from 'app/pages/apps/store/apps-store.service';
+import { KubernetesStore } from 'app/pages/apps/store/kubernetes-store.service';
 import { AppLoaderService, DialogService } from 'app/services';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
 
@@ -345,7 +345,7 @@ describe('ChartWizardComponent', () => {
         mockCall('catalog.get_item_details', existingCatalogApp),
         mockCall('chart.release.query', [existingChartEdit]),
       ]),
-      mockProvider(AppsStore, {
+      mockProvider(KubernetesStore, {
         selectedPool$: of('pool set'),
       }),
       mockProvider(MatDialog, {
@@ -377,7 +377,7 @@ describe('ChartWizardComponent', () => {
       const router = spectator.inject(Router);
       jest.spyOn(router, 'navigate').mockImplementation();
 
-      const store = spectator.inject(AppsStore);
+      const store = spectator.inject(KubernetesStore);
       Object.defineProperty(store, 'selectedPool$', { value: of(undefined) });
       spectator.component.ngOnInit();
 
@@ -431,7 +431,7 @@ describe('ChartWizardComponent', () => {
       const router = spectator.inject(Router);
       jest.spyOn(router, 'navigate').mockImplementation();
 
-      const store = spectator.inject(AppsStore);
+      const store = spectator.inject(KubernetesStore);
       Object.defineProperty(store, 'selectedPool$', { value: of(undefined) });
       spectator.component.ngOnInit();
 

--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.ts
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.ts
@@ -35,7 +35,7 @@ import { FormErrorHandlerService } from 'app/modules/ix-forms/services/form-erro
 import { IxValidatorsService } from 'app/modules/ix-forms/services/ix-validators.service';
 import { forbiddenAsyncValues } from 'app/modules/ix-forms/validators/forbidden-values-validation/forbidden-values-validation';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
-import { AppsStore } from 'app/pages/apps/store/apps-store.service';
+import { KubernetesStore } from 'app/pages/apps/store/kubernetes-store.service';
 import { AppLoaderService, DialogService } from 'app/services';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { LayoutService } from 'app/services/layout.service';
@@ -111,7 +111,7 @@ export class ChartWizardComponent implements OnInit, AfterViewInit, OnDestroy {
     private loader: AppLoaderService,
     private router: Router,
     private errorHandler: ErrorHandlerService,
-    private applicationsStore: AppsStore,
+    private kubernetesStore: KubernetesStore,
   ) {}
 
   ngOnInit(): void {
@@ -454,7 +454,7 @@ export class ChartWizardComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private checkIfPoolSetAndManageApplication(): void {
-    this.applicationsStore.selectedPool$.pipe(untilDestroyed(this)).subscribe((pool) => {
+    this.kubernetesStore.selectedPool$.pipe(untilDestroyed(this)).subscribe((pool) => {
       this.wasPoolSet = Boolean(pool);
 
       if (!pool) {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2770,6 +2770,7 @@
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2123,6 +2123,7 @@
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1034,6 +1034,7 @@
   "Setting up LDAP": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2967,6 +2967,7 @@
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -110,6 +110,7 @@
   "Service configuration saved": "",
   "Set to inhibit some syslog diagnostics to avoid error messages. See <a href=\"https://man7.org/linux/man-pages/man5/exports.5.html\" target=\"_blank\">exports(5)</a> for examples.": "",
   "Settings saved": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share your thoughts on our product's features, usability, or any suggestions for improvement.": "",
   "Snapshot Directory": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2955,6 +2955,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2699,6 +2699,7 @@
   "Setting up LDAP": "",
   "Settings saved": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2670,6 +2670,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3179,6 +3179,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -80,6 +80,7 @@
   "Select action": "",
   "Select image you want attach to review": "",
   "Select rating": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share your thoughts on our product's features, usability, or any suggestions for improvement.": "",
   "Some of the disks are attached to the exported pools\n  mentioned in this list. Checking a pool name means you want to\n  allow reallocation of the disks attached to that pool.": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3092,6 +3092,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3116,6 +3116,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3008,6 +3008,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1532,6 +1532,7 @@
   "Setting up LDAP": "",
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -139,6 +139,7 @@
   "Sensitive": "",
   "Service configuration saved": "",
   "Settings saved": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share your thoughts on our product's features, usability, or any suggestions for improvement.": "",
   "Snapshot Directory": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3187,6 +3187,7 @@
   "Settings saved": "",
   "Settings saved.": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -171,6 +171,7 @@
   "Select rating": "",
   "Selected": "",
   "Selected SSH connection uses non-root user. Would you like to use sudo with <i>/usr/sbin/zfs</i> commands? Passwordless sudo must be enabled on the remote system.\nIf not checked, <i>zfs allow</i> must be used to grant non-user permissions to perform ZFS tasks. Mounting ZFS filesystems by non-root still would not be possible due to Linux restrictions.": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share your thoughts on our product's features, usability, or any suggestions for improvement.": "",
   "Some of the disks are attached to the exported pools\n  mentioned in this list. Checking a pool name means you want to\n  allow reallocation of the disks attached to that pool.": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2425,6 +2425,7 @@
   "Settings Requiring Re-Initialization": "",
   "Settings saved": "",
   "Setup Method": "",
+  "Setup Pool To Create Custom App": "",
   "Setup Pool To Install": "",
   "Share ACL for {share}": "",
   "Share Attached": "",


### PR DESCRIPTION
Testing:
Unset pool

Visit **Apps Discovery** page:
http://localhost:4200/apps/available

You should see `Custom App` button disabled - With a tooltip on hover
<img width="523" alt="Screenshot 2023-06-27 at 15 14 08" src="https://github.com/truenas/webui/assets/22980553/e20e2769-95f5-41b1-8fec-2f4933620bed">

Since button was used in 2 places, I created new component for it and added tests.

As well I handled disabling visiting **App Install/Edit page** _directly_ in this PR:
https://github.com/truenas/webui/pull/8349