### PR TITLE
NAS-124962 / 24.04 / Fix scrolling on pane-details layout

### DIFF
--- a/src/app/modules/ix-table2/components/ix-table-body/ix-table-body.component.html
+++ b/src/app/modules/ix-table2/components/ix-table-body/ix-table-body.component.html
@@ -2,7 +2,9 @@
   <tr
     class="row"
     [ixTest]="getTestAttr(row)"
-    [ngStyle]="{ cursor: detailsTemplate ? 'pointer' : 'auto', display: isLoading ? 'none' : 'grid' }"
+    [ngStyle]="{ cursor: detailsTemplate ? 'pointer' : 'auto' }"
+    [ngClass]="{ hidden: isLoading }"
+    [hidden]="isLoading"
     (click)="onToggle(row)"
   >
     <td
@@ -38,6 +40,7 @@
     *ngIf="detailsTemplate && isExpanded(row)"
     ixTest="details"
     class="details"
+    [ngClass]="{ hidden: isLoading }"
   >
     <td [attr.colspan]="displayedColumns.length + 1">
       <ng-container *ngTemplateOutlet="detailsTemplate; context: { $implicit: row }"></ng-container>

--- a/src/app/modules/ix-table2/components/ix-table-body/ix-table-body.component.html
+++ b/src/app/modules/ix-table2/components/ix-table-body/ix-table-body.component.html
@@ -2,8 +2,7 @@
   <tr
     class="row"
     [ixTest]="getTestAttr(row)"
-    [ngStyle]="{ cursor: detailsTemplate ? 'pointer' : 'auto' }"
-    [hidden]="isLoading"
+    [ngStyle]="{ cursor: detailsTemplate ? 'pointer' : 'auto', display: isLoading ? 'none' : 'grid' }"
     (click)="onToggle(row)"
   >
     <td
@@ -35,7 +34,11 @@
       </button>
     </td>
   </tr>
-  <tr *ngIf="detailsTemplate && isExpanded(row)" ixTest="details" class="details" [hidden]="isLoading">
+  <tr
+    *ngIf="detailsTemplate && isExpanded(row)"
+    ixTest="details"
+    class="details"
+  >
     <td [attr.colspan]="displayedColumns.length + 1">
       <ng-container *ngTemplateOutlet="detailsTemplate; context: { $implicit: row }"></ng-container>
     </td>

--- a/src/app/modules/ix-table2/components/ix-table-body/ix-table-body.component.html
+++ b/src/app/modules/ix-table2/components/ix-table-body/ix-table-body.component.html
@@ -3,8 +3,7 @@
     class="row"
     [ixTest]="getTestAttr(row)"
     [ngStyle]="{ cursor: detailsTemplate ? 'pointer' : 'auto' }"
-    [ngClass]="{ hidden: isLoading }"
-    [hidden]="isLoading"
+    [class.hidden]="isLoading"
     (click)="onToggle(row)"
   >
     <td
@@ -40,7 +39,7 @@
     *ngIf="detailsTemplate && isExpanded(row)"
     ixTest="details"
     class="details"
-    [ngClass]="{ hidden: isLoading }"
+    [class.hidden]="isLoading"
   >
     <td [attr.colspan]="displayedColumns.length + 1">
       <ng-container *ngTemplateOutlet="detailsTemplate; context: { $implicit: row }"></ng-container>

--- a/src/app/modules/ix-table2/components/ix-table-body/ix-table-body.component.scss
+++ b/src/app/modules/ix-table2/components/ix-table-body/ix-table-body.component.scss
@@ -2,6 +2,10 @@
   background: var(--bg2);
 }
 
