### PR TITLE
NAS-123648 / 23.10 / Fix styles

### DIFF
--- a/src/app/modules/scheduler/components/scheduler-modal/scheduler-modal.component.scss
+++ b/src/app/modules/scheduler/components/scheduler-modal/scheduler-modal.component.scss
@@ -10,6 +10,7 @@
 .settings-column {
   margin-bottom: 10px;
   margin-top: 19px;
+  width: 100%;
 
   .no-spaces-hint {
     font-size: 85%;


### PR DESCRIPTION
Backported

**Testing**

On the **Data Protection** page,

At Add/edit form for **Periodic Snapshot Task,**

When **Custom** option is picked from the **Schedule** dropdown,

In the **Days of Week** section of the **Custom Scheduler**, the "Sat" checkbox label should be seen.

Original PR: https://github.com/truenas/webui/pull/8670