### PR TITLE
NAS-124179 / 23.10 / Fix long text in Error dialog (by denysbutenko)

### DIFF
--- a/src/app/modules/common/dialog/error-dialog/error-dialog.component.html
+++ b/src/app/modules/common/dialog/error-dialog/error-dialog.component.html
@@ -3,7 +3,9 @@
   {{ title | translate }}
 </h1>
 <div #errorMdContent mat-dialog-content id="err-md-content">
-  <div #errorMessageWrapper id="err-message-wrapper"><span [innerHTML]="message"></span></div>
+  <div #errorMessageWrapper id="err-message-wrapper" class="err-message-wrapper">
+    <span [innerHTML]="message"></span>
+  </div>
   <div
     *ngIf="backtrace"
     class="more-info"

--- a/src/app/modules/common/dialog/error-dialog/error-dialog.component.scss
+++ b/src/app/modules/common/dialog/error-dialog/error-dialog.component.scss
@@ -48,3 +48,7 @@ $opened-scroll-container-height: calc(80vh - 48px - 240px); // Viewport - topbar
 .err-title {
   align-items: center;
 }
+
+.err-message-wrapper {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
For testing, go to backup credentials and open Cloud Credentials form, fill required data with random strings and press the "Verify Credentials" button to see the Error dialog. To have long string error you can replace the following line:

https://github.com/truenas/webui/blob/c82d0f048d474d0262cedd4e52291e4835a2656c/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts#L206

```diff
- message: response.excerpt,
+ message: Array.from({ length: 1000 }, () => String.fromCharCode(Math.floor(Math.random() * 26) + 97)).join('')
```

Original PR: https://github.com/truenas/webui/pull/8893
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124179