### PR TITLE
NAS-124339 / 23.10 / Sorting on installed applications screen (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
@@ -1,13 +1,14 @@
+<div class="cell cell-checkbox">
+  <mat-checkbox
+    color="primary"
+    [ixTest]="app.name"
+    [checked]="app.selected"
+    (click)="$event.stopPropagation()"
+    (change)="toggleAppChecked($event.checked)"
+  ></mat-checkbox>
+</div>
 <div class="cell cell-name">
   <div class="name">
-    <mat-checkbox
-      color="primary"
-      [ixTest]="app.name"
-      [checked]="app.selected"
-      (click)="$event.stopPropagation()"
-      (change)="toggleAppChecked($event.checked)"
-    ></mat-checkbox>
-
     <div class="app-logo">
       <img [src]="app.chart_metadata.icon" />
     </div>

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.scss
@@ -9,7 +9,7 @@
   display: grid;
   font-weight: 500;
   grid-gap: 8px;
-  grid-template-columns: minmax(200px, auto) minmax(100px, 130px) minmax(100px, 115px) 60px;
+  grid-template-columns: 40px minmax(160px, auto) minmax(100px, 130px) minmax(100px, 115px) 60px;
   min-height: 48px;
   min-width: fit-content;
   padding: 0;
@@ -81,6 +81,21 @@
         display: inline-flex;
       }
     }
+
+    &:nth-child(2) {
+      @media (max-width: $breakpoint-tablet) {
+        display: inline-flex;
+
+        > div {
+          padding: 0;
+        }
+      }
+    }
+  }
+
+  .cell-checkbox {
+    padding-left: 15px;
+    padding-right: 15px;
   }
 
   .cell-name {

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.html
@@ -1,6 +1,3 @@
-<mat-spinner
-  *ngIf="inProgress"
-  [diameter]="20"
-  [matTooltip]="job?.progress?.description"
-></mat-spinner>
-<span>{{ appStatus | mapValue: appStatusLabels | translate }}</span>
+<span [matTooltip]="job?.progress?.description">
+  {{ appStatus | mapValue: appStatusLabels | translate }}
+</span>

--- a/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-status-cell/app-status-cell.component.spec.ts
@@ -42,7 +42,6 @@ describe('AppStatusCellComponent', () => {
   it('checks status for deploying app', () => {
     setupTest(AppStatus.Deploying);
 
-    expect(spectator.query('mat-spinner')).toBeTruthy();
     expect(spectator.query('span')).toHaveText('Deploying');
   });
 
@@ -56,7 +55,6 @@ describe('AppStatusCellComponent', () => {
       } as Job<ChartScaleResult, ChartScaleQueryParams>,
     );
 
-    expect(spectator.query('mat-spinner')).toBeTruthy();
     expect(spectator.query('span')).toHaveText('Starting');
   });
 
@@ -70,7 +68,6 @@ describe('AppStatusCellComponent', () => {
       } as Job<ChartScaleResult, ChartScaleQueryParams>,
     );
 
-    expect(spectator.query('mat-spinner')).toBeTruthy();
     expect(spectator.query('span')).toHaveText('Stopping');
   });
 });

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.html
@@ -89,7 +89,7 @@
 
     <div class="app-search">
       <ix-fake-progress-bar *ngIf="!showMobileDetails" [loading]="isLoading"></ix-fake-progress-bar>
-    
+
       <ix-search-input
         [disabled]="!dataSource.length"
         [value]="filterString"
@@ -97,7 +97,13 @@
       ></ix-search-input>
     </div>
 
-    <div class="app-wrapper">
+    <div class="app-wrapper"
+      matSort
+      matSortActive="application"
+      matSortDirection="asc"
+      matSortDisableClear
+      (matSortChange)="sortChanged($event)"
+    >
       <div class="app-inner">
         <div class="app-header-row">
           <div>
@@ -109,12 +115,26 @@
                 [checked]="allAppsChecked"
                 (change)="toggleAppsChecked($event.checked)"
               ></mat-checkbox>
-              {{ 'Application' | translate }}
             </span>
           </div>
-          <div>{{ 'Status' | translate }}</div>
-          <!-- TODO: Waiting for the https://ixsystems.atlassian.net/browse/NAS-121614 CPU / RAM / DISK -->
-          <div class="app-update-header">
+          <div
+            [matColumnDef]="sortableField.Application"
+            [mat-sort-header]="sortableField.Application"
+          >
+            {{ 'Application' | translate }}
+          </div>
+          <div
+            [matColumnDef]="sortableField.Status"
+            [mat-sort-header]="sortableField.Status"
+          >
+            {{ 'Status' | translate }}
+          </div>
+          <div
+            class="app-update-header"
+            [matColumnDef]="sortableField.Updates"
+            [mat-sort-header]="hasUpdates ? sortableField.Updates : null"
+            [disabled]="!hasUpdates"
+          >
             <span>{{ 'Updates' | translate }}</span>
             <ix-icon
               *ngIf="hasUpdates"

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
@@ -93,7 +93,7 @@ $header-height: 193px;
   background-color: var(--bg2);
   padding: 16px;
   position: relative;
