### PR TITLE
NAS-124606 / 23.10.0 / Duplicate name error is not shown in SMB shares (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -263,6 +263,7 @@ export class SmbFormComponent implements OnInit {
     if (pathControl.value && (!nameControl.value || !nameControl.dirty)) {
       const name = pathControl.value.split('/').pop();
       nameControl.setValue(name);
+      nameControl.markAsTouched();
     }
     this.cdr.markForCheck();
   }


### PR DESCRIPTION
Testing: see ticket

Original PR: https://github.com/truenas/webui/pull/9039
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124606