### PR TITLE
NAS-123358 / 22.12.3 / Don't initialize observable so loading is shown on select (by RehanY147)

### DIFF
--- a/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.ts
+++ b/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.ts
@@ -1,12 +1,12 @@
 import {
-  ChangeDetectionStrategy, Component, Inject, OnInit,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit,
 } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { MatDialog, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import filesize from 'filesize';
-import { Observable, of } from 'rxjs';
+import { Observable, delay, of } from 'rxjs';
 import helptext from 'app/helptext/storage/volumes/volume-status';
 import { Option } from 'app/interfaces/option.interface';
 import { UnusedDisk } from 'app/interfaces/storage.interface';
@@ -34,7 +34,7 @@ export class ReplaceDiskDialogComponent implements OnInit {
 
   unusedDisks: UnusedDisk[] = [];
 
-  unusedDisksOptions$: Observable<Option[]> = of([]);
+  unusedDisksOptions$: Observable<Option[]>;
 
   readonly helptext = helptext;
 
@@ -47,6 +47,7 @@ export class ReplaceDiskDialogComponent implements OnInit {
     private snackbar: SnackbarService,
     @Inject(MAT_DIALOG_DATA) public data: ReplaceDiskDialogData,
     private dialogService: DialogService,
+    private cdr: ChangeDetectorRef,
   ) {}
 
   ngOnInit(): void {
@@ -55,7 +56,7 @@ export class ReplaceDiskDialogComponent implements OnInit {
   }
 
   loadUnusedDisks(): void {
-    this.ws.call('disk.get_unused').pipe(untilDestroyed(this)).subscribe((unusedDisks) => {
+    this.ws.call('disk.get_unused').pipe(delay(5000), untilDestroyed(this)).subscribe((unusedDisks) => {
       this.unusedDisks = unusedDisks;
       const unusedDiskOptions = unusedDisks.map((disk) => {
         const exportedPool = disk.exported_zpool ? ` (${disk.exported_zpool})` : '';
@@ -67,6 +68,7 @@ export class ReplaceDiskDialogComponent implements OnInit {
         };
       });
       this.unusedDisksOptions$ = of(unusedDiskOptions);
+      this.cdr.markForCheck();
     });
   }
 

--- a/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.ts
+++ b/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.ts
@@ -6,7 +6,7 @@ import { MatDialog, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dial
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import filesize from 'filesize';
-import { Observable, delay, of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import helptext from 'app/helptext/storage/volumes/volume-status';
 import { Option } from 'app/interfaces/option.interface';
 import { UnusedDisk } from 'app/interfaces/storage.interface';
@@ -56,7 +56,7 @@ export class ReplaceDiskDialogComponent implements OnInit {
   }
 
   loadUnusedDisks(): void {
-    this.ws.call('disk.get_unused').pipe(delay(5000), untilDestroyed(this)).subscribe((unusedDisks) => {
+    this.ws.call('disk.get_unused').pipe(untilDestroyed(this)).subscribe((unusedDisks) => {
       this.unusedDisks = unusedDisks;
       const unusedDiskOptions = unusedDisks.map((disk) => {
         const exportedPool = disk.exported_zpool ? ` (${disk.exported_zpool})` : '';


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 63f931decbfed9223eb1a550d9c7119d4b5b220e
    git cherry-pick -x 0f5aa8986a20a5d8a81af7d9ce5f51170779b5f5

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 82f240754180c1d317c3d82cc3ca9190e5b0b70f



Original PR: https://github.com/truenas/webui/pull/8633
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123358