### PR TITLE
Fix reading [0] from undefined

### DIFF
--- a/src/app/services/schema/app-schema.service.ts
+++ b/src/app/services/schema/app-schema.service.ts
@@ -273,7 +273,7 @@ export class AppSchemaService {
   ): HierarchicalObjectMap<ChartFormValue>[] {
     return list.map((listItem: HierarchicalObjectMap<ChartFormValue>) => {
       // TODO: Consider refactoring.
-      if (fieldSchemaNode?.schema?.items[0]?.schema?.type === ChartSchemaType.Dict) {
+      if (fieldSchemaNode?.schema?.items?.[0]?.schema?.type === ChartSchemaType.Dict) {
         return this.serializeFormGroup(listItem, schema);
       }
 


### PR DESCRIPTION
While trying to edit the TrueCharts' `authelia 4.37.5_15.1.29` app, this error appears on the browser's console:

```
TypeError: Cannot read properties of undefined (reading '0')
    at app-schema.service.ts:272:36
    at Array.map (<anonymous>)
    at Ae.serializeFormList (app-schema.service.ts:270:17)
    at Ae.serializeFormValue (app-schema.service.ts:232:19)
    at app-schema.service.ts:248:26
    at Array.forEach (<anonymous>)
    at Ae.serializeFormGroup (app-schema.service.ts:245:29)
    at app-schema.service.ts:273:21
    at Array.map (<anonymous>)
    at Ae.serializeFormList (app-schema.service.ts:270:17)
```

With this PR's fix it should avoid throwing when the `items` field is missing, like in this case (copied from browser debugger):


```json
{
    "variable": "domain",
    "group": "App Configuration",
    "label": "Domain",
    "description": "The highest domain level possible, for example: domain.com when using app.domain.com",
    "schema": {
        "type": "string",
        "default": "",
        "required": true
    }
}
```