### PR TITLE
NAS-122258 / 22.12.4 / Showing extent disk on edit (by undsoft)

### DIFF
--- a/src/app/pages/sharing/iscsi/extent/extent-form/extent-form.component.ts
+++ b/src/app/pages/sharing/iscsi/extent/extent-form/extent-form.component.ts
@@ -6,13 +6,16 @@ import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import _ from 'lodash';
-import { Observable, of } from 'rxjs';
+import {
+  BehaviorSubject, combineLatest, Observable, of,
+} from 'rxjs';
 import { map } from 'rxjs/operators';
 import { IscsiExtentRpm, IscsiExtentType } from 'app/enums/iscsi.enum';
 import { mntPath } from 'app/enums/mnt-path.enum';
 import { choicesToOptions } from 'app/helpers/options.helper';
 import { helptextSharingIscsi } from 'app/helptext/sharing';
 import { IscsiExtent } from 'app/interfaces/iscsi.interface';
+import { Option } from 'app/interfaces/option.interface';
 import { FormErrorHandlerService } from 'app/modules/ix-forms/services/form-error-handler.service';
 import { IscsiService, WebSocketService } from 'app/services';
 import { FilesystemService } from 'app/services/filesystem.service';
@@ -63,14 +66,23 @@ export class ExtentFormComponent implements OnInit {
 
   isLoading = false;
 
+  private extentDiskBeingEdited$ = new BehaviorSubject<Option>(undefined);
+
   readonly helptext = helptextSharingIscsi;
 
   readonly rpms$ = of(this.helptext.extent_form_enum_rpm);
   readonly types$ = of(this.helptext.extent_form_enum_type);
   readonly blocksizes$ = of(this.helptext.extent_form_enum_blocksize);
-  readonly disks$ = this.iscsiService.getExtentDevices().pipe(
-    choicesToOptions(),
-    map((options) => {
+  readonly disks$ = combineLatest([
+    this.iscsiService.getExtentDevices().pipe(choicesToOptions()),
+    this.extentDiskBeingEdited$,
+  ]).pipe(
+    map(([availableOptions, extentDiskBeingEdited]) => {
+      const options = [...availableOptions];
+      if (extentDiskBeingEdited) {
+        options.push(extentDiskBeingEdited);
+      }
+
       return _.sortBy(options, ['label']);
     }),
   );
@@ -105,15 +117,12 @@ export class ExtentFormComponent implements OnInit {
   }
 
   setExtentForEdit(extent: IscsiExtent): void {
-    if (extent.type === IscsiExtentType.Disk) {
-      if (_.startsWith(extent.path, 'zvol')) {
-        extent.disk = extent.path;
-      }
-      delete extent.path;
-    }
-
     this.editingExtent = extent;
     this.form.patchValue(extent);
+
+    if (this.editingExtent.type === IscsiExtentType.Disk) {
+      this.setExtentDisk();
+    }
   }
 
   onSubmit(): void {
@@ -152,6 +161,21 @@ export class ExtentFormComponent implements OnInit {
         this.errorHandler.handleWsFormError(error, this.form);
         this.cdr.markForCheck();
       },
+    });
+  }
+
+  private setExtentDisk(): void {
+    if (!_.startsWith(this.editingExtent.path, 'zvol')) {
+      return;
+    }
+
+    const extentDiskBeingEdited = this.editingExtent.path.slice('zvol'.length + 1);
+    this.extentDiskBeingEdited$.next({
+      label: extentDiskBeingEdited,
+      value: this.editingExtent.path,
+    });
+    this.form.patchValue({
+      disk: this.editingExtent.path,
     });
   }
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 528d15b150d62494f5b01882dbca1d4a7913bf2f
    git cherry-pick -x d0605c119892a74c557b249851a2a6a939434e78

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 88ec05c88a0028048ef80aef38fd3c8f8e7ddffd

Testing: when editing an extent that was created with type = Device, Device dropdown should be filled in.

Original PR: https://github.com/truenas/webui/pull/8804
Jira URL: https://ixsystems.atlassian.net/browse/NAS-122258