### PR TITLE
NAS-124445: Fix wrong state on VM page

### DIFF
--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -3,7 +3,8 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
-import { filter, switchMap } from 'rxjs/operators';
+import { lastValueFrom, of } from 'rxjs';
+import { catchError, filter, map, switchMap } from 'rxjs/operators';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { ProductType } from 'app/enums/product-type.enum';
 import { ServiceStatus } from 'app/enums/service-status.enum';
@@ -112,21 +113,27 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow> {
     private slideInService: IxSlideInService,
   ) {}
 
+  prerequisite(): Promise<boolean> {
+    return lastValueFrom(
+      this.vmService.getVirtualizationDetails().pipe(
+        map((virtualization) => {
+          this.virtualizationDetails = virtualization;
+          this.hasVirtualizationSupport = virtualization.supported;
+          this.canAdd = virtualization.supported;
+          return true;
+        }),
+        catchError(() => {
+          this.canAdd = true;
+          this.hasVirtualizationSupport = true;
+          return of(true);
+        }),
+      ),
+    );
+  }
+
   afterInit(entityList: EntityTableComponent<VirtualMachineRow>): void {
     this.checkMemory();
     this.entityList = entityList;
-
-    this.vmService.getVirtualizationDetails().pipe(untilDestroyed(this)).subscribe({
-      next: (virtualization) => {
-        this.virtualizationDetails = virtualization;
-        this.hasVirtualizationSupport = virtualization.supported;
-        this.canAdd = virtualization.supported;
-      },
-      error: () => {
-        // fallback when endpoint is unavailable
-        this.canAdd = true;
-      },
-    });
 
     this.ws.subscribe('vm.query').pipe(untilDestroyed(this)).subscribe((event) => {
       entityList.patchCurrentRows(
@@ -173,7 +180,7 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow> {
   }
 
   resourceTransformIncomingRestData(vms: VirtualMachine[]): VirtualMachineRow[] {
-    return vms.map((vm) => {
+    return !this.hasVirtualizationSupport ? [] : vms.map((vm) => {
       const transformed = {
         ...vm,
         state: vm.status.state,


### PR DESCRIPTION
**Summary**

This bug was occurring due to a race condition between `vm.query` and `vm.virtualization_details`. If the latter response is too slow, then `supported: false` flag gets ignored, which causes an issue described in the ticket.

**Testing**

Use mocking on front-end (hard-code `supported: false` , and add some delay to the `vm.virtualization_details` response)

**Expected result:**

On **Virtualization** page you will see **Validation is not supported** error block.