### PR TITLE
NAS-123675 / 23.10 / Fixes for app info card (by denysbutenko)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -32,16 +32,22 @@
         <div class="details-item">
           <div class="label">{{ 'Name' | translate }}:</div>
           <div class="value">
-            <ng-container *ngIf="app?.chart_metadata?.name; else notAvailable">
-              {{ app.chart_metadata.name }}
+            <ng-container *ngIf="app?.name; else notAvailable">
+              {{ app.name }}
             </ng-container>
           </div>
         </div>
         <div class="details-item">
           <div class="label">{{ 'App Version' | translate }}:</div>
           <div class="value">
-            <ng-container *ngIf="app?.chart_metadata?.appVersion; else notAvailable">
-              {{ app.chart_metadata.appVersion }}
+            <ng-container *ngIf="!ixChartApp">
+              <ng-container *ngIf="app?.chart_metadata?.appVersion; else notAvailable">
+                {{ app.chart_metadata.appVersion }}
+              </ng-container>
+            </ng-container>
+            <ng-container *ngIf="ixChartApp">
+              <!-- Show docker image tag as version for custom apps -->
+              {{ app.human_version.split(':')[1].split('_')[0] }}
             </ng-container>
           </div>
         </div>

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -28,7 +28,7 @@ describe('AppInfoCardComponent', () => {
 
   const app = {
     id: 'ix-test-app',
-    name: 'ix-test-app',
+    name: 'test-user-app-name',
     human_version: '1.2.3_3.2.1',
     history: {
       '1.0.11': {
@@ -114,7 +114,7 @@ describe('AppInfoCardComponent', () => {
     expect(details).toEqual([
       {
         label: 'Name:',
-        value: 'ix-test-app',
+        value: 'test-user-app-name',
       },
       {
         label: 'App Version:',
@@ -180,7 +180,7 @@ describe('AppInfoCardComponent', () => {
 
     expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith({
       title: 'Delete',
-      message: 'Delete ix-test-app?',
+      message: 'Delete test-user-app-name?',
     });
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -7,6 +7,7 @@ import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { startCase, isEmpty } from 'lodash';
 import { filter, map, take } from 'rxjs';
+import { ixChartApp } from 'app/constants/catalog.constants';
 import helptext from 'app/helptext/apps/apps';
 import { UpgradeSummary } from 'app/interfaces/application.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
@@ -49,6 +50,10 @@ export class AppInfoCardComponent {
 
   get hasUpdates(): boolean {
     return this.app?.update_available || this.app?.container_images_update_available;
+  }
+
+  get ixChartApp(): boolean {
+    return this.app.chart_metadata.name === ixChartApp;
   }
 
   portalName(name = 'web_portal'): string {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x f595321717962e6168ddfa4e6281a9a89ba55d63

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 69e407af66c1a73c4ed1292ce66c50286d984d43

App Info Card should display:

- application name specified by the user and not the chart name.
- docker image tag as the app version for custom apps

BETA-1:
<img width="385" alt="image" src="https://github.com/truenas/webui/assets/351613/6a6c7eba-5036-41e0-a692-6a52c806f3a1">

Changes:
![image](https://github.com/truenas/webui/assets/351613/28c882a7-6e03-4995-8db9-720684a1d554)



Original PR: https://github.com/truenas/webui/pull/8681
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123675