+.hidden {
+  display: none;
+}
+
 .row {
   border-top: solid 1px var(--contrast-lighter);
   height: 48px;

--- a/src/app/pages/apps/components/available-apps/available-apps.component.scss
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.scss
@@ -21,7 +21,7 @@
     padding: 15px 0;
     position: sticky;
     text-transform: capitalize;
-    top: -15px;
+    top: -16px;
     z-index: 1;
 
     ~ .apps {

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.html
@@ -192,6 +192,7 @@
 
   <div
     *ngIf="selectedApp"
+    ixDetailsHeight
     class="details-container"
     [class.details-container-mobile]="showMobileDetails"
   >

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.html
@@ -101,59 +101,69 @@
       ></ix-search-input>
     </div>
 
-    <div class="app-wrapper"
+    <div
+      class="sticky-header"
       matSort
       matSortActive="application"
       matSortDirection="asc"
       matSortDisableClear
       (matSortChange)="sortChanged($event)"
     >
-      <div class="app-inner">
-        <div class="app-header-row">
-          <div>
-            <span class="name-header">
-              <mat-checkbox
-                *ngIf="dataSource.length"
-                color="primary"
-                ixTest="select-all-app"
-                [checked]="allAppsChecked"
-                [indeterminate]="!allAppsChecked && !!selection.selected.length"
-                (change)="toggleAppsChecked($event.checked)"
-              ></mat-checkbox>
-            </span>
-          </div>
-          <div
-            [matColumnDef]="sortableField.Application"
-            [mat-sort-header]="sortableField.Application"
-          >
-            {{ 'Application' | translate }}
-          </div>
-          <div
-            [matColumnDef]="sortableField.Status"
-            [mat-sort-header]="sortableField.Status"
-          >
-            {{ 'Status' | translate }}
-          </div>
-          <div>{{ 'CPU' | translate }}</div>
-          <div>{{ 'RAM' | translate }}</div>
-          <div>{{ 'Network' | translate }}</div>
-          <div
-            class="app-update-header"
-            [matColumnDef]="sortableField.Updates"
-            [mat-sort-header]="hasUpdates ? sortableField.Updates : null"
-            [disabled]="!hasUpdates"
-          >
-            <span>{{ 'Updates' | translate }}</span>
-            <ix-icon
-              *ngIf="hasUpdates"
-              name="mdi-alert-circle"
-              matTooltipPosition="above"
-              [matTooltip]="'Updates available' | translate"
-            ></ix-icon>
-          </div>
-          <div></div>
+      <div class="app-header-row">
+        <div>
+          <span class="name-header">
+            <mat-checkbox
+              *ngIf="dataSource.length"
+              color="primary"
+              ixTest="select-all-app"
+              [checked]="allAppsChecked"
+              [indeterminate]="!allAppsChecked && !!selection.selected.length"
+              (change)="toggleAppsChecked($event.checked)"
+            ></mat-checkbox>
+          </span>
         </div>
+        <div
+          [matColumnDef]="sortableField.Application"
+          [mat-sort-header]="sortableField.Application"
+        >
+          {{ 'Application' | translate }}
+        </div>
+        <div
+          [matColumnDef]="sortableField.Status"
+          [mat-sort-header]="sortableField.Status"
+        >
+          {{ 'Status' | translate }}
+        </div>
+        <div>{{ 'CPU' | translate }}</div>
+        <div>{{ 'RAM' | translate }}</div>
+        <div>{{ 'Network' | translate }}</div>
+        <div
+          class="app-update-header"
+          [matColumnDef]="sortableField.Updates"
+          [mat-sort-header]="hasUpdates ? sortableField.Updates : null"
+          [disabled]="!hasUpdates"
+        >
+          <span>{{ 'Updates' | translate }}</span>
+          <ix-icon
+            *ngIf="hasUpdates"
+            name="mdi-alert-circle"
+            matTooltipPosition="above"
+            [matTooltip]="'Updates available' | translate"
+          ></ix-icon>
+        </div>
+        <div></div>
+      </div>
+    </div>
 
+    <div
+      matSort
+      matSortDisableClear
+      matSortActive="application"
+      matSortDirection="asc"
+      class="app-wrapper"
+      (matSortChange)="sortChanged($event)"
+    >
+      <div class="app-inner">
         <div class="apps-rows">
           <ng-container *ngFor="let app of filteredApps; trackBy: trackAppBy">
             <ix-app-row
@@ -183,7 +193,6 @@
   <div
     *ngIf="selectedApp"
     class="details-container"
-    ixDetailsHeight="rightside-content-hold"
     [class.details-container-mobile]="showMobileDetails"
   >
     <ix-app-details-panel

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
@@ -1,7 +1,7 @@
 @import 'scss-imports/splitview';
 @import 'mixins/layout';
 
-@include tree-node-with-details-container(193px);
+@include tree-node-with-details-container;
 
 :host {
   display: block;

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
@@ -109,7 +109,6 @@ ix-app-row,
     }
   }
 
-
   .app-update-header {
     align-items: center;
     display: flex;

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -39,7 +39,6 @@ import { InstalledAppsStore } from 'app/pages/apps/store/installed-apps-store.se
 import { KubernetesStore } from 'app/pages/apps/store/kubernetes-store.service';
 import { DialogService } from 'app/services/dialog.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
-import { WebSocketService } from 'app/services/ws.service';
 
 enum SortableField {
   Application = 'application',
@@ -70,6 +69,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
     active: SortableField.Application,
     direction: SortDirection.Asc,
   };
+  ixTreeHeaderWidth: number | null = null;
   readonly sortableField = SortableField;
 
   entityEmptyConf: EmptyConfig = {
@@ -147,7 +147,6 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
     private slideInService: IxSlideInService,
     private breakpointObserver: BreakpointObserver,
     @Inject(WINDOW) private window: Window,
-    private ws: WebSocketService,
   ) {
     this.router.events
       .pipe(

--- a/src/app/pages/audit/audit.module.ts
+++ b/src/app/pages/audit/audit.module.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatSelectModule } from '@angular/material/select';
 import { TranslateModule } from '@ngx-translate/core';
+import { CoreComponents } from 'app/core/core-components.module';
 import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
 import { IxIconModule } from 'app/modules/ix-icon/ix-icon.module';
 import { IxTable2Module } from 'app/modules/ix-table2/ix-table2.module';
@@ -29,6 +30,7 @@ import { LogDetailsPanelComponent } from './components/log-details-panel/log-det
     MatSelectModule,
     IxTable2Module,
     AppLoaderModule,
+    CoreComponents,
     routing,
   ],
   exports: [],

--- a/src/app/pages/audit/components/audit/audit.component.html
+++ b/src/app/pages/audit/components/audit/audit.component.html
@@ -6,7 +6,7 @@
   </ix-page-title-header>
 </ng-template>
 
-<mat-card class="header-card">
+<mat-card class="header-card item-search">
   <div class="header-card-item">
     <ix-fake-progress-bar
       class="loader-bar"
@@ -22,15 +22,19 @@
 
 <div class="container" fxLayoutGap="16px">
   <div class="table-container">
-    <ix-table2
-      [ix-table2-empty]="!(dataProvider.currentPageCount$ | async)"
-      [emptyConfig]="emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async)"
-    >
+    <div class="sticky-header">
       <thead
+        class="audit-header-row"
         ix-table-head
         [columns]="columns"
         [dataProvider]="dataProvider"
       ></thead>
+    </div>
+
+    <ix-table2
+      [ix-table2-empty]="!(dataProvider.currentPageCount$ | async)"
+      [emptyConfig]="emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async)"
+    >
       <tbody
         ix-table-body
         [columns]="columns"
@@ -43,7 +47,6 @@
 
   <div
     class="details-container"
-    ixDetailsHeight="rightside-content-hold"
     [class.details-container-mobile]="showMobileDetails"
   >
     <ix-log-details-panel

--- a/src/app/pages/audit/components/audit/audit.component.html
+++ b/src/app/pages/audit/components/audit/audit.component.html
@@ -46,6 +46,7 @@
   </div>
 
   <div
+    ixDetailsHeight
     class="details-container"
     [class.details-container-mobile]="showMobileDetails"
   >

--- a/src/app/pages/audit/components/audit/audit.component.scss
+++ b/src/app/pages/audit/components/audit/audit.component.scss
@@ -1,7 +1,7 @@
 @import 'scss-imports/splitview';
 @import 'mixins/layout';
 
-@include tree-node-with-details-container(284px);
+@include tree-node-with-details-container;
 
 :host ::ng-deep {
   ix-empty-row {

--- a/src/app/pages/audit/components/audit/audit.component.scss
+++ b/src/app/pages/audit/components/audit/audit.component.scss
@@ -74,6 +74,7 @@
 .details-container {
   flex: 1.2;
   max-width: 100%;
+  top: 65px;
 }
 
 .search-control {

--- a/src/app/pages/audit/components/audit/audit.component.scss
+++ b/src/app/pages/audit/components/audit/audit.component.scss
@@ -30,10 +30,6 @@
     display: grid;
     grid-gap: 8px;
     grid-template-columns: 1fr 1fr 1.5fr 1fr 1fr;
-
-    @media (max-width: $breakpoint-tablet) {
-      grid-template-columns: 45px auto 0 0 0;
-    }
   }
 
   .audit-header-row tr {

--- a/src/app/pages/audit/components/audit/audit.component.scss
+++ b/src/app/pages/audit/components/audit/audit.component.scss
@@ -4,23 +4,75 @@
 @include tree-node-with-details-container(284px);
 
 :host ::ng-deep {
-  .table-container table {
-    border: 0;
-  }
-
   ix-empty-row {
     height: 100%;
   }
+
+  .sticky-header {
+    height: inherit;
+    top: 59px;
+
+    thead {
+      align-items: center;
+      display: flex;
+      width: 100%;
+
+      th {
+        align-items: center;
+        display: flex;
+      }
+    }
+  }
+
+  table tbody tr,
+  .audit-header-row tr {
+    align-items: center;
+    display: grid;
+    grid-gap: 8px;
+    grid-template-columns: 1fr 1fr 1.5fr 1fr 1fr;
+
+    @media (max-width: $breakpoint-tablet) {
+      grid-template-columns: 45px auto 0 0 0;
+    }
+  }
+
+  .audit-header-row tr {
+    align-items: center;
+    background: var(--bg1);
+    border-bottom: 1px solid var(--lines);
+    color: var(--fg2);
+    display: grid;
+    grid-gap: 8px;
+    min-height: 48px;
+    min-width: fit-content;
+
+    position: sticky;
+    top: 0;
+    width: 100%;
+    z-index: 1;
+
+    > div {
+      align-items: center;
+      display: flex;
+      font-weight: bold;
+      height: 100%;
+      justify-content: flex-start;
+      padding: 4px 0;
+
+      @media (max-width: $breakpoint-tablet) {
+        display: none !important;
+      }
+    }
+  }
+}
+
+.item-search {
+  margin: 0;
 }
 
 .table-container {
   flex: 1.8;
   max-width: 100%;
-}
-
-ix-table2 {
-  height: 100%;
-  overflow: auto;
 }
 
 .details-container {

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
@@ -116,6 +116,7 @@
 
     <div
       *ngIf="selectedDataset$ | async as dataset"
+      ixDetailsHeight
       class="details-container"
       [class.details-container-mobile]="showMobileDetails"
     >

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
@@ -117,7 +117,6 @@
     <div
       *ngIf="selectedDataset$ | async as dataset"
       class="details-container"
-      ixDetailsHeight="rightside-content-hold"
       [class.details-container-mobile]="showMobileDetails"
     >
       <ix-fake-progress-bar

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
@@ -1,7 +1,7 @@
 @import 'scss-imports/splitview';
 @import 'mixins/layout';
 
-@include tree-node-with-details-container(193px);
+@include tree-node-with-details-container;
 
 :host {
   display: block;

--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.html
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.html
@@ -146,6 +146,7 @@
   </div>
   <div
     class="details-container"
+    ixDetailsHeight
     [class.details-container-mobile]="showMobileDetails"
   >
     <ix-disk-details-panel

--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.html
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.html
@@ -28,18 +28,21 @@
       ></ix-search-input>
     </div>
 
+    <div class="sticky-header">
+      <div class="tree-header">
+        <div>
+          <span class="name-header">
+            {{ 'Device Name' | translate }}
+          </span>
+        </div>
+        <div class="disk-status-header">{{ 'Status' | translate }}</div>
+        <div>{{ 'Capacity' | translate }}</div>
+        <div>{{ 'Errors' | translate }}</div>
+      </div>
+    </div>
+
     <div class="tree-wrapper">
       <div class="tree-inner">
-        <div class="tree-header">
-          <div>
-            <span class="name-header">
-              {{ 'Device Name' | translate }}
-            </span>
-          </div>
-          <div class="disk-status-header">{{ 'Status' | translate }}</div>
-          <div>{{ 'Capacity' | translate }}</div>
-          <div>{{ 'Errors' | translate }}</div>
-        </div>
         <ix-tree-view
           class="disk-tree"
           [ixDataSource]="dataSource"

--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.scss
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.scss
@@ -1,7 +1,7 @@
 @import 'scss-imports/splitview';
 @import 'mixins/layout';
 
-@include tree-node-with-details-container(193px);
+@include tree-node-with-details-container;
 
 :host {
   display: block;

--- a/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.scss
+++ b/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.scss
@@ -92,8 +92,6 @@
 
 .cards {
   @include details-cards();
-  height: 100%;
-  overscroll-behavior: contain;
 
   @media (max-width: $breakpoint-tablet) {
     overflow: hidden;

--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -11,7 +11,7 @@
   .scroll-window {
     columns: calc(50vw / 2.7);
     gap: 8px;
-    min-height: 100vh;
+    min-height: 100%;
 
     @media (max-width: $breakpoint-tablet) {
       columns: 1;

--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -3,7 +3,7 @@
 @import 'scss-imports/splitview';
 
 @mixin details-cards {
-  height: 100%;
+  height: 94%;
   overflow-y: auto;
   overscroll-behavior: contain;
   width: 100%;

--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -3,7 +3,7 @@
 @import 'scss-imports/splitview';
 
 @mixin details-cards {
-  height: 94%;
+  height: 100%;
   overflow-y: auto;
   overscroll-behavior: contain;
   width: 100%;

--- a/src/assets/styles/mixins/layout.scss
+++ b/src/assets/styles/mixins/layout.scss
@@ -19,6 +19,10 @@ $scrollbar-offset: 20px;
     position: sticky;
     top: 0;
 
+    @media(min-width: $breakpoint-tablet) {
+      height: calc(100vh - #{$header-height});
+    }
+
     // Hide Details
     @media (max-width: $breakpoint-hidden) {
       display: none;

--- a/src/assets/styles/mixins/layout.scss
+++ b/src/assets/styles/mixins/layout.scss
@@ -8,9 +8,9 @@ $scrollbar-offset: 20px;
     flex-direction: row;
     width: 100%;
 
-    @media(min-width: $breakpoint-tablet) {
-      height: calc(100vh - #{$header-height});
-    }
+    // @media(min-width: $breakpoint-tablet) {
+    //   height: calc(100vh - #{$header-height});
+    // }
   }
 
   .details-container {
@@ -48,7 +48,7 @@ $scrollbar-offset: 20px;
     background-color: var(--bg2);
     padding: 16px;
     position: sticky;
-    top: -15px;
+    top: -16px;
     z-index: 2;
   }
 

--- a/src/assets/styles/mixins/layout.scss
+++ b/src/assets/styles/mixins/layout.scss
@@ -2,7 +2,7 @@ $singlecolumn-max-width: ($card-width-slim + $gap * 2);
 $dualcolumn-slim-max-width: ($card-width-slim * 2 + $gap * 2);
 $scrollbar-offset: 20px;
 
-@mixin tree-node-with-details-container($header-height) {
+@mixin tree-node-with-details-container() {
   .container {
     display: flex;
     flex-direction: row;
@@ -18,10 +18,6 @@ $scrollbar-offset: 20px;
     padding: 0;
     position: sticky;
     top: 0;
-
-    @media(min-width: $breakpoint-tablet) {
-      height: calc(100vh - #{$header-height});
-    }
 
     // Hide Details
     @media (max-width: $breakpoint-hidden) {

--- a/src/assets/styles/mixins/layout.scss
+++ b/src/assets/styles/mixins/layout.scss
@@ -7,10 +7,6 @@ $scrollbar-offset: 20px;
     display: flex;
     flex-direction: row;
     width: 100%;
-
-    // @media(min-width: $breakpoint-tablet) {
-    //   height: calc(100vh - #{$header-height});
-    // }
   }
 
   .details-container {


### PR DESCRIPTION
Testing:
Check ticket and all related pages with similar layout:
- Datasets
- Devices
- Apps
- Audit

Upon scroll you should see search & table header sticked to the top while scrolling.
There should be less scrollbars or only one (to control the page scroll)