### PR TITLE
NAS-123284 / 24.04 / Unable to add spares in new Pool Creation Wizard

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -102,7 +102,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
 
   resetToDefaults(): void {
     this.form.reset({
-      layout: null,
+      layout: this.canChangeLayout ? null : this.limitLayouts[0],
       sizeAndType: [null, null],
       width: null,
       treatDiskSizeAsMinimum: false,
@@ -234,7 +234,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
 
     const isValueNull = this.form.controls.layout.value === null;
     if (!isValueNull && !layoutOptions.some((option) => option.value === this.form.controls.layout.value)) {
-      this.form.controls.layout.setValue(null, { emitEvent: false });
+      this.form.controls.layout.setValue(this.canChangeLayout ? null : this.limitLayouts[0], { emitEvent: false });
     }
     this.store.getLayoutsForVdevType(this.type)
       .pipe(

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -102,7 +102,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
 
   resetToDefaults(): void {
     this.form.reset({
-      layout: null,
+      layout: CreateVdevLayout.Stripe,
       sizeAndType: [null, null],
       width: null,
       treatDiskSizeAsMinimum: false,
@@ -234,7 +234,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
 
     const isValueNull = this.form.controls.layout.value === null;
     if (!isValueNull && !layoutOptions.some((option) => option.value === this.form.controls.layout.value)) {
-      this.form.controls.layout.setValue(null, { emitEvent: false });
+      this.form.controls.layout.setValue(CreateVdevLayout.Stripe, { emitEvent: false });
     }
     this.store.getLayoutsForVdevType(this.type)
       .pipe(

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -102,7 +102,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
 
   resetToDefaults(): void {
     this.form.reset({
-      layout: CreateVdevLayout.Stripe,
+      layout: null,
       sizeAndType: [null, null],
       width: null,
       treatDiskSizeAsMinimum: false,
@@ -234,7 +234,7 @@ export class AutomatedDiskSelectionComponent implements OnInit, OnChanges {
 
     const isValueNull = this.form.controls.layout.value === null;
     if (!isValueNull && !layoutOptions.some((option) => option.value === this.form.controls.layout.value)) {
-      this.form.controls.layout.setValue(CreateVdevLayout.Stripe, { emitEvent: false });
+      this.form.controls.layout.setValue(null, { emitEvent: false });
     }
     this.store.getLayoutsForVdevType(this.type)
       .pipe(


### PR DESCRIPTION
### Summary 

Please check the context of the ticket first. 

Note that on the step 4 (Spare) it's impossible to choose a layout (Stripe/Mirror/...). WebUI by design provides no ability to do so by not rendering **Layout** dropdown on this step.

The root cause of the bug is that the **Layout** have no selection, this prevents user from interacting with dependant fields (Treat disk..., Width, Number...) 

This fix ensures that these fields become enabled, by pre-selecting the correct item in the  **Layout** dropdown. The correct item is being chosen automatically based on the logic from `add-vdevs-legacy`.

### Repro steps

1. Have an existing pool and at least 2 unassigned disks
2. Go to **Storage** -> **Unassigned Disks** -> **Add To Pool** 
4. In the **Add To Pool** pop-up, select **Existing Pool** option, pick any pool in the **Existing pool** dropdown and click **Add Disks**
5. In Steps 1 of the wizard, check your disks one more time under **Select disks you want to use** and click **Next**
6. In Step 4 (Spare), select any item from the **Disk Size** dropdown, and try to select an item from **Width** and **Number of VDEVs** dropdowns

**Expected Result:** user should be able to select an item from **Width** and **Number of VDEVs** dropdowns