### PR TITLE
NAS-123801 / 23.10 / Better error tracking for 'ix-list'

### DIFF
--- a/src/app/modules/ix-dynamic-form/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
+++ b/src/app/modules/ix-dynamic-form/components/ix-dynamic-form/ix-dynamic-form-item/ix-dynamic-form-item.component.html
@@ -45,6 +45,7 @@
       [itemsSchema]="dynamicSchema.itemsSchema"
       [isEditMode]="isEditMode"
       [canAdd]="!isAllListControlsDisabled"
+      [formArray]="getFormArray"
       (add)="addControl($event)"
     >
       <ix-list-item

--- a/src/app/modules/ix-forms/components/ix-list/ix-list.component.html
+++ b/src/app/modules/ix-forms/components/ix-list/ix-list.component.html
@@ -18,6 +18,7 @@
       {{ 'Add' | translate }}
     </button>
   </div>
+  <ix-errors *ngIf="formArray" [control]="formArray" [label]="label"></ix-errors>
 
   <div class="input-container" [class.disabled]="isDisabled">
     <ng-content></ng-content>

--- a/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
+++ b/src/app/modules/ix-forms/components/ix-list/ix-list.component.ts
@@ -2,6 +2,7 @@ import {
   AfterViewInit,
   Component, EventEmitter, Input, Output,
 } from '@angular/core';
