### PR TITLE
NAS-124250 / 23.10 / Details panel does not always properly populate when clicking apps (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -45,9 +45,9 @@
                 {{ app.chart_metadata.appVersion }}
               </ng-container>
             </ng-container>
-            <ng-container *ngIf="ixChartApp">
+            <ng-container *ngIf="ixChartApp && app.human_version">
               <!-- Show docker image tag as version for custom apps -->
-              {{ app.human_version.split(':')[1].split('_')[0] }}
+              {{ app.human_version?.split(':')?.[1]?.split('_')?.[0] }}
             </ng-container>
           </div>
         </div>


### PR DESCRIPTION
I was not able to reproduce the bug, but I did fix based on an error provided.

Original PR: https://github.com/truenas/webui/pull/8971
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124250