### PR TITLE
NAS-123526 / 23.10 / Extend session may appear when there is no active connection (by AlexKarpov98)

### DIFF
--- a/src/app/services/token-lifetime.service.ts
+++ b/src/app/services/token-lifetime.service.ts
@@ -58,19 +58,17 @@ export class TokenLifetimeService {
       this.actionWaitTimeout = setTimeout(() => {
         this.stop();
         const showConfirmTime = 30000;
+
         this.terminateCancelTimeout = setTimeout(() => {
-          this.authService.logout().pipe(untilDestroyed(this)).subscribe({
-            next: () => {
-              this.authService.clearAuthToken();
-              this.router.navigate(['/sessions/signin']);
-              this.dialogService.closeAllDialogs();
-              this.snackbar.open(
-                this.translate.instant('Token expired'),
-                this.translate.instant('Close'),
-                { duration: 4000, verticalPosition: 'bottom' },
-              );
-            },
-          });
+          this.authService.clearAuthToken();
+          this.router.navigate(['/sessions/signin']);
+          this.dialogService.closeAllDialogs();
+          this.snackbar.open(
+            this.translate.instant('Token expired'),
+            this.translate.instant('Close'),
+            { duration: 4000, verticalPosition: 'bottom' },
+          );
+          this.authService.logout().pipe(untilDestroyed(this)).subscribe();
         }, showConfirmTime);
         this.dialogService.confirm({
           title: this.translate.instant('Logout'),


### PR DESCRIPTION
Testing: 
Check that you are logged out even tho there is no ws connection and user is logged in.
Extend session modal will appear as usual and closes the session, before once there was no connection - it stuck.

![image](https://github.com/truenas/webui/assets/22980553/aeaf18ab-7c0f-4e4c-973d-b4bfdb14d011)

example: 
11:55:19 on screenshot
but now 12:03:59 and session still is not closed

Original PR: https://github.com/truenas/webui/pull/8593
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123526