### PR TITLE
NAS-123891 / 23.10.1 / NAS-123773: syslog option for system dataset is deprecated and should be removed (by AlexKarpov98)

### DIFF
--- a/src/app/interfaces/system-dataset-config.interface.ts
+++ b/src/app/interfaces/system-dataset-config.interface.ts
@@ -4,7 +4,6 @@ export interface SystemDatasetConfig {
   is_decrypted: boolean;
   path: string;
   pool: string;
-  syslog: boolean;
   uuid: string;
   uuid_a: string;
   uuid_b: string;
@@ -13,5 +12,4 @@ export interface SystemDatasetConfig {
 export interface SystemDatasetUpdate {
   pool?: string;
   pool_exclude?: string;
-  syslog?: boolean;
 }

--- a/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.html
+++ b/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.html
@@ -38,12 +38,6 @@
           {{ advancedConfig.syslog_transport }}
         </span>
       </mat-list-item>
-      <mat-list-item>
-        <span class="label">{{ 'Use System Dataset' | translate }}:</span>
-        <span *ixWithLoadingState="syslog$ as syslog" class="value">
-          {{ syslog ? ('Enabled' | translate) : ('Disabled' | translate)  }}
-        </span>
-      </mat-list-item>
     </mat-list>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.spec.ts
+++ b/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.spec.ts
@@ -6,10 +6,8 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { CoreComponents } from 'app/core/core-components.module';
-import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { SyslogLevel, SyslogTransport } from 'app/enums/syslog.enum';
 import { AdvancedConfig } from 'app/interfaces/advanced-config.interface';
-import { SystemDatasetConfig } from 'app/interfaces/system-dataset-config.interface';
 import { AdvancedSettingsService } from 'app/pages/system/advanced/advanced-settings.service';
 import { SyslogCardComponent } from 'app/pages/system/advanced/syslog/syslog-card/syslog-card.component';
 import { SyslogFormComponent } from 'app/pages/system/advanced/syslog/syslog-form/syslog-form.component';
@@ -25,11 +23,6 @@ describe('SyslogCardComponent', () => {
       CoreComponents,
     ],
     providers: [
-      mockWebsocket([
-        mockCall('systemdataset.config', {
-          syslog: true,
-        } as SystemDatasetConfig),
-      ]),
       provideMockStore({
         selectors: [
           {
@@ -64,7 +57,6 @@ describe('SyslogCardComponent', () => {
       'Syslog Level: Alert',
       'Syslog Server: 127.1.2.3',
       'Syslog Transport: TCP',
-      'Use System Dataset: Enabled',
     ]);
   });
 

--- a/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.ts
+++ b/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.ts
@@ -1,12 +1,10 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { map, startWith, switchMap } from 'rxjs/operators';
 import { syslogLevelLabels } from 'app/enums/syslog.enum';
 import { toLoadingState } from 'app/helpers/to-loading-state.helper';
 import { AdvancedSettingsService } from 'app/pages/system/advanced/advanced-settings.service';
 import { SyslogFormComponent } from 'app/pages/system/advanced/syslog/syslog-form/syslog-form.component';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
-import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
 import { waitForAdvancedConfig } from 'app/store/system-config/system-config.selectors';
 
@@ -22,18 +20,10 @@ export class SyslogCardComponent {
     toLoadingState(),
   );
 
-  syslog$ = this.slideInService.onClose$.pipe(
-    startWith(undefined),
-    switchMap(() => this.ws.call('systemdataset.config')),
-    map((config) => config.syslog),
-    toLoadingState(),
-  );
-
   readonly syslogLevelLabels = syslogLevelLabels;
 
   constructor(
     private store$: Store<AppState>,
-    private ws: WebSocketService,
     private slideInService: IxSlideInService,
     private advancedSettings: AdvancedSettingsService,
   ) {}

--- a/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.html
+++ b/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.html
@@ -48,11 +48,6 @@
             [required]="true"
           ></ix-select>
         </ng-container>
-        <ix-checkbox
-          formControlName="syslog"
-          [label]="'Use System Dataset' | translate"
-          [tooltip]="tooltips.syslog | translate"
-        ></ix-checkbox>
       </ix-fieldset>
 
       <mat-divider></mat-divider>

--- a/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.spec.ts
+++ b/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.spec.ts
@@ -7,7 +7,6 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { mockCall, mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { SyslogLevel, SyslogTransport } from 'app/enums/syslog.enum';
 import { AdvancedConfig } from 'app/interfaces/advanced-config.interface';
-import { SystemDatasetConfig } from 'app/interfaces/system-dataset-config.interface';
 import { IxSlideInRef } from 'app/modules/ix-forms/components/ix-slide-in/ix-slide-in-ref';
 import { SLIDE_IN_DATA } from 'app/modules/ix-forms/components/ix-slide-in/ix-slide-in.token';
 import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
@@ -36,9 +35,6 @@ describe('SyslogFormComponent', () => {
           syslog_transport: SyslogTransport.Udp,
           syslog_tls_certificate: 2,
         } as AdvancedConfig),
-        mockCall('systemdataset.config', {
-          syslog: true,
-        } as SystemDatasetConfig),
         mockCall('system.advanced.syslog_certificate_choices', {
           1: 'Certificate 1',
           2: 'Certificate 2',
@@ -69,13 +65,11 @@ describe('SyslogFormComponent', () => {
     const values = await form.getValues();
 
     expect(ws.call).toHaveBeenCalledWith('system.advanced.config');
-    expect(ws.call).toHaveBeenCalledWith('systemdataset.config');
     expect(values).toEqual({
       'Use FQDN for Logging': true,
       'Syslog Level': 'Error',
       'Syslog Server': 'existing.server.com',
       'Syslog Transport': 'UDP',
-      'Use System Dataset': true,
     });
   });
 
@@ -86,7 +80,6 @@ describe('SyslogFormComponent', () => {
       'Syslog Level': 'Info',
       'Syslog Server': 'new.server.com',
       'Syslog Transport': SyslogTransport.Tcp,
-      'Use System Dataset': false,
     });
 
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -100,7 +93,6 @@ describe('SyslogFormComponent', () => {
         syslog_transport: SyslogTransport.Tcp,
       },
     ]);
-    expect(ws.job).toHaveBeenCalledWith('systemdataset.update', [{ syslog: false }]);
   });
 
   it('shows certificate fields when transport is TLS and saves it', async () => {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -3453,7 +3453,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",
   "Use compressed WRITE records to make the  stream more efficient. The destination system must also support  compressed WRITE records. See  <a href=\"https://linux.die.net/man/8/zfs\"  target=\"_blank\">zfs(8)</a>.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2716,7 +2716,6 @@
   "Use Samba LDAP schema extensions to provide support for LDAP authentication with SMB shares. DEPRECATED: Support for legacy samba schema for LDAP has been deprecated and will be removed in a future TrueNAS version.": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",
   "Use compressed WRITE records to make the  stream more efficient. The destination system must also support  compressed WRITE records. See  <a href=\"https://linux.die.net/man/8/zfs\"  target=\"_blank\">zfs(8)</a>.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1455,7 +1455,6 @@
   "Use Preset": "",
   "Use Samba LDAP schema extensions to provide support for LDAP authentication with SMB shares. DEPRECATED: Support for legacy samba schema for LDAP has been deprecated and will be removed in a future TrueNAS version.": "",
   "Use Sudo For ZFS Commands": "",
-  "Use System Dataset": "",
   "Use compressed WRITE records to make the  stream more efficient. The destination system must also support  compressed WRITE records. See  <a href=\"https://linux.die.net/man/8/zfs\"  target=\"_blank\">zfs(8)</a>.": "",
   "Use snapshot <i>{snapshot}</i> to roll <b>{dataset}</b> back to {datetime}?": "",
   "Use this option to allow legacy SMB clients to connect to the  server. Note that SMB1 is being deprecated and it is advised  to upgrade clients to operating system versions that support  modern versions of the SMB protocol.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3664,7 +3664,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",
   "Use compressed WRITE records to make the  stream more efficient. The destination system must also support  compressed WRITE records. See  <a href=\"https://linux.die.net/man/8/zfs\"  target=\"_blank\">zfs(8)</a>.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -3963,7 +3963,6 @@
   "Use Signature Version 2": "Utiliser Signature Version 2",
   "Use Sudo For ZFS Commands": "Utiliser Sudo pour les commandes ZFS",
   "Use Syslog Only": "Utiliser uniquement Syslog",
-  "Use System Dataset": "Utiliser le dataset système",
   "Use all disk space": "Utiliser tout l'espace disque",
   "Use an exported encryption key file to unlock datasets.": "Utilisez un fichier de clé de chiffrement exporté pour déverrouiller les datasets.",
   "Use as Home Share": "Utiliser comme partage d'accueil (home)",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3674,7 +3674,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3358,7 +3358,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3397,7 +3397,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3893,7 +3893,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -3968,7 +3968,6 @@
   "Use Signature Version 2": "Handtekening versie 2 gebruiken",
   "Use Sudo For ZFS Commands": "Sudo gebruiken voor ZFS opdrachten",
   "Use Syslog Only": "Alleen Syslog gebruiken",
-  "Use System Dataset": "Systeem dataset gebruiken",
   "Use all disk space": "Alle schijfruimte gebruiken",
   "Use an exported encryption key file to unlock datasets.": "Een geëxporteerd versleutelingssleutelbestand gebruiken om datasets te ontgrendelen.",
   "Use as Home Share": "Als Home-share gebruiken",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3810,7 +3810,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3832,7 +3832,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2946,7 +2946,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",
   "Use compressed WRITE records to make the  stream more efficient. The destination system must also support  compressed WRITE records. See  <a href=\"https://linux.die.net/man/8/zfs\"  target=\"_blank\">zfs(8)</a>.": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -2063,7 +2063,6 @@
   "Use Samba LDAP schema extensions to provide support for LDAP authentication with SMB shares. DEPRECATED: Support for legacy samba schema for LDAP has been deprecated and will be removed in a future TrueNAS version.": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",
   "Use compressed WRITE records to make the  stream more efficient. The destination system must also support  compressed WRITE records. See  <a href=\"https://linux.die.net/man/8/zfs\"  target=\"_blank\">zfs(8)</a>.": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -3978,7 +3978,6 @@
   "Use Signature Version 2": "Використати підпис версії 2",
   "Use Sudo For ZFS Commands": "Використовуйте Sudo для команд ZFS",
   "Use Syslog Only": "Використовувати лише Syslog",
-  "Use System Dataset": "Використовувати системний набір даних",
   "Use all disk space": "Використати весь простір дисків",
   "Use an exported encryption key file to unlock datasets.": "Використовати експортований файл ключа шифрування, щоб розблокувати набори даних.",
   "Use as Home Share": "Використовувати як домашній ресурс",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3899,7 +3899,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use all disk space": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -3981,7 +3981,6 @@
   "Use Signature Version 2": "使用签名版本2",
   "Use Sudo For ZFS Commands": "使用sudo来运行zfs命令",
   "Use Syslog Only": "仅使用系统日志",
-  "Use System Dataset": "使用系统数据集",
   "Use all disk space": "使用所有的磁盘空间",
   "Use an exported encryption key file to unlock datasets.": "使用导出的加密密钥文件来解锁数据集。",
   "Use as Home Share": "用作家庭共享",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -3026,7 +3026,6 @@
   "Use Signature Version 2": "",
   "Use Sudo For ZFS Commands": "",
   "Use Syslog Only": "",
-  "Use System Dataset": "",
   "Use an exported encryption key file to unlock datasets.": "",
   "Use as Home Share": "",
   "Use compressed WRITE records to make the  stream more efficient. The destination system must also support  compressed WRITE records. See  <a href=\"https://linux.die.net/man/8/zfs\"  target=\"_blank\">zfs(8)</a>.": "",


### PR DESCRIPTION
Testing: see that there are no `syslog` option anymore. See ticket.

Original PR: https://github.com/truenas/webui/pull/9024
Jira URL: https://ixsystems.atlassian.net/browse/NAS-123891