### PR TITLE
NAS-123154 / 23.10 / Fix Edit SMB ACL Share tracebacks (by dszidi)

### DIFF
--- a/src/app/modules/ix-forms/classes/group-combobox-provider.ts
+++ b/src/app/modules/ix-forms/classes/group-combobox-provider.ts
@@ -32,5 +32,5 @@ export class GroupComboboxProvider implements IxComboboxProvider {
       );
   }
 
-  constructor(private userService: UserService, private optionsValueField: 'group' | 'id' = 'group') {}
+  constructor(private userService: UserService, private optionsValueField: 'group' | 'gid' | 'id' = 'group') {}
 }

--- a/src/app/modules/ix-forms/classes/user-combobox-provider.ts
+++ b/src/app/modules/ix-forms/classes/user-combobox-provider.ts
@@ -15,7 +15,9 @@ export class UserComboboxProvider implements IxComboboxProvider {
 
     return this.userService.userQueryDsCache(filterValue, offset)
       .pipe(
-        map((users) => this.userQueryResToOptions(users)),
+        map((users) => {
+          return this.userQueryResToOptions(users);
+        }),
       );
   }
 
@@ -34,5 +36,5 @@ export class UserComboboxProvider implements IxComboboxProvider {
       );
   }
 
-  constructor(private userService: UserService, private optionsValueField: 'username' | 'id' = 'username') {}
+  constructor(private userService: UserService, private optionsValueField: 'username' | 'uid' | 'id' = 'username') {}
 }

--- a/src/app/modules/ix-forms/classes/user-combobox-provider.ts
+++ b/src/app/modules/ix-forms/classes/user-combobox-provider.ts
@@ -15,9 +15,7 @@ export class UserComboboxProvider implements IxComboboxProvider {
 
     return this.userService.userQueryDsCache(filterValue, offset)
       .pipe(
-        map((users) => {
-          return this.userQueryResToOptions(users);
-        }),
+        map((users) => this.userQueryResToOptions(users)),
       );
   }
 

