### PR TITLE
Fix Edit SMB ACL Share tracebacks

### DIFF
--- a/src/app/modules/ix-forms/classes/group-combobox-provider.ts
+++ b/src/app/modules/ix-forms/classes/group-combobox-provider.ts
@@ -32,5 +32,5 @@ export class GroupComboboxProvider implements IxComboboxProvider {
       );
   }
 
-  constructor(private userService: UserService, private optionsValueField: 'group' | 'id' = 'group') {}
+  constructor(private userService: UserService, private optionsValueField: 'group' | 'gid' | 'id' = 'group') {}
 }

--- a/src/app/modules/ix-forms/classes/user-combobox-provider.ts
+++ b/src/app/modules/ix-forms/classes/user-combobox-provider.ts
@@ -15,7 +15,9 @@ export class UserComboboxProvider implements IxComboboxProvider {
 
     return this.userService.userQueryDsCache(filterValue, offset)
       .pipe(
-        map((users) => this.userQueryResToOptions(users)),
+        map((users) => {
+          return this.userQueryResToOptions(users);
+        }),
       );
   }
 
@@ -34,5 +36,5 @@ export class UserComboboxProvider implements IxComboboxProvider {
       );
   }
 
-  constructor(private userService: UserService, private optionsValueField: 'username' | 'id' = 'username') {}
+  constructor(private userService: UserService, private optionsValueField: 'username' | 'uid' | 'id' = 'username') {}
 }

--- a/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.ts
+++ b/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.ts
@@ -114,7 +114,9 @@ export class IxComboboxComponent implements ControlValueAccessor, OnInit {
         this.onChange(this.value);
       }
       if (!this.selectedOption && this.value !== null && this.value !== '') {
-        const setOption = this.options.find((option: Option) => option.value === this.value);
+        const setOption = this.options.find((option: Option) => {
+          return option.value === this.value;
+        });
         if (setOption) {
           this.selectedOption = setOption ? { ...setOption } : null;
           if (this.selectedOption) {
@@ -199,6 +201,7 @@ export class IxComboboxComponent implements ControlValueAccessor, OnInit {
   }
 
   onChanged(changedValue: string): void {
+    console.warn(changedValue);
     if (this.selectedOption || this.value) {
       this.resetInput();
     }

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
@@ -73,7 +73,7 @@ export class SmbAclComponent implements OnInit {
   readonly helptext = helptextSharingSmb;
   readonly nfsAclTag = NfsAclTag;
   readonly userProvider = new UserComboboxProvider(this.userService, 'uid');
-  readonly groupProvider = new GroupComboboxProvider(this.userService, 'id');
+  readonly groupProvider = new GroupComboboxProvider(this.userService, 'gid');
 
   constructor(
     private formBuilder: FormBuilder,

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
@@ -72,7 +72,7 @@ export class SmbAclComponent implements OnInit {
 
   readonly helptext = helptextSharingSmb;
   readonly nfsAclTag = NfsAclTag;
-  readonly userProvider = new UserComboboxProvider(this.userService, 'id');
+  readonly userProvider = new UserComboboxProvider(this.userService, 'uid');
   readonly groupProvider = new GroupComboboxProvider(this.userService, 'id');
 
   constructor(

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -41,7 +41,7 @@ export class UserService {
     }
     return combineLatest([
       this.groupQueryDsCacheByName(search),
-      this.ws.call(this.groupQuery, [queryArgs, { ...this.queryOptions, offset }]),
+      this.ws.call(this.groupQuery, [queryArgs, { ...this.queryOptions, offset, order_by: ['builtin'] }]),
     ]).pipe(map(([groupSearchedByName, groups]) => {
       const groupIds = groupSearchedByName.map((groupsByName) => groupsByName.id);
       groups = groups.filter(

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -63,7 +63,7 @@ export class UserService {
     if (search.length > 0) {
       queryArgs = [['username', '^', search]];
     }
-    return this.ws.call(this.userQuery, [queryArgs, { ...this.queryOptions, offset }]);
+    return this.ws.call(this.userQuery, [queryArgs, { ...this.queryOptions, offset, order_by: ['builtin'] }]);
   }
 
   getUserByName(username: string): Observable<DsUncachedUser> {


### PR DESCRIPTION
Testing:

- Go to https://nas-url/sharing/smb and trigger "Edit Share ACL" row action from table row
- In slide in form Who field, select User.
- If there is a current value for the User field, ensure it shows name and not id
- Combobox options for User field should show `builtin` users being shown last
- Saving the form should now work without traceback
- Repeat this process with groups