### PR TITLE
NAS-122480 / 23.10 / Fix Home Directory Permissions

### DIFF
--- a/src/app/pages/account/users/user-form/user-form.component.spec.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.spec.ts
@@ -248,7 +248,6 @@ describe('UserFormComponent', () => {
       await form.fillForm({
         'Auxiliary Groups': ['mock-group'],
         'Full Name': 'updated',
-        'Home Directory Permissions': '755',
         'Home Directory': '/home/updated',
         'Primary Group': 'mock-group',
         'Create Home Directory': true,
@@ -260,6 +259,10 @@ describe('UserFormComponent', () => {
         'Allowed sudo commands': ['pwd'],
         'Allowed sudo commands with no password': [],
         'Allow all sudo commands with no password': true,
+      });
+
+      await form.fillForm({
+        'Home Directory Permissions': '755',
       });
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -310,7 +313,6 @@ describe('UserFormComponent', () => {
       const disabled = await form.getDisabledState();
 
       expect(disabled).toEqual(expect.objectContaining({
-        'Home Directory Permissions': true,
         'Home Directory': true,
         'Primary Group': true,
         Username: true,

--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -81,7 +81,7 @@ export class UserFormComponent implements OnInit {
     group_create: [true],
     groups: [[] as number[]],
     home: [defaultHomePath, []],
-    home_mode: ['755'],
+    home_mode: ['700'],
     home_create: [false],
     sshpubkey: [null as string],
     sshpubkey_file: [null as File[]],
@@ -203,6 +203,20 @@ export class UserFormComponent implements OnInit {
       this.updateShellOptions(this.form.value.group, groups);
     });
 
+    this.form.controls.home.valueChanges.pipe(untilDestroyed(this)).subscribe((home) => {
+      if (home === defaultHomePath) {
+        this.form.controls.home_mode.disable();
+      } else {
+        this.form.controls.home_mode.enable();
+      }
+    });
+
+    this.form.controls.home_create.valueChanges.pipe(untilDestroyed(this)).subscribe((checked) => {
+      if (checked) {
+        this.form.patchValue({ home_mode: '700' });
+      }
+    });
+
     this.form.controls.password_conf.addValidators(
       this.validatorsService.withMessage(
         matchOtherValidator('password'),
@@ -216,7 +230,8 @@ export class UserFormComponent implements OnInit {
         this.homeModeOldValue = stat.mode.toString(8).substring(2, 5);
       });
     } else {
-      this.form.patchValue({ home_mode: '755' });
+      this.form.patchValue({ home_mode: '700' });
+      this.form.controls.home_mode.disable();
     }
     this.subscriptions.push(
       this.form.controls.locked.disabledWhile(this.form.controls.password_disabled.value$),


### PR DESCRIPTION
**Testing**

On the **Credentials > Local Users > Add User** form, 

1. By default, the checkboxes in **Home Directory Permissions**:
   - should be set to `700` by default (User: Read+Write+Execute, Group: -, Other: -)
   - should be disabled

1. Enabled/Disabled state of the checkboxes in **Home Directory Permissions** should depend on whether the **Home Directory** is equals `/nonexistent`

1. If user changes **Create Home Directory** from `unchecked` to `checked`:
   the checkboxes in **Home Directory Permissions** should **reset to `700`**