### PR TITLE
NAS-123312 / 23.10 / The Text “2 warnings” is Displayed Without Any Description When a Pool Contains Stripe VDev’s of Differing Sizes On the Storage Dashboard (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
@@ -20,7 +20,7 @@
         <b>{{ 'Data VDEVs' | translate }}</b>
         <div class="vdev-stats">
           <span
-            *ngIf="isTopologyWarning(topologyWarningsState.data)"
+            *ngIf="!!topologyWarningsState.data"
             class="warning"
             [matTooltip]="topologyWarningsState.data"
           >
@@ -33,7 +33,7 @@
         <b>{{ 'Metadata VDEVs' | translate }}</b>
         <div class="vdev-stats">
           <span
-            *ngIf="isTopologyWarning(topologyWarningsState.metadata)"
+            *ngIf="!!topologyWarningsState.metadata"
             class="warning"
             [matTooltip]="topologyWarningsState.metadata"
           >
@@ -46,7 +46,7 @@
         <b>{{ 'Log VDEVs' | translate }}</b>
         <div class="vdev-stats">
           <span
-            *ngIf="isTopologyWarning(topologyWarningsState.log)"
+            *ngIf="!!topologyWarningsState.log"
             class="warning"
             [matTooltip]="topologyWarningsState.log"
           >
@@ -59,7 +59,7 @@
         <b>{{ 'Cache VDEVs' | translate }}</b>
         <div class="vdev-stats">
           <span
-            *ngIf="isTopologyWarning(topologyWarningsState.cache)"
+            *ngIf="!!topologyWarningsState.cache"
             class="warning"
             [matTooltip]="topologyWarningsState.cache"
           >
@@ -72,7 +72,7 @@
         <b>{{ 'Spare VDEVs' | translate }}</b>
         <div class="vdev-stats">
           <span
-            *ngIf="isTopologyWarning(topologyWarningsState.spare)"
+            *ngIf="!!topologyWarningsState.spare"
             class="warning"
             [matTooltip]="topologyWarningsState.spare"
           >
@@ -85,7 +85,7 @@
         <b>{{ 'Dedup VDEVs' | translate }}</b>
         <div class="vdev-stats">
           <span
-            *ngIf="isTopologyWarning(topologyWarningsState.dedup)"
+            *ngIf="!!topologyWarningsState.dedup"
             class="warning"
             [matTooltip]="topologyWarningsState.dedup"
           >

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.html
@@ -19,11 +19,7 @@
       <div class="vdev-line">
         <b>{{ 'Data VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span
-            *ngIf="!!topologyWarningsState.data"
-            class="warning"
-            [matTooltip]="topologyWarningsState.data"
-          >
+          <span *ngIf="!!topologyWarningsState.data" class="warning" [matTooltip]="topologyWarningsState.data">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.data }}</span>
@@ -32,11 +28,7 @@
       <div class="vdev-line">
         <b>{{ 'Metadata VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span
-            *ngIf="!!topologyWarningsState.metadata"
-            class="warning"
-            [matTooltip]="topologyWarningsState.metadata"
-          >
+          <span *ngIf="!!topologyWarningsState.metadata" class="warning" [matTooltip]="topologyWarningsState.metadata">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.metadata }}</span>
@@ -45,11 +37,7 @@
       <div class="vdev-line">
         <b>{{ 'Log VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span
-            *ngIf="!!topologyWarningsState.log"
-            class="warning"
-            [matTooltip]="topologyWarningsState.log"
-          >
+          <span *ngIf="!!topologyWarningsState.log" class="warning" [matTooltip]="topologyWarningsState.log">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.log }}</span>
@@ -58,11 +46,7 @@
       <div class="vdev-line">
         <b>{{ 'Cache VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span
-            *ngIf="!!topologyWarningsState.cache"
-            class="warning"
-            [matTooltip]="topologyWarningsState.cache"
-          >
+          <span *ngIf="!!topologyWarningsState.cache" class="warning" [matTooltip]="topologyWarningsState.cache">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.cache }}</span>
@@ -71,11 +55,7 @@
       <div class="vdev-line">
         <b>{{ 'Spare VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span
-            *ngIf="!!topologyWarningsState.spare"
-            class="warning"
-            [matTooltip]="topologyWarningsState.spare"
-          >
+          <span *ngIf="!!topologyWarningsState.spare" class="warning" [matTooltip]="topologyWarningsState.spare">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.spare }}</span>
@@ -84,11 +64,7 @@
       <div class="vdev-line">
         <b>{{ 'Dedup VDEVs' | translate }}</b>
         <div class="vdev-stats">
-          <span
-            *ngIf="!!topologyWarningsState.dedup"
-            class="warning"
-            [matTooltip]="topologyWarningsState.dedup"
-          >
+          <span *ngIf="!!topologyWarningsState.dedup" class="warning" [matTooltip]="topologyWarningsState.dedup">
             <ix-icon name="error" class="pool-icon icon-warning"></ix-icon>
           </span>
           <span class="vdev-value">{{ topologyState.dedup }}</span>

--- a/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/topology-card/topology-card.component.ts
@@ -7,7 +7,7 @@ import { TranslateService } from '@ngx-translate/core';
 import filesize from 'filesize';
 import { PoolCardIconType } from 'app/enums/pool-card-icon-type.enum';
 import { PoolStatus } from 'app/enums/pool-status.enum';
-import { VdevType, TopologyWarning } from 'app/enums/v-dev-type.enum';
+import { VdevType } from 'app/enums/v-dev-type.enum';
 import { Pool, PoolTopology } from 'app/interfaces/pool.interface';
 import { SmartTestResult } from 'app/interfaces/smart-test.interface';
 import {
@@ -34,7 +34,6 @@ export interface EmptyDiskObject {
 }
 
 const notAssignedDev = 'VDEVs not assigned';
-const multiWarning = 'warnings';
 
 @UntilDestroy()
 @Component({
@@ -170,7 +169,7 @@ export class TopologyCardComponent implements OnInit, OnChanges {
       outputString = warnings[0];
     }
     if (warnings.length > 1) {
-      outputString = warnings.length.toString() + ' ' + multiWarning;
+      outputString = warnings.join(', ');
     }
     return outputString;
   }
@@ -190,24 +189,6 @@ export class TopologyCardComponent implements OnInit, OnChanges {
       PoolStatus.Offline,
       PoolStatus.Degraded,
     ].includes(poolState.status);
-  }
-
-  isTopologyWarning(topologyWarningState: string): boolean {
-    if (topologyWarningState.includes(multiWarning)) {
-      return true;
-    }
-
-    switch (topologyWarningState) {
-      case TopologyWarning.NoRedundancy:
-      case TopologyWarning.RedundancyMismatch:
-      case TopologyWarning.MixedVdevLayout:
-      case TopologyWarning.MixedVdevCapacity:
-      case TopologyWarning.MixedDiskCapacity:
-      case TopologyWarning.MixedVdevWidth:
-        return true;
-      default:
-        return false;
-    }
   }
 
   dashboardDiskToDisk(dashDisk: StorageDashboardDisk): Disk {


### PR DESCRIPTION
Testing: see ticket

Result:
<img width="742" alt="Screenshot 2023-08-29 at 16 56 59" src="https://github.com/truenas/webui/assets/22980553/4c2ec272-be79-42b7-abf2-8aee6f48b27d">


Original PR: https://github.com/truenas/webui/pull/8692
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123312