### PR TITLE
NAS-124802 / 23.10.1 / Add Metadata or Dedup VDEV types (by bvasilenko)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -62,7 +62,7 @@ describe('DataWizardStepComponent', () => {
     expect(layoutComponent.description).toBe(helptext.special_vdev_description);
     expect(layoutComponent.canChangeLayout).toBeTruthy();
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.limitLayouts).toStrictEqual(Object.values(CreateVdevLayout));
+    expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror, CreateVdevLayout.Stripe]);
     expect(layoutComponent.type).toStrictEqual(VdevType.Special);
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -19,13 +19,14 @@ export class MetadataWizardStepComponent implements OnInit {
   @Input() stepWarning: string | null;
   @Output() goToLastStep = new EventEmitter<void>();
 
+  canChangeLayout = true;
+
   protected readonly VdevType = VdevType;
   readonly helptext = helptext;
 
-  canChangeLayout = true;
   protected readonly inventory$ = this.store.getInventoryForStep(VdevType.Special);
+  protected allowedLayouts = [CreateVdevLayout.Mirror, CreateVdevLayout.Stripe];
 
-  protected allowedLayouts = Object.values(CreateVdevLayout);
   constructor(
     private addVdevsStore: AddVdevsStore,
     private store: PoolManagerStore,

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
@@ -2,8 +2,8 @@
   [description]="helptext.dedup_vdev_description | translate"
   [type]="VdevType.Dedup"
   [inventory]="inventory$ | async"
-  [canChangeLayout]="false"
-  [limitLayouts]="dataVdevLayout$ | async"
+  [canChangeLayout]="canChangeLayout"
+  [limitLayouts]="allowedLayouts"
   [isStepActive]="isStepActive"
 ></ix-layout-step>
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -55,9 +55,9 @@ describe('DataWizardStepComponent', () => {
   it('has the correct inputs', () => {
     const layoutComponent = spectator.query(LayoutStepComponent);
     expect(layoutComponent.description).toBe(helptext.dedup_vdev_description);
-    expect(layoutComponent.canChangeLayout).toBeFalsy();
+    expect(layoutComponent.canChangeLayout).toBeTruthy();
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
+    expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror, CreateVdevLayout.Stripe]);
     expect(layoutComponent.type).toStrictEqual(VdevType.Dedup);
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -2,8 +2,7 @@ import {
   ChangeDetectionStrategy, Component, EventEmitter, Input, Output,
 } from '@angular/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
-import { map } from 'rxjs';
-import { VdevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, VdevType } from 'app/enums/v-dev-type.enum';
 import helptext from 'app/helptext/storage/volumes/manager/manager';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
 
@@ -18,13 +17,13 @@ export class DedupWizardStepComponent {
   @Input() stepWarning: string | null;
   @Output() goToLastStep = new EventEmitter<void>();
 
+  canChangeLayout = true;
+
   protected readonly VdevType = VdevType;
   readonly helptext = helptext;
 
   protected readonly inventory$ = this.store.getInventoryForStep(VdevType.Dedup);
-  protected dataVdevLayout$ = this.store.topology$.pipe(
-    map((topology) => [topology.data.layout]),
-  );
+  protected allowedLayouts = [CreateVdevLayout.Mirror, CreateVdevLayout.Stripe];
 
   constructor(
     private store: PoolManagerStore,

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/add-vdev-to-pool.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/add-vdev-to-pool.spec.ts
@@ -228,6 +228,7 @@ describe('AddVdevsComponent – Add Vdev to existing pool', () => {
     expect(await (await wizard.getActiveStep()).getLabel()).toBe('Dedup (Optional)');
 
     await wizard.fillStep({
+      Layout: 'Mirror',
       'Disk Size': '20 GiB (HDD)',
       'Treat Disk Size as Minimum': true,
       Width: '3',

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/create-pool.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/create-pool.spec.ts
@@ -190,6 +190,7 @@ describe('PoolManagerComponent – create pool', () => {
     // Dedup
     await wizard.clickNext();
     await wizard.fillStep({
+      Layout: 'Stripe',
       'Disk Size': '20 GiB (HDD)',
       Width: '1',
       'Number of VDEVs': '1',

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/wizard-start-over.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/wizard-start-over.spec.ts
@@ -198,6 +198,7 @@ describe('PoolManagerComponent – start over functionality', () => {
     // DEDUP step activated
     expect(await (await wizard.getActiveStep()).getLabel()).toBe('Dedup (Optional)');
     await wizard.fillStep({
+      Layout: 'Stripe',
       'Disk Size': '20 GiB (HDD)',
       Width: '1',
       'Number of VDEVs': '1',
@@ -293,6 +294,7 @@ describe('PoolManagerComponent – start over functionality', () => {
     // DEDUP step activated and reset to default
     expect(await (await wizard.getActiveStep()).getLabel()).toBe('Dedup (Optional)');
     expect(await wizard.getStepValues()).toStrictEqual({
+      Layout: '',
       'Disk Size': '',
       'Number of VDEVs': '',
       'Treat Disk Size as Minimum': false,


### PR DESCRIPTION
Backported

**Testing**

Have at least 12 disks. Ensure it's possible to create a pool specified in the ticket. 

I. **Layout** UI element and **Width,** **VDEVs** options under **Metadata** or **Dedup** sections

1. On **Storage** \> **Create Pool**, at **Data** expandable section, select these options:
   1. Layout: **RAIDZ1**
   2. Width: **5**
   3. VDEVs: **2**
2. At **Metadata** expandable section, try to select these options:
   1. Layout: **Mirror**
   2. Width: **2**
   3. VDEVs: **1**
   * **Expected:**
     * **Layout:** this UI element is shown,
     * **Width:** list of available options should contain the proper options
     * **VDEVs:** list of available options should contain the proper options
     * The submission of the whole **Create Pool** form: does not require force-creation, and is correctly recognized after creation without raising any errors (assuming that redundancy level is equal)
3. Same for **Dedup** expandable section

II. Double check **Manual Disk Selection** adds blocks of correct layout, when special layout is chosen for **Metadata** and **Dedup** sections

1. On **Storage** > **Create Pool**, at **Data** expandable section, select same options as in "I"
2. At **Metadata** expandable section click **Manual Disk Selection** button
3. Click **Add** button in the top right corner of **Manual Selection** modal window

   **Expected:** new "MIRROR" block appears

III. Double check **Add To Pool** works

1. On **Storage** \> **Create Pool**, at **Data** expandable section, select same options as in "I"
2. Submit pool creation and wait for pool to be created
3. Add 2 disks as **Metadata** (layout MIRROR, 5 wide, 2 VDEVs)

   **Expected:** it can be done
4. Same for **Dedup**

Original PR: https://github.com/truenas/webui/pull/9137
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124802