### PR TITLE
NAS-123931 / 24.04 / Time axis on the reporting charts values incorrect on zooms

### DIFF
--- a/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.ts
+++ b/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.ts
@@ -159,7 +159,10 @@ export class LineChartComponent implements AfterViewInit, OnDestroy, OnChanges {
         const zoomRange = endDate - startDate;
 
         if (zoomRange < maxZoomLevel) {
-          this.chart.updateOptions({ dateWindow: [this.lastMinDate, this.lastMaxDate] });
+          this.chart.updateOptions({
+            dateWindow: [this.lastMinDate, this.lastMaxDate],
+            animatedZooms: false,
+          });
           return;
         }
 


### PR DESCRIPTION
Testing: See ticket.

Go to reports and try to zoom chart by hands, you will be stopped at some point (max 5 minutes)
If you try to zoom in greater (shorter distance) than 5 minutes (like 2 minutes)
You should be not able to do it and reset to previous valid time range.

<img width="1003" alt="Screenshot 2023-09-07 at 22 38 47" src="https://github.com/truenas/webui/assets/22980553/0862b3fd-5afb-4791-be29-9f477cd6aaae">
