### PR TITLE
NAS-125003 / 24.04 / Dashboard is missing Loading State (only blank screen)

### DIFF
--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.html
@@ -61,7 +61,7 @@
   >
     <!-- LOADING WIDGETS -->
     <ng-container *ngIf="!isLoaded && screenType === ScreenType.Desktop">
-      <div *ngFor="let _ of availableWidgets">
+      <div *ngFor="let _ of [1,2,3,4,5,6]">
         <div class="widget placeholder">
           <div class="card-container front">
             <mat-card [class.loading]="true"></mat-card>

--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
@@ -76,7 +76,6 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
   dashState: DashConfigItem[]; // Saved State
   previousState: DashConfigItem[];
   activeMobileWidget: DashConfigItem[] = [];
-  availableWidgets: DashConfigItem[];
   renderedWidgets: DashConfigItem[];
 
   readonly ScreenType = ScreenType;
@@ -158,7 +157,6 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
         this.volumeData = state.volumesData;
         this.systemInformation = state.sysInfoWithFeatures;
         this.isHaLicensed = state.isHaLicensed;
-        this.availableWidgets = state.availableWidgets;
         this.setDashState(state.dashboardState);
       }),
       untilDestroyed(this),
@@ -270,8 +268,6 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
     conf.push({ name: WidgetName.Memory, rendered: true, id: conf.length.toString() });
     conf.push({ name: WidgetName.Storage, rendered: true, id: conf.length.toString() });
     conf.push({ name: WidgetName.Network, rendered: true, id: conf.length.toString() });
-
-    this.availableWidgets = conf;
   }
 
   showConfigForm(): void {


### PR DESCRIPTION
Testing: see ticket and result.
I think we can just show loaders with static 6 items, we don't need more or less. After some updates we got empty page and then widgets.

Result:
<img width="1728" alt="Screenshot 2023-11-03 at 12 13 35" src="https://github.com/truenas/webui/assets/22980553/9bb87916-32ca-498e-a2c2-23c404fca7dc">
