### PR TITLE
NAS-125192 / 24.04 / Hide "Mixed Capacity Vdevs" alert for vdevs with ≤2GiB difference eg: vdevs created with different SWAP settings

### DIFF
--- a/src/app/services/storage.service.spec.ts
+++ b/src/app/services/storage.service.spec.ts
@@ -1,4 +1,5 @@
 import { HttpClient } from '@angular/common/http';
+import { GiB } from 'app/constants/bytes.constant';
 import { MockStorageScenario } from 'app/core/testing/enums/mock-storage.enum';
 import { AddTopologyOptions } from 'app/core/testing/interfaces/mock-storage-generator.interface';
 import { MockStorageGenerator } from 'app/core/testing/utils/mock-storage-generator.utils';
@@ -152,6 +153,10 @@ describe('StorageService', () => {
       expect(dedupVdevCapacities.size).toBe(1);
       const isDedupMixed: boolean = storageService.isMixedVdevCapacity(dedupVdevCapacities);
       expect(isDedupMixed).toBe(false);
+
+      // Check mixed VDEV when the difference is less than 2 GiB
+      expect(storageService.isMixedVdevCapacity(new Set([GiB, GiB * 3 - 1]))).toBe(false);
+      expect(storageService.isMixedVdevCapacity(new Set([GiB, GiB * 3]))).toBe(true);
     });
   });
 

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -4,6 +4,7 @@ import { SortDirection } from '@angular/material/sort';
 import { format } from 'date-fns-tz';
 import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
+import { GiB } from 'app/constants/bytes.constant';
 import { VdevType, TopologyItemType, TopologyWarning } from 'app/enums/v-dev-type.enum';
 import { FileSystemStat } from 'app/interfaces/filesystem-stat.interface';
 import { Option } from 'app/interfaces/option.interface';
@@ -308,7 +309,8 @@ export class StorageService {
 
   // Check to see if every VDEV has the same capacity. Best practices dictate every vdev should be uniform
   isMixedVdevCapacity(allVdevCapacities: Set<number>): boolean {
-    return allVdevCapacities.size > 1;
+    const diff = Math.max(...allVdevCapacities) - Math.min(...allVdevCapacities);
+    return allVdevCapacities.size > 1 && diff >= GiB * 2;
   }
 
   getVdevDiskCapacities(vdevs: TopologyItem[], disks: Disk[]): Set<number>[] {


### PR DESCRIPTION
**Testing**

1. Go to **System > Advanced > Storage**, reset **Swap Size** to 2Gb (default value)

2. Create pool with 1 VDEV

2. Adjust **Swap Size** to a different value, for example 1Gb

4. Add another VDEV to your pool

**Expected:** No warnings next to "mixed capacity" at **Storage > Topology**