### PR TITLE
NAS-123907 / 23.10 / Do not show New & Updated in search results (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/store/apps-filter-store.service.ts
+++ b/src/app/pages/apps/store/apps-filter-store.service.ts
@@ -57,8 +57,8 @@ export class AppsFilterStore extends ComponentStore<AppsFilterState> {
       state,
     ]) => {
       const allApps: AvailableApp[] = state.filteredApps?.length ? [...state.filteredApps] : [...availableApps];
-      const filteredApps: AvailableApp[] = allApps
-        .filter((app) => this.doesAppContainString(state.searchQuery, app));
+      const filteredApps: AvailableApp[] = allApps.filter((app) => this.doesAppContainString(state.searchQuery, app));
+
       if (state.filter.sort === AppsFiltersSort.Name) {
         return this.sortAppsByName(filteredApps);
       }
@@ -70,8 +70,8 @@ export class AppsFilterStore extends ComponentStore<AppsFilterState> {
       }
       return this.sortAppsByCategory(
         filteredApps,
-        recommendedApps,
-        latestApps,
+        state.searchQuery.length ? [] : recommendedApps,
+        state.searchQuery.length ? [] : latestApps,
         appsCategories,
         state,
       );


### PR DESCRIPTION
Testing:
Go to Available Apps section --> Search for any app and see that `New & Updated Apps`  section is not there while searching.

<img width="1728" alt="Screenshot 2023-09-29 at 11 07 56" src="https://github.com/truenas/webui/assets/22980553/bd6fd5c1-27f9-4208-b1f2-32e9abb0a33e">


Original PR: https://github.com/truenas/webui/pull/8969
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123907