### PR TITLE
NAS-124724 / 24.04 / Update to `ChangeDetection.OnPush` in ix-table2 and pages/dashboard

### DIFF
--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 
@@ -6,6 +6,7 @@ import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-
   selector: 'ix-cell-actions',
   templateUrl: './ix-cell-actions.component.html',
   styleUrls: ['./ix-cell-actions.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellActionsComponent<T> extends ColumnComponent<T> {
   actions: {

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-checkbox/ix-cell-checkbox.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-checkbox/ix-cell-checkbox.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { IxHeaderCellCheckboxComponent } from 'app/modules/ix-table2/components/ix-table-head/head-cells/ix-header-cell-checkbox/ix-header-cell-checkbox.component';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
@@ -6,6 +6,7 @@ import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-
 @Component({
   selector: 'ix-cell-checkbox',
   templateUrl: './ix-cell-checkbox.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellCheckboxComponent<T> extends ColumnComponent<T> {
   onRowCheck: (row: T, checked: boolean) => void;

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-date/ix-cell-date.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-date/ix-cell-date.component.ts
@@ -1,10 +1,11 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ApiTimestamp } from 'app/interfaces/api-date.interface';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 
 @Component({
   selector: 'ix-cell-date',
   templateUrl: './ix-cell-date.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellDateComponent<T> extends ColumnComponent<T> {
   get date(): number | Date {

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { FormatDateTimePipe } from 'app/core/pipes/format-datetime.pipe';
 import { formatDistanceToNowShortened } from 'app/helpers/format-distance-to-now-shortened';
@@ -7,6 +7,7 @@ import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-
 @Component({
   selector: 'ix-cell-relative-date',
   templateUrl: './ix-cell-relative-date.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellRelativeDateComponent<T> extends ColumnComponent<T> {
   translate: TranslateService;

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-schedule/ix-cell-schedule.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-schedule/ix-cell-schedule.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 
 @Component({
   selector: 'ix-cell-schedule',
   templateUrl: './ix-cell-schedule.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellScheduleComponent<T> extends ColumnComponent<T> {}
 

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 
 @Component({
   selector: 'ix-cell-size',
   templateUrl: './ix-cell-size.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellSizeComponent<T> extends ColumnComponent<T> {
   get size(): number {

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-state-button/ix-cell-state-button.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-state-button/ix-cell-state-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
@@ -23,6 +23,7 @@ interface RowState {
 @Component({
   templateUrl: './ix-cell-state-button.component.html',
   styleUrls: ['./ix-cell-state-button.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellStateButtonComponent<T> extends ColumnComponent<T> {
   matDialog: MatDialog;

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-template/ix-cell-template.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-template/ix-cell-template.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 
 @Component({
   selector: 'ix-cell-template',
   template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellTemplateComponent<T> extends ColumnComponent<T> {}
 

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 
 @Component({
   selector: 'ix-cell-text',
   templateUrl: './ix-cell-text.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellTextComponent<T> extends ColumnComponent<T> {}
 

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-toggle/ix-cell-toggle.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-toggle/ix-cell-toggle.component.ts
@@ -1,10 +1,11 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 
 @Component({
   selector: 'ix-cell-toggle',
   templateUrl: './ix-cell-toggle.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellToggleComponent<T> extends ColumnComponent<T> {
   onRowToggle: (row: T, checked: boolean) => void;

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-yesno/ix-cell-yesno.component.spec.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-yesno/ix-cell-yesno.component.spec.ts
@@ -28,7 +28,7 @@ describe('IxCellYesNoComponent', () => {
 
   it('shows "No" when "false"', () => {
     spectator.component.setRow({ yesNoField: false });
-    spectator.fixture.detectChanges();
+    spectator.detectComponentChanges();
     expect(spectator.element.textContent.trim()).toBe('No');
   });
 });

--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-yesno/ix-cell-yesno.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-yesno/ix-cell-yesno.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 
 @Component({
   selector: 'ix-cell-yesno',
   templateUrl: './ix-cell-yesno.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxCellYesNoComponent<T> extends ColumnComponent<T> {}
 

--- a/src/app/modules/ix-table2/components/ix-table-head/head-cells/ix-header-cell-checkbox/ix-header-cell-checkbox.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-head/head-cells/ix-header-cell-checkbox/ix-header-cell-checkbox.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { map, Observable } from 'rxjs';
@@ -7,6 +7,7 @@ import { ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.i
 @UntilDestroy()
 @Component({
   templateUrl: './ix-header-cell-checkbox.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxHeaderCellCheckboxComponent<T> extends ColumnComponent<T> {
   onColumnCheck: (checked: boolean) => void;

--- a/src/app/modules/ix-table2/components/ix-table-head/head-cells/ix-header-cell-text/ix-header-cell-text.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-head/head-cells/ix-header-cell-text/ix-header-cell-text.component.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 
 @Component({
   templateUrl: './ix-header-cell-text.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IxHeaderCellTextComponent<T> extends ColumnComponent<T> {}

--- a/src/app/pages/dashboard/components/widget-controller/widget-controller.component.ts
+++ b/src/app/pages/dashboard/components/widget-controller/widget-controller.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, Input, Output, EventEmitter,
+  Component, Input, Output, EventEmitter, ChangeDetectionStrategy,
 } from '@angular/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { EmptyConfig } from 'app/interfaces/empty-config.interface';
@@ -21,6 +21,7 @@ export interface DashConfigItem {
     '../widget/widget.component.scss',
     './widget-controller.component.scss',
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WidgetControllerComponent {
   @Input() dashState: DashConfigItem[] = [];

--- a/src/app/pages/dashboard/components/widget-help/widget-help.component.ts
+++ b/src/app/pages/dashboard/components/widget-help/widget-help.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { MediaObserver } from '@angular/flex-layout';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
@@ -16,6 +16,7 @@ import { SystemGeneralService } from 'app/services/system-general.service';
     '../widget/widget.component.scss',
     './widget-help.component.scss',
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WidgetHelpComponent extends WidgetComponent implements OnInit {
   systemType: ProductType;
@@ -30,6 +31,7 @@ export class WidgetHelpComponent extends WidgetComponent implements OnInit {
     public mediaObserver: MediaObserver,
     private sysGenService: SystemGeneralService,
     public translate: TranslateService,
+    private cdr: ChangeDetectorRef,
   ) {
     super(translate);
 
@@ -42,6 +44,7 @@ export class WidgetHelpComponent extends WidgetComponent implements OnInit {
   ngOnInit(): void {
     this.sysGenService.getProductType$.pipe(untilDestroyed(this)).subscribe((productType) => {
       this.systemType = productType;
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/pages/dashboard/components/widget-pool-wrapper/widget-pool-wrapper.component.ts
+++ b/src/app/pages/dashboard/components/widget-pool-wrapper/widget-pool-wrapper.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component, EventEmitter, Input, Output,
 } from '@angular/core';
 import { filter, map } from 'rxjs';
@@ -8,6 +9,7 @@ import { deepCloneState } from 'app/pages/dashboard/utils/deep-clone-state.helpe
 @Component({
   selector: 'ix-widget-pool-wrapper',
   templateUrl: './widget-pool-wrapper.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WidgetPoolWrapperComponent {
   @Input() pool: string;

--- a/src/app/pages/dashboard/components/widget-pool/widget-pool.component.ts
+++ b/src/app/pages/dashboard/components/widget-pool/widget-pool.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
@@ -55,6 +56,7 @@ enum PoolHealthLevel {
     '../widget/widget.component.scss',
     './widget-pool.component.scss',
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WidgetPoolComponent extends WidgetComponent implements OnInit, AfterViewInit, OnChanges {
   @Input() poolState: Pool;
@@ -249,6 +251,7 @@ export class WidgetPoolComponent extends WidgetComponent implements OnInit, Afte
         delete disks[0].zfs_guid;
         this.currentDiskDetails = disks[0];
       }
+      this.cdr.markForCheck();
     });
   }
 

--- a/src/app/pages/dashboard/components/widget-storage/widget-storage.component.ts
+++ b/src/app/pages/dashboard/components/widget-storage/widget-storage.component.ts
@@ -1,5 +1,5 @@
 import {
-  AfterViewInit, Component,
+  AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component,
 } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
@@ -55,6 +55,7 @@ interface PoolInfoMap {
     '../widget/widget.component.scss',
     './widget-storage.component.scss',
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WidgetStorageComponent extends WidgetComponent implements AfterViewInit {
   protected pools: Pool[];
@@ -105,6 +106,7 @@ export class WidgetStorageComponent extends WidgetComponent implements AfterView
   constructor(
     public translate: TranslateService,
     private dashboardStorageStore$: DashboardStorageStore,
+    private cdr: ChangeDetectorRef,
   ) {
     super(translate);
   }
@@ -129,6 +131,7 @@ export class WidgetStorageComponent extends WidgetComponent implements AfterView
       next: () => {
         this.updateGridInfo();
         this.updatePoolInfoMap();
+        this.cdr.markForCheck();
       },
     });
   }

--- a/src/app/pages/dashboard/components/widget-sys-info/simple-failover-btn.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/simple-failover-btn.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component, Input,
 } from '@angular/core';
 import { Router } from '@angular/router';
@@ -12,6 +13,7 @@ import { DialogService } from 'app/services/dialog.service';
   selector: 'ix-simple-failover-button',
   templateUrl: './simple-failover-btn.component.html',
   styleUrls: ['./simple-failover-btn.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SimpleFailoverBtnComponent {
   @Input() color = 'default';

--- a/src/app/pages/dashboard/components/widget/widget.component.ts
+++ b/src/app/pages/dashboard/components/widget/widget.component.ts
@@ -1,10 +1,11 @@
 import {
-  Component, Input, Output, EventEmitter,
+  Component, Input, Output, EventEmitter, ChangeDetectionStrategy,
 } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WidgetComponent {
   @Input() showReorderHandle = false;


### PR DESCRIPTION
**Summary** 
This is an optimization of redundant UI updates at 2 different places:
1. OnPush at ix-table2
2. OnPush at `pages/dashboard`

**Testing**

1. Test that pages/dashboard displaying up-to-date information:
   - from the hardware reporting streams
   - when pool gets added or removed (exported) 
   - when 2nd network adapter gets connected and disconnected

2. Test that UI stays up-to-date during interactions on the pages where ix-table2 is used. 