### PR TITLE
NAS-123336 / 22.12.4 / WebUI tooltips are malfunctioning in chrome (by AlexKarpov98)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -78,7 +78,7 @@ import { WebSocketService } from './services/ws.service';
       useHash: false,
       preloadingStrategy: PreloadAllModules,
     }),
-    NgxPopperjsModule.forRoot({ appendTo: 'body' }),
+    NgxPopperjsModule.forRoot({ appendTo: 'body', hideOnScroll: true }),
     MarkdownModule.forRoot(),
     CoreComponents,
     MatSnackBarModule,

--- a/src/app/modules/ix-forms/components/ix-slide-in/ix-slide-in.component.ts
+++ b/src/app/modules/ix-forms/components/ix-slide-in/ix-slide-in.component.ts
@@ -5,6 +5,7 @@ import {
   Input,
   OnDestroy,
   OnInit,
+  Renderer2,
   Type,
   ViewChild,
   ViewContainerRef,
@@ -37,7 +38,8 @@ export class IxSlideInComponent implements OnInit, OnDestroy {
 
   constructor(
     private el: ElementRef,
-    protected slideInService: IxSlideInService,
+    private slideInService: IxSlideInService,
+    private renderer: Renderer2,
   ) {
     this.element = this.el.nativeElement;
   }
@@ -67,6 +69,7 @@ export class IxSlideInComponent implements OnInit, OnDestroy {
 
   closeSlideIn(): void {
     this.isSlideInOpen = false;
+    this.renderer.removeStyle(document.body, 'overflow');
     this.wasBodyCleared = true;
 
     this.timeOutOfClear = timer(200).pipe(untilDestroyed(this)).subscribe(() => {
@@ -79,6 +82,7 @@ export class IxSlideInComponent implements OnInit, OnDestroy {
 
   openSlideIn<T>(componentType: Type<T>, params?: { wide: boolean }): T {
     this.isSlideInOpen = true;
+    this.renderer.setStyle(document.body, 'overflow', 'hidden');
     this.wide = !!params?.wide;
 
     if (this.wasBodyCleared) {

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -896,8 +896,18 @@ ul.nested-list li {
   padding: 0;
 }
 
+ix-tooltip {
+  popper-content {
+    display: none;
+  }
+}
+
 .ngxp__container {
   border-radius: 6px !important;
+
+  &[aria-hidden='false'] {
+    display: block !important;
+  }
 
   &[data-popper-placement=right] {
     margin-left: 13px !important;

--- a/src/assets/styles/other/_root-variables.scss
+++ b/src/assets/styles/other/_root-variables.scss
@@ -9,6 +9,7 @@
   --light-theme-lines: var(--contrast-darkest);
   --dark-theme-lines: var(--contrast-lighter);
   --lines: var(--dark-theme-lines);
+  --primary-txt: #fff;
   --sidenav-width: 240px;
   --btn-default-bg: var(--alt-bg2);
   --hover-bg: var(--lines) !important;


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 3937ce5924bcbcc4fb09a4e7aa0304645c209c97
    git cherry-pick -x 0f98346863c06c5e49cd312a2ea1d1151c731b7b
    git cherry-pick -x b04b69305e1348f1ecf1deda325023da90005d50
    git cherry-pick -x 65c8fbe791d07f0b16f5d8e20864e5b6ffce7bcb
    git cherry-pick -x cc8a6f0817d681c08a8b5066dc0a972acf4b5eb5

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 7af1be307094a79188afdf8faebad0ad46010d80

Testing: 
See ticket description (I tested on Bluefin as well, problem occurs there as well, it's browser update problem)

and 👇

Check help tooltips
<img width="1159" alt="Screenshot 2023-08-03 at 16 55 07" src="https://github.com/truenas/webui/assets/22980553/ce0df291-d2eb-46f4-8e2c-7310f84bb660">

(as well added hide on scroll feature, I think it's useful)

Original PR: https://github.com/truenas/webui/pull/8527
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123336