### PR TITLE
NAS-123405 / 23.10 / Basic Options Cannot Save Due to Hidden Advanced Options Error On The Active Directory Setup Screen (by AlexKarpov98)

### DIFF
--- a/src/app/pages/directory-service/components/active-directory/active-directory.component.html
+++ b/src/app/pages/directory-service/components/active-directory/active-directory.component.html
@@ -28,6 +28,13 @@
               [label]="'Domain Account Password' | translate"
               [tooltip]="helptext.activedirectory_bindpw_tooltip | translate"
             ></ix-input>
+
+            <ix-input
+              formControlName="netbiosname"
+              [label]="'NetBIOS Name' | translate"
+              [tooltip]="helptext.activedirectory_netbiosname_tooltip | translate"
+              [required]="true"
+            ></ix-input>
           </ng-container>
 
           <ix-checkbox
@@ -120,13 +127,6 @@
             [tooltip]="helptext.activedirectory_nss_info_tooltip | translate"
             [options]="nssOptions$"
           ></ix-select>
-
-          <ix-input
-            formControlName="netbiosname"
-            [label]="'NetBIOS Name' | translate"
-            [tooltip]="helptext.activedirectory_netbiosname_tooltip | translate"
-            [required]="true"
-          ></ix-input>
 
           <ix-chips
             formControlName="netbiosalias"

--- a/src/app/pages/directory-service/components/active-directory/active-directory.component.spec.ts
+++ b/src/app/pages/directory-service/components/active-directory/active-directory.component.spec.ts
@@ -110,6 +110,7 @@ describe('ActiveDirectoryComponent', () => {
       'Domain Account Password': '',
       'Domain Name': 'AD.IXSYSTEMS.NET',
       'Enable (requires password or Kerberos principal)': false,
+      'NetBIOS Name': 'truenas',
     });
   });
 


### PR DESCRIPTION
Testing: see ticket


Original PR: https://github.com/truenas/webui/pull/8644
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123405