### PR TITLE
NAS-124255 / 23.10 / Miss-match between step name and list item on the Pool Creation Wizard (by AlexKarpov98)

### DIFF
--- a/src/app/enums/v-dev-type.enum.ts
+++ b/src/app/enums/v-dev-type.enum.ts
@@ -96,7 +96,7 @@ export enum VdevType {
 export const vdevTypeLabels = new Map<VdevType, string>([
   [VdevType.Data, T('Data')],
   [VdevType.Log, T('Log')],
-  [VdevType.Special, T('Special')],
+  [VdevType.Special, T('Metadata')],
   [VdevType.Spare, T('Spare')],
   [VdevType.Dedup, T('Dedup')],
   [VdevType.Cache, T('Cache')],

--- a/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/configuration-preview/configuration-preview.component.spec.ts
@@ -108,7 +108,7 @@ describe('ConfigurationPreviewComponent', () => {
       'Dedup:': 'None',
       'Log:': '2 × RAIDZ1 | 3 × 3 GiB (HDD)',
       'Spare:': 'Manual layout | 2 VDEVs',
-      'Special:': 'None',
+      'Metadata:': 'None',
     });
   });
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/create-pool.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/create-pool.spec.ts
@@ -201,7 +201,7 @@ describe('PoolManagerComponent – create pool', () => {
       Dedup: '1 × STRIPE | 1 × 20 GiB (HDD)',
       Log: '1 × STRIPE | 1 × 20 GiB (HDD)',
       Spare: '1 × 20 GiB (HDD)',
-      Special: '1 × STRIPE | 1 × 20 GiB (HDD)',
+      Metadata: '1 × STRIPE | 1 × 20 GiB (HDD)',
     });
     expect(await reviewView.getWarnings()).toEqual([
       'A stripe log VDEV may result in data loss if it fails combined with a power outage.',

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2912,7 +2912,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2273,7 +2273,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1191,7 +1191,6 @@
   "Spare": "",
   "Spare VDEVs": "",
   "Spare VDev": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specify the logical cores that VM is allowed to use. Better cache locality can be achieved by setting CPU set base on CPU topology. E.g. to assign cores: 0,1,2,5,9,10,11 you can write: 1-2,5,9-11": "",
   "Specify this certificate's valid Key Usages. Web certificates           typically need at least Digital Signature and possibly Key Encipherment           or Key Agreement, while other applications may need other usages.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3115,7 +3115,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -187,7 +187,6 @@
   "Some changes might not take affect until the {name} service has been restarted. Would you like to restart the {name} service now?": "",
   "Sort": "",
   "Spare VDev": "",
-  "Special": "",
   "Standby: TrueNAS Controller {id}": "",
   "Stateful Sets": "",
   "Statefulsets": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3102,7 +3102,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2840,7 +2840,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2825,7 +2825,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3321,7 +3321,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -242,7 +242,6 @@
   "Some of the disks are attached to the exported pools\n  mentioned in this list. Checking a pool name means you want to\n  allow reallocation of the disks attached to that pool.": "",
   "Some of the selected disks have exported pools on them. Using those disks will make existing pools on them unable to be imported. You will lose any and all data in selected disks.": "",
   "Spare VDev": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Start Over": "",
   "Statefulsets": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3238,7 +3238,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3260,7 +3260,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2473,7 +2473,6 @@
   "Spare VDEVs": "",
   "Spare VDev": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1688,7 +1688,6 @@
   "Spare": "",
   "Spare VDEVs": "",
   "Spare VDev": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify the logical cores that VM is allowed to use. Better cache locality can be achieved by setting CPU set base on CPU topology. E.g. to assign cores: 0,1,2,5,9,10,11 you can write: 1-2,5,9-11": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -301,7 +301,6 @@
   "Some of the disks are attached to the exported pools\n  mentioned in this list. Checking a pool name means you want to\n  allow reallocation of the disks attached to that pool.": "",
   "Some of the selected disks have exported pools on them. Using those disks will make existing pools on them unable to be imported. You will lose any and all data in selected disks.": "",
   "Spare VDev": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Start Over": "",
   "Statefulsets": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3327,7 +3327,6 @@
   "Spare VDev": "",
   "Spares": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -3445,7 +3445,6 @@
   "Spare VDEVs": "备用 VDEV",
   "Spares": "备用",
   "Sparse": "备用",
-  "Special": "特殊的",
   "Specifies the auxiliary directory service ID provider.": "指定辅助目录服务ID提供程序。",
   "Specify a size and value such as <i>10 GiB</i>.": "指定大小和值，例如<i>10 GiB</i> 。",
   "Specify the PCI device to pass thru (bus#/slot#/fcn#).": "Specify the PCI device to pass thru (bus\\#/slot\\#/fcn\\#).",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2552,7 +2552,6 @@
   "Spare VDEVs": "",
   "Spare VDev": "",
   "Sparse": "",
-  "Special": "",
   "Special Allocation class, used to create Fusion pools. Optional VDEV type which is used to speed up metadata and small block IO.": "",
   "Specifies the auxiliary directory service ID provider.": "",
   "Specify a size and value such as <i>10 GiB</i>.": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b4fcca90d2166198873a1b040b41585f3018ab95
    git cherry-pick -x 3d0fbb3657c897509f21fd068f5acc48aeb0dc47

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 472314c9c6c448fdc5fe2c6e08cdd00b6911bba5

Check label:
<img width="1728" alt="Screenshot 2023-09-29 at 12 59 07" src="https://github.com/truenas/webui/assets/22980553/038e50f6-ba99-4f57-8114-266516bb34ae">


Original PR: https://github.com/truenas/webui/pull/8975
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124255