### PR TITLE
NAS-123985 / 24.04 / Misaligned warning icon in standby card

### DIFF
--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
@@ -278,6 +278,7 @@ img.clickable,
   &.freenas,
   &.truenas {
     .generic {
+      margin: 0 auto;
       padding-bottom: 10%;
     }
   }


### PR DESCRIPTION
Testing: see ticket

Result:
<img width="229" alt="Screenshot 2023-09-11 at 19 58 56" src="https://github.com/truenas/webui/assets/22980553/3636d23c-9700-419c-ab51-f014feec13ca">
