### PR TITLE
NAS-124731 / 23.10.1 / Remove the "Remove" and "Extend" buttons for the DRAID pool (by bvasilenko)

### DIFF
--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
@@ -42,12 +42,19 @@ export class ZfsInfoCardComponent {
     return raidzItems.includes(this.topologyItem.type);
   }
 
+  get isDraidOrMirrorParent(): boolean {
+    return [
+      TopologyItemType.Mirror,
+      TopologyItemType.Draid,
+    ].includes(this.topologyParentItem.type);
+  }
+
   get isDisk(): boolean {
     return isTopologyDisk(this.topologyItem);
   }
 
   get canExtendDisk(): boolean {
-    return this.topologyParentItem.type !== TopologyItemType.Mirror
+    return !this.isDraidOrMirrorParent
       && !this.isRaidzParent
       && this.topologyItem.type === TopologyItemType.Disk
       && (this.topologyCategory === VdevType.Data
@@ -57,7 +64,7 @@ export class ZfsInfoCardComponent {
   }
 
   get canRemoveDisk(): boolean {
-    return this.topologyParentItem.type !== TopologyItemType.Mirror
+    return !this.isDraidOrMirrorParent
       && !this.isRaidzParent
       && (!this.hasTopLevelRaidz
     || this.topologyCategory === VdevType.Cache


### PR DESCRIPTION
Backported

**Testing**

1. Connect to `remote: '10.220.16.10', // m60-100.dc1.ixsystems.net`
2. On Storage > (Pool block) > Manage Devices page,

   - **Expected Result:** When actions “Extend” and “Remove” are not applicable (see ticket), the respective buttons should not be displayed in WebUI in the aforementioned conditions.

Original PR: https://github.com/truenas/webui/pull/9114
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124731