### PR TITLE
NAS-123979 / 13.0 / Tooltip for syslog info level is incorrect (by AlexKarpov98)

### DIFF
--- a/src/app/helptext/system/advanced.ts
+++ b/src/app/helptext/system/advanced.ts
@@ -112,8 +112,8 @@ simultaneously.'),
   sysloglevel: {
     placeholder: T('Syslog Level'),
     tooltip: T(
-      'When <i>Syslog Server</i> is defined, only logs matching this\
- level are sent.',
+      'Select the minimum priority level to send to the remote syslog server.\
+The system only sends logs matching this level or higher.',
     ),
     options: [
       { label: T('Emergency'), value: 'F_EMERG' },

--- a/src/assets/i18n/af.po
+++ b/src/assets/i18n/af.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ar.po
+++ b/src/assets/i18n/ar.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ast.po
+++ b/src/assets/i18n/ast.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/az.po
+++ b/src/assets/i18n/az.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/be.po
+++ b/src/assets/i18n/be.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/bg.po
+++ b/src/assets/i18n/bg.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/bn.po
+++ b/src/assets/i18n/bn.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/br.po
+++ b/src/assets/i18n/br.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/bs.po
+++ b/src/assets/i18n/bs.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ca.po
+++ b/src/assets/i18n/ca.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/cs.po
+++ b/src/assets/i18n/cs.po
@@ -14486,8 +14486,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/cy.po
+++ b/src/assets/i18n/cy.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/da.po
+++ b/src/assets/i18n/da.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/de.po
+++ b/src/assets/i18n/de.po
@@ -15435,8 +15435,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/dsb.po
+++ b/src/assets/i18n/dsb.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/el.po
+++ b/src/assets/i18n/el.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/en-au.po
+++ b/src/assets/i18n/en-au.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/en-gb.po
+++ b/src/assets/i18n/en-gb.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/en.po
+++ b/src/assets/i18n/en.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/eo.po
+++ b/src/assets/i18n/eo.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/es-ar.po
+++ b/src/assets/i18n/es-ar.po
@@ -17531,8 +17531,8 @@ msgstr ""
 "clave estática para usar con el cliente OpenVPN."
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/es-co.po
+++ b/src/assets/i18n/es-co.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/es-mx.po
+++ b/src/assets/i18n/es-mx.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/es-ni.po
+++ b/src/assets/i18n/es-ni.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/es-ve.po
+++ b/src/assets/i18n/es-ve.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/es.po
+++ b/src/assets/i18n/es.po
@@ -14397,8 +14397,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/et.po
+++ b/src/assets/i18n/et.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/eu.po
+++ b/src/assets/i18n/eu.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/fa.po
+++ b/src/assets/i18n/fa.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/fi.po
+++ b/src/assets/i18n/fi.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/fr.po
+++ b/src/assets/i18n/fr.po
@@ -17615,8 +17615,8 @@ msgstr ""
 "automatiquement générée pour être utilisée avec le client OpenVPN."
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/fy.po
+++ b/src/assets/i18n/fy.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ga.po
+++ b/src/assets/i18n/ga.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/gd.po
+++ b/src/assets/i18n/gd.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/gl.po
+++ b/src/assets/i18n/gl.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/he.po
+++ b/src/assets/i18n/he.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/hi.po
+++ b/src/assets/i18n/hi.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/hr.po
+++ b/src/assets/i18n/hr.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/hsb.po
+++ b/src/assets/i18n/hsb.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/hu.po
+++ b/src/assets/i18n/hu.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ia.po
+++ b/src/assets/i18n/ia.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/id.po
+++ b/src/assets/i18n/id.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/io.po
+++ b/src/assets/i18n/io.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/is.po
+++ b/src/assets/i18n/is.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/it.po
+++ b/src/assets/i18n/it.po
@@ -14521,8 +14521,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ja.po
+++ b/src/assets/i18n/ja.po
@@ -14654,8 +14654,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ka.po
+++ b/src/assets/i18n/ka.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/kk.po
+++ b/src/assets/i18n/kk.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/km.po
+++ b/src/assets/i18n/km.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/kn.po
+++ b/src/assets/i18n/kn.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ko.po
+++ b/src/assets/i18n/ko.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/lb.po
+++ b/src/assets/i18n/lb.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/lt.po
+++ b/src/assets/i18n/lt.po
@@ -14426,8 +14426,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/lv.po
+++ b/src/assets/i18n/lv.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/mk.po
+++ b/src/assets/i18n/mk.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ml.po
+++ b/src/assets/i18n/ml.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/mn.po
+++ b/src/assets/i18n/mn.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/mr.po
+++ b/src/assets/i18n/mr.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/my.po
+++ b/src/assets/i18n/my.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/nb.po
+++ b/src/assets/i18n/nb.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ne.po
+++ b/src/assets/i18n/ne.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/nl.po
+++ b/src/assets/i18n/nl.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/nn.po
+++ b/src/assets/i18n/nn.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/os.po
+++ b/src/assets/i18n/os.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/pa.po
+++ b/src/assets/i18n/pa.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/pl.po
+++ b/src/assets/i18n/pl.po
@@ -14401,8 +14401,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/pt-br.po
+++ b/src/assets/i18n/pt-br.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/pt.po
+++ b/src/assets/i18n/pt.po
@@ -14400,8 +14400,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ro.po
+++ b/src/assets/i18n/ro.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ru.po
+++ b/src/assets/i18n/ru.po
@@ -16399,8 +16399,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/sk.po
+++ b/src/assets/i18n/sk.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/sl.po
+++ b/src/assets/i18n/sl.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/sq.po
+++ b/src/assets/i18n/sq.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/sr-latn.po
+++ b/src/assets/i18n/sr-latn.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/sr.po
+++ b/src/assets/i18n/sr.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/strings.po
+++ b/src/assets/i18n/strings.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/sv.po
+++ b/src/assets/i18n/sv.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/sw.po
+++ b/src/assets/i18n/sw.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/ta.po
+++ b/src/assets/i18n/ta.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/te.po
+++ b/src/assets/i18n/te.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/th.po
+++ b/src/assets/i18n/th.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/tr.po
+++ b/src/assets/i18n/tr.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/tt.po
+++ b/src/assets/i18n/tt.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/udm.po
+++ b/src/assets/i18n/udm.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/uk.po
+++ b/src/assets/i18n/uk.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/vi.po
+++ b/src/assets/i18n/vi.po
@@ -14395,8 +14395,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/zh-hans.po
+++ b/src/assets/i18n/zh-hans.po
@@ -15307,8 +15307,8 @@ msgstr ""
 "时，将自动生成一个静态密钥以用于OpenVPN客户端。"
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""

--- a/src/assets/i18n/zh-hant.po
+++ b/src/assets/i18n/zh-hant.po
@@ -14410,8 +14410,8 @@ msgid ""
 msgstr ""
 
 msgid ""
-"When <i>Syslog Server</i> is defined, only logs matching this level are "
-"sent."
+"Select the minimum priority level to send to the remote syslog server."
+"The system only sends logs matching this level or higher."
 msgstr ""
 
 msgid ""


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 4ce05efe970d8bad690f8ef3c6f35a55162f3809

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x a27f4fd95d786da207bf9a6af929ac72420ef58e

Testing:
Tooltip update.
<img width="808" alt="Screenshot 2023-09-11 at 13 18 20" src="https://github.com/truenas/webui/assets/22980553/cccee1a0-674b-40a9-abb5-9aee6b9b69b2">


Original PR: https://github.com/truenas/webui/pull/8816
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123979