### PR TITLE
NAS-124763 / 23.10.0 / Incorrect indentation in dataset tree (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-tree/components/nested-tree-node/nested-tree-node.component.scss
+++ b/src/app/modules/ix-tree/components/nested-tree-node/nested-tree-node.component.scss
@@ -4,3 +4,11 @@
   margin-top: 0;
   min-width: fit-content;
 }
+
+:host ::ng-deep {
+  ix-nested-tree-node {
+    &[aria-level='2'] .ix-tree-node-toggle {
+      margin-left: 10px;
+    }
+  }
+}

--- a/src/app/modules/ix-tree/components/tree-view/tree-view.component.scss
+++ b/src/app/modules/ix-tree/components/tree-view/tree-view.component.scss
@@ -6,3 +6,10 @@ ix-tree-view {
   flex-direction: column;
   min-width: fit-content;
 }
+
+::ng-deep {
+  .ix-tree-node-toggle {
+    height: 40px !important;
+    width: 40px !important;
+  }
+}

--- a/src/app/modules/ix-tree/components/tree-virtual-scroll-view/tree-virtual-scroll-view.component.scss
+++ b/src/app/modules/ix-tree/components/tree-virtual-scroll-view/tree-virtual-scroll-view.component.scss
@@ -11,6 +11,12 @@
 
     cdk-virtual-scroll-viewport {
       height: 100%;
+
+      ix-tree-node {
+        .ix-tree-node-toggle {
+          margin-left: 10px;
+        }
+      }
     }
 
     .scrollTop {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c1eefa4108e9043f8fbd26ddbdb35eb8925fcdcf

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 928c173382f09caa2ba8ad378939ffe4d9b7a10d

Testing: 
check that rows are aligned correctly now:
<img width="710" alt="Screenshot 2023-10-24 at 17 58 57" src="https://github.com/truenas/webui/assets/22980553/117eb589-a2c7-4931-9b35-4450fd32bae3">

Before it was like:
![image](https://github.com/truenas/webui/assets/22980553/2042df27-96d4-4e68-96c5-22bed11f263e)


Original PR: https://github.com/truenas/webui/pull/9104
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124763