### PR TITLE
NAS-123647 / 23.10 / Add Replication Task Advanced Form [SAVE] button - is always active (by AlexKarpov98)

### DIFF
--- a/src/app/pages/data-protection/replication/replication-form/properties-override-validator/properties-override-validator.service.ts
+++ b/src/app/pages/data-protection/replication/replication-form/properties-override-validator/properties-override-validator.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { AbstractControl } from '@angular/forms';
+import { AbstractControl, Validators } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { IxValidatorsService } from 'app/modules/ix-forms/services/ix-validators.service';
 
@@ -17,7 +17,7 @@ export class PropertiesOverrideValidatorService {
 
   private validatePropertyOverride(control: AbstractControl): boolean {
     const overrides = control.value as string[];
-    if (!overrides?.length) {
+    if (!overrides?.length && control.hasValidator(Validators.required)) {
       return false;
     }
 

--- a/src/app/pages/data-protection/replication/replication-form/replication-form.component.html
+++ b/src/app/pages/data-protection/replication/replication-form/replication-form.component.html
@@ -46,6 +46,7 @@
           type="submit"
           color="primary"
           ixTest="save"
+          [disabled]="!isFormValid"
           (click)="onSubmit(); $event.preventDefault();"
         >{{ 'Save' | translate }}</button>
         <button

--- a/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
+++ b/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
@@ -120,6 +120,10 @@ export class ReplicationFormComponent implements OnInit {
     return this.sourceSection.form.controls.schema_or_regex.value === SnapshotNamingOption.NameRegex;
   }
 
+  get isFormValid(): boolean {
+    return this.sections.every((section) => section.form.valid);
+  }
+
   setForEdit(): void {
     this.cdr.markForCheck();
   }


### PR DESCRIPTION
Testing:
Check Replication Task Advanced form SAVE button.
It should be disabled if form is invalid. (previously it was always active)

Original PR: https://github.com/truenas/webui/pull/8646
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123647