-  
+
   ix-fake-progress-bar {
     height: 2px;
     left: 0;
@@ -133,10 +133,10 @@ $header-height: 193px;
 
 ix-app-row,
 .app-header-row {
-  grid-template-columns: minmax(200px, auto) minmax(100px, 130px) minmax(100px, 115px) 60px;
+  grid-template-columns: 40px minmax(160px, auto) minmax(100px, 130px) minmax(100px, 115px) 60px;
 
   @media (max-width: $breakpoint-tablet) {
-    grid-template-columns: auto 0 0 0 0 0 0;
+    grid-template-columns: 45px auto 0 0 0 0 0 0;
   }
 }
 
@@ -156,7 +156,11 @@ ix-app-row,
   z-index: 1;
 
   > div {
+    align-items: center;
+    display: flex;
     font-weight: bold;
+    height: 100%;
+    justify-content: flex-start;
     padding: 4px 0;
 
     @media (max-width: $breakpoint-tablet) {
@@ -171,12 +175,20 @@ ix-app-row,
         display: block !important;
       }
     }
+
+    &:nth-child(2) {
+      @media (max-width: $breakpoint-tablet) {
+        display: flex !important;
+      }
+    }
   }
 
   .app-name-header {
-    background: linear-gradient(90deg, var(--bg1) 0%, var(--bg1) calc(100% - 13px), transparent 100%);
+    align-items: center;
+    background: linear-gradient(90deg, var(--bg1) 0%, var(--bg1) 0, transparent 80%);
+    display: flex;
     padding-left: 15px;
-    padding-right: 15px;
+    padding-right: 0;
   }
 
   .app-update-header {
@@ -188,6 +200,7 @@ ix-app-row,
       color: var(--yellow);
       font-size: 18px;
       line-height: 1;
+      margin-left: 4px;
     }
   }
 }

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -429,6 +429,8 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
             (b.update_available || b.container_images_update_available) ? 1 : 0,
             isAsc,
           );
+        default:
+          return doSortCompare(a.name, b.name, isAsc);
       }
     });
   }

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -8,6 +8,7 @@ import {
   Inject,
 } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import {
   ActivatedRoute, NavigationEnd, NavigationStart, Router,
 } from '@angular/router';
@@ -27,6 +28,7 @@ import { CoreBulkResponse } from 'app/interfaces/core-bulk.interface';
 import { EmptyConfig } from 'app/interfaces/empty-config.interface';
 import { Job } from 'app/interfaces/job.interface';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
+import { SortDirection } from 'app/modules/ix-table2/enums/sort-direction.enum';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { AppBulkUpgradeComponent } from 'app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component';
 import { KubernetesSettingsComponent } from 'app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component';
@@ -36,6 +38,16 @@ import { InstalledAppsStore } from 'app/pages/apps/store/installed-apps-store.se
 import { KubernetesStore } from 'app/pages/apps/store/kubernetes-store.service';
 import { DialogService } from 'app/services/dialog.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
+
+enum SortableField {
+  Application = 'application',
+  Status = 'status',
+  Updates = 'updates',
+}
+
+function doSortCompare(a: number | string, b: number | string, isAsc: boolean): number {
+  return (a < b ? -1 : 1) * (isAsc ? 1 : -1);
+}
 
 @UntilDestroy()
 @Component({
@@ -51,6 +63,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
   showMobileDetails = false;
   isMobileView = false;
   appJobs = new Map<string, Job<ChartScaleResult, ChartScaleQueryParams>>();
+  readonly sortableField = SortableField;
 
   entityEmptyConf: EmptyConfig = {
     type: EmptyType.Loading,
@@ -264,8 +277,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
       untilDestroyed(this),
     ).subscribe({
       next: ([,,charts]) => {
-        this.dataSource = charts;
-
+        this.dataSource = charts.sort((a, b) => doSortCompare(a.name, b.name, true));
         this.selectAppForDetails(this.activatedRoute.snapshot.paramMap.get('appId'));
         this.cdr.markForCheck();
       },
@@ -400,6 +412,25 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
       }
     }
     return status;
+  }
+
+  sortChanged(sort: Sort): void {
+    this.dataSource = this.dataSource.sort((a, b) => {
+      const isAsc = sort.direction === SortDirection.Asc;
+
+      switch (sort.active) {
+        case SortableField.Application:
+          return doSortCompare(a.name, b.name, isAsc);
+        case SortableField.Status:
+          return doSortCompare(a.status, b.status, isAsc);
+        case SortableField.Updates:
+          return doSortCompare(
+            (a.update_available || a.container_images_update_available) ? 1 : 0,
+            (b.update_available || b.container_images_update_available) ? 1 : 0,
+            isAsc,
+          );
+      }
+    });
   }
 
   private selectAppForDetails(appId: string): void {

--- a/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.scss
+++ b/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.scss
@@ -70,7 +70,7 @@ $padding-left: 8px;
   width: 100%;
 
   @media (max-width: $breakpoint-tablet) {
-    grid-template-columns: auto 0 0 0 0 0 0;
+    grid-template-columns: 45px auto 0 0 0 0 0 0;
     width: auto;
   }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x caeb0c72e66e084f8f335fca3282df0e18608898
    git cherry-pick -x 0c9f405d7c0ff4d35e7d6a053b8c33f5ed8951ab
    git cherry-pick -x ad7195a486f6e9d01c65967a616be3e03fb3302b
    git cherry-pick -x 10af49452ffa0e3d25772839c090280b5d13e7ab

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x bd14cfe0c04671481487fd68d1c9ad0d73f9d8c5

Testing:
Check installed apps page, you should be able to sort by APPLICATION, STATUS, UPDATE AVAILABLE (if there are some apps with update available)

<img width="1724" alt="Screenshot 2023-09-27 at 18 16 22" src="https://github.com/truenas/webui/assets/22980553/18d83be2-0ce3-4ecb-a3de-34ab2d176136">


Original PR: https://github.com/truenas/webui/pull/8958
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124339