### PR TITLE
NAS-124703 / 24.04 / Fix `bucketNodeProvider`

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -20,7 +20,7 @@ import helptext from 'app/helptext/data-protection/cloudsync/cloudsync-form';
 import { CloudSyncTaskUi, CloudSyncTaskUpdate } from 'app/interfaces/cloud-sync-task.interface';
 import { CloudsyncBucket, CloudsyncCredential } from 'app/interfaces/cloudsync-credential.interface';
 import { SelectOption } from 'app/interfaces/option.interface';
-import { ExplorerNodeData } from 'app/interfaces/tree-node.interface';
+import { ExplorerNodeData, TreeNode } from 'app/interfaces/tree-node.interface';
 import { WebsocketError } from 'app/interfaces/websocket-error.interface';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
 import { TreeNodeProvider } from 'app/modules/ix-forms/components/ix-explorer/tree-node-provider.interface';
@@ -484,7 +484,7 @@ export class CloudsyncFormComponent implements OnInit {
   }
 
   getBucketsNodeProvider(): TreeNodeProvider {
-    return () => {
+    return (node: TreeNode<ExplorerNodeData>) => {
       let bucket = '';
       if (this.form.controls.bucket.enabled) {
         bucket = this.form.controls.bucket.value;
@@ -500,7 +500,7 @@ export class CloudsyncFormComponent implements OnInit {
         encryption_salt: this.form.controls.encryption_salt.value,
         attributes: {
           bucket,
-          folder: '/',
+          folder: node.path.slice(1).join('') || '/',
         },
         args: '',
       };
@@ -518,7 +518,7 @@ export class CloudsyncFormComponent implements OnInit {
                 path: '/' + file.Name,
                 name: file.Name,
                 type: ExplorerNodeType.Directory,
-                hasChildren: false,
+                hasChildren: true,
               });
             }
           });


### PR DESCRIPTION
**Testing**

On **Credentials \> Backup Credentials \> Cloud Credentials** connect to any Dropbox account for debugging.

On **Data Protection** page,

Set up a Dropbox cloud sync task. Under **Remote**, in the **Folder** section, click the triangle to expand the / folder; it will show all of the first-level subfolders.

* **Expected:** every subfolder to have a clickable "triangle" icon , and when clicked it displays deeper subfolders