### PR TITLE
NAS-123932 / 23.10 / Pool creation shows type for spares (by AlexKarpov98)

### DIFF
--- a/src/app/helpers/storage.helper.ts
+++ b/src/app/helpers/storage.helper.ts
@@ -1,0 +1,5 @@
+import { VdevType } from 'app/enums/v-dev-type.enum';
+
+export function isTopologyLimitedToOneLayout(type: string): boolean {
+  return type === VdevType.Spare || type === VdevType.Cache;
+}

--- a/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.html
@@ -13,7 +13,7 @@
           {{ category.key | mapValue: vdevTypeLabels | translate }}:
         </div>
         <div class="value">
-          {{ category.value | ixTopologyCategoryDescription }}
+          {{ category.value | ixTopologyCategoryDescription: !isLimitedToOneLayout(category.key) }}
         </div>
       </div>
       <div class="details-item">

--- a/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.spec.ts
@@ -105,7 +105,7 @@ describe('ConfigurationPreviewComponent', () => {
   it('shows description for every vdev type in topology', () => {
     expect(getItems()).toMatchObject({
       'Data:': '2 × STRIPE | 3 × 2 GiB (HDD)',
-      'Cache:': '5 × RAIDZ1 | 2 × 5 GiB (HDD)',
+      'Cache:': '2 × 5 GiB (HDD)',
       'Dedup:': 'None',
       'Log:': '2 × RAIDZ1 | 3 × 3 GiB (HDD)',
       'Spare:': 'Manual layout | 2 VDEVs',

--- a/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.ts
@@ -4,6 +4,7 @@ import {
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { vdevTypeLabels } from 'app/enums/v-dev-type.enum';
+import { isTopologyLimitedToOneLayout } from 'app/helpers/storage.helper';
 import {
   PoolManagerStore,
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
@@ -22,6 +23,7 @@ export class ConfigurationPreviewComponent {
   protected encryption$ = this.store.encryption$;
   protected topology$ = this.store.topology$;
   protected totalCapacity$ = this.store.totalUsableCapacity$;
+  protected isLimitedToOneLayout = isTopologyLimitedToOneLayout;
 
   constructor(
     private store: PoolManagerStore,

--- a/src/app/pages/storage/modules/pool-manager/components/existing-configuration-preview/existing-configuration-preview.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/existing-configuration-preview/existing-configuration-preview.component.html
@@ -13,7 +13,7 @@
           {{ category.key | mapValue: vdevTypeLabels | translate }}:
         </span>
         <span class="value">
-          {{ category.value | ixTopologyCategoryDescription }}
+          {{ category.value | ixTopologyCategoryDescription: !isLimitedToOneLayout(category.key) }}
         </span>
       </div>
       <div class="details-item">

--- a/src/app/pages/storage/modules/pool-manager/components/existing-configuration-preview/existing-configuration-preview.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/existing-configuration-preview/existing-configuration-preview.component.ts
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import {
   CreateVdevLayout, TopologyItemType, VdevType, vdevTypeLabels,
 } from 'app/enums/v-dev-type.enum';
+import { isTopologyLimitedToOneLayout } from 'app/helpers/storage.helper';
 import { PoolTopology } from 'app/interfaces/pool.interface';
 import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
 import {
@@ -35,14 +36,20 @@ const defaultCategory: PoolManagerTopologyCategory = {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ExistingConfigurationPreviewComponent implements OnChanges {
-  protected readonly vdevTypeLabels = vdevTypeLabels;
-
-  VdevType = VdevType;
   @Input() name: string;
   @Input() topology: PoolTopology;
   @Input() size: number;
   @Input() disks: Disk[];
+
+  VdevType = VdevType;
+
+  protected readonly vdevTypeLabels = vdevTypeLabels;
   protected poolTopology: PoolManagerTopology;
+  protected isLimitedToOneLayout = isTopologyLimitedToOneLayout;
+
+  get unknownProp(): string {
+    return this.translate.instant('None');
+  }
 
   constructor(
     private translate: TranslateService,
@@ -65,6 +72,7 @@ export class ExistingConfigurationPreviewComponent implements OnChanges {
       dedup: _.cloneDeep(defaultCategory),
       special: _.cloneDeep(defaultCategory),
     };
+
     for (const [, value] of Object.entries(VdevType)) {
       if (!topology[value]?.length) {
         continue;
@@ -110,9 +118,5 @@ export class ExistingConfigurationPreviewComponent implements OnChanges {
       }
     }
     return poolManagerTopology;
-  }
-
-  get unknownProp(): string {
-    return this.translate.instant('None');
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/new-devices/new-devices-preview.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/new-devices/new-devices-preview.component.html
@@ -4,16 +4,16 @@
   </mat-card-header>
   <mat-card-content>
     <div>
-      
+
       <div *ngFor="let category of topology$ | async | keyvalue" class="details-item">
         <span class="label">
           {{ category.key | mapValue: vdevTypeLabels | translate }}:
         </span>
         <span class="value">
-          {{ category.value | ixTopologyCategoryDescription }}
+          {{ category.value | ixTopologyCategoryDescription: !isLimitedToOneLayout(category.key) }}
         </span>
       </div>
-      
+
     </div>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/storage/modules/pool-manager/components/new-devices/new-devices-preview.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/new-devices/new-devices-preview.component.ts
@@ -4,6 +4,7 @@ import {
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { vdevTypeLabels } from 'app/enums/v-dev-type.enum';
+import { isTopologyLimitedToOneLayout } from 'app/helpers/storage.helper';
 import {
   PoolManagerStore,
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
@@ -17,15 +18,15 @@ import {
 })
 export class NewDevicesPreviewComponent {
   protected readonly vdevTypeLabels = vdevTypeLabels;
-
   protected topology$ = this.store.topology$;
+  protected isLimitedToOneLayout = isTopologyLimitedToOneLayout;
+
+  get unknownProp(): string {
+    return this.translate.instant('None');
+  }
 
   constructor(
     private store: PoolManagerStore,
     private translate: TranslateService,
   ) {}
-
-  get unknownProp(): string {
-    return this.translate.instant('None');
-  }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.html
@@ -24,7 +24,7 @@
             {{ category[0] | mapValue: vdevTypeLabels | translate }}
           </div>
           <div class="value">
-            {{ category[1] | ixTopologyCategoryDescription }}
+            {{ category[1] | ixTopologyCategoryDescription: !isLimitedToOneLayout(category[0]) }}
           </div>
         </div>
       </ng-container>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
@@ -7,6 +7,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { filter } from 'rxjs';
 import { VdevType, vdevTypeLabels } from 'app/enums/v-dev-type.enum';
+import { isTopologyLimitedToOneLayout } from 'app/helpers/storage.helper';
 import {
   InspectVdevsDialogComponent,
 } from 'app/pages/storage/modules/pool-manager/components/inspect-vdevs-dialog/inspect-vdevs-dialog.component';
@@ -34,13 +35,12 @@ export class ReviewWizardStepComponent implements OnInit {
 
   state: PoolManagerState;
   nonEmptyTopologyCategories: [VdevType, PoolManagerTopologyCategory][] = [];
+  poolCreationErrors: PoolCreationError[];
+  isCreateDisabled = false;
 
   protected totalCapacity$ = this.store.totalUsableCapacity$;
   protected readonly vdevTypeLabels = vdevTypeLabels;
-
-  poolCreationErrors: PoolCreationError[];
-
-  isCreateDisabled = false;
+  protected isLimitedToOneLayout = isTopologyLimitedToOneLayout;
 
   constructor(
     private matDialog: MatDialog,

--- a/src/app/pages/storage/modules/pool-manager/pipes/topology-category-description.pipe.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/pipes/topology-category-description.pipe.spec.ts
@@ -40,4 +40,15 @@ describe('TopologyCategoryDescriptionPipe', () => {
       vdevs: [[{}], [{}]],
     } as PoolManagerTopologyCategory)).toBe('2 × STRIPE | 3 × 2 GiB (HDD)');
   });
+
+  it('returns a string describing Typology which has layout limit', () => {
+    expect(spectator.service.transform({
+      diskSize: 2 * GiB,
+      vdevsNumber: 2,
+      layout: CreateVdevLayout.Stripe,
+      width: 3,
+      diskType: DiskType.Hdd,
+      vdevs: [[{}], [{}]],
+    } as PoolManagerTopologyCategory, false)).toBe('3 × 2 GiB (HDD)');
+  });
 });

--- a/src/app/pages/storage/modules/pool-manager/pipes/topology-category-description.pipe.ts
+++ b/src/app/pages/storage/modules/pool-manager/pipes/topology-category-description.pipe.ts
@@ -11,7 +11,7 @@ export class TopologyCategoryDescriptionPipe implements PipeTransform {
     private translate: TranslateService,
   ) {}
 
-  transform(category: PoolManagerTopologyCategory): string {
+  transform(category: PoolManagerTopologyCategory, notLimitedToOneLayout = true): string {
     if (category.vdevs.length === 0) {
       return this.translate.instant('None');
     }
@@ -20,7 +20,9 @@ export class TopologyCategoryDescriptionPipe implements PipeTransform {
       return `${this.translate.instant('Manual layout')} | ${category.vdevs.length} VDEVs`;
     }
 
+    const layoutTypeData = notLimitedToOneLayout ? `${category.vdevsNumber} × ${category.layout} | ` : '';
+
     const diskSize = filesize(Number(category.diskSize || 0), { standard: 'iec' });
-    return `${category.vdevsNumber} × ${category.layout} | ${category.width} × ${diskSize} (${category.diskType})`;
+    return `${layoutTypeData}${category.width} × ${diskSize} (${category.diskType})`;
   }
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 1029572282fc7d511a0de3a9ed5e66992ca29f3a
    git cherry-pick -x dd6ced2ca6afdf1a88fdddff6e6b43346396625f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x d105be277b087d5077b900bc69dc6d2d2085f61c

Testing: see ticket

Original PR: https://github.com/truenas/webui/pull/8782
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123932