### PR TITLE
NAS-124004 / 23.10-RC.1 / Do not show success message when snapshot form is closed (by denysbutenko)

### DIFF
--- a/src/app/pages/datasets/components/data-protection-card/data-protection-card.component.ts
+++ b/src/app/pages/datasets/components/data-protection-card/data-protection-card.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import { filter } from 'rxjs';
 import { DatasetDetails } from 'app/interfaces/dataset.interface';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { SnapshotAddFormComponent } from 'app/pages/datasets/modules/snapshots/snapshot-add-form/snapshot-add-form.component';
@@ -25,7 +26,7 @@ export class DataProtectionCardComponent {
 
   addSnapshot(): void {
     const slideInRef = this.slideInService.open(SnapshotAddFormComponent, { data: this.dataset.id });
-    slideInRef.slideInClosed$.pipe(untilDestroyed(this)).subscribe(() => {
+    slideInRef.slideInClosed$.pipe(filter(Boolean), untilDestroyed(this)).subscribe(() => {
       this.snackbarService.success(this.translate.instant('Snapshot added successfully.'));
     });
   }


### PR DESCRIPTION
For testing, go to datasets, and on the details panel, press the `Create Snapshot` button and close it, ensuring no `Snapshot added successfully` toast appears. Try to submit the form to ensure that the message appears.

Original PR: https://github.com/truenas/webui/pull/8790
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124004