### PR TITLE
Correct typo and clarify auto-trim setting text

### DIFF
--- a/src/app/helptext/storage/volumes/volume-list.ts
+++ b/src/app/helptext/storage/volumes/volume-list.ts
@@ -49,7 +49,7 @@ the system dataset transfers back to the TrueNAS operating system device.'),
 
   pool_options_dialog: {
     autotrim_tooltip: T('Enable for TrueNAS to periodically review data blocks and identify\
- empty blocks of obsolete blocks that can be deleted. Unset to use dirty block\
+ empty blocks, or obsolete blocks that can be deleted. Unset to use dirty block\
  overwrites (default).'),
   },
   lock_dataset_dialog: {

--- a/src/app/helptext/storage/volumes/volume-list.ts
+++ b/src/app/helptext/storage/volumes/volume-list.ts
@@ -49,8 +49,8 @@ the system dataset transfers back to the TrueNAS operating system device.'),
 
   pool_options_dialog: {
     autotrim_tooltip: T('Enable for TrueNAS to periodically review data blocks and identify\
- empty blocks of obsolete blocks that can be deleted. Unset to incorporate day block\
- overwrites when a device write is started (default).'),
+ empty blocks of obsolete blocks that can be deleted. Unset to use dirty block\
+ overwrites (default).'),
   },
   lock_dataset_dialog: {
     button: T('Lock'),


### PR DESCRIPTION
Hello! 

This is a simple PR to fix a typo that's been present in SCALE for a while, in the auto-trim settings. It fixes the "day block" typo, and rewrites the sentence slightly to be easier to understand.