### PR TITLE
NAS-123319 / 23.10-BETA.1 / The Layout Selection Field is Missing When Creating a New Pool Using The New Pool Creation Wizard After Adding a Disk to an Existing Pool Using The New Pool Creation Wizard (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service.ts
@@ -1,9 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ComponentStore, tapResponse } from '@ngrx/component-store';
 import _ from 'lodash';
-import {
-  filter, switchMap, tap,
-} from 'rxjs';
+import { filter, switchMap, tap } from 'rxjs';
 import { Pool, PoolTopology } from 'app/interfaces/pool.interface';
 import { Disk } from 'app/interfaces/storage.interface';
 import { WebsocketError } from 'app/interfaces/websocket-error.interface';
@@ -37,6 +35,10 @@ export class AddVdevsStore extends ComponentStore<AddVdevsState> {
     private errorHandler: ErrorHandlerService,
   ) {
     super(initialState);
+  }
+
+  resetStoreToInitialState(): void {
+    this.patchState({ ...initialState });
   }
 
   initialize = this.effect((trigger$) => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.ts
@@ -1,5 +1,5 @@
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, OnInit, Output, ViewChild,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, OnDestroy, OnInit, Output, ViewChild,
 } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatStepper } from '@angular/material/stepper';
@@ -27,7 +27,6 @@ import { PoolManagerValidationService } from 'app/pages/storage/modules/pool-man
 import { PoolManagerState, PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
 import { topologyToPayload } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 import { DialogService } from 'app/services/dialog.service';
-import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
 import { waitForSystemFeatures } from 'app/store/system-info/system-info.selectors';
 
@@ -38,7 +37,7 @@ import { waitForSystemFeatures } from 'app/store/system-info/system-info.selecto
   styleUrls: ['./pool-manager-wizard.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PoolManagerWizardComponent implements OnInit {
+export class PoolManagerWizardComponent implements OnInit, OnDestroy {
   protected existingPool: Pool = null;
   @Output() stepChanged = new EventEmitter<PoolCreationWizardStep>();
 
@@ -71,7 +70,6 @@ export class PoolManagerWizardComponent implements OnInit {
     private snackbar: SnackbarService,
     private poolManagerValidation: PoolManagerValidationService,
     private route: ActivatedRoute,
-    private ws: WebSocketService,
     private addVdevsStore: AddVdevsStore,
     private dialogService: DialogService,
   ) {}
@@ -83,6 +81,10 @@ export class PoolManagerWizardComponent implements OnInit {
     if (this.route.snapshot.url.toString().includes('add-vdevs')) {
       this.loadExistingPoolDetails();
     }
+  }
+
+  ngOnDestroy(): void {
+    this.addVdevsStore.resetStoreToInitialState();
   }
 
   loadExistingPoolDetails(): void {


### PR DESCRIPTION
Testing: 
Go to Add to Pool screen:
<img width="1209" alt="Screenshot 2023-08-01 at 18 50 53" src="https://github.com/truenas/webui/assets/22980553/380b58d1-7d6b-474d-8b2e-56ad7d199f44">

Go to DATA step, you should not see Layout selection.
<img width="941" alt="Screenshot 2023-08-01 at 18 51 15" src="https://github.com/truenas/webui/assets/22980553/d7b61da3-b351-47d7-8c77-e1a606819d23">

After that -> go to the default Create Pool screen -> Data STEP 
<img width="908" alt="Screenshot 2023-08-01 at 18 51 56" src="https://github.com/truenas/webui/assets/22980553/fb8f4958-c3f4-4d36-9d32-246142026028">

There you should see Layout select. 

Previously it was not there after the steps I described.

Original PR: https://github.com/truenas/webui/pull/8511
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123319