### PR TITLE
NAS-125124 / 24.04 / Reports page is not showing preloader on initial load if I reload the page, I see empty page

### DIFF
--- a/src/app/pages/reports-dashboard/reports-dashboard.component.html
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.html
@@ -7,7 +7,7 @@
 </ng-template>
 
 <div
-  *ngIf="visibleReports && activeReports"
+  *ngIf="visibleReports?.length && activeReports; else initialLoader"
   class="master-container"
 >
   <cdk-virtual-scroll-viewport [itemSize]="325" [minBufferPx]="325" [maxBufferPx]="325">
@@ -25,3 +25,9 @@
     <div class="bottom-spacer"></div>
   </cdk-virtual-scroll-viewport>
 </div>
+
+<ng-template #initialLoader>
+  <div *ngFor="let _ of [1,2,3,4]" class="initial-loader">
+    <mat-card fxLayout="row wrap" fxLayoutAlign="space-between stretch"></mat-card>
+  </div>
+</ng-template>

--- a/src/app/pages/reports-dashboard/reports-dashboard.component.scss
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.scss
@@ -10,6 +10,16 @@
   margin-top: -#{$outer-padding * 2};
   position: relative;
 
+  .initial-loader {
+    padding-top: 5px;
+
+    mat-card {
+      @include background-logo-loader(1);
+      margin: 0 6px;
+      min-height: 325px;
+    }
+  }
+
   &.loading {
     @include background-logo-loader(1.5);
 


### PR DESCRIPTION
Similar to https://github.com/truenas/webui/pull/9162
We are getting blank screen on reports page for a fraction of a second. 
Test that you see loaders and no empty screen.