### PR TITLE
NAS-124727 / 24.04 / Show disks assigned to configured DRAID

### DIFF
--- a/src/app/pages/system/view-enclosure/stores/enclosure-store.service.ts
+++ b/src/app/pages/system/view-enclosure/stores/enclosure-store.service.ts
@@ -324,6 +324,7 @@ export class EnclosureStore extends ComponentStore<EnclosureState> {
           case TopologyItemType.Raidz1:
           case TopologyItemType.Raidz2:
           case TopologyItemType.Raidz3:
+          case TopologyItemType.Draid:
             return item.children.find((device: TopologyDisk) => device.disk === disk.name);
           default:
             return false;


### PR DESCRIPTION
**Testing**

1. Connect to `remote:`
2. Go to **System Settings > Enclosure** page

   - **Expected Result:** DRAID pools and related disks should be shown in the Enclosure UI.