### PR TITLE
NAS-124756 / 24.04 / Return ws data after auth error

### DIFF
--- a/src/app/services/websocket-connection.service.ts
+++ b/src/app/services/websocket-connection.service.ts
@@ -3,7 +3,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { UUID } from 'angular2-uuid';
 import { environment } from 'environments/environment';
 import {
-  BehaviorSubject, EMPTY, interval, NEVER, Observable, of, switchMap, tap, timer,
+  BehaviorSubject, interval, NEVER, Observable, of, switchMap, tap, timer,
 } from 'rxjs';
 import { webSocket as rxjsWebsocket, WebSocketSubject } from 'rxjs/webSocket';
 import { IncomingApiMessageType, OutgoingApiMessageType } from 'app/enums/api-message-type.enum';
@@ -79,7 +79,6 @@ export class WebsocketConnectionService {
       switchMap((data: IncomingWebsocketMessage) => {
         if (this.hasAuthError(data)) {
           this.ws$.complete();
-          return EMPTY;
         }
         return of(data);
       }),


### PR DESCRIPTION
**Summary**

The bug, which is reported in the ticket, appeared due to the code in line 21 in file **src/app/store/system-info/system-info.effects.ts** ( 83c73779fbbe1fc43877524a0d791d05bfb8164c). The middleware returns a response with error code `207` and `ws$.complete()` is called.

After the fix, the the connection will be closed and reopened only once.