### PR TITLE
NAS-123402 / 23.10 / Hiding vdevs count field for spare vdev step

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -34,6 +34,7 @@
         ></ix-select>
 
         <ix-select
+          *ngIf="!isSpareVdev"
           formControlName="vdevsNumber"
           [label]="'Number of VDEVs' | translate"
           [options]="numberOptions$"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -41,7 +41,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
 
   @Output() manualSelectionClicked = new EventEmitter<void>();
 
-  protected form = this.formBuilder.group({
+  form = this.formBuilder.group({
     layout: [CreateVdevLayout.Stripe, Validators.required],
     sizeAndType: [[null, null] as SizeAndType, Validators.required],
     width: [{ value: null as number, disabled: true }, Validators.required],

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -41,7 +41,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
 
   @Output() manualSelectionClicked = new EventEmitter<void>();
 
-  form = this.formBuilder.group({
+  protected form = this.formBuilder.group({
     layout: [CreateVdevLayout.Stripe, Validators.required],
     sizeAndType: [[null, null] as SizeAndType, Validators.required],
     width: [{ value: null as number, disabled: true }, Validators.required],
@@ -64,26 +64,30 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
     protected store: PoolManagerStore,
   ) {}
 
-  get selectedDiskSize(): number {
+  protected get selectedDiskSize(): number {
     return this.form.controls.sizeAndType.value?.[0];
   }
 
-  get isSizeSelected(): boolean {
+  protected get isSizeSelected(): boolean {
     return !!this.form.value.sizeAndType?.length
       && !!this.form.value.sizeAndType[0]
       && !!this.form.value.sizeAndType[1];
   }
 
-  get isLayoutSelected(): boolean {
+  protected get isLayoutSelected(): boolean {
     return !!this.form.value.layout;
   }
 
-  get isWidthSelected(): boolean {
+  protected get isWidthSelected(): boolean {
     return !!this.form.value.width;
   }
 
-  get selectedDiskType(): DiskType {
+  protected get selectedDiskType(): DiskType {
     return this.form.controls.sizeAndType.value?.[1];
+  }
+
+  protected get isSpareVdev(): boolean {
+    return this.type === VdevType.Spare;
   }
 
   ngOnInit(): void {
@@ -98,9 +102,13 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
         this.resetToDefaults();
       }
     });
+
+    if (this.isSpareVdev) {
+      this.form.controls.vdevsNumber.disable();
+    }
   }
 
-  resetToDefaults(): void {
+  private resetToDefaults(): void {
     this.form.reset({
       layout: null,
       sizeAndType: [null, null],
@@ -127,7 +135,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
     }
   }
 
-  updateLayoutOptionsFromLimitedLayouts(limitLayouts: CreateVdevLayout[]): void {
+  private updateLayoutOptionsFromLimitedLayouts(limitLayouts: CreateVdevLayout[]): void {
     this.vdevLayoutOptions$ = of(
       limitLayouts.map(
         (layout) => ({
@@ -146,7 +154,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
     this.updateWidthOptions();
   }
 
-  openManualDiskSelection(): void {
+  protected openManualDiskSelection(): void {
     this.manualSelectionClicked.emit();
   }
 
@@ -166,7 +174,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
         if (this.form.controls.treatDiskSizeAsMinimum.disabled) {
           this.form.controls.treatDiskSizeAsMinimum.enable();
         }
-        if (this.isWidthSelected && this.form.controls.vdevsNumber.disabled) {
+        if (this.isWidthSelected && this.form.controls.vdevsNumber.disabled && !this.isSpareVdev) {
           this.form.controls.vdevsNumber.enable();
         }
       }
@@ -185,7 +193,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
         if (this.form.controls.treatDiskSizeAsMinimum.disabled) {
           this.form.controls.treatDiskSizeAsMinimum.enable();
         }
-        if (this.isWidthSelected && this.form.controls.vdevsNumber.disabled) {
+        if (this.isWidthSelected && this.form.controls.vdevsNumber.disabled && !this.isSpareVdev) {
           this.form.controls.vdevsNumber.enable();
         }
       }
@@ -197,7 +205,13 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
       distinctUntilChanged(),
       untilDestroyed(this),
     ).subscribe((width) => {
-      if (this.isSizeSelected && this.isLayoutSelected && !!width && this.form.controls.vdevsNumber.disabled) {
+      if (
+        this.isSizeSelected
+        && this.isLayoutSelected
+        && !!width
+        && this.form.controls.vdevsNumber.disabled
+        && !this.isSpareVdev
+      ) {
         this.form.controls.vdevsNumber.enable();
       }
       this.updateNumberOptions();
@@ -222,7 +236,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
       diskSize: this.selectedDiskSize,
       diskType: this.selectedDiskType,
       width: values.width,
-      vdevsNumber: values.vdevsNumber,
+      vdevsNumber: this.isSpareVdev ? 1 : values.vdevsNumber,
       treatDiskSizeAsMinimum: values.treatDiskSizeAsMinimum,
     });
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.html
@@ -99,6 +99,7 @@
       </mat-step>
 
       <mat-step
+        *ngIf="!existingPool?.topology?.spare?.length"
         ixStepActivation
         [errorMessage]="getTopLevelErrorForStep(PoolCreationWizardStep.Spare)"
         [hasError]="!!getTopLevelErrorForStep(PoolCreationWizardStep.Spare) && getWasStepActivated(PoolCreationWizardStep.Spare)"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.ts
@@ -89,6 +89,7 @@ export class PoolManagerWizardComponent implements OnInit, OnDestroy {
 
   loadExistingPoolDetails(): void {
     this.addVdevsStore.pool$.pipe(
+      filter(Boolean),
       tap((pool) => {
         this.existingPool = _.cloneDeep(pool);
         this.cdr.markForCheck();


### PR DESCRIPTION
Test that the Spare vdev step doesn't have the Vdevs Count field. It should only be allowed to have 1 vdev. Also, test that if there is already a spare vdev in the pool, you are not allowed to add a new spare vdev. 