### PR TITLE
NAS-124161 / 23.10 / During pool creation on Cobia nightlies, if dRAID is selected as a layout other options are not available (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.html
@@ -99,7 +99,7 @@
       </mat-step>
 
       <mat-step
-        *ngIf="!(usesDraidLayout$ | async) && !alreadyHasSpare"
+        *ngIf="!(usesDraidLayout$ | async) && !alreadyHasSpare && state.topology[PoolCreationWizardStep.Spare]"
         ixStepActivation
         [errorMessage]="getTopLevelErrorForStep(PoolCreationWizardStep.Spare)"
         [hasError]="!!getTopLevelErrorForStep(PoolCreationWizardStep.Spare) && getWasStepActivated(PoolCreationWizardStep.Spare)"


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 653b2e57a0dd6659b92e6ceecfd947aa208c8c5b
    git cherry-pick -x 6302aa85aabc0d2f08eec1367a6a317723196a33
    git cherry-pick -x 26c4b8e4749a4440f935b10f5936b30d3a35a6bc

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 279f977de3a752afef77bf2608ba026216020ecf

Testing:
see ticket, there should be no errors in console as well.

Original PR: https://github.com/truenas/webui/pull/8925
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124161