### PR TITLE
NAS-125343 / 24.04 / Fix network send/receive rate

### DIFF
--- a/src/app/interfaces/reporting.interface.ts
+++ b/src/app/interfaces/reporting.interface.ts
@@ -45,9 +45,7 @@ export interface AllNetworkInterfacesUpdate {
 
 export interface NetworkInterfaceUpdate {
   link_state: LinkState;
-  received_bytes: number;
   received_bytes_rate: number;
-  sent_bytes: number;
   sent_bytes_rate: number;
   speed: number;
 }

--- a/src/app/modules/common/interface-status-icon/interface-status-icon.component.spec.ts
+++ b/src/app/modules/common/interface-status-icon/interface-status-icon.component.spec.ts
@@ -45,7 +45,7 @@ describe('InterfaceStatusIconComponent', () => {
       spectator.setInput('update', {
         link_state: LinkState.Up,
         sent_bytes_rate: 100 * KiB,
-        received_bytes_rate: 20 * MiB,
+        received_bytes_rate: 30 * MiB,
       } as NetworkInterfaceUpdate);
     });
 

--- a/src/app/modules/common/interface-status-icon/interface-status-icon.component.spec.ts
+++ b/src/app/modules/common/interface-status-icon/interface-status-icon.component.spec.ts
@@ -44,10 +44,8 @@ describe('InterfaceStatusIconComponent', () => {
       jest.spyOn(spectator.component, 'updateStateInfoIcon');
       spectator.setInput('update', {
         link_state: LinkState.Up,
-        sent_bytes: 100 * KiB,
         sent_bytes_rate: 100 * KiB,
         received_bytes_rate: 20 * MiB,
-        received_bytes: 30 * MiB,
       } as NetworkInterfaceUpdate);
     });
 

--- a/src/app/modules/common/interface-status-icon/interface-status-icon.component.ts
+++ b/src/app/modules/common/interface-status-icon/interface-status-icon.component.ts
@@ -35,8 +35,8 @@ export class InterfaceStatusIconComponent implements OnChanges {
 
   get tooltipText(): string {
     return this.translate.instant('Sent: {sent} Received: {received}', {
-      sent: filesize(this.update.sent_bytes, { standard: 'iec' }),
-      received: filesize(this.update.received_bytes, { standard: 'iec' }),
+      sent: filesize(this.update.sent_bytes_rate, { standard: 'iec' }),
+      received: filesize(this.update.received_bytes_rate, { standard: 'iec' }),
     });
   }
 

--- a/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
+++ b/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
@@ -227,17 +227,17 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
           nicInfo.out = usageUpdate.sent_bytes_rate;
 
           if (
-            usageUpdate.sent_bytes !== undefined
-            && usageUpdate.sent_bytes - nicInfo.lastSent > this.minSizeToActiveTrafficArrowIcon
+            usageUpdate.sent_bytes_rate !== undefined
+            && usageUpdate.sent_bytes_rate - nicInfo.lastSent > this.minSizeToActiveTrafficArrowIcon
           ) {
-            nicInfo.lastSent = usageUpdate.sent_bytes;
+            nicInfo.lastSent = usageUpdate.sent_bytes_rate;
           }
 
           if (
-            usageUpdate.received_bytes !== undefined
-            && usageUpdate.received_bytes - nicInfo.lastReceived > this.minSizeToActiveTrafficArrowIcon
+            usageUpdate.received_bytes_rate !== undefined
+            && usageUpdate.received_bytes_rate - nicInfo.lastReceived > this.minSizeToActiveTrafficArrowIcon
           ) {
-            nicInfo.lastReceived = usageUpdate.received_bytes;
+            nicInfo.lastReceived = usageUpdate.received_bytes_rate;
           }
         }
         this.cdr.markForCheck();


### PR DESCRIPTION
For testing, use the latest nightly, check the dashboard and ensure no console errors are emitted.

send_bytes/received_bytes keys were removed in https://github.com/truenas/middleware/pull/12502