### PR TITLE
NAS-124826 / 23.10.1 / Using rawvalue instead of value

### DIFF
--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
@@ -224,7 +224,7 @@ describe('OtherOptionsSectionComponent', () => {
         recordsize: inherit,
         snapdev: DatasetSnapdev.Hidden,
         snapdir: DatasetSnapdir.Visible,
-        special_small_block_size: 'INHERIT',
+        special_small_block_size: inherit,
         aclmode: AclMode.Discard,
         acltype: DatasetAclType.Posix,
       });

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
@@ -205,7 +205,7 @@ describe('OtherOptionsSectionComponent', () => {
         'Record Size': 'Inherit (128 KiB)',
         'ACL Type': 'POSIX',
         'ACL Mode': 'Discard',
-        'Metadata (Special) Small Block Size': '0',
+        'Metadata (Special) Small Block Size': 'Inherit (0)',
       });
     });
 
@@ -224,7 +224,7 @@ describe('OtherOptionsSectionComponent', () => {
         recordsize: inherit,
         snapdev: DatasetSnapdev.Hidden,
         snapdir: DatasetSnapdir.Visible,
-        special_small_block_size: 0,
+        special_small_block_size: 'INHERIT',
         aclmode: AclMode.Discard,
         acltype: DatasetAclType.Posix,
       });

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
@@ -133,6 +133,7 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
     private formatter: IxFormatterService,
     private ws: WebSocketService,
     private datasetFormService: DatasetFormService,
+    private ixFormatterService: IxFormatterService,
   ) {}
 
   ngOnInit(): void {
@@ -207,6 +208,11 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
       return;
     }
 
+    let specialSmallBlockSize = getFieldValue(this.existing.special_small_block_size, this.parent) as (number | 'INHERIT');
+    if (specialSmallBlockSize !== 'INHERIT') {
+      specialSmallBlockSize = this.ixFormatterService.convertHumanStringToNum(specialSmallBlockSize.toString());
+    }
+
     this.form.patchValue({
       deduplication: getFieldValue(this.existing.deduplication, this.parent),
       checksum: getFieldValue(this.existing.checksum, this.parent),
@@ -222,7 +228,7 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
       aclmode: getFieldValue(this.existing.aclmode, this.parent) as AclMode,
       casesensitivity: this.existing.casesensitivity?.value,
       special_small_block_size: this.existing.special_small_block_size
-        ? Number(this.existing.special_small_block_size.rawvalue)
+        ? specialSmallBlockSize
         : null,
     });
   }

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
@@ -222,7 +222,7 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
       aclmode: getFieldValue(this.existing.aclmode, this.parent) as AclMode,
       casesensitivity: this.existing.casesensitivity?.value,
       special_small_block_size: this.existing.special_small_block_size
-        ? Number(this.existing.special_small_block_size.value)
+        ? Number(this.existing.special_small_block_size.rawvalue)
         : null,
     });
   }

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
@@ -133,7 +133,6 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
     private formatter: IxFormatterService,
     private ws: WebSocketService,
     private datasetFormService: DatasetFormService,
-    private ixFormatterService: IxFormatterService,
   ) {}
 
   ngOnInit(): void {
@@ -210,7 +209,7 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
 
     let specialSmallBlockSize = getFieldValue(this.existing.special_small_block_size, this.parent) as (number | 'INHERIT');
     if (specialSmallBlockSize !== 'INHERIT') {
-      specialSmallBlockSize = this.ixFormatterService.convertHumanStringToNum(specialSmallBlockSize.toString());
+      specialSmallBlockSize = this.formatter.convertHumanStringToNum(specialSmallBlockSize.toString());
     }
 
     this.form.patchValue({


### PR DESCRIPTION
When editing a dataset, set value for the `Metadata (Special) Small Block Size` field in the `Advanced Fields`. Save the form successfully and then edit it again. The field should be populated with the last saved value.