--- a/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.ts
+++ b/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.ts
@@ -114,9 +114,7 @@ export class IxComboboxComponent implements ControlValueAccessor, OnInit {
         this.onChange(this.value);
       }
       if (!this.selectedOption && this.value !== null && this.value !== '') {
-        const setOption = this.options.find((option: Option) => {
-          return option.value === this.value;
-        });
+        const setOption = this.options.find((option: Option) => option.value === this.value);
         if (setOption) {
           this.selectedOption = setOption ? { ...setOption } : null;
           if (this.selectedOption) {
@@ -201,7 +199,6 @@ export class IxComboboxComponent implements ControlValueAccessor, OnInit {
   }
 
   onChanged(changedValue: string): void {
-    console.warn(changedValue);
     if (this.selectedOption || this.value) {
       this.resetInput();
     }

--- a/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.ts
+++ b/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.ts
@@ -114,7 +114,9 @@ export class IxComboboxComponent implements ControlValueAccessor, OnInit {
         this.onChange(this.value);
       }
       if (!this.selectedOption && this.value !== null && this.value !== '') {
-        const setOption = this.options.find((option: Option) => option.value === this.value);
+        const setOption = this.options.find((option: Option) => {
+          return option.value === this.value;
+        });
         if (setOption) {
           this.selectedOption = setOption ? { ...setOption } : null;
           if (this.selectedOption) {
@@ -199,6 +201,7 @@ export class IxComboboxComponent implements ControlValueAccessor, OnInit {
   }
 
   onChanged(changedValue: string): void {
+    console.warn(changedValue);
     if (this.selectedOption || this.value) {
       this.resetInput();
     }

--- a/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.ts
+++ b/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.component.ts
@@ -37,6 +37,7 @@ export class IxComboboxComponent implements ControlValueAccessor, OnInit {
   @Input() tooltip: string;
   @Input() allowCustomValue = false;
   @Input() provider: IxComboboxProvider;
+  @Input() initialValue?: Option | null;
 
   @ViewChild('ixInput') inputElementRef: ElementRef<HTMLInputElement>;
   @ViewChild('auto') autoCompleteRef: MatAutocomplete;
@@ -120,6 +121,13 @@ export class IxComboboxComponent implements ControlValueAccessor, OnInit {
           if (this.selectedOption) {
             this.filterChanged$.next('');
           }
+        } else if (this.initialValue?.value) {
+          /**
+           * Workaround!
+           * TODO: Redesign ix-combobox provider to reliably fetch initial values without needing fake options
+           * */
+          this.options.push(this.initialValue);
+          this.selectedOption = this.initialValue;
         } else {
           /**
            * We are adding a custom fake option here so we can show the current value of the control even

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
@@ -44,6 +44,7 @@
                 [label]="'Group' | translate"
                 [provider]="groupProvider"
                 [required]="true"
+                [initialValue]="initialOptions[i]"
               ></ix-combobox>
             </div>
 

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
@@ -8,7 +8,9 @@ import { of } from 'rxjs';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { NfsAclTag } from 'app/enums/nfs-acl.enum';
 import { SmbSharesecPermission, SmbSharesecType } from 'app/enums/smb-sharesec.enum';
+import { Group } from 'app/interfaces/group.interface';
 import { SmbSharesec } from 'app/interfaces/smb-share.interface';
+import { User as TnUser } from 'app/interfaces/user.interface';
 import { IxComboboxHarness } from 'app/modules/ix-forms/components/ix-combobox/ix-combobox.harness';
 import { IxListHarness } from 'app/modules/ix-forms/components/ix-list/ix-list.harness';
 import { IxSlideInRef } from 'app/modules/ix-forms/components/ix-slide-in/ix-slide-in-ref';
@@ -49,6 +51,13 @@ describe('SmbAclComponent', () => {
       },
     ],
   } as SmbSharesec;
+
+  const rootUser: Partial<TnUser> = {
+    id: 0,
+    uid: 0,
+    username: 'root',
+  };
+
   const createComponent = createComponentFactory({
     component: SmbAclComponent,
     imports: [
@@ -59,17 +68,19 @@ describe('SmbAclComponent', () => {
       mockWebsocket([
         mockCall('sharing.smb.getacl', mockAcl),
         mockCall('sharing.smb.setacl'),
+        mockCall('user.query', [rootUser] as TnUser[]),
+        mockCall('group.query', [{ group: 'wheel', id: 1, gid: 1 }] as Group[]),
       ]),
       mockProvider(IxSlideInService),
       mockProvider(DialogService),
       mockProvider(IxSlideInRef),
       mockProvider(UserService, {
         userQueryDsCache: () => of([
-          { username: 'root', id: 0 },
+          { username: 'root', id: 0, uid: 0 },
           { username: 'trunk' },
         ] as User[]),
         groupQueryDsCache: () => of([
-          { group: 'wheel', id: 1 },
+          { group: 'wheel', id: 1, gid: 1 },
           { group: 'vip' },
         ]),
       }),

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
@@ -24,6 +24,31 @@ describe('SmbAclComponent', () => {
   let spectator: Spectator<SmbAclComponent>;
   let loader: HarnessLoader;
   let entriesList: IxListHarness;
+  const mockAcl = {
+    id: 13,
+    share_name: 'myshare',
+    share_acl: [
+      {
+        ae_who_sid: 'S-1-1-0',
+        ae_type: SmbSharesecType.Allowed,
+        ae_who_id: {
+          id_type: NfsAclTag.Everyone,
+          id: null,
+        },
+        ae_perm: SmbSharesecPermission.Read,
+      },
+      {
+        ae_who_sid: 'S-1-1-1',
+        ae_type: SmbSharesecType.Denied,
+        ae_perm: SmbSharesecPermission.Full,
+        ae_who_id: {
+          id_type: NfsAclTag.User,
+          id: 3001,
+        },
+        ae_who_str: 'myuser',
+      },
+    ],
+  } as SmbSharesec;
   const createComponent = createComponentFactory({
     component: SmbAclComponent,
     imports: [
@@ -32,31 +57,7 @@ describe('SmbAclComponent', () => {
     ],
     providers: [
       mockWebsocket([
-        mockCall('sharing.smb.getacl', {
-          id: 13,
-          share_name: 'myshare',
-          share_acl: [
-            {
-              ae_who_sid: 'S-1-1-0',
-              ae_type: SmbSharesecType.Allowed,
-              ae_who_id: {
-                id_type: NfsAclTag.Everyone,
-                id: null,
-              },
-              ae_perm: SmbSharesecPermission.Read,
-            },
-            {
-              ae_who_sid: 'S-1-1-1',
-              ae_type: SmbSharesecType.Denied,
-              ae_perm: SmbSharesecPermission.Full,
-              ae_who_id: {
-                id_type: NfsAclTag.User,
-                id: 0,
-              },
-              ae_who_str: 'root',
-            },
-          ],
-        } as SmbSharesec),
+        mockCall('sharing.smb.getacl', mockAcl),
         mockCall('sharing.smb.setacl'),
       ]),
       mockProvider(IxSlideInService),
@@ -128,7 +129,7 @@ describe('SmbAclComponent', () => {
       },
       {
         Who: 'User',
-        User: 'root',
+        User: '3001',
         Permission: 'FULL',
         Type: 'DENIED',
       },
@@ -159,7 +160,7 @@ describe('SmbAclComponent', () => {
           ae_perm: SmbSharesecPermission.Full,
           ae_type: SmbSharesecType.Denied,
           ae_who_id: {
-            id: 0,
+            id: 3001,
             id_type: 'USER',
           },
         },

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
@@ -73,7 +73,7 @@ export class SmbAclComponent implements OnInit {
   readonly helptext = helptextSharingSmb;
   readonly nfsAclTag = NfsAclTag;
   readonly userProvider = new UserComboboxProvider(this.userService, 'uid');
-  readonly groupProvider = new GroupComboboxProvider(this.userService, 'id');
+  readonly groupProvider = new GroupComboboxProvider(this.userService, 'gid');
 
   constructor(
     private formBuilder: FormBuilder,

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
@@ -196,8 +196,8 @@ export class SmbAclComponent implements OnInit {
       const queryArgs: QueryFilter<Group>[] = [['uid', '=', ace.ae_who_id?.id]];
       return this.ws.call('user.query', [queryArgs]);
     }
-    // False positive. Linter thinks it's a conditional statement
-    return of([]); // NOSONAR
+
+    return of([]);
   }
 
   private extractOptionFromAcl(shareAcl: SmbSharesecAce[]): void {

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
@@ -72,7 +72,7 @@ export class SmbAclComponent implements OnInit {
 
   readonly helptext = helptextSharingSmb;
   readonly nfsAclTag = NfsAclTag;
-  readonly userProvider = new UserComboboxProvider(this.userService, 'id');
+  readonly userProvider = new UserComboboxProvider(this.userService, 'uid');
   readonly groupProvider = new GroupComboboxProvider(this.userService, 'id');
 
   constructor(

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -41,7 +41,7 @@ export class UserService {
     }
     return combineLatest([
       this.groupQueryDsCacheByName(search),
-      this.ws.call(this.groupQuery, [queryArgs, { ...this.queryOptions, offset }]),
+      this.ws.call(this.groupQuery, [queryArgs, { ...this.queryOptions, offset, order_by: ['builtin'] }]),
     ]).pipe(map(([groupSearchedByName, groups]) => {
       const groupIds = groupSearchedByName.map((groupsByName) => groupsByName.id);
       groups = groups.filter(

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -63,7 +63,7 @@ export class UserService {
     if (search.length > 0) {
       queryArgs = [['username', '^', search]];
     }
-    return this.ws.call(this.userQuery, [queryArgs, { ...this.queryOptions, offset }]);
+    return this.ws.call(this.userQuery, [queryArgs, { ...this.queryOptions, offset, order_by: ['builtin'] }]);
   }
 
   getUserByName(username: string): Observable<DsUncachedUser> {


### PR DESCRIPTION
Testing:

- Go to https://nas-url/sharing/smb and trigger "Edit Share ACL" row action from table row
- In slide in form Who field, select User.
- If there is a current value for the User field, ensure it shows name and not id
- Combobox options for User field should show `builtin` users being shown last
- Saving the form should now work without traceback
- Repeat this process with groups

Original PR: https://github.com/truenas/webui/pull/8499
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123154