### PR TITLE
NAS-122909: Update system info on dashboard init

### DIFF
--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -24,6 +24,7 @@ import { ThemeService } from 'app/services/theme/theme.service';
 import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
 import { selectHasOnlyMismatchVersionsReason, selectHaStatus, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
+import { systemInfoUpdated } from 'app/store/system-info/system-info.actions';
 import { selectIsIxHardware, waitForSystemInfo } from 'app/store/system-info/system-info.selectors';
 
 @UntilDestroy()
@@ -119,6 +120,7 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
         this.hasHa = haStatus.hasHa;
       });
     } else {
+      this.store$.dispatch(systemInfoUpdated());
       this.store$.pipe(waitForSystemInfo, untilDestroyed(this)).subscribe({
         next: (systemInfo) => {
           this.processSysInfo(systemInfo);


### PR DESCRIPTION
**Summary**

Fix for Uptime is not updating.

**Testing**

On **Dashboard** page, at **System Info** widget the **Uptime** should update, when user navigates away to another page, and then returns back to dashboard.