### PR TITLE
Add reset button to pool manager step actions

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -90,13 +90,23 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
     this.initControls();
 
     this.store.startOver$.pipe(untilDestroyed(this)).subscribe(() => {
-      this.form.reset({
-        layout: CreateVdevLayout.Stripe,
-        sizeAndType: [null, null],
-        width: null,
-        treatDiskSizeAsMinimum: false,
-        vdevsNumber: null,
-      });
+      this.resetToDefaults();
+    });
+
+    this.store.resetStep$.pipe(untilDestroyed(this)).subscribe((vdevType: VdevType) => {
+      if (vdevType === this.type) {
+        this.resetToDefaults();
+      }
+    });
+  }
+
+  resetToDefaults(): void {
+    this.form.reset({
+      layout: null, // CreateVdevLayout.Stripe,
+      sizeAndType: [null, null],
+      width: null,
+      treatDiskSizeAsMinimum: false,
+      vdevsNumber: null,
     });
   }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/custom-layout-applied/custom-layout-applied.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/custom-layout-applied/custom-layout-applied.component.html
@@ -12,15 +12,6 @@
       >
         {{ 'Edit Manual Disk Selection' | translate }}
       </button>
-      <button
-        mat-button
-        class="manual-disk-selection"
-        type="button"
-        ixTest="reset"
-        (click)="resetLayout()"
-      >
-        {{ 'Reset' | translate }}
-      </button>
     </div>
   </div>
   <div class="right-column">

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/custom-layout-applied/custom-layout-applied.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/custom-layout-applied/custom-layout-applied.component.ts
@@ -1,11 +1,13 @@
 import {
   ChangeDetectionStrategy, Component, EventEmitter, Input, Output,
 } from '@angular/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { VdevType } from 'app/enums/v-dev-type.enum';
 import helptext from 'app/helptext/storage/volumes/manager/manager';
 import { UnusedDisk } from 'app/interfaces/storage.interface';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
 
