### PR TITLE
NAS-122599 / 23.10 / Apps filter should reset when the user navigates away from the apps dashboard page (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/apps-routing.module.ts
+++ b/src/app/pages/apps/apps-routing.module.ts
@@ -8,6 +8,7 @@ import { ChartWizardComponent } from 'app/pages/apps/components/chart-wizard/cha
 import { InstalledAppsComponent } from 'app/pages/apps/components/installed-apps/installed-apps.component';
 import { PodLogsComponent } from 'app/pages/apps/components/installed-apps/pod-logs/pod-logs.component';
 import { PodShellComponent } from 'app/pages/apps/components/installed-apps/pod-shell/pod-shell.component';
+import { AppsNavigateAwayGuard } from 'app/pages/apps/guards/apps-navigate-away.guard';
 import { appNameResolver } from 'app/pages/apps/resolvers/app-name.resolver';
 import { AppDetailViewComponent } from './components/app-detail-view/app-detail-view.component';
 import { AppRouterOutletComponent } from './components/app-router-outlet/app-router-outlet.component';
@@ -15,6 +16,7 @@ import { AppRouterOutletComponent } from './components/app-router-outlet/app-rou
 const routes: Routes = [
   {
     path: '',
+    canDeactivate: [AppsNavigateAwayGuard],
     data: { breadcrumb: T('Applications') },
     children: [
       {

--- a/src/app/pages/apps/apps.module.ts
+++ b/src/app/pages/apps/apps.module.ts
@@ -61,6 +61,7 @@ import { PodShellComponent } from 'app/pages/apps/components/installed-apps/pod-
 import { PodSelectDialogComponent } from 'app/pages/apps/components/pod-select-dialog/pod-select-dialog.component';
 import { PodSelectLogsDialogComponent } from 'app/pages/apps/components/pod-select-logs/pod-select-logs-dialog.component';
 import { SelectPoolDialogComponent } from 'app/pages/apps/components/select-pool-dialog/select-pool-dialog.component';
+import { AppsNavigateAwayGuard } from 'app/pages/apps/guards/apps-navigate-away.guard';
 import { CustomFormsModule } from 'app/pages/apps/modules/custom-forms/custom-forms.module';
 import { AppsFilterStore } from 'app/pages/apps/store/apps-filter-store.service';
 import { AppsStore } from 'app/pages/apps/store/apps-store.service';
@@ -176,6 +177,7 @@ import { KubernetesStatusComponent } from './components/installed-apps/kubernete
     AppsFilterStore,
     KubernetesStore,
     InstalledAppsStore,
+    AppsNavigateAwayGuard,
   ],
 })
 export class AppsModule { }

--- a/src/app/pages/apps/guards/apps-navigate-away.guard.ts
+++ b/src/app/pages/apps/guards/apps-navigate-away.guard.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { UntilDestroy } from '@ngneat/until-destroy';
+import { AppsFilterStore } from 'app/pages/apps/store/apps-filter-store.service';
+
+@UntilDestroy()
+@Injectable()
+export class AppsNavigateAwayGuard {
+  constructor(private appsFilterStore: AppsFilterStore) {}
+
+  canDeactivate(): boolean {
+    this.appsFilterStore.resetFilters();
+    return true;
+  }
+}


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c8542f5bcad7e96354ffacd03b093b1a79a6ff06

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 0016584d13a21aaa954a038ecfb97808dd470767

Testing:
See ticket.

Final result:

https://github.com/truenas/webui/assets/22980553/b30770f6-4a85-489b-b90c-b705bd9c5926



Original PR: https://github.com/truenas/webui/pull/8597
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122599