### PR TITLE
NAS-123723 / 22.12.4 / View Enclosure Elements contain empty Descriptor column (by AlexKarpov98)

### DIFF
--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
@@ -38,7 +38,7 @@
   <ix-tab-content
     *ngIf="currentTab.alias !== 'Disks'"
     class="other-tab"
-    [data]="system.enclosures[selectedEnclosure.enclosureKey].elements[currentTab.elementIndex] | cast"
+    [data]="omitDescriptor(system.enclosures[selectedEnclosure.enclosureKey].elements[currentTab.elementIndex]) | cast"
   ></ix-tab-content>
 
   <mat-card-content id="Disks-content" [class]="currentTab.alias">

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
@@ -1263,4 +1263,12 @@ export class EnclosureDisksComponent implements AfterContentInit, OnChanges, OnD
         }
       });
   }
+
+  omitDescriptor(group: EnclosureElementsGroup | EnclosureElement): EnclosureElementsGroup | EnclosureElement {
+    const returnValue = { ...group as EnclosureElementsGroup };
+    if (returnValue.header) {
+      returnValue.header = returnValue.header.filter((header) => header !== 'Descriptor');
+    }
+    return returnValue;
+  }
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 1ba92e27a10e3375c7caaae70125b5df3cd2e494
    git cherry-pick -x 42108f438a61a7de196a8a540767f0b27a38e87b

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x e56a5f24e52f4a3ff6dabae2d64eddfde4974b43

Testing: see that Descriptor field on Enclosure page is no longer there for Cobia & Bluefin:
<img width="1728" alt="Screenshot 2023-09-06 at 00 45 46" src="https://github.com/truenas/webui/assets/22980553/dbdfcec4-5476-4743-a360-f55a58a90e7f">


Original PR: https://github.com/truenas/webui/pull/8764
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123723