### PR TITLE
NAS-123802 / 24.04 / Fix position of children in dataset tree

### DIFF
--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -264,6 +264,7 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
       return new Intl.Collator(undefined, {
         numeric: true,
         sensitivity: 'accent',
+        ignorePunctuation: true,
       }).compare(a.name, b.name);
     };
     this.dataSource.data = datasets;


### PR DESCRIPTION
**Testing**

On **Datasets** page,

1. Create 2 datasets, with identical names, but the second one containing `-` character and some arbitrary postfix in it's name. For example:
   1. **pool/data**
   2. **pool/data-system**
2. Select one of these datasets, and create a child dataset. For example, **media**
   * **Expected result:** media is displayed under "pool/data"
