### PR TITLE
NAS-124741: Wait for existing values before subscribing to type

### DIFF
--- a/src/app/pages/vm/devices/device-form/device-form.component.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.ts
@@ -229,8 +229,6 @@ export class DeviceFormComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.generateMacWhenNicIsSelected();
-
     this.usbForm.controls.usb.disable();
     this.usbForm.controls.device.valueChanges.pipe(untilDestroyed(this)).subscribe((device) => {
       if (device === specifyCustom) {
@@ -249,6 +247,8 @@ export class DeviceFormComponent implements OnInit {
       this.existingDevice = this.slideInData.device;
       this.setDeviceForEdit();
     }
+
+    this.handleDeviceTypeChange();
   }
 
   setVirtualMachineId(): void {
@@ -304,7 +304,7 @@ export class DeviceFormComponent implements OnInit {
     });
   }
 
-  generateMacWhenNicIsSelected(): void {
+  handleDeviceTypeChange(): void {
     this.typeControl.valueChanges.pipe(untilDestroyed(this)).subscribe((type) => {
       if (type === VmDeviceType.Nic && this.nicForm.value.mac === '') {
         this.generateMacAddress();


### PR DESCRIPTION
Go to the team VM with this PR, edit an NIC device on one of the VMs which has a mac address configured. When editing such a device, the mac adress field should show the previous value instead of a randomly generated value.