### PR TITLE
NAS-123810 / 24.04 / Fix initialization on ixDetailsHeight directive

### DIFF
--- a/src/app/core/components/directives/details-height/details-height.directive.ts
+++ b/src/app/core/components/directives/details-height/details-height.directive.ts
@@ -48,6 +48,7 @@ export class IxDetailsHeightDirective implements OnInit, OnDestroy, OnChanges {
 
     this.element.nativeElement.style.height = this.heightCssValue;
     this.window.addEventListener('scroll', this.onScrollHandler, true);
+    setTimeout(() => this.onScroll());
   }
 
   ngOnChanges(changes: IxSimpleChanges<this>): void {


### PR DESCRIPTION
For testing, go to Apps and check that the extra scrollbar does not appear. Ensure other places that use `ixDetailsHeight` are still functional after switching between pages (e.g., from Datasets to Apps pages).

![image](https://github.com/truenas/webui/assets/351613/0f287f88-0bf4-400c-ae84-88fa880b6e0c)
