### PR TITLE
Add Checkbox to enable integrated metrics server

### DIFF
--- a/src/app/interfaces/kubernetes-config.interface.ts
+++ b/src/app/interfaces/kubernetes-config.interface.ts
@@ -12,6 +12,7 @@ export interface KubernetesConfig {
   route_v6_interface: string;
   service_cidr: string;
   servicelb: boolean;
+  metrics_server: boolean;
 }
 
 export interface KubernetesConfigUpdate {
@@ -22,6 +23,7 @@ export interface KubernetesConfigUpdate {
   route_v4_gateway: string;
   route_v4_interface: string;
   service_cidr: string;
+  metrics_server: boolean;
   migrate_applications?: boolean;
   configure_gpus?: boolean;
   force?: boolean;

--- a/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.html
+++ b/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.html
@@ -37,6 +37,11 @@
           formControlName="servicelb"
           [label]="'Enable Integrated Loadbalancer' | translate"
         ></ix-checkbox>
+
+        <ix-checkbox
+          formControlName="metrics_server"
+          [label]="'Enable Integrated Metrics Server' | translate"
+        ></ix-checkbox>
       </ix-fieldset>
 
       <ix-fieldset [title]="'Settings Requiring Re-Initialization' | translate">

--- a/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.spec.ts
@@ -39,6 +39,7 @@ describe('KubernetesSettingsComponent', () => {
           cluster_cidr: '172.16.0.0/16',
           service_cidr: '172.17.0.0/16',
           cluster_dns_ip: '172.17.0.1',
+          metrics_server: true,
         } as KubernetesConfig),
         mockJob('kubernetes.update'),
       ]),
@@ -82,6 +83,7 @@ describe('KubernetesSettingsComponent', () => {
       'Enable Container Image Updates': true,
       'Enable GPU support': true,
       'Enable Integrated Loadbalancer': true,
+      'Enable Integrated Metrics Server': true,
       'Cluster CIDR': '172.16.0.0/16',
       'Service CIDR': '172.17.0.0/16',
       'Cluster DNS IP': '172.17.0.1',
@@ -98,6 +100,7 @@ describe('KubernetesSettingsComponent', () => {
       'Enable Container Image Updates': false,
       'Enable GPU support': false,
       'Enable Integrated Loadbalancer': false,
+      'Enable Integrated Metrics Server': false,
       Force: true,
     });
 
@@ -114,6 +117,7 @@ describe('KubernetesSettingsComponent', () => {
       cluster_cidr: '172.16.0.0/16',
       service_cidr: '172.17.0.0/16',
       cluster_dns_ip: '172.17.0.1',
+      metrics_server: false,
       force: true,
     }]);
     expect(spectator.inject(ApplicationsService).updateContainerConfig).toHaveBeenCalledWith(false);
@@ -145,6 +149,7 @@ describe('KubernetesSettingsComponent', () => {
       service_cidr: '172.17.1.0/16',
       cluster_dns_ip: '172.17.1.1',
       servicelb: true,
+      metrics_server: true,
       force: false,
     }]);
   });

--- a/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.ts
+++ b/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.ts
@@ -40,6 +40,7 @@ export class KubernetesSettingsComponent implements OnInit {
     enable_container_image_update: [true],
     configure_gpus: [true],
     servicelb: [true],
+    metrics_server: [false],
     cluster_cidr: ['', Validators.required],
     service_cidr: ['', Validators.required],
     cluster_dns_ip: ['', Validators.required],

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1168,6 +1168,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB2/3 Durable Handles": "",
   "Enable SMTP configuration": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -878,6 +878,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable SMTP configuration": "",
   "Enable Two Factor Authentication Globally": "",
   "Enable Two Factor Authentication for SSH": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -404,6 +404,7 @@
   "Empty": "",
   "Enable FIPS": "",
   "Enable Hyper-V Enlightenments": "",
+  "Enable Integrated Metrics Server": "",
   "Enable Two Factor Authentication Globally": "",
   "Enable Two Factor Authentication for SSH": "",
   "Enable a Display (Virtual Network Computing) remote connection. Requires <i>UEFI</i> booting.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1151,6 +1151,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB2/3 Durable Handles": "",
   "Enable SMTP configuration": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -42,6 +42,7 @@
   "Edit Reporting Exporter": "",
   "Editing interface will result in default gateway being removed, which may result in TrueNAS being inaccessible. You can provide new default gateway now:": "",
   "Enable FIPS": "",
+  "Enable Integrated Metrics Server": "",
   "Enable for TrueNAS to periodically review data blocks and identify empty blocks, or obsolete blocks that can be deleted. Unset to use dirty block overwrites (default).": "",
   "Enable this SMB share. Unset to disable this SMB share without deleting it.": "",
   "Enable to use thin provisioning where disk space for this volume is allocated <b>‘on demand’</b> as new writes are received. Use caution when enabling this feature, as writes can fail when the pool is low on space.": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1064,6 +1064,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1031,6 +1031,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -782,6 +782,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1273,6 +1273,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -127,6 +127,7 @@
   "Edit Reporting Exporter": "",
   "Editing interface will result in default gateway being removed, which may result in TrueNAS being inaccessible. You can provide new default gateway now:": "",
   "Enable FIPS": "",
+  "Enable Integrated Metrics Server": "",
   "Enable Two Factor Authentication Globally": "",
   "Enable Two Factor Authentication for SSH": "",
   "Enable for TrueNAS to periodically review data blocks and identify empty blocks, or obsolete blocks that can be deleted. Unset to use dirty block overwrites (default).": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1218,6 +1218,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1215,6 +1215,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -825,6 +825,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",
   "Enable SMTP configuration": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -638,6 +638,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable SMTP configuration": "",
   "Enable Two Factor Authentication Globally": "",
   "Enable Two Factor Authentication for SSH": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -147,6 +147,7 @@
   "Edit Reporting Exporter": "",
   "Editing interface will result in default gateway being removed, which may result in TrueNAS being inaccessible. You can provide new default gateway now:": "",
   "Enable FIPS": "",
+  "Enable Integrated Metrics Server": "",
   "Enable Two Factor Authentication Globally": "",
   "Enable Two Factor Authentication for SSH": "",
   "Enable for TrueNAS to periodically review data blocks and identify empty blocks, or obsolete blocks that can be deleted. Unset to use dirty block overwrites (default).": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1279,6 +1279,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable S.M.A.R.T.": "",
   "Enable SMB1 support": "",
   "Enable SMB2/3 Durable Handles": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -174,6 +174,7 @@
   "Edit Reporting Exporter": "",
   "Editing interface will result in default gateway being removed, which may result in TrueNAS being inaccessible. You can provide new default gateway now:": "",
   "Enable FIPS": "",
+  "Enable Integrated Metrics Server": "",
   "Enable Two Factor Authentication Globally": "",
   "Enable Two Factor Authentication for SSH": "",
   "Enable for TrueNAS to periodically review data blocks and identify empty blocks, or obsolete blocks that can be deleted. Unset to use dirty block overwrites (default).": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -945,6 +945,7 @@
   "Enable HTTPS Redirect": "",
   "Enable Hyper-V Enlightenments": "",
   "Enable Integrated Loadbalancer": "",
+  "Enable Integrated Metrics Server": "",
   "Enable SMB2/3 Durable Handles": "",
   "Enable SMTP configuration": "",
   "Enable Two Factor Authentication Globally": "",


### PR DESCRIPTION
This will add Checkbox to give users a safe way to enable the integrated metrics server that apps like homepage in the IX community train can take advantage of. Currently the only way to enable the metrics server would be via CLI which if improperly done could result in the loss of user applications.