### PR TITLE
NAS-124947 / 23.10.1 / [Apps/UI]: Immutable fields in an item, leaks in other items too (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.ts
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.ts
@@ -177,8 +177,11 @@ export class ChartWizardComponent implements OnInit, OnDestroy {
 
   addItem(event: AddListItemEvent): void {
     this.appSchemaService.addFormListItem({
-      event,
-      isNew: this.isNew,
+      event: {
+        ...event,
+        schema: event.schema.map((item) => ({ ...item, schema: { ...item.schema, immutable: false } })),
+      },
+      isNew: true,
       isParentImmutable: false,
     });
   }

--- a/src/app/services/schema/app-schema.transformer.ts
+++ b/src/app/services/schema/app-schema.transformer.ts
@@ -32,15 +32,13 @@ export function isCommonSchemaType(type: ChartSchemaType): boolean {
 }
 
 export function buildCommonSchemaBase(payload: Partial<CommonSchemaTransform>): CommonSchemaBase {
-  const {
-    schema, chartSchemaNode, isNew, isParentImmutable,
-  } = payload;
+  const { schema, chartSchemaNode } = payload;
 
   return {
     controlName: chartSchemaNode.variable,
     title: chartSchemaNode.label,
     required: schema.required,
-    editable: (!isNew && (!!schema.immutable || isParentImmutable)) ? false : schema.editable,
+    editable: schema.editable,
     tooltip: chartSchemaNode.description,
   };
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x a5c777e2ce2f1e9fadb1ba76c39b2986e59a4a0d

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x bf3ee7a062ce3f41064b9b01cbe3aa0bd1ac1906

Testing: see ticket, on m40 I tested with `komga` app:
http://localhost:4200/apps/installed/TRUENAS/community/komga-krpv/edit

Newly added items in edit mode shall be editable:
<img width="347" alt="Screenshot 2023-11-06 at 14 06 25" src="https://github.com/truenas/webui/assets/22980553/07c80ab1-cf75-46af-bfe6-34c0e1a0cb15">

Correct logic: 
IMMUTABLE field - is only for EDIT mode, but it should not spread on the ADD NEW ITEM ON THE LIST in EDIT mode.
We made a bug where we spread IMMUTABLE field for new item on the list in edit mode.

Original PR: https://github.com/truenas/webui/pull/9172
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124947