### PR TITLE
NAS-124152 / 23.10 / Show fallback image when product image loading has failure (by denysbutenko)

### DIFF
--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
@@ -74,7 +74,7 @@
 
               <div
                 fxFlex="20"
-                [class]="['platform-logo-wrapper', productType?.toLowerCase()]"
+                [ngClass]="['platform-logo-wrapper', sysGenService.getProductType()?.toLowerCase()]"
               >
                 <ng-container *ngIf="productImage || isPassive; else textOnly">
                   <ix-icon
@@ -96,12 +96,12 @@
                 fxFlex.gt-xs="60"
                 fxLayout="column"
                 fxLayoutAlign="center center"
-                [fxFlex.xs]="productType === ProductType.ScaleEnterprise && productImage === 'X10' ? 80 : 100"
+                [fxFlex.xs]="sysGenService.isEnterprise && productImage === 'X10' ? 80 : 100"
               >
                 <div
                   [class]="'product-image ' + productEnclosure"
-                  [class.truenas]="productType === ProductType.ScaleEnterprise"
-                  [class.freenas]="productType !== ProductType.ScaleEnterprise"
+                  [class.truenas]="sysGenService.isEnterprise"
+                  [class.freenas]="!sysGenService.isEnterprise"
                   [class.ix-logo]="productImage === 'ix-original.svg'"
                 >
                   <img
@@ -137,7 +137,7 @@
                   <div *ngIf="productImage && isHaLicensed && isPassive && hasHa" class="ha-node-status">
                     ({{ 'Standby' | translate }})
                   </div>
-                  <div *ngIf="ready && !productImage && productType === ProductType.ScaleEnterprise && hasHa" class="ha-node-status">
+                  <div *ngIf="ready && !productImage && sysGenService.isEnterprise && hasHa" class="ha-node-status">
                     ({{ 'Unsupported Hardware' | translate }})
                   </div>
                 </div>

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
@@ -111,7 +111,8 @@
                     [id]="productModel"
                     [class.clickable]="enclosureSupport"
                     [matTooltipDisabled]="!enclosureSupport"
-                    [src]="'assets/images/' + productImage"
+                    [src]="'assets/images' + productImage"
+                    [src-fallback]="'assets/images/truenas_scale_ondark_favicon.png'"
                     (click)="goToEnclosure()"
                   />
 

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -10,7 +10,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { addSeconds } from 'date-fns';
 import { filter, take } from 'rxjs/operators';
 import { JobState } from 'app/enums/job-state.enum';
-import { ProductType } from 'app/enums/product-type.enum';
 import { ScreenType } from 'app/enums/screen-type.enum';
 import { SystemUpdateStatus } from 'app/enums/system-update.enum';
 import { WINDOW } from 'app/helpers/window.helper';
@@ -59,7 +58,6 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
   certified = false;
   updateAvailable = false;
   isIxHardware = false;
-  productType = this.sysGenService.getProductType();
   isUpdateRunning = false;
   hasHa: boolean;
   updateMethod = 'update.update';
@@ -67,7 +65,6 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
   uptimeString: string;
   dateTime: string;
 
-  readonly ProductType = ProductType;
   readonly ScreenType = ScreenType;
 
   constructor(
@@ -118,7 +115,7 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
       this.isIxHardware = isIxHardware;
       this.setProductImage();
     });
-    if (this.sysGenService.getProductType() === ProductType.ScaleEnterprise) {
+    if (this.sysGenService.isEnterprise) {
       this.store$.select(selectIsHaLicensed).pipe(untilDestroyed(this)).subscribe((isHaLicensed) => {
         this.isHaLicensed = isHaLicensed;
         if (isHaLicensed) {

--- a/src/app/pages/dashboard/dashboard.module.ts
+++ b/src/app/pages/dashboard/dashboard.module.ts
@@ -12,6 +12,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgxFilesizeModule } from 'ngx-filesize';
+import { ImgFallbackModule } from 'ngx-img-fallback';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { CoreComponents } from 'app/core/core-components.module';
 import { CommonDirectivesModule } from 'app/directives/common/common-directives.module';
@@ -72,6 +73,7 @@ import { routing } from './dashboard.routing';
     TestIdModule,
     NgxFilesizeModule,
     NgxSkeletonLoaderModule,
+    ImgFallbackModule,
   ],
   declarations: [
     DashboardComponent,


### PR DESCRIPTION
Changes:

- When product image returns 404 not found error - show fallback image instead of broken one
- Ensure there is single slash in the path: `/assets/images//servers/F100.png`

For testing, use system from the ticket.

Original PR: https://github.com/truenas/webui/pull/8892
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124152