### PR TITLE
NAS-123278 / 24.04 / `zfs.snapshot.query` `REMOVED` event will not include child snapshots

### DIFF
--- a/src/app/pages/datasets/modules/snapshots/store/snapshot.effects.ts
+++ b/src/app/pages/datasets/modules/snapshots/store/snapshot.effects.ts
@@ -47,7 +47,7 @@ export class SnapshotEffects {
     switchMap(() => {
       return this.ws.subscribe('zfs.snapshot.query').pipe(
         filter((event) => event.msg !== IncomingApiMessageType.Removed),
-        // event.fields is not sent for some reason and that's why list is not updated, so this gonna jelp
+        // event.fields is not sent for some reason and that's why list is not updated, so this gonna help
         map(() => snapshotPageEntered()),
       );
     }),

--- a/src/app/pages/datasets/modules/snapshots/store/snapshot.effects.ts
+++ b/src/app/pages/datasets/modules/snapshots/store/snapshot.effects.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import { EMPTY, of } from 'rxjs';
+import { of } from 'rxjs';
 import {
   catchError, filter, map, switchMap,
 } from 'rxjs/operators';
@@ -10,7 +10,6 @@ import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
 import { ZfsSnapshot } from 'app/interfaces/zfs-snapshot.interface';
 import { snapshotExcludeBootQueryFilter } from 'app/pages/datasets/modules/snapshots/constants/snapshot-exclude-boot.constant';
 import {
-  snapshotAdded, snapshotChanged,
   snapshotPageEntered,
   snapshotRemoved, snapshotsLoaded, snapshotsNotLoaded,
 } from 'app/pages/datasets/modules/snapshots/store/snapshot.actions';
@@ -48,16 +47,8 @@ export class SnapshotEffects {
     switchMap(() => {
       return this.ws.subscribe('zfs.snapshot.query').pipe(
         filter((event) => event.msg !== IncomingApiMessageType.Removed),
-        switchMap((event) => {
-          switch (event.msg) {
-            case IncomingApiMessageType.Added:
-              return of(snapshotAdded({ snapshot: event.fields }));
-            case IncomingApiMessageType.Changed:
-              return of(snapshotChanged({ snapshot: event.fields }));
-            default:
-              return EMPTY;
-          }
-        }),
+        // event.fields is not sent for some reason and that's why list is not updated, so this gonna jelp
+        map(() => snapshotPageEntered()),
       );
     }),
   ));

--- a/src/app/pages/datasets/modules/snapshots/store/snapshot.reducer.ts
+++ b/src/app/pages/datasets/modules/snapshots/store/snapshot.reducer.ts
@@ -14,8 +14,8 @@ export interface SnapshotsState extends EntityState<ZfsSnapshot> {
 }
 
 export const adapter = createEntityAdapter<ZfsSnapshot>({
-  selectId: (snapshot) => snapshot.name,
-  sortComparer: (a, b) => a.snapshot_name.localeCompare(b.snapshot_name),
+  selectId: (snapshot) => snapshot?.name,
+  sortComparer: (a, b) => a?.snapshot_name?.localeCompare(b?.snapshot_name),
 });
 
 export const snapshotsInitialState = adapter.getInitialState({
@@ -32,7 +32,7 @@ export const snapshotReducer = createReducer(
 
   on(snapshotAdded, (state, { snapshot }) => adapter.addOne(snapshot, state)),
   on(snapshotChanged, (state, { snapshot }) => adapter.updateOne({
-    id: snapshot.name,
+    id: snapshot?.name,
     changes: snapshot,
   }, state)),
   on(snapshotRemoved, (state, { id }) => adapter.removeOne(id, state)),


### PR DESCRIPTION
I checked that this ticket will not break anything on the UI since we don't use `{"recursive": true}` option.
But I found out that subscribing to updates, will not update the list
// event.fields is not sent for some reason and that's why list is not updated, so this gonna help

So I came up with an idea. (check code changes)