### PR TITLE
NAS-123675 / 24.04 / Fixes for app info card

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -32,8 +32,8 @@
         <div class="details-item">
           <div class="label">{{ 'Name' | translate }}:</div>
           <div class="value">
-            <ng-container *ngIf="app?.chart_metadata?.name; else notAvailable">
-              {{ app.chart_metadata.name }}
+            <ng-container *ngIf="app?.name; else notAvailable">
+              {{ app.name }}
             </ng-container>
           </div>
         </div>

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -40,8 +40,14 @@
         <div class="details-item">
           <div class="label">{{ 'App Version' | translate }}:</div>
           <div class="value">
-            <ng-container *ngIf="app?.chart_metadata?.appVersion; else notAvailable">
-              {{ app.chart_metadata.appVersion }}
+            <ng-container *ngIf="!ixChartApp">
+              <ng-container *ngIf="app?.chart_metadata?.appVersion; else notAvailable">
+                {{ app.chart_metadata.appVersion }}
+              </ng-container>
+            </ng-container>
+            <ng-container *ngIf="ixChartApp">
+              <!-- Show docker image tag as version for custom apps -->
+              {{ app.human_version.split(':')[1].split('_')[0] }}
             </ng-container>
           </div>
         </div>

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -27,7 +27,7 @@ describe('AppInfoCardComponent', () => {
 
   const app = {
     id: 'ix-test-app',
-    name: 'ix-test-app',
+    name: 'test-user-app-name',
     human_version: '1.2.3_3.2.1',
     history: {
       '1.0.11': {
@@ -112,7 +112,7 @@ describe('AppInfoCardComponent', () => {
     expect(details).toEqual([
       {
         label: 'Name:',
-        value: 'ix-test-app',
+        value: 'test-user-app-name',
       },
       {
         label: 'App Version:',
@@ -178,7 +178,7 @@ describe('AppInfoCardComponent', () => {
 
     expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith({
       title: 'Delete',
-      message: 'Delete ix-test-app?',
+      message: 'Delete test-user-app-name?',
     });
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -7,7 +7,7 @@ import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { startCase, isEmpty } from 'lodash';
 import { filter, map, take } from 'rxjs';
-import { appImagePlaceholder } from 'app/constants/catalog.constants';
+import { appImagePlaceholder, ixChartApp } from 'app/constants/catalog.constants';
 import helptext from 'app/helptext/apps/apps';
 import { UpgradeSummary } from 'app/interfaces/application.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
@@ -49,6 +49,10 @@ export class AppInfoCardComponent {
 
   get hasUpdates(): boolean {
     return this.app?.update_available || this.app?.container_images_update_available;
+  }
+
+  get ixChartApp(): boolean {
+    return this.app.chart_metadata.name === ixChartApp;
   }
 
   portalName(name = 'web_portal'): string {


### PR DESCRIPTION
App Info Card should display:

- application name specified by the user and not the chart name.
- docker image tag as the app version for custom apps

BETA-1:
<img width="385" alt="image" src="https://github.com/truenas/webui/assets/351613/6a6c7eba-5036-41e0-a692-6a52c806f3a1">

Changes:
![image](https://github.com/truenas/webui/assets/351613/28c882a7-6e03-4995-8db9-720684a1d554)