+@UntilDestroy()
 @Component({
   selector: 'ix-custom-layout-applied',
   templateUrl: './custom-layout-applied.component.html',
@@ -21,7 +23,13 @@ export class CustomLayoutAppliedComponent {
 
   constructor(
     private poolManagerStore: PoolManagerStore,
-  ) {}
+  ) {
+    this.poolManagerStore.resetStep$.pipe(untilDestroyed(this)).subscribe((vdevType: VdevType) => {
+      if (vdevType === this.type) {
+        this.resetLayout();
+      }
+    });
+  }
 
   openManualDiskSelection(): void {
     this.manualSelectionClicked.emit();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.html
@@ -1,6 +1,7 @@
 <div class="step-description">
   {{ description }}
 </div>
+
 <ix-automated-disk-selection
   *ngIf="!topologyCategory.hasCustomDiskSelection; else customLayout"
   class="content-container"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.html
@@ -30,6 +30,17 @@
   >
     {{ 'Next' | translate }}
   </button>
+
+  <button
+    mat-button
+    color="error"
+    type="button"
+    ixTest="reset-fields-in-step"
+    (click)="resetStep()"
+  >
+    {{ 'Reset Fields in Step' | translate }}
+  </button>
+
   <button
     mat-button
     color="accent"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.ts
@@ -55,4 +55,8 @@ export class DataWizardStepComponent implements OnInit {
   goToReviewStep(): void {
     this.goToLastStep.emit();
   }
+
+  resetStep(): void {
+    this.store.resetStep(VdevType.Data);
+  }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.html
@@ -33,6 +33,16 @@
 
   <button
     mat-button
+    color="error"
+    type="button"
+    ixTest="reset-fields-in-step"
+    (click)="resetStep()"
+  >
+    {{ 'Reset Fields in Step' | translate }}
+  </button>
+
+  <button
+    mat-button
     color="accent"
     type="button"
     ixTest="save-ang-go-to-review"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.ts
@@ -55,4 +55,8 @@ export class LogWizardStepComponent implements OnInit {
   goToReviewStep(): void {
     this.goToLastStep.emit();
   }
+
+  resetStep(): void {
+    this.store.resetStep(VdevType.Log);
+  }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.html
@@ -33,6 +33,16 @@
 
   <button
     mat-button
+    color="error"
+    type="button"
+    ixTest="reset-fields-in-step"
+    (click)="resetStep()"
+  >
+    {{ 'Reset Fields in Step' | translate }}
+  </button>
+
+  <button
+    mat-button
     color="accent"
     type="button"
     ixTest="save-ang-go-to-review"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.ts
@@ -28,4 +28,8 @@ export class SpareWizardStepComponent {
   goToReviewStep(): void {
     this.goToLastStep.emit();
   }
+
+  resetStep(): void {
+    this.store.resetStep(VdevType.Spare);
+  }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/6-cache-wizard-step/cache-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/6-cache-wizard-step/cache-wizard-step.component.html
@@ -34,6 +34,16 @@
 
   <button
     mat-button
+    color="error"
+    type="button"
+    ixTest="reset-fields-in-step"
+    (click)="resetStep()"
+  >
+    {{ 'Reset Fields in Step' | translate }}
+  </button>
+
+  <button
+    mat-button
     color="accent"
     type="button"
     ixTest="save-ang-go-to-review"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/6-cache-wizard-step/cache-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/6-cache-wizard-step/cache-wizard-step.component.ts
@@ -28,4 +28,8 @@ export class CacheWizardStepComponent {
   goToReviewStep(): void {
     this.goToLastStep.emit();
   }
+
+  resetStep(): void {
+    this.store.resetStep(VdevType.Cache);
+  }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
@@ -33,6 +33,16 @@
 
   <button
     mat-button
+    color="error"
+    type="button"
+    ixTest="reset-fields-in-step"
+    (click)="resetStep()"
+  >
+    {{ 'Reset Fields in Step' | translate }}
+  </button>
+
+  <button
+    mat-button
     color="accent"
     type="button"
     ixTest="save-ang-go-to-review"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -33,4 +33,8 @@ export class MetadataWizardStepComponent {
   goToReviewStep(): void {
     this.goToLastStep.emit();
   }
+
+  resetStep(): void {
+    this.store.resetStep(VdevType.Special);
+  }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
@@ -33,6 +33,16 @@
 
   <button
     mat-button
+    color="error"
+    type="button"
+    ixTest="reset-fields-in-step"
+    (click)="resetStep()"
+  >
+    {{ 'Reset Fields in Step' | translate }}
+  </button>
+
+  <button
+    mat-button
     color="accent"
     type="button"
     ixTest="save-ang-go-to-review"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -33,4 +33,8 @@ export class DedupWizardStepComponent {
   goToReviewStep(): void {
     this.goToLastStep.emit();
   }
+
+  resetStep(): void {
+    this.store.resetStep(VdevType.Dedup);
+  }
 }

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -98,6 +98,7 @@ export const initialState: PoolManagerState = {
 @Injectable()
 export class PoolManagerStore extends ComponentStore<PoolManagerState> {
   readonly startOver$ = new Subject<void>();
+  readonly resetStep$ = new Subject<VdevType>();
   readonly isLoading$ = this.select((state) => state.isLoading);
   readonly name$ = this.select((state) => state.name);
   readonly encryption$ = this.select((state) => state.encryption);
@@ -185,6 +186,11 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
     this.startOver$.next();
     this.setState({ ...initialState, isLoading: true });
     this.loadStateInitialData().pipe(take(1)).subscribe();
+  }
+
+  resetStep(vdevType: VdevType): void {
+    this.resetStep$.next(vdevType);
+    this.updateTopologyCategory(vdevType, initialTopology[vdevType]);
   }
 
   readonly initialize = this.effect((trigger$) => {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2404,6 +2404,7 @@
   "Reserved space for this dataset and all children": "",
   "Reset": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1927,6 +1927,7 @@
   "Reserved for Dataset": "",
   "Reserved for Dataset & Children": "",
   "Reset": "",
+  "Reset Fields in Step": "",
   "Reset Search": "",
   "Reset Zoom": "",
   "Reset configuration": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -938,6 +938,7 @@
   "Requested action performed for selected Applications": "",
   "Reserved for Dataset": "",
   "Reserved for Dataset & Children": "",
+  "Reset Fields in Step": "",
   "Reset Search": "",
   "Reset Zoom": "",
   "Reset configuration": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2579,6 +2579,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -82,6 +82,7 @@
   "Related Kubernetes Events": "",
   "Renew 2FA Secret": "",
   "Renew 2FA secret": "",
+  "Reset Fields in Step": "",
   "Reset configuration": "",
   "Resilvering:": "",
   "Resume Scrub": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2545,6 +2545,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2363,6 +2363,7 @@
   "Reserved for Dataset & Children": "",
   "Reserved space for this dataset": "",
   "Reserved space for this dataset and all children": "",
+  "Reset Fields in Step": "",
   "Reset Search": "",
   "Reset Zoom": "",
   "Reset configuration": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2259,6 +2259,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2767,6 +2767,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -112,6 +112,7 @@
   "Renew 2FA secret": "",
   "Renew Certificate Days Before Expiry": "",
   "Replication <i>{name}</i> has started.": "",
+  "Reset Fields in Step": "",
   "Reset configuration": "",
   "Resilvering:": "",
   "Resume Scrub": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2699,6 +2699,7 @@
   "Reserved for Dataset": "",
   "Reserved for Dataset & Children": "",
   "Reset": "",
+  "Reset Fields in Step": "",
   "Reset Search": "",
   "Reset Zoom": "",
   "Reset configuration": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2704,6 +2704,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2125,6 +2125,7 @@
   "Required unless <b>Enable password login</b> is <i>No</i>. Passwords cannot contain a <b>?</b>.": "",
   "Reserved for Dataset": "",
   "Reserved for Dataset & Children": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Zoom": "",
   "Reset configuration": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1368,6 +1368,7 @@
   "Reserved for Dataset": "",
   "Reserved for Dataset & Children": "",
   "Reset": "",
+  "Reset Fields in Step": "",
   "Reset Search": "",
   "Reset Zoom": "",
   "Reset configuration": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -161,6 +161,7 @@
   "Replication task created.": "",
   "Replication task saved.": "",
   "Reporting configuration saved": "",
+  "Reset Fields in Step": "",
   "Reset configuration": "",
   "Resilver configuration saved": "",
   "Resilvering:": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2775,6 +2775,7 @@
   "Reset": "",
   "Reset Config": "",
   "Reset Configuration": "",
+  "Reset Fields in Step": "",
   "Reset Layout": "",
   "Reset Search": "",
   "Reset Zoom": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -192,6 +192,7 @@
   "Renew 2FA secret": "",
   "Renew Certificate Days Before Expiry": "",
   "Replication <i>{name}</i> has started.": "",
+  "Reset Fields in Step": "",
   "Reset configuration": "",
   "Resilver configuration saved": "",
   "Resilvering:": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2090,6 +2090,7 @@
   "Reserved space for this dataset": "",
   "Reserved space for this dataset and all children": "",
   "Reset": "",
+  "Reset Fields in Step": "",
   "Reset Search": "",
   "Reset Zoom": "",
   "Reset configuration": "",


### PR DESCRIPTION
Adds a reset button for each topology step in pool manager.
This PR also replaces current reset button when manual selection exists

Testing:

- create Data vdevs
- go to Log vdev step and configure one or more vdevs
- hit reset button in step actions
- check that all selections in step are reset to default values
- check that selections in other steps are not affected
