### PR TITLE
NAS-124389 / 23.10 / Add es60g2 to models.json

### DIFF
--- a/scripts/ui/models.json
+++ b/scripts/ui/models.json
@@ -69,6 +69,9 @@
     "ES60": {
       "model": "ES60"
     },
+    "ES60G2": {
+      "model": "ES60G2"
+    },
     "ES102": {
       "model": "ES102"
     },


### PR DESCRIPTION
To test run `yarn ui me -S` and make sure ES60G2 is listed in the output

NOTE: This does not need any backports. Reported problem only affects `stable/cobia` branch