### PR TITLE
NAS-124897 / 23.10.1 / Fix verify credentials in Cloud Credentials form (by denysbutenko)

### DIFF
--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.spec.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.spec.ts
@@ -45,7 +45,7 @@ jest.mock('./provider-forms/s3-provider-form/s3-provider-form.component', () => 
       getSubmitAttributes = jest.fn(() => ({
         s3attribute: 's3 value',
       })) as BaseProviderFormComponent['getSubmitAttributes'];
-      beforeSubmit = jest.fn(() => of(undefined)) as BaseProviderFormComponent['beforeSubmit'];
+      beforeSubmit = jest.fn(() => of(true)) as BaseProviderFormComponent['beforeSubmit'];
       form = {
         get invalid(): boolean {
           return false;

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -149,9 +149,7 @@ export class CloudCredentialsFormComponent implements OnInit {
   onSubmit(): boolean {
     this.isLoading = true;
 
-    const beforeSubmit$ = this.providerForm.beforeSubmit();
-
-    beforeSubmit$
+    this.providerForm.beforeSubmit()
       .pipe(
         switchMap(() => {
           const payload = this.preparePayload();
@@ -186,9 +184,7 @@ export class CloudCredentialsFormComponent implements OnInit {
   onVerify(): void {
     this.isLoading = true;
 
-    const beforeSubmit$ = this.providerForm.beforeSubmit();
-
-    beforeSubmit$
+    this.providerForm.beforeSubmit()
       .pipe(
         switchMap(() => {
           const { name, ...payload } = this.preparePayload();

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/base-provider-form.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/base-provider-form.ts
@@ -18,7 +18,7 @@ export abstract class BaseProviderFormComponent<T = CloudCredential['attributes'
    * TODO: Consider making this functionality part of the private key select.
    */
   beforeSubmit(): Observable<unknown> {
-    return of(undefined);
+    return of();
   }
 
   getSubmitAttributes(): T {

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/sftp-provider-form/sftp-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/sftp-provider-form/sftp-provider-form.component.ts
@@ -36,7 +36,7 @@ export class SftpProviderFormComponent extends BaseProviderFormComponent impleme
 
   beforeSubmit(): Observable<unknown> {
     if (this.form.value.private_key !== newOption) {
-      return of();
+      return of(true);
     }
 
     return this.makeNewKeypair();


### PR DESCRIPTION
For testing, go to Backup Credentials, edit SFTP credentials, and ensure that `cloudsync.credentials.verify` is sent to middleware when you press on the `Verify Credentials` button.

Original PR: https://github.com/truenas/webui/pull/9218
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124897