### PR TITLE
NAS-124423 / 24.04 / Add client_id and client_secret to Google Photos cloud credentials (by AlexKarpov98)

### DIFF
--- a/src/app/helptext/system/cloud-credentials.ts
+++ b/src/app/helptext/system/cloud-credentials.ts
@@ -146,6 +146,8 @@ a new application key, log in to the Backblaze account, go to the \
  <a href="https://developers.google.com/drive/api/v3/about-auth"\
  target="_blank">Google Drive</a>.',
     ),
+    oauth_tooltip: T('Photo Library API client secret generated from the \
+ <a href="https://developers.google.com/identity/protocols/oauth2" target="_blank">Google API Console</a>'),
   },
   team_drive_google_drive: {
     tooltip: T(

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -40,6 +40,7 @@ import {
 import {
   GoogleDriveProviderFormComponent,
 } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-drive-provider-form/google-drive-provider-form.component';
+import { GooglePhotosProviderFormComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component';
 import {
   HttpProviderFormComponent,
 } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/http-provider-form/http-provider-form.component';
@@ -289,10 +290,10 @@ export class CloudCredentialsFormComponent implements OnInit {
     const tokenOnlyProviders = [
       CloudsyncProviderName.Box,
       CloudsyncProviderName.Dropbox,
-      CloudsyncProviderName.GooglePhotos,
       CloudsyncProviderName.Hubic,
       CloudsyncProviderName.Yandex,
     ];
+
     if (tokenOnlyProviders.includes(this.selectedProvider.name)) {
       return TokenProviderFormComponent;
     }
@@ -303,6 +304,7 @@ export class CloudCredentialsFormComponent implements OnInit {
       [CloudsyncProviderName.Ftp, FtpProviderFormComponent],
       [CloudsyncProviderName.GoogleCloudStorage, GoogleCloudProviderFormComponent],
       [CloudsyncProviderName.GoogleDrive, GoogleDriveProviderFormComponent],
+      [CloudsyncProviderName.GooglePhotos, GooglePhotosProviderFormComponent],
       [CloudsyncProviderName.Http, HttpProviderFormComponent],
       [CloudsyncProviderName.Mega, MegaProviderFormComponent],
       [CloudsyncProviderName.MicrosoftOnedrive, OneDriveProviderFormComponent],

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component.ts
@@ -20,6 +20,7 @@ export interface OauthProviderData {
 })
 export class OauthProviderComponent {
   @Input() oauthUrl: string;
+
   @Output() authenticated = new EventEmitter<Record<string, unknown>>();
 
   form = this.formBuilder.group({

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/base-provider-form.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/base-provider-form.ts
@@ -18,7 +18,7 @@ export abstract class BaseProviderFormComponent<T = CloudCredential['attributes'
    * TODO: Consider making this functionality part of the private key select.
    */
   beforeSubmit(): Observable<unknown> {
-    return of();
+    return of(undefined);
   }
 
   getSubmitAttributes(): T {

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.html
@@ -1,0 +1,27 @@
+<ix-fieldset [title]="'OAuth Authentication' | translate" [formGroup]="form">
+  <ix-input
+    formControlName="client_id"
+    [label]="'OAuth Client ID' | translate"
+    [required]="true"
+    [tooltip]="oauthTooltip"
+  ></ix-input>
+
+  <ix-input
+    formControlName="client_secret"
+    type="password"
+    [label]="'OAuth Client Secret' | translate"
+    [required]="true"
+    [tooltip]="oauthTooltip"
+  ></ix-input>
+</ix-fieldset>
+
+<ix-fieldset [title]="'Authentication' | translate" [formGroup]="form">
+  <ix-input
+    formControlName="token"
+    type="password"
+    [label]="'Token' | translate"
+    [required]="true"
+    [tooltip]="tokenTooltip"
+  ></ix-input>
+</ix-fieldset>
+

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.spec.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.spec.ts
@@ -1,0 +1,58 @@
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ReactiveFormsModule } from '@angular/forms';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
+import { IxFormHarness } from 'app/modules/ix-forms/testing/ix-form.harness';
+import { GooglePhotosProviderFormComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component';
+import { DialogService } from 'app/services/dialog.service';
+
+describe('GooglePhotosProviderFormComponent', () => {
+  let spectator: Spectator<GooglePhotosProviderFormComponent>;
+  let form: IxFormHarness;
+  const createComponent = createComponentFactory({
+    component: GooglePhotosProviderFormComponent,
+    imports: [
+      ReactiveFormsModule,
+      IxFormsModule,
+    ],
+    declarations: [],
+    providers: [
+      mockProvider(DialogService),
+    ],
+  });
+
+  beforeEach(async () => {
+    spectator = createComponent();
+    form = await TestbedHarnessEnvironment.harnessForFixture(spectator.fixture, IxFormHarness);
+  });
+
+  it('show existing provider attributes when they are set as form values', async () => {
+    spectator.component.getFormSetter$().next({
+      client_id: 'client1234',
+      client_secret: 'secret1234',
+      token: 'token1234',
+    });
+
+    const values = await form.getValues();
+    expect(values).toEqual({
+      Token: 'token1234',
+      'OAuth Client ID': 'client1234',
+      'OAuth Client Secret': 'secret1234',
+    });
+  });
+
+  it('returns form attributes for submission when getSubmitAttributes() is called', async () => {
+    await form.fillForm({
+      Token: 'newtoken',
+      'OAuth Client ID': 'newclient',
+      'OAuth Client Secret': 'newsecret',
+    });
+
+    const values = spectator.component.getSubmitAttributes();
+    expect(values).toEqual({
+      client_id: 'newclient',
+      client_secret: 'newsecret',
+      token: 'newtoken',
+    });
+  });
+});

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component.ts
@@ -1,31 +1,32 @@
 import {
   AfterViewInit,
-  ChangeDetectionStrategy, Component, ViewChild,
+  ChangeDetectionStrategy, Component,
 } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { BehaviorSubject } from 'rxjs';
+import { helptextSystemCloudcredentials as helptext } from 'app/helptext/system/cloud-credentials';
 import { CloudCredential } from 'app/interfaces/cloud-sync-task.interface';
-import {
-  OauthProviderComponent,
-} from 'app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component';
 import {
   BaseProviderFormComponent,
 } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/base-provider-form';
 
 @UntilDestroy()
 @Component({
-  templateUrl: './google-drive-provider-form.component.html',
+  templateUrl: './google-photos-provider-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class GoogleDriveProviderFormComponent extends BaseProviderFormComponent implements AfterViewInit {
-  @ViewChild(OauthProviderComponent, { static: true }) oauthComponent: OauthProviderComponent;
+export class GooglePhotosProviderFormComponent extends BaseProviderFormComponent implements AfterViewInit {
   private formPatcher$ = new BehaviorSubject<CloudCredential['attributes']>({});
 
   form = this.formBuilder.group({
     token: ['', Validators.required],
-    team_drive: [''],
+    client_id: ['', Validators.required],
+    client_secret: ['', Validators.required],
   });
+
+  readonly oauthTooltip = helptext.token_google_photos.oauth_tooltip;
+  readonly tokenTooltip = helptext.token_google_photos.tooltip;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -36,7 +37,6 @@ export class GoogleDriveProviderFormComponent extends BaseProviderFormComponent 
   ngAfterViewInit(): void {
     this.formPatcher$.pipe(untilDestroyed(this)).subscribe((values) => {
       this.form.patchValue(values);
-      this.oauthComponent.form.patchValue(values);
     });
   }
 
@@ -44,14 +44,9 @@ export class GoogleDriveProviderFormComponent extends BaseProviderFormComponent 
     return this.formPatcher$;
   };
 
-  getSubmitAttributes(): OauthProviderComponent['form']['value'] & this['form']['value'] {
+  getSubmitAttributes(): this['form']['value'] {
     return {
-      ...this.oauthComponent?.form?.value,
       ...this.form.value,
     };
-  }
-
-  onOauthAuthenticated(attributes: Record<string, unknown>): void {
-    this.form.patchValue(attributes);
   }
 }

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/one-drive-provider-form/one-drive-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/one-drive-provider-form/one-drive-provider-form.component.ts
@@ -85,7 +85,7 @@ export class OneDriveProviderFormComponent extends BaseProviderFormComponent imp
   getSubmitAttributes(): OauthProviderComponent['form']['value'] & this['form']['value'] {
     const { drives, ...oneDriveValues } = this.form.value;
     return {
-      ...this.oauthComponent.form.value,
+      ...this.oauthComponent?.form?.value,
       ...oneDriveValues,
     };
   }

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/pcloud-provider-form/pcloud-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/pcloud-provider-form/pcloud-provider-form.component.ts
@@ -49,7 +49,7 @@ export class PcloudProviderFormComponent extends BaseProviderFormComponent imple
 
   getSubmitAttributes(): OauthProviderComponent['form']['value'] & this['form']['value'] {
     return {
-      ...this.oauthComponent.form.value,
+      ...this.oauthComponent?.form?.value,
       ...this.form.value,
     };
   }

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/token-provider-form/token-provider-form.component.ts
@@ -43,8 +43,6 @@ export class TokenProviderFormComponent extends BaseProviderFormComponent implem
         return helptext.token_box.tooltip;
       case CloudsyncProviderName.Dropbox:
         return helptext.token_dropbox.tooltip;
-      case CloudsyncProviderName.GooglePhotos:
-        return helptext.token_google_photos.tooltip;
       case CloudsyncProviderName.Hubic:
         return helptext.token_hubic.tooltip;
       case CloudsyncProviderName.Yandex:
@@ -77,7 +75,7 @@ export class TokenProviderFormComponent extends BaseProviderFormComponent implem
     }
 
     return {
-      ...this.oauthComponent.form.value,
+      ...this.oauthComponent?.form?.value,
       ...this.form.value,
     };
   }

--- a/src/app/pages/credentials/credentials.module.ts
+++ b/src/app/pages/credentials/credentials.module.ts
@@ -28,6 +28,7 @@ import {
 } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component';
 import { OauthProviderComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/oauth-provider/oauth-provider.component';
 import { BackblazeB2ProviderFormComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/backblaze-b2-provider-form/backblaze-b2-provider-form.component';
+import { GooglePhotosProviderFormComponent } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/google-photos-provider-form/google-photos-provider-form.component';
 import {
   StorjProviderFormComponent,
 } from 'app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/storj-provider-form/storj-provider-form.component';
@@ -115,6 +116,7 @@ import { CertificateSubjectComponent } from './certificates-dash/forms/common-st
     FtpProviderFormComponent,
     GoogleCloudProviderFormComponent,
     GoogleDriveProviderFormComponent,
+    GooglePhotosProviderFormComponent,
     HttpProviderFormComponent,
     TokenProviderFormComponent,
     MegaProviderFormComponent,

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2213,6 +2213,7 @@
   "Permissions Editor": "",
   "Permissions Type": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1811,6 +1811,7 @@
   "Permissions Advanced": "",
   "Permissions Basic": "",
   "Permissions Editor": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Please accept the terms of service for the given ACME Server.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -881,6 +881,7 @@
   "Performance": "",
   "Periodic Snapshot Task": "",
   "Permissions Editor": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Please click the button below to create a pool.": "",
   "Please specifies tag of the image": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2354,6 +2354,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -139,6 +139,7 @@
   "Once an enclosure is selected, all other VDEV creation steps will limit disk selection options to disks in the selected enclosure. If the enclosure selection is changed, all disk selections will be reset.": "",
   "Passphrase value must match Confirm Passphrase": "",
   "Percentage of total core utilization": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Provide helpful notations related to the share, e.g. ‘Shared to everybody’.     Maximum length is 120 characters.": "",
   "Pull Image": "",
   "RAIDZ1": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2313,6 +2313,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2159,6 +2159,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Please accept the terms of service for the given ACME Server.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2036,6 +2036,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2531,6 +2531,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -189,6 +189,7 @@
   "Passphrase value must match Confirm Passphrase": "",
   "Pause Scrub": "",
   "Percentage of total core utilization": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pool Creation Wizard": "",
   "Pool Name": "",
   "Pool created successfully": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2471,6 +2471,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2470,6 +2470,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1815,6 +1815,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Please accept the terms of service for the given ACME Server.": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1260,6 +1260,7 @@
   "Permissions Advanced": "",
   "Permissions Basic": "",
   "Permissions Editor": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Please click the button below to create a pool.": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -234,6 +234,7 @@
   "Password Login Groups": "",
   "Pause Scrub": "",
   "Percentage of total core utilization": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pool Creation Wizard": "",
   "Pool Name": "",
   "Pool created successfully": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2537,6 +2537,7 @@
   "Permissions Type": "",
   "Phone": "",
   "Phone Number": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Platform": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -263,6 +263,7 @@
   "Password Login Groups": "",
   "Pause Scrub": "",
   "Percentage of total core utilization": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pool Creation Wizard": "",
   "Pool Name": "",
   "Pool created successfully": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1938,6 +1938,7 @@
   "Permissions Advanced": "",
   "Permissions Basic": "",
   "Permissions Editor": "",
+  "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Pin vcpus": "",
   "Plain (No Encryption)": "",
   "Please click the button below to create a pool.": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 8398f13e762d411e04480bf7bed140e25c4ace8e
    git cherry-pick -x a263cea0a79d0674ecdc8ea31fdcc16f2f794c5f
    git cherry-pick -x 3211b9ac30571753ce013076bd9d09b33f9d8f5c
    git cherry-pick -x 036c74b092cc0cdbb27d107e268e1c9c906009d8
    git cherry-pick -x ad1bbeb7684b38fcf57425367ae692e2965043dc

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 90af0ef041257df0d269cfd5cdad3cf02c1bcf02

Testing:
For Google Photos Cloud Credentials - form should be without `Login To Provider` button and `Client ID` and `Client Secret` should be required.
<img width="485" alt="Screenshot 2023-10-04 at 16 20 10" src="https://github.com/truenas/webui/assets/22980553/cf146c23-2403-4b98-af7c-53a95f52ab76">


Original PR: https://github.com/truenas/webui/pull/9014
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124423