### PR TITLE
NAS-123749 / 23.10-RC.1 /  "Spares" category from pool creation "Configuration Preview" inaccurate/unneeded (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import { map } from 'rxjs';
 import { vdevTypeLabels } from 'app/enums/v-dev-type.enum';
 import {
   PoolManagerStore,
@@ -20,7 +21,15 @@ export class ConfigurationPreviewComponent {
 
   protected name$ = this.store.name$;
   protected encryption$ = this.store.encryption$;
-  protected topology$ = this.store.topology$;
+
+  protected topology$ = this.store.topology$.pipe(
+    map((topology) => {
+      if (this.store.isUsingDraidLayout(topology)) {
+        delete topology.spare;
+      }
+      return topology;
+    }),
+  );
   protected totalCapacity$ = this.store.totalUsableCapacity$;
 
   constructor(

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -157,11 +157,13 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
 
   readonly usesDraidLayout$ = this.select(
     this.topology$,
-    (topology) => {
-      const dataCategory = topology[VdevType.Data];
-      return [CreateVdevLayout.Draid1, CreateVdevLayout.Draid2, CreateVdevLayout.Draid3].includes(dataCategory.layout);
-    },
+    (topology) => this.isUsingDraidLayout(topology),
   );
+
+  isUsingDraidLayout(topology: PoolManagerTopology): boolean {
+    const dataCategory = topology[VdevType.Data];
+    return [CreateVdevLayout.Draid1, CreateVdevLayout.Draid2, CreateVdevLayout.Draid3].includes(dataCategory.layout);
+  }
 
   getLayoutsForVdevType(vdevType: VdevType): Observable<CreateVdevLayout[]> {
     switch (vdevType) {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x f5c03f81adaa36db7769d910fd2389ede1025b4b
    git cherry-pick -x b6a4891b46bf638130e82164d8281d941747a770
    git cherry-pick -x 5660c556a4d504838238ff070adc099f44cc916f
    git cherry-pick -x 966a9573c21e0ee250b800840b4dcef0bfc48758
    git cherry-pick -x 52a2f35753c5294c17c720f8792827a604b61885
    git cherry-pick -x 631083f4ebee8f5dccaeed1a945aece56963be3a

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x f53a66f87676fa251494a74f9a34d4ead155e788

Testing: see ticket

Original PR: https://github.com/truenas/webui/pull/8707
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123749