### PR TITLE
NAS-124951 / 23.10.1 / Remove required for periodic_snapshot_tasks, Disable ssh_credentials when transport is local

### DIFF
--- a/src/app/pages/data-protection/replication/replication-form/sections/source-section/source-section.component.html
+++ b/src/app/pages/data-protection/replication/replication-form/sections/source-section/source-section.component.html
@@ -48,7 +48,6 @@
     formControlName="periodic_snapshot_tasks"
     [label]="'Periodic Snapshot Tasks' | translate"
     [options]="periodicSnapshotTasks$"
-    [required]="true"
     [multiple]="true"
     [tooltip]="helptext.periodic_snapshot_tasks_tooltip | translate"
   ></ix-select>

--- a/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.ts
+++ b/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.ts
@@ -70,6 +70,12 @@ export class TransportSectionComponent implements OnChanges {
     if (this.replication) {
       this.setFormValues(this.replication);
     }
+
+    if (this.isLocal) {
+      this.form.controls.ssh_credentials.disable();
+    } else {
+      this.form.controls.ssh_credentials.enable();
+    }
   }
 
   get isLocal(): boolean {


### PR DESCRIPTION
**Summary**

1. Ticket's video contains a mandatory field `periodic_snapshot_tasks` which was not filled. This field is not mandatory in the middleware, so I made `periodic_snapshot_tasks` not mandatory in WebUI as well
2. Ticket's screenshots depict expectation of the required ssh credentials field, for LOCAL, where obviously this should not be there. This is fixed in a 2nd commit

**Testing**
Data Protection > Replication Tasks > Add > Advanced Replication Creation