### PR TITLE
NAS-123351 / 24.04 / Takeout `checkForUpdate`

### DIFF
--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -136,10 +136,8 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
         error: (error) => {
           console.error('System Info not available', error);
         },
-        complete: () => {
-          this.checkForUpdate();
-        },
       });
+      this.checkForUpdate();
     }
     if (this.sysGenService.getProductType() === ProductType.ScaleEnterprise) {
       this.store$.select(selectIsHaLicensed).pipe(untilDestroyed(this)).subscribe((isHaLicensed) => {

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -284,20 +284,15 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
     this.ws.call('update.check_available').pipe(
       take(1),
       untilDestroyed(this),
-    ).subscribe({
-      next: (update) => {
-        if (update.status !== SystemUpdateStatus.Available) {
-          this.updateAvailable = false;
-          sessionStorage.updateAvailable = 'false';
-          return;
-        }
+    ).subscribe((update) => {
+      if (update.status !== SystemUpdateStatus.Available) {
+        this.updateAvailable = false;
+        sessionStorage.updateAvailable = 'false';
+        return;
+      }
 
-        this.updateAvailable = true;
-        sessionStorage.updateAvailable = 'true';
-      },
-      error: (err) => {
-        this.errorHandler.logToSentry(err);
-      },
+      this.updateAvailable = true;
+      sessionStorage.updateAvailable = 'true';
     });
   }
 }

--- a/src/app/services/error-handler.service.spec.ts
+++ b/src/app/services/error-handler.service.spec.ts
@@ -1,6 +1,5 @@
 import { HttpErrorResponse, HttpEventType, HttpHeaders } from '@angular/common/http';
 import { Injector } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
@@ -96,15 +95,9 @@ describe('ErrorHandlerService', () => {
       expect(spectator.service.logToSentry).toHaveBeenCalledWith(error);
     });
 
-    it('logs websocket error via dialog', () => {
-      spectator.inject(MatDialog);
+    it('logs websocket error', () => {
       spectator.service.handleError(wsError);
 
-      expect(spectator.service.dialog.error).toHaveBeenCalledWith({
-        backtrace: 'FORMATTED',
-        message: 'SOME REASON',
-        title: 'CLASS',
-      });
       expect(spectator.service.logToSentry).toHaveBeenCalledWith({
         backtrace: 'FORMATTED',
         message: 'SOME REASON',
@@ -112,15 +105,9 @@ describe('ErrorHandlerService', () => {
       });
     });
 
-    it('logs job error via dialog', () => {
-      spectator.inject(MatDialog);
+    it('logs job error', () => {
       spectator.service.handleError(failedJob);
 
-      expect(spectator.service.dialog.error).toHaveBeenCalledWith([{
-        backtrace: 'EXCEPTION',
-        message: 'DUMMY_ERROR',
-        title: 'Error: path',
-      }]);
       expect(spectator.service.logToSentry).toHaveBeenCalledWith([{
         backtrace: 'EXCEPTION',
         message: 'DUMMY_ERROR',

--- a/src/app/services/error-handler.service.ts
+++ b/src/app/services/error-handler.service.ts
@@ -36,7 +36,6 @@ export class ErrorHandlerService implements ErrorHandler {
     const parsedError = this.parseError(error);
     if (parsedError) {
       error = parsedError;
-      this.dialog?.error(parsedError);
     }
     this.logToSentry(error);
   }


### PR DESCRIPTION
**Summary**

After refactoring, the `checkForUpdate` was moved to a place in code, which was out of reach of `untilDestroy` pipe.

Moveover, the call `checkForUpdate` was waiting for the sys info to be fetched, without need to do so.

**Testing**

1. Tweak the code to simulate delayed error in `checkForUpdate`
2. Drop update-related keys from your `sessionStorage`
3. Go to Dashboard, not stay too long
4. Quickly navigate from Dashboard to any other page (/system/services, /storage/, ...)

**Expected result:**
Once you left Dashboard page, you should never see an pop-up with an error from Pt "1"