### PR TITLE
NAS-122283 / 23.10 / Fix reporting zoom level for 6 months

### DIFF
--- a/src/app/pages/reports-dashboard/components/report/report.component.ts
+++ b/src/app/pages/reports-dashboard/components/report/report.component.ts
@@ -344,7 +344,7 @@ export class ReportComponent extends WidgetComponent implements OnInit, OnChange
     switch (timespan) {
       case ReportZoomLevel.HalfYear:
         durationUnit = 'months';
-        value = 5;
+        value = 6;
         break;
       case ReportZoomLevel.Month:
         durationUnit = 'months';

--- a/src/app/pages/reports-dashboard/enums/report-zoom-level.enum.ts
+++ b/src/app/pages/reports-dashboard/enums/report-zoom-level.enum.ts
@@ -5,7 +5,7 @@ export enum ReportZoomLevel {
   Day = '24h',
   Week = '7d',
   Month = '1M',
-  HalfYear = '5M',
+  HalfYear = '6M',
 }
 
 export const zoomLevelLabels = new Map<ReportZoomLevel, string>([


### PR DESCRIPTION
For testing, go to reporting and zoom out to 6 months, ensuring the time interval is accurate and should match ~180+- days.