### PR TITLE
NAS-123426 / 22.12.4 / Fix default home path (by bvasilenko) (by bugclerk)

### DIFF
--- a/src/app/pages/account/users/user-form/user-form.component.spec.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.spec.ts
@@ -127,7 +127,7 @@ describe('UserFormComponent', () => {
 
       const usernameInput = await loader.getHarness(IxInputHarness.with({ label: 'Username' }));
       await usernameInput.setValue('test');
-      expect(await homeInput.getValue()).toBe('/mnt/users/test');
+      expect(await homeInput.getValue()).toBe('/mnt/users');
     });
 
     it('checks download ssh key button is hidden', async () => {

--- a/src/app/pages/account/users/user-form/user-form.component.ts
+++ b/src/app/pages/account/users/user-form/user-form.component.ts
@@ -8,7 +8,7 @@ import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import _ from 'lodash';
 import {
-  combineLatest, from, Observable, of, Subscription,
+  from, Observable, of, Subscription,
 } from 'rxjs';
 import {
   debounceTime, filter, map, switchMap, take,
@@ -384,14 +384,9 @@ export class UserFormComponent {
     ]]).pipe(
       filter((shares) => !!shares.length),
       map((shares) => shares[0].path),
-      switchMap((homeSharePath) => {
-        this.form.patchValue({ home: homeSharePath });
-
-        return combineLatest([of(homeSharePath), this.form.get('username').valueChanges]);
-      }),
       untilDestroyed(this),
-    ).subscribe(([homeSharePath, username]) => {
-      this.form.patchValue({ home: `${homeSharePath}/${username}` });
+    ).subscribe((homeSharePath) => {
+      this.form.patchValue({ home: homeSharePath });
     });
   }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x bbbbd915cf5fee4af636b7a3b7fb4f98459cd7a6

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x d6b83a08ba55b0fc86b78880a6a7d9eaff79007a

**Testing**

1. **Datasets > Add Dataset** Add a dataset named e.g. `home`

![image](https://github.com/truenas/webui/assets/20611516/7d5ff757-b0a1-4981-87c9-24eb02be99cf)

2. **Shares > Windows (SMB) Shares > Add**
   - Path - this dataset (`home`)
   - Purpose - **No presets**
   - Use as Home Share - `true`

![image](https://github.com/truenas/webui/assets/20611516/97e41e68-fcb8-48e7-811b-a1699de5c64c)

3. **Credentials \> Local Users \> Add**
   - Full name - for example, `newUser`
   - Password - for example, `qwerty`
   - Create Home Directoty - `true`

![image](https://github.com/truenas/webui/assets/20611516/8fe518a4-e440-4913-92d1-a42e14888cea)

**Expected Behavior:** A user should be added, with a Home Directory similar to `mnt/my pool/home/newUser`

![image](https://github.com/truenas/webui/assets/20611516/cb7da4bf-cc94-4643-a54c-5e367cc25a2e)


Original PR: https://github.com/truenas/webui/pull/8621
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123426

Original PR: https://github.com/truenas/webui/pull/8669
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123426