### PR TITLE
NAS-123415 / 24.04 / "Mixing vdev layouts not allowed" error appears when creating a new pool

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service.ts
@@ -38,7 +38,7 @@ export class AddVdevsStore extends ComponentStore<AddVdevsState> {
   }
 
   resetStoreToInitialState(): void {
-    this.patchState({ ...initialState });
+    this.setState({ ...initialState });
   }
 
   initialize = this.effect((trigger$) => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.ts
@@ -85,6 +85,7 @@ export class PoolManagerWizardComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.addVdevsStore.resetStoreToInitialState();
+    this.store.resetStoreToInitialState();
   }
 
   loadExistingPoolDetails(): void {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.spec.ts
@@ -182,7 +182,7 @@ describe('ReviewWizardStepComponent', () => {
       }));
 
       const store = spectator.inject(PoolManagerStore);
-      expect(store.reset).toHaveBeenCalled();
+      expect(store.startOver).toHaveBeenCalled();
     });
   });
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
@@ -114,7 +114,7 @@ export class ReviewWizardStepComponent implements OnInit {
         filter(Boolean),
         untilDestroyed(this),
       ).subscribe(() => {
-        this.store.reset();
+        this.store.startOver();
       });
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -7,7 +7,6 @@ import {
 } from 'rxjs';
 import { CreateVdevLayout, TopologyItemType, VdevType } from 'app/enums/v-dev-type.enum';
 import helptext from 'app/helptext/storage/volumes/manager/manager';
-import { Pool } from 'app/interfaces/pool.interface';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { getNonUniqueSerialDisksWarning } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/pool-warnings/get-non-unique-serial-disks';
 import { DispersalStrategy } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/2-enclosure-wizard-step/enclosure-wizard-step.component';
@@ -21,8 +20,6 @@ import { waitForSystemFeatures } from 'app/store/system-info/system-info.selecto
 
 @Injectable()
 export class PoolManagerValidationService {
-  private existingPool: Pool = null;
-
   constructor(
     protected store: PoolManagerStore,
     protected systemStore$: Store<AppState>,
@@ -43,13 +40,7 @@ export class PoolManagerValidationService {
     ]),
   ])
     .pipe(
-      map(([
-        pool, name, topology, enclosure,
-        [hasMultipleEnclosures, hasEnclosureSupport],
-      ]) => {
-        if (pool) {
-          this.existingPool = _.cloneDeep(pool);
-        }
+      map(([existingPool, name, topology, enclosure, [hasMultipleEnclosures, hasEnclosureSupport]]) => {
         const hasAtleastOneVdev = Object.values(VdevType).some((vdevType) => topology[vdevType]?.vdevs.length > 0);
         const hasDataVdevs = topology[VdevType.Data].vdevs.length > 0;
         const errors: PoolCreationError[] = [];
@@ -74,18 +65,14 @@ export class PoolManagerValidationService {
           });
         }
 
-        if (this.existingPool) {
-          let oldDataLayoutType = this.existingPool.topology.data[0].type;
-          if (oldDataLayoutType === TopologyItemType.Disk
-            && !this.existingPool.topology.data[0].children?.length
-          ) {
+        if (existingPool) {
+          let oldDataLayoutType = existingPool.topology.data[0].type;
+
+          if (oldDataLayoutType === TopologyItemType.Disk && !existingPool.topology.data[0].children?.length) {
             oldDataLayoutType = TopologyItemType.Stripe;
           }
 
-          if (hasDataVdevs
-            && topology[VdevType.Data].layout
-            !== oldDataLayoutType as unknown as CreateVdevLayout
-          ) {
+          if (hasDataVdevs && topology[VdevType.Data].layout !== oldDataLayoutType as unknown as CreateVdevLayout) {
             errors.push({
               text: this.translate.instant(
                 'Mixing Vdev layout types is not allowed. This pool already has some {type} Data Vdevs. You can only add vdevs of {type} type.',
@@ -95,6 +82,7 @@ export class PoolManagerValidationService {
               step: PoolCreationWizardStep.Data,
             });
           }
+
           if (!hasAtleastOneVdev) {
             errors.push({
               text: this.translate.instant('At least 1 vdev is required to make an update to the pool.'),
@@ -112,12 +100,11 @@ export class PoolManagerValidationService {
 
         const nonEmptyTopologyCategories = this.filterNonEmptyCategories(topology);
 
-        nonEmptyTopologyCategories.forEach((
-          [typologyCategoryType, typologyCategory],
-        ) => {
-          if (this.existingPool) {
+        nonEmptyTopologyCategories.forEach(([typologyCategoryType, typologyCategory]) => {
+          if (existingPool) {
             return;
           }
+
           if (
             [VdevType.Dedup, VdevType.Log, VdevType.Special, VdevType.Data].includes(typologyCategoryType)
             && typologyCategory.vdevs.length >= 1 && typologyCategory.layout === CreateVdevLayout.Stripe

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
@@ -123,7 +123,7 @@ describe('PoolManagerStore', () => {
 
   describe('start over functionality', () => {
     it('reverts state to initial state', async () => {
-      spectator.service.reset();
+      spectator.service.startOver();
 
       expect(await firstValueFrom(spectator.service.state$)).toMatchObject({
         ...initialState,

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -191,7 +191,11 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
     super(initialState);
   }
 
-  reset(): void {
+  resetStoreToInitialState(): void {
+    this.setState({ ...initialState });
+  }
+
+  startOver(): void {
     this.startOver$.next();
     this.setState({ ...initialState, isLoading: true });
     this.loadStateInitialData().pipe(take(1)).subscribe();


### PR DESCRIPTION
Testing:
How it was reproducing before:
- Create new Pool with RaidZ1 `Data` Layout step.
- Add Vdev for newly created Pool
- Create new pool with any Layout in `Data` step.
--- Here error showed up 
![image](https://github.com/truenas/webui/assets/22980553/e8b924b9-3f5e-47c8-8dae-4fcf50d8816c)

You can try on latest nightly to reproduce the bug; (you can as well check ticket description video)

On localhost:
Try to go ahead with above steps -> you should no longer see that error.
