### PR TITLE
Dataset storage use could be finer graded

### DIFF
--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.html
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.html
@@ -8,9 +8,11 @@
     </span>
   </div>
   <div class="cell cell-used">
-    {{ dataset.used.parsed | filesize: { standard: 'iec', round: 0 } }}
-    /
-    {{ dataset.available.parsed | filesize: { standard: 'iec', round: 0 } }}
+    <div class="cell-used-content">
+      <span>{{ dataset.used.parsed | filesize: { standard: 'iec', round: 2 } }}</span>
+      /
+      <span>{{ dataset.available.parsed | filesize: { standard: 'iec', round: 2 } }}</span>
+    </div>
   </div>
   <div class="cell cell-encryption">
     <ix-dataset-encryption-cell

--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
@@ -76,6 +76,9 @@
     }
   }
 
+  .cell-used-content span {
+    white-space: nowrap;
+  }
 }
 
 // TODO: Fragile (at least with css selectors)


### PR DESCRIPTION
**Testing**

On **Datasets** page, the accurate volume should be displayed for a dataset. 

For example, for a dataset with 1.43 terabyte,  the "1\.43TiB" should be reported in the dataset level. You should compare the value displayed to the volume displayed on **Data Protection** page, when adding a replication task
