### PR TITLE
NAS-116080: Fix network dashboard widget issues

### DIFF
--- a/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
+++ b/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
@@ -99,7 +99,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
       },
       tooltip: {
         callbacks: {
-          label(tooltipItem) {
+          label: (tooltipItem) => {
             let label = tooltipItem.dataset.label || '';
             if (label) {
               label += ': ';
@@ -107,13 +107,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
             if (tooltipItem.parsed.y === 0) {
               label += 0;
             } else {
-              const converted = filesize(Number(tooltipItem.parsed.y), {
-                round: 1,
-                output: 'object',
-                standard: 'iec',
-              });
-
-              label = `${label}${converted.value}${converted.unit.charAt(0)}`;
+              label = this.getSpeedLabel(Number(tooltipItem.parsed.y));
             }
             return label;
           },
@@ -143,14 +137,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
             if (value === 0) {
               return 0;
             }
-
-            const converted = filesize(value as number, {
-              round: 1,
-              output: 'object',
-              standard: 'iec',
-            });
-
-            return `${converted.value}${converted.unit.charAt(0)}`;
+            return this.getSpeedLabel(value as number);
           },
         },
       },
@@ -216,8 +203,8 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
           if (evt.data.link_state) {
             nicInfo.state = evt.data.link_state;
           }
-          nicInfo.in = `${filesize(evt.data.received_bytes_rate, { standard: 'iec' })}/s`;
-          nicInfo.out = `${filesize(evt.data.sent_bytes_rate, { standard: 'iec' })}/s`;
+          nicInfo.in = this.getSpeedLabel(evt.data.received_bytes_rate * 8);
+          nicInfo.out = this.getSpeedLabel(evt.data.sent_bytes_rate * 8);
 
           if (
             evt.data.sent_bytes !== undefined
@@ -397,7 +384,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
               },
               {
                 label: `outgoing [${networkInterfaceName}]`,
-                data: (response.data as number[][]).map((item, index) => ({ x: labels[index], y: -item[1] })),
+                data: (response.data as number[][]).map((item, index) => ({ x: labels[index], y: item[1] })),
                 borderColor: this.themeService.currentTheme().orange,
                 backgroundColor: this.themeService.currentTheme().orange,
                 pointBackgroundColor: this.themeService.currentTheme().orange,
@@ -476,5 +463,17 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
 
   getIpAddressTooltip(nic: BaseNetworkInterface): string {
     return `${this.translate.instant('IP Address')}: ${this.getIpAddress(nic)}`;
+  }
+
+  private getSpeedLabel(value: number): string {
+    const converted = filesize(value, { round: 3, output: 'object', standard: 'iec' });
+    return `${this.splitValue(converted.value)}${converted.unit}/s`;
+  }
+
+  private splitValue(value: number): number {
+    if (value < 1024) {
+      return Number(value.toString().slice(0, 5));
+    }
+    return Math.round(value);
   }
 }


### PR DESCRIPTION
**Summary**

1. Updated the axis labels in the Network dashboard widget. Changed "M" into "Mb/s"

2. Fixed the inconsistency between the axis labels provided in megabits/s and the In/Out values of the widget provided in mebibytes/s

3. Made sure that there's no negative Y axis label ("-476.8M") 

**Testing**

Go to **Dashboard** and check axes of the charts on the **Network** widget