### PR TITLE
NAS-123521 / 24.04 / Show readonly layout field for Data VDEVs when adding disks to existing pool

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -7,7 +7,7 @@
     [required]="true"
   ></ix-select>
 </div>
-<ng-template #showLayoutInfo class="layout-container">
+<ng-template #showLayoutInfo>
   <ix-input
     *ngIf="isDataVdev"
     [formControl]="layoutControl"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="canChangeLayout" class="layout-container">
+<div *ngIf="canChangeLayout; else showLayoutInfo" class="layout-container">
   <ix-select
     [formControl]="layoutControl"
     [label]="'Layout' | translate"
@@ -7,6 +7,16 @@
     [required]="true"
   ></ix-select>
 </div>
+<ng-template #showLayoutInfo class="layout-container">
+  <ix-input
+    *ngIf="isDataVdev"
+    [formControl]="layoutControl"
+    [label]="'Layout' | translate"
+    [readonly]="true"
+    [tooltip]="dataLayoutTooltip"
+    [required]="false"
+  ></ix-input>
+</ng-template>
 
 <ix-draid-selection
   *ngIf="usesDraidLayout; else normalSelection"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { merge, of } from 'rxjs';
@@ -35,6 +28,16 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
   @Output() manualSelectionClicked = new EventEmitter<void>();
 
   readonly layoutControl = new FormControl(null as CreateVdevLayout, Validators.required);
+
+  get isDataVdev(): boolean {
+    return this.type === VdevType.Data;
+  }
+
+  get dataLayoutTooltip(): string {
+    if (this.isDataVdev) {
+      return 'Read only field: The layout of this device has been preselected to match the layout of the existing Data devices in the pool';
+    }
+  }
 
   protected vdevLayoutOptions$ = of<SelectOption<CreateVdevLayout>[]>([]);
 


### PR DESCRIPTION
This PR exposes preselected layout field for data vdevs when adding vdevs to existing pool

To test:
- go to add vdevs page
- On Data step check to see that layout field is visible as a read only input field
- Check that the read only field has tooltip text 