### PR TITLE
NAS-121466 / 23.10 / Topology overview hides VDEV information if there is a warning for redundancy mismatch (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
@@ -19,7 +19,11 @@
       <div class="vdev-line">
         <b>{{ 'Data VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span *ngIf="isTopologyWarning(topologyState.data)" class="warning">
+          <span
+            *ngIf="isTopologyWarning(topologyWarningsState.data)"
+            class="warning"
+            [matTooltip]="topologyWarningsState.data"
+          >
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.data }}</span>
@@ -27,8 +31,12 @@
       </div>
       <div class="vdev-line">
         <b>{{ 'Metadata VDEVs' | translate }}</b>
-        <div class="vdevs-stats">
-          <span *ngIf="isTopologyWarning(topologyState.metadata)" class="warning">
+        <div class="vdev-stats">
+          <span
+            *ngIf="isTopologyWarning(topologyWarningsState.metadata)"
+            class="warning"
+            [matTooltip]="topologyWarningsState.metadata"
+          >
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.metadata }}</span>
@@ -37,7 +45,11 @@
       <div class="vdev-line">
         <b>{{ 'Log VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span *ngIf="isTopologyWarning(topologyState.log)" class="warning">
+          <span
+            *ngIf="isTopologyWarning(topologyWarningsState.log)"
+            class="warning"
+            [matTooltip]="topologyWarningsState.log"
+          >
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.log }}</span>
@@ -46,7 +58,11 @@
       <div class="vdev-line">
         <b>{{ 'Cache VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span *ngIf="isTopologyWarning(topologyState.cache)" class="warning">
+          <span
+            *ngIf="isTopologyWarning(topologyWarningsState.cache)"
+            class="warning"
+            [matTooltip]="topologyWarningsState.cache"
+          >
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.cache }}</span>
@@ -55,7 +71,11 @@
       <div class="vdev-line">
         <b>{{ 'Spare VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span *ngIf="isTopologyWarning(topologyState.spare)" class="warning">
+          <span
+            *ngIf="isTopologyWarning(topologyWarningsState.spare)"
+            class="warning"
+            [matTooltip]="topologyWarningsState.spare"
+          >
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.spare }}</span>
@@ -64,7 +84,11 @@
       <div class="vdev-line">
         <b>{{ 'Dedup VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span *ngIf="isTopologyWarning(topologyState.dedup)" class="warning">
+          <span
+            *ngIf="isTopologyWarning(topologyWarningsState.dedup)"
+            class="warning"
+            [matTooltip]="topologyWarningsState.dedup"
+          >
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.dedup }}</span>

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.spec.ts
@@ -88,7 +88,7 @@ describe('TopologyCardComponent', () => {
 
     // Redundancy level should match data VDEVs
     expect(captions[1]).toHaveText('Metadata');
-    expect(values[1]).toHaveText('Redundancy Mismatch');
+    expect(values[1]).toHaveText('1 x MIRROR | 3 wide | 4 TiB');
     expect(captions[5]).toHaveText('Dedup VDEVs');
     expect(values[5]).toHaveText('VDEVs not assigned');
   });

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
@@ -54,6 +54,8 @@ export class TopologyCardComponent implements OnInit, OnChanges {
     dedup: notAssignedDev,
   };
 
