### PR TITLE
NAS-123274 / 23.10 / Remove usages of CoreService for getting disk temperatures

### DIFF
--- a/src/app/interfaces/events/disk-events.interface.ts
+++ b/src/app/interfaces/events/disk-events.interface.ts
@@ -1,12 +1,5 @@
 import { EnclosureView } from 'app/interfaces/enclosure.interface';
 import { DriveTray } from 'app/pages/system/view-enclosure/classes/drivetray';
-import { Temperature } from 'app/services/disk-temperature.service';
-
-export interface DiskTemperaturesEvent {
-  name: 'DiskTemperatures';
-  sender: unknown;
-  data: Temperature;
-}
 
 export interface DriveSelectedEvent {
   name: 'DriveSelected';

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks-mini/enclosure-disks-mini.component.ts
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks-mini/enclosure-disks-mini.component.ts
@@ -15,7 +15,6 @@ import {
   EnclosureDisksComponent,
 } from 'app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component';
 import { EnclosureStore } from 'app/pages/system/view-enclosure/stores/enclosure-store.service';
-import { CoreService } from 'app/services/core-service/core.service';
 import { DialogService } from 'app/services/dialog.service';
 import { DiskTemperatureService } from 'app/services/disk-temperature.service';
 import { ThemeService } from 'app/services/theme/theme.service';
@@ -38,7 +37,6 @@ export class EnclosureDisksMiniComponent extends EnclosureDisksComponent {
   }
 
   constructor(
-    protected core: CoreService,
     public cdr: ChangeDetectorRef,
     public dialogService: DialogService,
     protected translate: TranslateService,
@@ -50,7 +48,6 @@ export class EnclosureDisksMiniComponent extends EnclosureDisksComponent {
     protected enclosureStore: EnclosureStore,
   ) {
     super(
-      core,
       cdr,
       dialogService,
       translate,

--- a/src/app/services/disk-temperature.service.ts
+++ b/src/app/services/disk-temperature.service.ts
@@ -74,6 +74,10 @@ export class DiskTemperatureService implements OnDestroy {
   }
 
   start(): void {
+    if (this.broadcast) {
+      return;
+    }
+
     this.fetch(this.disks.map((disk) => disk.name));
     this.broadcast = setInterval(() => {
       this.fetch(this.disks.map((disk) => disk.name));

--- a/src/app/services/disk-temperature.service.ts
+++ b/src/app/services/disk-temperature.service.ts
@@ -4,7 +4,6 @@ import { map, Subject } from 'rxjs';
 import { DiskType } from 'app/enums/disk-type.enum';
 import { Disk, DiskTemperatures } from 'app/interfaces/storage.interface';
 import { Interval } from 'app/interfaces/timeout.interface';
-import { CoreService } from 'app/services/core-service/core.service';
 import { DisksUpdateService } from 'app/services/disks-update.service';
 import { WebSocketService } from 'app/services/ws.service';
 
@@ -26,27 +25,14 @@ export class DiskTemperatureService implements OnDestroy {
 
   private disksUpdateSubscriptionId: string;
 
+  temperature$ = new Subject<Temperature>();
+
   constructor(
-    protected core: CoreService,
     protected websocket: WebSocketService,
     private disksUpdateService: DisksUpdateService,
   ) { }
 
   listenForTemperatureUpdates(): void {
-    this.core.register({ observerClass: this, eventName: 'DiskTemperaturesSubscribe' }).subscribe(() => {
-      this.subscribers++;
-      if (!this.broadcast) {
-        this.start();
-      }
-    });
-
-    this.core.register({ observerClass: this, eventName: 'DiskTemperaturesUnsubscribe' }).subscribe(() => {
-      this.subscribers--;
-      if (this.subscribers === 0) {
-        this.stop();
-      }
-    });
-
     this.websocket.call('disk.query', [[], { select: ['name', 'type'] }]).subscribe((disks) => {
       this.disks = disks;
       if (this.subscribers > 0) this.start();
@@ -64,6 +50,20 @@ export class DiskTemperatureService implements OnDestroy {
       if (this.subscribers > 0) this.start();
     });
     this.disksUpdateSubscriptionId = this.disksUpdateService.addSubscriber(disksUpdateTrigger$, true);
+  }
+
+  diskTemperaturesSubscribe(): void {
+    this.subscribers++;
+    if (!this.broadcast) {
+      this.start();
+    }
+  }
+
+  diskTemperaturesUnsubscribe(): void {
+    this.subscribers--;
+    if (this.subscribers === 0) {
+      this.stop();
+    }
   }
 
   start(): void {
@@ -86,7 +86,7 @@ export class DiskTemperatureService implements OnDestroy {
         unit: 'Celsius',
         symbolText: '°',
       };
-      this.core.emit({ name: 'DiskTemperatures', data, sender: this });
+      this.temperature$.next(data);
     });
   }
 


### PR DESCRIPTION
**Testing**

Emulating "Enclosure":
1. run `yarn ui mock -e`
2. run `yarn ui mock-enclosure -e`
3. navigate to **System Settings > Enclosure**

**Expected result:** Disk temperatures should still be fetched every N seconds, according to the new approach. So please test the closure page to make sure that temperatures are still updated properly. `