+import { AbstractControl } from '@angular/forms';
 import { ChartSchemaNode } from 'app/interfaces/chart-release.interface';
 
 @Component({
@@ -10,6 +11,7 @@ import { ChartSchemaNode } from 'app/interfaces/chart-release.interface';
   styleUrls: ['./ix-list.component.scss'],
 })
 export class IxListComponent implements AfterViewInit {
+  @Input() formArray: AbstractControl;
   @Input() label: string;
   @Input() tooltip: string;
   @Input() empty: boolean;

--- a/src/app/modules/ix-forms/services/form-error-handler.service.ts
+++ b/src/app/modules/ix-forms/services/form-error-handler.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { AbstractControl, UntypedFormGroup, UntypedFormArray } from '@angular/forms';
+import { AbstractControl, UntypedFormGroup } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { ResponseErrorType } from 'app/enums/response-error-type.enum';
 import { Job } from 'app/interfaces/job.interface';
@@ -50,20 +50,13 @@ export class FormErrorHandlerService {
       const field = extraItem[0].split('.')[1];
       const errorMessage = extraItem[1];
 
-      let control = this.getFormField(formGroup, field, fieldsMap);
+      const control = this.getFormField(formGroup, field, fieldsMap);
 
       if (!control) {
         console.error(`Could not find control ${field}.`);
         // Fallback to default modal error message.
         this.dialog.error(this.errorHandler.parseError(error));
         return;
-      }
-
-      if ((control as UntypedFormArray).controls?.length) {
-        const isExactMatch = (text: string, match: string): boolean => new RegExp(`\\b${match}\\b`).test(text);
-
-        control = (control as UntypedFormArray).controls
-          .find((controlOfArray) => isExactMatch(errorMessage, controlOfArray.value));
       }
 
       control.setErrors({

--- a/src/app/pages/credentials/certificates-dash/certificate-acme-add/certificate-acme-add.component.html
+++ b/src/app/pages/credentials/certificates-dash/certificate-acme-add/certificate-acme-add.component.html
@@ -39,7 +39,11 @@
       </ix-fieldset>
 
       <ix-fieldset [title]="'Domains' | translate">
-        <ix-list formArrayName="domains" [canAdd]="false">
+        <ix-list
+          formArrayName="domains" 
+          [canAdd]="false" 
+          [formArray]="form.get('domains')"
+        >
           <ix-list-item
             *ngFor="let domain of domains; let i = index"
             [canDelete]="false"

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.html
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.html
@@ -29,6 +29,7 @@
           [empty]="form.controls.datasets.controls.length === 0"
           [label]="'Datasets' | translate"
           [canAdd]="false"
+          [formArray]="form.get('datasets')"
         >
           <ix-list-item
             *ngFor="let dataset of form.controls.datasets.controls; let i = index"

--- a/src/app/pages/network/components/interface-form/interface-form.component.html
+++ b/src/app/pages/network/components/interface-form/interface-form.component.html
@@ -149,6 +149,7 @@
           formArrayName="aliases"
           [empty]="form.controls.aliases.controls.length === 0"
           [label]="'Aliases' | translate"
+          [formArray]="form.get('aliases')"
           (add)="addAlias()"
         >
           <ix-list-item

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/steps/portal-wizard-step/portal-wizard-step.component.html
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/steps/portal-wizard-step/portal-wizard-step.component.html
@@ -53,6 +53,7 @@
       [empty]="form.controls.listen.controls.length === 0"
       [label]="helptextSharingIscsi.portal_form_placeholder_ip | translate"
       [tooltip]="helptextSharingIscsi.portal_form_tooltip_ip | translate"
+      [formArray]="form.get('listen')"
       (add)="addAddress()"
     >
       <ix-list-item

--- a/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.html
+++ b/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.html
@@ -32,6 +32,7 @@
 
       <ix-fieldset [title]="'IP Address' | translate">
         <ix-list
+          formArrayName="ip"
           [empty]="listen.length === 0"
           [label]="'Add listen' | translate"
           (add)="onAdd()"
@@ -39,7 +40,7 @@
           <ng-container *ngFor="let item of listen; let i = index">
             <ix-list-item (delete)="onDelete(i)">
               <ix-select
-                [formControlName]="'ip' + listPrefix + i"
+                [formControlName]="i"
                 [label]="labels.ip | translate"
                 [tooltip]="tooltips.ip | translate"
                 [options]="listenOptions$"

--- a/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.html
+++ b/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.html
@@ -33,6 +33,7 @@
       <ix-fieldset [title]="'IP Address' | translate">
         <ix-list
           formArrayName="ip"
+          [formArray]="form.get('ip')"
           [empty]="listen.length === 0"
           [label]="'Add listen' | translate"
           (add)="onAdd()"

--- a/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.ts
+++ b/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.ts
@@ -3,10 +3,9 @@ import {
   ChangeDetectorRef, Component, Inject, OnInit,
 } from '@angular/core';
 import { Validators } from '@angular/forms';
-import { FormBuilder, FormControl } from '@ngneat/reactive-forms';
+import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
-import * as _ from 'lodash';
 import { Observable, of } from 'rxjs';
 import { IscsiAuthMethod } from 'app/enums/iscsi.enum';
 import { choicesToOptions, tagArrayToOptions } from 'app/helpers/options.helper';
@@ -28,7 +27,6 @@ import { WebSocketService } from 'app/services/ws.service';
 export class PortalFormComponent implements OnInit {
   isLoading = false;
   listen: IscsiInterface[] = [];
-  listPrefix = '__';
 
   get isNew(): boolean {
     return !this.editingIscsiPortal;
@@ -44,6 +42,7 @@ export class PortalFormComponent implements OnInit {
     comment: [''],
     discovery_authmethod: [IscsiAuthMethod.None],
     discovery_authgroup: [null as number],
+    ip: this.fb.array<string>([]),
   });
 
   readonly labels = {
@@ -79,14 +78,6 @@ export class PortalFormComponent implements OnInit {
   readonly authgroupOptions$ = this.iscsiService.getAuth().pipe(tagArrayToOptions());
   readonly listenOptions$ = this.iscsiService.getIpChoices().pipe(choicesToOptions());
 
-  private ipAddressFromControls = [
-    {
-      name: 'ip',
-      default: '' as string,
-      validator: [Validators.required, ipValidator('all')],
-    },
-  ];
-
   constructor(
     private fb: FormBuilder,
     private translate: TranslateService,
@@ -105,15 +96,10 @@ export class PortalFormComponent implements OnInit {
   }
 
   setupForm(): void {
-    this.editingIscsiPortal.listen.forEach((listen, index) => {
+    this.editingIscsiPortal.listen.forEach((listen) => {
       const newListItem = {} as IscsiInterface;
-      this.ipAddressFromControls.forEach((fc) => {
-        if (fc.name === 'ip') {
-          const defaultValue = listen.ip;
-          newListItem[fc.name] = defaultValue;
-          this.form.addControl(`${fc.name}${this.listPrefix}${index}`, new FormControl(defaultValue, fc.validator));
-        }
-      });
+      newListItem.ip = listen.ip;
+      this.form.controls.ip.push(this.fb.control(listen.ip, [Validators.required, ipValidator('all')]));
       this.listen.push(newListItem);
     });
 
@@ -124,43 +110,12 @@ export class PortalFormComponent implements OnInit {
   }
 
   onAdd(): void {
-    const newIndex = this.listen.length;
-    const newListItem = {} as IscsiInterface;
-    this.ipAddressFromControls.forEach((fc) => {
-      newListItem[fc.name as 'ip'] = fc.default;
-      this.form.addControl(`${fc.name}${this.listPrefix}${newIndex}`, new FormControl(fc.default, fc.validator));
-    });
-
-    this.listen.push(newListItem);
+    this.form.controls.ip.push(this.fb.control('', [Validators.required, ipValidator('all')]));
+    this.listen.push({ ip: '' } as IscsiInterface);
   }
 
   onDelete(index: number): void {
-    this.ipAddressFromControls.forEach((fc) => {
-      this.form.removeControl(`${fc.name}${this.listPrefix}${index}`);
-    });
-
     this.listen.splice(index, 1);
-  }
-
-  prepareSubmit(values: PortalFormComponent['form']['value']): IscsiInterface[] {
-    const listen = [] as IscsiInterface[];
-
-    const tempListen: { name: string; index: string; value: string | number | string[] }[] = [];
-    Object.keys(values).forEach((key) => {
-      const keys = key.split(this.listPrefix);
-      if (keys.length > 1) {
-        tempListen.push({ name: keys[0], index: keys[1], value: values[key as keyof PortalFormComponent['form']['value']] });
-      }
-    });
-
-    Object.values(_.groupBy(tempListen, 'index')).forEach((item) => {
-      const ip = item.find((ele) => ele.name === 'ip')?.value as string;
-      if (ip) {
-        listen.push({ ip } as IscsiInterface);
-      }
-    });
-
-    return listen;
   }
 
   onSubmit(): void {
@@ -169,7 +124,7 @@ export class PortalFormComponent implements OnInit {
       comment: values.comment,
       discovery_authmethod: values.discovery_authmethod,
       discovery_authgroup: values.discovery_authgroup,
-      listen: this.prepareSubmit(values),
+      listen: values.ip.map((ip) => ({ ip })) as IscsiInterface[],
     };
 
     this.isLoading = true;

--- a/src/app/pages/sharing/iscsi/target/target-form/target-form.component.html
+++ b/src/app/pages/sharing/iscsi/target/target-form/target-form.component.html
@@ -33,6 +33,7 @@
               formArrayName="auth_networks"
               [empty]="form.controls.auth_networks.length === 0"
               [label]="helptext.auth_network.placeholder | translate"
+              [formArray]="form.get('auth_networks')"
               (add)="addNetwork()"
             >
               <ix-list-item
@@ -53,6 +54,7 @@
           <ix-fieldset [title]="helptext.fieldset_target_group | translate">
             <ix-list
               formArrayName="groups"
+              [formArray]="form.get('groups')"
               [empty]="form.controls.groups.length === 0"
               [label]="'Add groups' | translate"
               (add)="addGroup()"

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.html
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.html
@@ -75,6 +75,7 @@
           formArrayName="networks"
           [empty]="form.controls.networks.controls.length === 0"
           [label]="'Networks' | translate"
+          [formArray]="form.get('networks')"
           (add)="addNetworkControl()"
         >
           <ix-list-item
@@ -95,6 +96,7 @@
           formArrayName="hosts"
           [empty]="form.controls.hosts.controls.length === 0"
           [label]="'Hosts' | translate"
+          [formArray]="form.get('hosts')"
           (add)="addHostControl()"
         >
           <ix-list-item

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
@@ -9,6 +9,7 @@
       <ix-fieldset [title]="'ACL Entries' | translate">
         <ix-list
           formArrayName="entries"
+          [formArray]="form.get('entries')"
           [empty]="form.controls.entries.length === 0 && !isLoading"
           [label]="'Add entry' | translate"
           (add)="addAce()"

--- a/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-form/allowed-addresses-form.component.html
+++ b/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-form/allowed-addresses-form.component.html
@@ -7,6 +7,7 @@
     <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
       <ix-list
         formArrayName="addresses"
+        [formArray]="form.get('addresses')"
         [empty]="form.controls.addresses.controls.length === 0"
         [label]="'Allowed IP Addresses' | translate"
         (add)="addAddress()"


### PR DESCRIPTION
The issue was that for an `ix-list` control which is of type `string[]`, when middleware complained about a validation error, it didn't have a way of specifying which specific control had the erroneous value. Furthermore, there was no way to track validity of the `FormArray` instance attached to the `ix-list` component. This PR adds `ix-errors` `ix-list` component and requires that the `FormArray` instance is passed as a property input for the `ix-list` component. That way, when the validity of the `FormArray` changes, we can show the error under the field name.

Follow ticket steps in order to reproduce errors that showcase the new behavior.