### PR TITLE
NAS-125008 / 24.04 / Apps: When a `show_if` tries to evaluate a field that is defined after it, results in both fields being hidden in the UI

### DIFF
--- a/src/app/modules/ix-forms/components/ix-input/ix-input.component.ts
+++ b/src/app/modules/ix-forms/components/ix-input/ix-input.component.ts
@@ -244,8 +244,8 @@ export class IxInputComponent implements ControlValueAccessor, OnInit, OnChanges
     });
 
     // handling initial value formatting from value to label
-    if (this.value !== undefined && this.value !== null) {
-      this.formatted = this.findExistingOption(this.value)?.label || '';
+    if (this.value !== undefined) {
+      this.formatted = this.findExistingOption(this.value)?.label ?? '';
     }
 
     this.filterOptions('');

--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.spec.ts
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.spec.ts
@@ -58,24 +58,6 @@ const appVersion121 = {
     ],
     questions: [
       {
-        description: 'Please specify type of workload to deploy',
-        group: 'Workload Details',
-        label: 'Workload Type',
-        schema: {
-          default: 'Deployment',
-          enum: [
-            {
-              description: 'Deploy a Deployment workload',
-              value: 'Deployment',
-            },
-          ],
-          hidden: true,
-          required: true,
-          type: 'string',
-        } as ChartSchemaNodeConf,
-        variable: 'workloadType',
-      },
-      {
         description: 'Upgrade Policy',
         group: 'Scaling/Upgrade Policy',
         label: 'Update Strategy',
@@ -112,6 +94,24 @@ const appVersion121 = {
           type: 'string',
         },
         variable: 'jobRestartPolicy',
+      },
+      {
+        description: 'Please specify type of workload to deploy',
+        group: 'Workload Details',
+        label: 'Workload Type',
+        schema: {
+          default: 'Deployment',
+          enum: [
+            {
+              description: 'Deploy a Deployment workload',
+              value: 'Deployment',
+            },
+          ],
+          hidden: true,
+          required: true,
+          type: 'string',
+        } as ChartSchemaNodeConf,
+        variable: 'workloadType',
       },
       {
         description: 'Add External Interfaces',

--- a/src/app/services/schema/app-schema.service.ts
+++ b/src/app/services/schema/app-schema.service.ts
@@ -536,7 +536,7 @@ export class AppSchemaService {
   }
 
   private handleAddFormControlWithSchemaVisible(payload: CommonSchemaAddControl): void {
-    const { schema, subscription, formGroup } = payload;
+    const { schema, subscription } = payload;
 
     const relations: Relation[] = schema.show_if.map((item) => ({
       fieldName: item[0],
@@ -545,18 +545,6 @@ export class AppSchemaService {
     }));
 
     relations.forEach((relation) => {
-      let control = formGroup.controls[relation.fieldName];
-      if (!control) {
-        formGroup.addControl(relation.fieldName, new CustomUntypedFormControl());
-        control = formGroup.controls[relation.fieldName];
-        const formField = (control as CustomUntypedFormField);
-        if (!formField.hidden$) {
-          formField.hidden$ = new BehaviorSubject<boolean>(false);
-        }
-        formField.hidden$.next(true);
-        formField.disable();
-      }
-
       if (relation.operatorName === '=') {
         subscription.add(
           timer(0).pipe(take(1)).subscribe(() => this.handleEqualOperatorNameSubscription(payload, relation)),


### PR DESCRIPTION
Testing: 

See tests updated, the order of the schema items changed but still it should work as expected.
Currently it was not working - because if there were no control yet, we created new one (hidden by default) [what is wrong]

Please use m40 device and go here:
Go to Apps -> Discover -> Minio 👇 
http://localhost:4200/apps/available/TRUENAS/charts/minio/install

or Ask @stavros-k for an app if the one I provided is not there anymore.


Before: (we didn't see `Minio Certificate` even tho it has no **show_if** logic)
![image](https://github.com/truenas/webui/assets/22980553/5685962a-2457-4c96-815c-f1f3ef22d883)

Now: (we see `Minio Certificate` and don't see `Minio Domain Name` because it depends on the Minio Certificate value and by default it's null, so we don't want to show Minio Domain Name in this case)
<img width="496" alt="Screenshot 2023-11-13 at 19 06 50" src="https://github.com/truenas/webui/assets/22980553/7978da22-e292-40c2-8264-0239372d506e">
