### PR TITLE
NAS-124423 / 23.10.0 / Add client_id and client_secret to Google Photos cloud credentials

### DIFF
--- a/src/app/helptext/system/cloud-credentials.ts
+++ b/src/app/helptext/system/cloud-credentials.ts
@@ -146,6 +146,8 @@ a new application key, log in to the Backblaze account, go to the \
  <a href="https://developers.google.com/drive/api/v3/about-auth"\
  target="_blank">Google Drive</a>.',
     ),
+    oauth_tooltip: T('Photo Library API client secret generated from the \
+ <a href="https://developers.google.com/identity/protocols/oauth2" target="_blank">Google API Console</a>'),
   },
   team_drive_google_drive: {
     tooltip: T(

--- a/src/app/pages/credentials/backup-credentials/backup-credentials.component.ts
+++ b/src/app/pages/credentials/backup-credentials/backup-credentials.component.ts
@@ -81,7 +81,7 @@ export class BackupCredentialsComponent implements OnInit {
           },
           dataSourceHelper: this.cloudCredentialsDataSourceHelper.bind(this),
           afterGetData: (credentials: CloudsyncCredential[]) => {
-            const state = this.navigation.extras.state as { editCredential: string; id: string };
+            const state = this.navigation?.extras?.state as { editCredential: string; id: string };
             if (!state || state.editCredential !== 'cloudcredentials' || !this.isFirstCredentialsLoad) {
               return;
             }

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.html
@@ -31,7 +31,7 @@
           type="submit"
           color="primary"
           ixTest="save"
-          [disabled]="areActionsDisabled || !isFormValid || isLoading"
+          [disabled]="areActionsDisabled"
         >
           {{ 'Save' | translate }}
         </button>
@@ -39,7 +39,7 @@
           mat-button
           type="button"
           ixTest="verify-credential"
-          [disabled]="areActionsDisabled || !isFormValid || isLoading"
+          [disabled]="areActionsDisabled"
           (click)="onVerify()"
         >
           {{ 'Verify Credential' | translate }}

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.html
@@ -31,7 +31,7 @@
           type="submit"
           color="primary"
           ixTest="save"
-          [disabled]="areActionsDisabled"
+          [disabled]="areActionsDisabled || !isFormValid || isLoading"
         >
           {{ 'Save' | translate }}
         </button>
@@ -39,7 +39,7 @@
           mat-button
           type="button"
           ixTest="verify-credential"
-          [disabled]="areActionsDisabled"
+          [disabled]="areActionsDisabled || !isFormValid || isLoading"
           (click)="onVerify()"
         >
           {{ 'Verify Credential' | translate }}

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -40,6 +40,7 @@ import {
 import {
   GoogleDriveProviderFormComponent,
 } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-drive-provider-form/google-drive-provider-form.component';
+import { GooglePhotosProviderFormComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component';
 import {
   HttpProviderFormComponent,
 } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/http-provider-form/http-provider-form.component';
@@ -124,14 +125,6 @@ export class CloudCredentialsFormComponent implements OnInit {
 
   get isGooglePhotosProvider(): boolean {
     return this.providerForm?.provider?.name === CloudsyncProviderName.GooglePhotos;
-  }
-
-  get isFormValid(): boolean {
-    if (this.isGooglePhotosProvider) {
-      return Boolean(this.submissionAttributes.client_secret && this.submissionAttributes.client_id);
-    }
-
-    return true;
   }
 
   get areActionsDisabled(): boolean {
@@ -305,10 +298,10 @@ export class CloudCredentialsFormComponent implements OnInit {
     const tokenOnlyProviders = [
       CloudsyncProviderName.Box,
       CloudsyncProviderName.Dropbox,
-      CloudsyncProviderName.GooglePhotos,
       CloudsyncProviderName.Hubic,
       CloudsyncProviderName.Yandex,
     ];
+
     if (tokenOnlyProviders.includes(this.selectedProvider.name)) {
       return TokenProviderFormComponent;
     }
@@ -319,6 +312,7 @@ export class CloudCredentialsFormComponent implements OnInit {
       [CloudsyncProviderName.Ftp, FtpProviderFormComponent],
       [CloudsyncProviderName.GoogleCloudStorage, GoogleCloudProviderFormComponent],
       [CloudsyncProviderName.GoogleDrive, GoogleDriveProviderFormComponent],
+      [CloudsyncProviderName.GooglePhotos, GooglePhotosProviderFormComponent],
       [CloudsyncProviderName.Http, HttpProviderFormComponent],
       [CloudsyncProviderName.Mega, MegaProviderFormComponent],
       [CloudsyncProviderName.MicrosoftOnedrive, OneDriveProviderFormComponent],

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -127,13 +127,11 @@ export class CloudCredentialsFormComponent implements OnInit {
   }
 
   get isFormValid(): boolean {
-    const isBaseFormValid = this.providerForm?.form?.valid;
-
     if (this.isGooglePhotosProvider) {
-      return this.submissionAttributes.client_secret && this.submissionAttributes.client_id && isBaseFormValid;
+      return Boolean(this.submissionAttributes.client_secret && this.submissionAttributes.client_id);
     }
 
-    return isBaseFormValid;
+    return true;
   }
 
   get areActionsDisabled(): boolean {

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -123,18 +123,10 @@ export class CloudCredentialsFormComponent implements OnInit {
     });
   }
 
-  get isGooglePhotosProvider(): boolean {
-    return this.providerForm?.provider?.name === CloudsyncProviderName.GooglePhotos;
-  }
-
   get areActionsDisabled(): boolean {
     return this.isLoading
       || this.commonForm.invalid
       || this.providerForm?.form?.invalid;
-  }
-
-  get submissionAttributes(): { [key: string]: string | number | boolean } {
-    return this.providerForm?.getSubmitAttributes() || {};
   }
 
   ngOnInit(): void {

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -122,10 +122,28 @@ export class CloudCredentialsFormComponent implements OnInit {
     });
   }
 
+  get isGooglePhotosProvider(): boolean {
+    return this.providerForm?.provider.name === CloudsyncProviderName.GooglePhotos;
+  }
+
+  get isFormValid(): boolean {
+    const isBaseFormValid = this.providerForm?.form?.valid;
+
+    if (this.isGooglePhotosProvider) {
+      return this.submissionAttributes.client_secret && this.submissionAttributes.client_id && isBaseFormValid;
+    }
+
+    return isBaseFormValid;
+  }
+
   get areActionsDisabled(): boolean {
     return this.isLoading
       || this.commonForm.invalid
       || this.providerForm?.form?.invalid;
+  }
+
+  get submissionAttributes(): { [key: string]: string | number | boolean } {
+    return this.providerForm?.getSubmitAttributes() || {};
   }
 
   ngOnInit(): void {

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -123,7 +123,7 @@ export class CloudCredentialsFormComponent implements OnInit {
   }
 
   get isGooglePhotosProvider(): boolean {
-    return this.providerForm?.provider.name === CloudsyncProviderName.GooglePhotos;
+    return this.providerForm?.provider?.name === CloudsyncProviderName.GooglePhotos;
   }
 
   get isFormValid(): boolean {

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.html
@@ -1,6 +1,5 @@
 <ix-fieldset [title]="'OAuth Authentication' | translate" [formGroup]="form">
   <button
-    *ngIf="!hideLoginToProviderButton"
     class="login-button"
     mat-button
     type="button"
@@ -13,15 +12,11 @@
   <ix-input
     formControlName="client_id"
     [label]="'OAuth Client ID' | translate"
-    [required]="hideLoginToProviderButton"
-    [tooltip]="oauthTooltip"
   ></ix-input>
 
   <ix-input
     formControlName="client_secret"
     type="password"
     [label]="'OAuth Client Secret' | translate"
-    [required]="hideLoginToProviderButton"
-    [tooltip]="oauthTooltip"
   ></ix-input>
 </ix-fieldset>

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.html
@@ -1,5 +1,6 @@
 <ix-fieldset [title]="'OAuth Authentication' | translate" [formGroup]="form">
   <button
+    *ngIf="!hideLoginToProviderButton"
     class="login-button"
     mat-button
     type="button"
@@ -12,11 +13,15 @@
   <ix-input
     formControlName="client_id"
     [label]="'OAuth Client ID' | translate"
+    [required]="hideLoginToProviderButton"
+    [tooltip]="oauthTooltip"
   ></ix-input>
 
   <ix-input
     formControlName="client_secret"
     type="password"
     [label]="'OAuth Client Secret' | translate"
+    [required]="hideLoginToProviderButton"
+    [tooltip]="oauthTooltip"
   ></ix-input>
 </ix-fieldset>

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.ts
@@ -3,7 +3,6 @@ import {
 } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
-import { CloudsyncProviderName } from 'app/enums/cloudsync-provider.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { helptextSystemCloudcredentials as helptext } from 'app/helptext/system/cloud-credentials';
 import { OauthMessage } from 'app/interfaces/oauth-message.interface';
@@ -24,7 +23,6 @@ export interface OauthProviderData {
 })
 export class OauthProviderComponent {
   @Input() oauthUrl: string;
-  @Input() providerName: CloudsyncProviderName;
 
   @Output() authenticated = new EventEmitter<Record<string, unknown>>();
 

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.ts
@@ -35,21 +35,6 @@ export class OauthProviderComponent {
 
   readonly helptext = helptext;
 
-  get isGooglePhotosProvider(): boolean {
-    return this.providerName === CloudsyncProviderName.GooglePhotos;
-  }
-
-  get hideLoginToProviderButton(): boolean {
-    return this.isGooglePhotosProvider;
-  }
-
-  get oauthTooltip(): string | null {
-    if (this.isGooglePhotosProvider) {
-      return helptext.token_google_photos.oauth_tooltip;
-    }
-    return null;
-  }
-
   constructor(
     private formBuilder: FormBuilder,
     private dialogService: DialogService,

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
+import { CloudsyncProviderName } from 'app/enums/cloudsync-provider.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { helptextSystemCloudcredentials as helptext } from 'app/helptext/system/cloud-credentials';
 import { OauthMessage } from 'app/interfaces/oauth-message.interface';
@@ -23,6 +24,8 @@ export interface OauthProviderData {
 })
 export class OauthProviderComponent {
   @Input() oauthUrl: string;
+  @Input() providerName: CloudsyncProviderName;
+
   @Output() authenticated = new EventEmitter<Record<string, unknown>>();
 
   form = this.formBuilder.group({
@@ -31,6 +34,21 @@ export class OauthProviderComponent {
   });
 
   readonly helptext = helptext;
+
+  get isGooglePhotosProvider(): boolean {
+    return this.providerName === CloudsyncProviderName.GooglePhotos;
+  }
+
+  get hideLoginToProviderButton(): boolean {
+    return this.isGooglePhotosProvider;
+  }
+
+  get oauthTooltip(): string | null {
+    if (this.isGooglePhotosProvider) {
+      return helptext.token_google_photos.oauth_tooltip;
+    }
+    return null;
+  }
 
   constructor(
     private formBuilder: FormBuilder,

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/base-provider-form.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/base-provider-form.ts
@@ -18,7 +18,7 @@ export abstract class BaseProviderFormComponent<T = CloudCredential['attributes'
    * TODO: Consider making this functionality part of the private key select.
    */
   beforeSubmit(): Observable<unknown> {
-    return of();
+    return of(undefined);
   }
 
   getSubmitAttributes(): T {

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-drive-provider-form/google-drive-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-drive-provider-form/google-drive-provider-form.component.html
@@ -1,6 +1,5 @@
 <ix-oauth-provider-authentication
   [oauthUrl]="provider.credentials_oauth"
-  [providerName]="provider.name"
   (authenticated)="onOauthAuthenticated($event)"
 ></ix-oauth-provider-authentication>
 

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-drive-provider-form/google-drive-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-drive-provider-form/google-drive-provider-form.component.html
@@ -1,5 +1,6 @@
 <ix-oauth-provider-authentication
   [oauthUrl]="provider.credentials_oauth"
+  [providerName]="provider.name"
   (authenticated)="onOauthAuthenticated($event)"
 ></ix-oauth-provider-authentication>
 

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-drive-provider-form/google-drive-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-drive-provider-form/google-drive-provider-form.component.ts
@@ -46,7 +46,7 @@ export class GoogleDriveProviderFormComponent extends BaseProviderFormComponent 
 
   getSubmitAttributes(): OauthProviderComponent['form']['value'] & this['form']['value'] {
     return {
-      ...this.oauthComponent.form.value,
+      ...this.oauthComponent?.form?.value,
       ...this.form.value,
     };
   }

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.html
@@ -1,0 +1,27 @@
+<ix-fieldset [title]="'OAuth Authentication' | translate" [formGroup]="form">
+  <ix-input
+    formControlName="client_id"
+    [label]="'OAuth Client ID' | translate"
+    [required]="true"
+    [tooltip]="oauthTooltip"
+  ></ix-input>
+
+  <ix-input
+    formControlName="client_secret"
+    type="password"
+    [label]="'OAuth Client Secret' | translate"
+    [required]="true"
+    [tooltip]="oauthTooltip"
+  ></ix-input>
+</ix-fieldset>
+
+<ix-fieldset [title]="'Authentication' | translate" [formGroup]="form">
+  <ix-input
+    formControlName="token"
+    type="password"
+    [label]="'Token' | translate"
+    [required]="true"
+    [tooltip]="tokenTooltip"
+  ></ix-input>
+</ix-fieldset>
+

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.spec.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.spec.ts
@@ -1,0 +1,58 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ReactiveFormsModule } from '@angular/forms';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
+import { IxFormHarness } from 'app/modules/ix-forms/testing/ix-form.harness';
+import { GooglePhotosProviderFormComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component';
+import { DialogService } from 'app/services/dialog.service';
+
+describe('GooglePhotosProviderFormComponent', () => {
+  let spectator: Spectator<GooglePhotosProviderFormComponent>;
+  let form: IxFormHarness;
+  const createComponent = createComponentFactory({
+    component: GooglePhotosProviderFormComponent,
+    imports: [
+      ReactiveFormsModule,
+      IxFormsModule,
+    ],
+    declarations: [],
+    providers: [
+      mockProvider(DialogService),
+    ],
+  });
+
+  beforeEach(async () => {
+    spectator = createComponent();
+    form = await TestbedHarnessEnvironment.harnessForFixture(spectator.fixture, IxFormHarness);
+  });
+
+  it('show existing provider attributes when they are set as form values', async () => {
+    spectator.component.getFormSetter$().next({
+      client_id: 'client1234',
+      client_secret: 'secret1234',
+      token: 'token1234',
+    });
+
+    const values = await form.getValues();
+    expect(values).toEqual({
+      Token: 'token1234',
+      'OAuth Client ID': 'client1234',
+      'OAuth Client Secret': 'secret1234',
+    });
+  });
+
+  it('returns form attributes for submission when getSubmitAttributes() is called', async () => {
+    await form.fillForm({
+      Token: 'newtoken',
+      'OAuth Client ID': 'newclient',
+      'OAuth Client Secret': 'newsecret',
+    });
+
+    const values = spectator.component.getSubmitAttributes();
+    expect(values).toEqual({
+      client_id: 'newclient',
+      client_secret: 'newsecret',
+      token: 'newtoken',
+    });
+  });
+});

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.ts
@@ -1,0 +1,52 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy, Component,
+} from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { BehaviorSubject } from 'rxjs';
+import { helptextSystemCloudcredentials as helptext } from 'app/helptext/system/cloud-credentials';
+import { CloudCredential } from 'app/interfaces/cloud-sync-task.interface';
+import {
+  BaseProviderFormComponent,
+} from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/base-provider-form';
+
+@UntilDestroy()
+@Component({
+  templateUrl: './google-photos-provider-form.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class GooglePhotosProviderFormComponent extends BaseProviderFormComponent implements AfterViewInit {
+  private formPatcher$ = new BehaviorSubject<CloudCredential['attributes']>({});
+
+  form = this.formBuilder.group({
+    token: ['', Validators.required],
+    client_id: ['', Validators.required],
+    client_secret: ['', Validators.required],
+  });
+
+  readonly oauthTooltip = helptext.token_google_photos.oauth_tooltip;
+  readonly tokenTooltip = helptext.token_google_photos.tooltip;
+
+  constructor(
+    private formBuilder: FormBuilder,
+  ) {
+    super();
+  }
+
+  ngAfterViewInit(): void {
+    this.formPatcher$.pipe(untilDestroyed(this)).subscribe((values) => {
+      this.form.patchValue(values);
+    });
+  }
+
+  getFormSetter$ = (): BehaviorSubject<CloudCredential['attributes']> => {
+    return this.formPatcher$;
+  };
+
+  getSubmitAttributes(): this['form']['value'] {
+    return {
+      ...this.form.value,
+    };
+  }
+}

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/one-drive-provider-form/one-drive-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/one-drive-provider-form/one-drive-provider-form.component.html
@@ -1,6 +1,5 @@
 <ix-oauth-provider-authentication
   [oauthUrl]="provider.credentials_oauth"
-  [providerName]="provider.name"
   (authenticated)="onOauthAuthenticated($event)"
 ></ix-oauth-provider-authentication>
 

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/one-drive-provider-form/one-drive-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/one-drive-provider-form/one-drive-provider-form.component.html
@@ -1,5 +1,6 @@
 <ix-oauth-provider-authentication
   [oauthUrl]="provider.credentials_oauth"
+  [providerName]="provider.name"
   (authenticated)="onOauthAuthenticated($event)"
 ></ix-oauth-provider-authentication>
 

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/one-drive-provider-form/one-drive-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/one-drive-provider-form/one-drive-provider-form.component.ts
@@ -87,7 +87,7 @@ export class OneDriveProviderFormComponent extends BaseProviderFormComponent imp
   getSubmitAttributes(): OauthProviderComponent['form']['value'] & this['form']['value'] {
     const { drives, ...oneDriveValues } = this.form.value;
     return {
-      ...this.oauthComponent.form.value,
+      ...this.oauthComponent?.form?.value,
       ...oneDriveValues,
     };
   }

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/pcloud-provider-form/pcloud-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/pcloud-provider-form/pcloud-provider-form.component.html
@@ -1,6 +1,5 @@
 <ix-oauth-provider-authentication
   [oauthUrl]="provider.credentials_oauth"
-  [providerName]="provider.name"
   (authenticated)="onOauthAuthenticated($event)"
 ></ix-oauth-provider-authentication>
 

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/pcloud-provider-form/pcloud-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/pcloud-provider-form/pcloud-provider-form.component.html
@@ -1,5 +1,6 @@
 <ix-oauth-provider-authentication
   [oauthUrl]="provider.credentials_oauth"
+  [providerName]="provider.name"
   (authenticated)="onOauthAuthenticated($event)"
 ></ix-oauth-provider-authentication>
 

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/pcloud-provider-form/pcloud-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/pcloud-provider-form/pcloud-provider-form.component.ts
@@ -49,7 +49,7 @@ export class PcloudProviderFormComponent extends BaseProviderFormComponent imple
 
   getSubmitAttributes(): OauthProviderComponent['form']['value'] & this['form']['value'] {
     return {
-      ...this.oauthComponent.form.value,
+      ...this.oauthComponent?.form?.value,
       ...this.form.value,
     };
   }

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.html
@@ -1,6 +1,5 @@
 <ix-oauth-provider-authentication
   *ngIf="hasOAuth"
-  [providerName]="provider.name"
   [oauthUrl]="provider.credentials_oauth"
   (authenticated)="onOauthAuthenticated($event)"
 ></ix-oauth-provider-authentication>

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.html
@@ -1,5 +1,6 @@
 <ix-oauth-provider-authentication
   *ngIf="hasOAuth"
+  [providerName]="provider.name"
   [oauthUrl]="provider.credentials_oauth"
   (authenticated)="onOauthAuthenticated($event)"
 ></ix-oauth-provider-authentication>

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.ts
@@ -43,8 +43,6 @@ export class TokenProviderFormComponent extends BaseProviderFormComponent implem
         return helptext.token_box.tooltip;
       case CloudsyncProviderName.Dropbox:
         return helptext.token_dropbox.tooltip;
-      case CloudsyncProviderName.GooglePhotos:
-        return helptext.token_google_photos.tooltip;
       case CloudsyncProviderName.Hubic:
         return helptext.token_hubic.tooltip;
       case CloudsyncProviderName.Yandex:

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.ts
@@ -77,7 +77,7 @@ export class TokenProviderFormComponent extends BaseProviderFormComponent implem
     }
 
     return {
-      ...this.oauthComponent.form.value,
+      ...this.oauthComponent?.form?.value,
       ...this.form.value,
     };
   }

--- a/src/app/pages/credentials/credentials.module.ts
+++ b/src/app/pages/credentials/credentials.module.ts
@@ -23,6 +23,7 @@ import {
 } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component';
 import { OauthProviderComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component';
 import { BackblazeB2ProviderFormComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/backblaze-b2-provider-form/backblaze-b2-provider-form.component';
+import { GooglePhotosProviderFormComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component';
 import {
   StorjProviderFormComponent,
 } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/storj-provider-form/storj-provider-form.component';
@@ -103,6 +104,7 @@ import { CertificateSubjectComponent } from './certificates-dash/forms/common-st
     FtpProviderFormComponent,
     GoogleCloudProviderFormComponent,
     GoogleDriveProviderFormComponent,
+    GooglePhotosProviderFormComponent,
     HttpProviderFormComponent,
     TokenProviderFormComponent,
     MegaProviderFormComponent,

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2219,6 +2219,7 @@
   "Permissions Editor": "",
   "Permissions Type": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1816,6 +1816,7 @@
   "Permissions Advanced": "",
   "Permissions Basic": "",
   "Permissions Editor": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -885,6 +885,7 @@
   "Performance": "",
   "Periodic Snapshot Task": "",
   "Permissions Editor": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Please click the button below to create a pool.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2359,6 +2359,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -154,6 +154,7 @@
   "Once an enclosure is selected, all other VDEV creation steps will limit disk selection options to disks in the selected enclosure. If the enclosure selection is changed, all disk selections will be reset.": "",
   "One or more data VDEVs has disks of different sizes.": "",
   "Optional. Only needed for private images.": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pool Manager": "",
   "Provide helpful notations related to the share, e.g. ‘Shared to everybody’.     Maximum length is 120 characters.": "",
   "Pull Image": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2318,6 +2318,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2163,6 +2163,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2041,6 +2041,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -185,6 +185,7 @@
   "One or more data VDEVs has disks of different sizes.": "",
   "Optional. Only needed for private images.": "",
   "Pause Scrub": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pool Creation Wizard": "",
   "Pool Manager": "",
   "Pool Name": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2477,6 +2477,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2476,6 +2476,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1819,6 +1819,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1264,6 +1264,7 @@
   "Permissions Advanced": "",
   "Permissions Basic": "",
   "Permissions Editor": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -228,6 +228,7 @@
   "Parent Path": "",
   "Password Login Groups": "",
   "Pause Scrub": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pool Creation Wizard": "",
   "Pool Manager": "",
   "Pool Name": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2543,6 +2543,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -257,6 +257,7 @@
   "Optional. Only needed for private images.": "",
   "Password Login Groups": "",
   "Pause Scrub": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pool Creation Wizard": "",
   "Pool Manager": "",
   "Pool Name": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1942,6 +1942,7 @@
   "Permissions Advanced": "",
   "Permissions Basic": "",
   "Permissions Editor": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pick a display device to open": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",


### PR DESCRIPTION
Testing:
For Google Photos Cloud Credentials - form should be without `Login To Provider` button and `Client ID` and `Client Secret` should be required.
<img width="485" alt="Screenshot 2023-10-04 at 16 20 10" src="https://github.com/truenas/webui/assets/22980553/cf146c23-2403-4b98-af7c-53a95f52ab76">
