### PR TITLE
NAS-124846 / 23.10.1 / Standardize dRAID and RAIDZ pool creation width (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.spec.ts
@@ -92,7 +92,7 @@ describe('DraidSelectionComponent', () => {
     });
 
     const dataDevices = await form.getControl('Data Devices') as IxSelectHarness;
-    expect(await dataDevices.getOptionLabels()).toEqual(['1', '2', '3']);
+    expect(await dataDevices.getOptionLabels()).toEqual(['2', '3']);
   });
 
   it('updates Spares and Children options when Data Devices are selected', async () => {
@@ -187,40 +187,17 @@ describe('DraidSelectionComponent', () => {
     );
   });
 
-  it('selects options in controls automatically when only one option is available', async () => {
-    await form.fillForm({
-      'Disk Size': '30 GiB (SSD)',
-    });
-
-    expect(await form.getValues()).toMatchObject({
-      'Data Devices': '1',
-      Children: '2',
-      'Distributed Hot Spares': '0',
-      'Number of VDEVs': '1',
-    });
-
-    const store = spectator.inject(PoolManagerStore);
-    expect(store.setAutomaticTopologyCategory).toHaveBeenLastCalledWith(
-      VdevType.Spare,
-      {
-        draidDataDisks: 1,
-        draidSpareDisks: 0,
-        vdevsNumber: 1,
-        width: 2,
-      },
-    );
-  });
-
   it('resets to default values when store emits a reset event', async () => {
     await form.fillForm({
-      'Disk Size': '30 GiB (SSD)',
+      'Disk Size': '10 GiB (HDD)',
     });
 
-    expect(await form.getValues()).toMatchObject({
-      'Data Devices': '1',
-      Children: '2',
-      'Distributed Hot Spares': '0',
-      'Number of VDEVs': '1',
+    await form.fillForm({
+      'Treat Disk Size as Minimum': true,
+      'Data Devices': '2',
+      'Distributed Hot Spares': '1',
+      Children: '4',
+      'Number of VDEVs': '2',
     });
 
     startOver$.next();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.ts
@@ -149,7 +149,7 @@ export class DraidSelectionComponent implements OnInit, OnChanges {
     const maxPossibleGroups = this.selectedDisks.length - this.parityDevices;
     let nextOptions: Option[] = [];
     if (maxPossibleGroups) {
-      nextOptions = generateOptionsRange(1, maxPossibleGroups);
+      nextOptions = generateOptionsRange(2, maxPossibleGroups);
     }
 
     unsetControlIfNoMatchingOption(this.form.controls.dataDevicesPerGroup, nextOptions);

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/draid-pool-creation.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/draid-pool-creation.spec.ts
@@ -152,14 +152,14 @@ describe('PoolManagerComponent – creating dRAID pool', () => {
 
     await wizard.fillStep({
       'Disk Size': '20 GiB (HDD)',
-      'Data Devices': '1',
+      'Data Devices': '2',
       'Distributed Hot Spares': '1',
-      Children: '3',
+      Children: '4',
       'Number of VDEVs': '1',
     });
 
     expect(await wizard.getConfigurationPreviewSummary()).toMatchObject({
-      'Data:': '1 × DRAID1 | 3 × 20 GiB (HDD)',
+      'Data:': '1 × DRAID1 | 4 × 20 GiB (HDD)',
     });
 
     const stepper = await wizard.getStepper();
@@ -185,9 +185,9 @@ describe('PoolManagerComponent – creating dRAID pool', () => {
       topology: {
         data: [
           {
-            disks: ['sda3', 'sda0', 'sda1'],
+            disks: ['sda3', 'sda0', 'sda1', 'sda2'],
             type: CreateVdevLayout.Draid1,
-            draid_data_disks: 1,
+            draid_data_disks: 2,
             draid_spare_disks: 1,
           },
         ],


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 346cd901efe0ef58357a1e4a63aef6d7f56d3c83
    git cherry-pick -x 22c876e5378cb809df69347c81a0b7f30730902b

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 5b5f15a8637ff327d52bb289f0097c4910f9970c

Testing: 
Check that for any Draid configuration the minimum amount of `Data Devices` is **2**
<img width="500" alt="Screenshot 2023-10-30 at 10 38 33" src="https://github.com/truenas/webui/assets/22980553/6bd8802f-c436-4c54-85f2-687ff023158c">


Original PR: https://github.com/truenas/webui/pull/9128
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124846