+  topologyWarningsState: TopologyState = { ...this.topologyState };
+
   get iconType(): PoolCardIconType {
     if (this.isStatusError(this.poolState)) {
       return PoolCardIconType.Error;
@@ -97,29 +99,18 @@ export class TopologyCardComponent implements OnInit, OnChanges {
     this.topologyState.log = this.parseDevs(topology.log, VdevType.Log);
     this.topologyState.cache = this.parseDevs(topology.cache, VdevType.Cache);
     this.topologyState.spare = this.parseDevs(topology.spare, VdevType.Spare);
+    this.topologyState.metadata = this.parseDevs(topology.special, VdevType.Special);
+    this.topologyState.dedup = this.parseDevs(topology.dedup, VdevType.Dedup);
 
-    this.topologyState.metadata = this.parseDevs(
-      topology.special,
-      VdevType.Special,
-      topology.data,
-    );
-    this.topologyState.dedup = this.parseDevs(
-      topology.dedup,
-      VdevType.Dedup,
-      topology.data,
-    );
+    this.topologyWarningsState.data = this.parseDevsWarnings(topology.data, VdevType.Data);
+    this.topologyWarningsState.log = this.parseDevsWarnings(topology.log, VdevType.Log);
+    this.topologyWarningsState.cache = this.parseDevsWarnings(topology.cache, VdevType.Cache);
+    this.topologyWarningsState.spare = this.parseDevsWarnings(topology.spare, VdevType.Spare);
+    this.topologyWarningsState.metadata = this.parseDevsWarnings(topology.special, VdevType.Special, topology.data);
+    this.topologyWarningsState.dedup = this.parseDevsWarnings(topology.dedup, VdevType.Dedup, topology.data);
   }
 
-  private parseDevs(
-    vdevs: TopologyItem[],
-    category: VdevType,
-    dataVdevs?: TopologyItem[],
-  ): string {
-    const disks: Disk[] = this.disks.map((disk: StorageDashboardDisk) => {
-      return this.dashboardDiskToDisk(disk);
-    });
-    const warnings = this.storageService.validateVdevs(category, vdevs, disks, dataVdevs);
-
+  private parseDevs(vdevs: TopologyItem[], category: VdevType): string {
     let outputString = vdevs.length ? '' : notAssignedDev;
 
     // Check VDEV Widths
@@ -140,15 +131,7 @@ export class TopologyCardComponent implements OnInit, OnChanges {
       vdevWidth = Array.from(allVdevWidths.values())[0];
     }
 
-    if (warnings.length === 1) {
-      return warnings[0];
-    }
-
-    if (warnings.length > 1) {
-      return warnings.length.toString() + ' ' + multiWarning;
-    }
-
-    if (!warnings.length && outputString && outputString === notAssignedDev) {
+    if (outputString && outputString === notAssignedDev) {
       return outputString;
     }
 
@@ -169,6 +152,21 @@ export class TopologyCardComponent implements OnInit, OnChanges {
     return outputString;
   }
 
+  private parseDevsWarnings(vdevs: TopologyItem[], category: VdevType, dataVdevs?: TopologyItem[]): string {
+    let outputString = '';
+    const disks: Disk[] = this.disks.map((disk: StorageDashboardDisk) => {
+      return this.dashboardDiskToDisk(disk);
+    });
+    const warnings = this.storageService.validateVdevs(category, vdevs, disks, dataVdevs);
+    if (warnings.length === 1) {
+      outputString = warnings[0];
+    }
+    if (warnings.length > 1) {
+      outputString = warnings.length.toString() + ' ' + multiWarning;
+    }
+    return outputString;
+  }
+
   private isStatusError(poolState: Pool): boolean {
     return [
       PoolStatus.Faulted,
@@ -186,12 +184,12 @@ export class TopologyCardComponent implements OnInit, OnChanges {
     ].includes(poolState.status);
   }
 
-  isTopologyWarning(topologyState: string): boolean {
-    if (topologyState.includes(multiWarning)) {
+  isTopologyWarning(topologyWarningState: string): boolean {
+    if (topologyWarningState.includes(multiWarning)) {
       return true;
     }
 
-    switch (topologyState) {
+    switch (topologyWarningState) {
       case TopologyWarning.NoRedundancy:
       case TopologyWarning.RedundancyMismatch:
       case TopologyWarning.MixedVdevLayout:


### PR DESCRIPTION
Testing: see ticket:

**Before:**
<img width="738" alt="Screenshot 2023-08-22 at 17 51 51" src="https://github.com/truenas/webui/assets/22980553/37f43e94-5a9f-431b-bed0-da0e245e1135">

**After:**
<img width="738" alt="Screenshot 2023-08-22 at 17 51 57" src="https://github.com/truenas/webui/assets/22980553/c27b207a-74af-41b8-b1ee-a118b2409da0">


Original PR: https://github.com/truenas/webui/pull/8647
Jira URL: https://ixsystems.atlassian.net/browse/NAS-121466