### PR TITLE
NAS-123536 / 23.10 / The Storage Widget Continues to Display After a Pool has Been Exported On The Dashboard (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/store/dashboard-storage-store.service.ts
+++ b/src/app/pages/dashboard/store/dashboard-storage-store.service.ts
@@ -2,9 +2,8 @@ import { Injectable } from '@angular/core';
 import { ComponentStore } from '@ngrx/component-store';
 import _ from 'lodash';
 import {
-  Observable, filter, map, of, switchMap, tap,
+  Observable, map, of, switchMap, tap,
 } from 'rxjs';
-import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
 import { ApiEvent } from 'app/interfaces/api-message.interface';
 import { Dataset } from 'app/interfaces/dataset.interface';
 import { Pool } from 'app/interfaces/pool.interface';
@@ -35,6 +34,8 @@ export class DashboardStorageStore extends ComponentStore<DashboardStorageState>
   ) {
     super(initialState);
     this.initialize();
+    this.listenToPoolUpdates().subscribe();
+    this.listenForScanUpdates().subscribe();
   }
 
   initialize = this.effect((trigger$) => {
@@ -48,8 +49,6 @@ export class DashboardStorageStore extends ComponentStore<DashboardStorageState>
         ...state,
         isLoading: false,
       }))),
-      switchMap(() => this.listenForScanUpdates()),
-      switchMap(() => this.listenToPoolUpdates()),
     );
   });
 
@@ -99,7 +98,6 @@ export class DashboardStorageStore extends ComponentStore<DashboardStorageState>
 
   private listenToPoolUpdates(): Observable<unknown> {
     return this.ws.subscribe('pool.query').pipe(
-      filter((event) => event.msg !== IncomingApiMessageType.Removed),
       switchMap(() => this.loadPoolData()),
     );
   }

--- a/src/app/pages/dashboard/store/dashboard-store.service.ts
+++ b/src/app/pages/dashboard/store/dashboard-store.service.ts
@@ -240,7 +240,17 @@ export class DashboardStore extends ComponentStore<DashboardState> {
     pools: Pool[],
     nics: DashboardNetworkInterface[],
   ): DashConfigItem[] {
-    return dashboardState?.filter((widget) => {
+    const updatedDashboardStateWithLatestPools = [
+      ...dashboardState?.filter((widget) => widget.name !== WidgetName.Pool),
+      ...pools.map((pool) => ({
+        name: WidgetName.Pool,
+        identifier: `name,Pool:${pool.name}`,
+        rendered: dashboardState
+          .find((widget) => widget.identifier === `name,Pool:${pool.name}`)?.rendered || false,
+      })),
+    ] as DashConfigItem[];
+
+    return updatedDashboardStateWithLatestPools?.filter((widget) => {
       if ([WidgetName.Cpu, WidgetName.Memory].includes(widget.name)) {
         return true;
       }

--- a/src/app/pages/dashboard/store/dashboard-store.service.ts
+++ b/src/app/pages/dashboard/store/dashboard-store.service.ts
@@ -242,12 +242,15 @@ export class DashboardStore extends ComponentStore<DashboardState> {
   ): DashConfigItem[] {
     const updatedDashboardStateWithLatestPools = [
       ...dashboardState?.filter((widget) => widget.name !== WidgetName.Pool),
-      ...pools.map((pool) => ({
-        name: WidgetName.Pool,
-        identifier: `name,Pool:${pool.name}`,
-        rendered: dashboardState
-          .find((widget) => widget.identifier === `name,Pool:${pool.name}`)?.rendered || false,
-      })),
+      ...pools.map((pool) => {
+        const existingWidget = dashboardState.find((widget) => widget.identifier === `name,Pool:${pool.name}`);
+        return {
+          id: existingWidget?.id || pool.id,
+          name: WidgetName.Pool,
+          identifier: `name,Pool:${pool.name}`,
+          rendered: existingWidget?.rendered || false,
+        };
+      }),
     ] as DashConfigItem[];
 
     return updatedDashboardStateWithLatestPools?.filter((widget) => {


### PR DESCRIPTION
Testing: see ticket.
Try creating/exporting the pool.
See the updates on the dashboard page with latest pools data. 

Original PR: https://github.com/truenas/webui/pull/8617
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123536