### PR TITLE
NAS-123852 / 24.04 / Remove horizontal scroll from entity job dialogs

### DIFF
--- a/src/app/modules/entity/entity-job/entity-job.component.scss
+++ b/src/app/modules/entity/entity-job/entity-job.component.scss
@@ -1,3 +1,5 @@
+@import 'scss-imports/splitview';
+
 :host {
   display: block;
   position: relative;
@@ -11,9 +13,14 @@
 
 mat-dialog-content.entity-job-dialog {
   max-height: 350px;
-  max-width: 400px;
-  min-width: 400px;
-
+  max-width: 100%;
+  width: 100%;
+  
+  @media (min-width: $breakpoint-tablet) {
+    max-width: 400px;
+    min-width: 400px;
+  }
+  
   .mat-mdc-dialog-content {
     overflow: auto !important;
   }


### PR DESCRIPTION

![image](https://github.com/truenas/webui/assets/351613/52b9af93-d64c-48ea-8249-0e00986cd3c6)

For testing, ensure no horizontal scrollbar on entity job dialog when page width < 768px.