### PR TITLE
NAS-123911 / 23.10-BETA.1 / Remove Number of VDEVs dropdown for cache and log (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.ts
@@ -39,6 +39,10 @@ export class LayoutStepComponent implements OnInit {
   protected topologyCategory: PoolManagerTopologyCategory;
   private enclosures: Enclosure[] = [];
 
+  get isVdevsLimitedToOne(): boolean {
+    return this.type === VdevType.Spare || this.type === VdevType.Cache || this.type === VdevType.Log;
+  }
+
   constructor(
     private store: PoolManagerStore,
     private dialog: MatDialog,
@@ -61,6 +65,7 @@ export class LayoutStepComponent implements OnInit {
         layout: this.topologyCategory.layout,
         enclosures: this.enclosures,
         vdevs: this.topologyCategory.vdevs,
+        vdevsLimit: this.isVdevsLimitedToOne ? 1 : null,
       } as ManualDiskSelectionParams,
       panelClass: 'manual-selection-dialog',
     })


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 3bab38d0c1dd4be9f24633449565ab4043c7cf98
    git cherry-pick -x 5f3a0a03930afe2731af1023036bea29cff0560a
    git cherry-pick -x 8cc806145913d644ce3d0a99d1c681304fa674f8
    git cherry-pick -x ce5af5e8fc6bff2729a36300873e65dfd3710848

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 6c8abf9ff8fa44612c1f41c6f1b14f6f1ca26e9a

Testing: see ticket.

Original PR: https://github.com/truenas/webui/pull/8752
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123911