### PR TITLE
NAS-124232 / 23.10 / Added query param to fetch `display_available` attribute

### DIFF
--- a/src/app/interfaces/virtual-machine.interface.ts
+++ b/src/app/interfaces/virtual-machine.interface.ts
@@ -37,6 +37,7 @@ export interface VirtualMachine {
   suspend_on_snapshot: boolean;
   min_memory: number;
   uuid: string;
+  display_available: boolean;
 }
 
 export type VirtualMachineUpdate = Omit<VirtualMachine, 'status' | 'id' | 'devices'>;

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -13,6 +13,7 @@ import helptext from 'app/helptext/vm/vm-list';
 import wizardHelptext from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { ApiParams } from 'app/interfaces/api-directory.interface';
 import { EmptyConfig } from 'app/interfaces/empty-config.interface';
+import { QueryParams } from 'app/interfaces/query-api.interface';
 import {
   VirtualizationDetails,
   VirtualMachine, VirtualMachineUpdate,
@@ -49,6 +50,11 @@ const noMemoryError = 'ENOMEM';
 export class VmListComponent implements EntityTableConfig<VirtualMachineRow> {
   title = this.translate.instant('Virtual Machines');
   queryCall = 'vm.query' as const;
+  queryCallOption: QueryParams<VirtualMachine, { extra: { retrieve_display_available_info: boolean } }> = [[], {
+    extra: {
+      retrieve_display_available_info: true,
+    },
+  }];
   wsDelete = 'vm.delete' as const;
   protected dialogRef: MatDialogRef<EntityJobComponent>;
   private productType = this.systemGeneralService.getProductType();
@@ -442,7 +448,7 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow> {
   }
 
   isActionVisible(actionId: string, row: VirtualMachineRow): boolean {
-    if (actionId === 'DISPLAY' && (row.status.state !== ServiceStatus.Running || !this.checkDisplay(row))) {
+    if (actionId === 'DISPLAY' && (row.status.state !== ServiceStatus.Running || !row.display_available)) {
       return false;
     }
     if ((actionId === 'POWER_OFF' || actionId === 'STOP' || actionId === 'RESTART'

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -13,7 +13,6 @@ import helptext from 'app/helptext/vm/vm-list';
 import wizardHelptext from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { ApiParams } from 'app/interfaces/api-directory.interface';
 import { EmptyConfig } from 'app/interfaces/empty-config.interface';
-import { QueryParams } from 'app/interfaces/query-api.interface';
 import {
   VirtualizationDetails,
   VirtualMachine, VirtualMachineUpdate,
@@ -50,11 +49,6 @@ const noMemoryError = 'ENOMEM';
 export class VmListComponent implements EntityTableConfig<VirtualMachineRow> {
   title = this.translate.instant('Virtual Machines');
   queryCall = 'vm.query' as const;
-  queryCallOption: QueryParams<VirtualMachine, { extra: { retrieve_display_available_info: boolean } }> = [[], {
-    extra: {
-      retrieve_display_available_info: true,
-    },
-  }];
   wsDelete = 'vm.delete' as const;
   protected dialogRef: MatDialogRef<EntityJobComponent>;
   private productType = this.systemGeneralService.getProductType();

--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -183,7 +183,7 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow> {
         memoryString: this.formatter.convertBytesToHumanReadable(vm.memory * 1048576, 2),
       } as VirtualMachineRow;
 
-      if (this.checkDisplay(vm)) {
+      if (vm.display_available) {
         transformed.port = this.getDisplayPort(vm);
       } else {
         transformed.port = 'N/A';
@@ -194,23 +194,6 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow> {
 
       return transformed;
     });
-  }
-
-  checkDisplay(vm: VirtualMachine | VirtualMachineRow): boolean {
-    const devices = vm.devices;
-    if (!devices || devices.length === 0) {
-      return false;
-    }
-    if (this.productType !== ProductType.Scale && ([VmBootloader.Grub, VmBootloader.UefiCsm].includes(vm.bootloader))) {
-      return false;
-    }
-    for (const device of devices) {
-      if (devices && device.dtype === VmDeviceType.Display) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   getDisplayPort(vm: VirtualMachine): boolean | number {


### PR DESCRIPTION
Wait for https://github.com/truenas/middleware/pull/12200 to be ported to `cobia` before testing. This removes the need for UI to make decisions about whether or not to show the display button for running vms. Now, middleware will tell us if a display is available or not.