### PR TITLE
NAS-124732 / 24.04 / Request:  Improve sorting for Replace Disk Search for DRAIDs 

### DIFF
--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.html
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.html
@@ -3,13 +3,13 @@
 </h1>
 
 <form class="ix-form-container" (submit)="onSubmit($event)">
-  <ix-select
+  <ix-combobox
     [formControl]="newDiskControl"
     [label]="'New Disk' | translate"
     [required]="true"
-    [options]="unusedDiskOptions$"
+    [provider]="disksProvider"
     [tooltip]="helptext.dialogFormFields.new_disk.tooltip | translate"
-  ></ix-select>
+  ></ix-combobox>
 
   <ix-form-actions>
     <button mat-button type="button" ixTest="cancel" [matDialogClose]="false">

--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.html
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.html
@@ -2,9 +2,9 @@
   {{ 'Extend Vdev' | translate }}
 </h1>
 
-<form class="ix-form-container" (submit)="onSubmit($event)">
+<form class="ix-form-container" [formGroup]="form" (submit)="onSubmit($event)">
   <ix-combobox
-    [formControl]="newDiskControl"
+    formControlName="newDisk"
     [label]="'New Disk' | translate"
     [required]="true"
     [provider]="disksProvider"
@@ -20,7 +20,7 @@
       type="submit"
       color="primary"
       ixTest="extend"
-      [disabled]="!newDiskControl.valid"
+      [disabled]="form.invalid"
     >
       {{ 'Extend' | translate }}
     </button>

--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.spec.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.spec.ts
@@ -7,8 +7,8 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
 import { mockCall, mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { UnusedDisk } from 'app/interfaces/storage.interface';
-import { IxSelectHarness } from 'app/modules/ix-forms/components/ix-select/ix-select.harness';
 import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
+import { IxFormHarness } from 'app/modules/ix-forms/testing/ix-form.harness';
 import { AppLoaderModule } from 'app/modules/loader/app-loader.module';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import {
@@ -19,7 +19,7 @@ import { WebSocketService } from 'app/services/ws.service';
 describe('ExtendDialogComponent', () => {
   let spectator: Spectator<ExtendDialogComponent>;
   let loader: HarnessLoader;
-  let newDiskSelect: IxSelectHarness;
+
   const createComponent = createComponentFactory({
     component: ExtendDialogComponent,
     imports: [
@@ -59,19 +59,17 @@ describe('ExtendDialogComponent', () => {
     ],
   });
 
-  beforeEach(async () => {
+  beforeEach(() => {
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
-    newDiskSelect = await loader.getHarness(IxSelectHarness);
-  });
-
-  it('loads unused disks and shows them in a New Disk select', async () => {
-    expect(spectator.inject(WebSocketService).call).toHaveBeenCalled();
-    expect(await newDiskSelect.getOptionLabels()).toEqual(['sde (10.91 TiB)', 'sdf (9.1 TiB)']);
   });
 
   it('extends a vdev when new unused disk is selected', async () => {
-    await newDiskSelect.setValue('sde (10.91 TiB)');
+    const form = await loader.getHarness(IxFormHarness);
+    await form.fillForm({
+      'New Disk': 'sde (10.91 TiB)',
+    });
+
     const extendButton = await loader.getHarness(MatButtonHarness.with({ text: 'Extend' }));
     await extendButton.click();
 
@@ -87,7 +85,11 @@ describe('ExtendDialogComponent', () => {
   });
 
   it('sends submit request with allow_duplicate_serials = true when selected disk is listed as having duplicate serial', async () => {
-    await newDiskSelect.setValue('sdf (9.1 TiB)');
+    const form = await loader.getHarness(IxFormHarness);
+    await form.fillForm({
+      'New Disk': 'sdf (9.1 TiB)',
+    });
+
     const extendButton = await loader.getHarness(MatButtonHarness.with({ text: 'Extend' }));
     await extendButton.click();
 

--- a/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.html
+++ b/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.html
@@ -2,13 +2,13 @@
   {{ 'Replacing disk {name}' | translate: { name: data.diskName } }}
 </h1>
 <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
-  <ix-select
+  <ix-combobox
     formControlName="replacement"
     [label]="'Member Disk' | translate"
     [required]="true"
-    [options]="unusedDisksOptions$"
+    [provider]="disksProvider"
     [tooltip]="helptext.dialogFormFields.disk.tooltip | translate"
-  ></ix-select>
+  ></ix-combobox>
 
   <ix-checkbox
     formControlName="force"

--- a/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.ts
+++ b/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.ts
@@ -1,5 +1,5 @@
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit,
+  ChangeDetectionStrategy, Component, Inject, OnInit,
 } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { MatDialog, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
@@ -48,7 +48,6 @@ export class ReplaceDiskDialogComponent implements OnInit {
     private snackbar: SnackbarService,
     @Inject(MAT_DIALOG_DATA) public data: ReplaceDiskDialogData,
     private dialogService: DialogService,
-    private cdr: ChangeDetectorRef,
   ) {}
 
   ngOnInit(): void {

--- a/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.ts
+++ b/src/app/pages/storage/modules/disks/components/replace-disk-dialog/replace-disk-dialog.component.ts
@@ -67,7 +67,7 @@ export class ReplaceDiskDialogComponent implements OnInit {
           label: `${disk.devname} - ${size} ${exportedPool}`,
           value: disk.identifier,
         };
-      });
+      }).sort((a, b) => a.label.localeCompare(b.label));
       this.unusedDisksOptions$ = of(unusedDiskOptions);
       this.cdr.markForCheck();
     });

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -337,12 +337,12 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
   }
 
   .mat-mdc-select-panel .mat-mdc-option:hover,
-  .mat-mdc-option-active,
+  mat-option.mat-mdc-option-active,
   .mat-mdc-menu-content button.mat-mdc-menu-item:hover,
   .mat-mdc-menu-content button.mat-mdc-menu-item:hover .mat-icon:not(.theme-picker-swatch-icon),
   .mat-mdc-menu-content button.mat-mdc-menu-item:focus,
   .mat-mdc-menu-content button.mat-mdc-menu-item:focus .mat-icon:not(.theme-picker-swatch-icon) {
-    background-color: var(--hover-bg);
+    background-color: var(--hover-bg) !important;
   }
 
   // Treelists in storage/volumes


### PR DESCRIPTION
Testing: Go to Devices and click Replace
Disks input shall appear and now they are sorted alphabetically and filtering is available.
As well selected item is highlighted (fixed this issue - before it was not)

<img width="425" alt="Screenshot 2023-10-25 at 16 49 39" src="https://github.com/truenas/webui/assets/22980553/8ac9f17e-6b58-4a26-9e8e-8036394be5c3">

