### PR TITLE
NAS-124237 / 23.10 / Fix password icon in ix-input (by denysbutenko)

### DIFF
--- a/src/app/modules/ix-forms/components/ix-input/ix-input.component.scss
+++ b/src/app/modules/ix-forms/components/ix-input/ix-input.component.scss
@@ -83,9 +83,6 @@
   .toggle_pw {
     @include variable(display, --toggle_pw_display_prop, $toggle-pw-display-prop);
     opacity: var(--disabled-opacity);
-    position: absolute;
-    right: 0;
-    top: -5px;
   }
 
   .toggle_pw ix-icon {


### PR DESCRIPTION
Check password field on sign-in page, ensure icon is aligned well.

Original PR: https://github.com/truenas/webui/pull/8904
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124237