### PR TITLE
NAS-122781 / UI does not present "Remove" options for L2ARC or SLOG when pool contains RAIDZ data vdevs

### DIFF
--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
@@ -58,11 +58,15 @@ export class ZfsInfoCardComponent {
   get canRemoveDisk(): boolean {
     return this.topologyParentItem.type !== TopologyItemType.Mirror
       && !this.isRaidzParent
-      && !this.hasTopLevelRaidz;
+      && (!this.hasTopLevelRaidz
+    || this.topologyCategory === VdevType.Cache
+    || this.topologyCategory === VdevType.Log);
   }
 
   get canRemoveVDEV(): boolean {
-    return !this.hasTopLevelRaidz;
+    return !this.hasTopLevelRaidz
+    || this.topologyCategory === VdevType.Cache
+    || this.topologyCategory === VdevType.Log;
   }
 
   get canDetachDisk(): boolean {


### PR DESCRIPTION
Added logic in canRemoveDisk and canRemoveVDEV to allow removal of VdevType.Cache and .Log when hasTopLevelRaidz is TRUE - these vdev types are still removable even when a top-level RAIDZ vdev exists so the REMOVE button should be presented for the appropriate disk/vdevs