### PR TITLE
NAS-124397 / 24.04 / Notes card in apps UI does not show full text

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.scss
@@ -15,6 +15,7 @@
   background-color: rgba(0, 0, 0, 0.1);
   overflow: hidden;
   padding: 12px;
+  word-wrap: break-word;
 
   markdown ::ng-deep {
     h1,


### PR DESCRIPTION
Testing: use inspector to put a long unbreakable string in App -> Notes.