### PR TITLE
NAS-125161 / 24.04 / Get PCI ids for GPU isolation

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -423,6 +423,7 @@ export interface ApiCallDirectory {
 
   // Device
   'device.get_info': { params: [DeviceType]; response: Device[] };
+  'device.get_pci_ids_for_gpu_isolation': { params: [string]; response: string[] };
 
   // Disk
   'disk.query': { params: QueryParams<Disk, ExtraDiskQueryOptions>; response: Disk[] };

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
@@ -79,6 +79,7 @@ describe('VmEditFormComponent', () => {
           Pentium: 'Pentium',
         }),
         mockCall('vm.update'),
+        mockCall('device.get_pci_ids_for_gpu_isolation', ['10DE:1401']),
       ]),
       mockProvider(DialogService),
       mockProvider(GpuService, {
@@ -212,7 +213,7 @@ describe('VmEditFormComponent', () => {
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
-    expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith(existingVm, ['0000:03:00.0']);
-    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0']);
+    expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith(existingVm, ['0000:03:00.0', '10DE:1401']);
+    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0', '10DE:1401']);
   });
 });

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
@@ -4,7 +4,7 @@ import {
 import { FormBuilder, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
-import { forkJoin, of } from 'rxjs';
+import { forkJoin, map, of, switchMap } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
 import {
   VmBootloader, VmCpuMode, VmDeviceType, VmTime, vmTimeNames,
@@ -128,11 +128,19 @@ export class VmEditFormComponent implements OnInit {
     delete vmPayload.gpus;
 
     const gpusIds = this.form.value.gpus;
-    forkJoin([
-      this.ws.call('vm.update', [this.existingVm.id, vmPayload as VirtualMachineUpdate]),
-      this.vmGpuService.updateVmGpus(this.existingVm, gpusIds),
-      this.gpuService.addIsolatedGpuPciIds(gpusIds),
-    ])
+
+    const pciIdsRequests$ = gpusIds.map((gpu) => {
+      return this.ws.call('device.get_pci_ids_for_gpu_isolation', [gpu]);
+    });
+
+    forkJoin(pciIdsRequests$).pipe(
+      map((pciIds) => pciIds.flat()),
+      switchMap((pciIds) => [
+        this.ws.call('vm.update', [this.existingVm.id, vmPayload as VirtualMachineUpdate]),
+        this.vmGpuService.updateVmGpus(this.existingVm, gpusIds.concat(pciIds)),
+        this.gpuService.addIsolatedGpuPciIds(gpusIds.concat(pciIds)),
+      ]),
+    )
       .pipe(untilDestroyed(this))
       .subscribe({
         complete: () => {

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
@@ -91,6 +91,7 @@ describe('VmWizardComponent', () => {
         mockCall('vm.device.nic_attach_choices', {
           eno2: 'eno2',
         }),
+        mockCall('device.get_pci_ids_for_gpu_isolation', ['10DE:1401']),
       ]),
       mockProvider(GpuService, {
         getGpuOptions: () => of([
@@ -316,8 +317,8 @@ describe('VmWizardComponent', () => {
         web: true,
       },
     }]);
-    expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith({ id: 4 }, ['0000:03:00.0']);
-    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0']);
+    expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith({ id: 4 }, ['0000:03:00.0', '10DE:1401']);
+    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0', '10DE:1401']);
     expect(spectator.inject(IxSlideInRef).close).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**Testing**

Mock response for `device.get_gpus`

```
❯ midclt call device.get_gpus | jq .
[
  {
    "addr": {
      "pci_slot": "0000:01:00.0",
      "domain": "0000",
      "bus": "01",
      "slot": "00"
    },
    "description": "NVIDIA Corporation GM206 [GeForce GTX 960]",
    "devices": [
      {
        "pci_id": "10DE:1401",
        "pci_slot": "0000:01:00.0",
        "vm_pci_slot": "pci_0000_01_00_0"
      },
      {
        "pci_id": "10DE:0FBA",
        "pci_slot": "0000:01:00.1",
        "vm_pci_slot": "pci_0000_01_00_1"
      }
    ],
    "vendor": "NVIDIA",
    "uses_system_critical_devices": false,
    "available_to_host": true
  }
]
```