### PR TITLE
NAS-125343 / 23.10.1 / Fix network send/receive rate (by denysbutenko)

### DIFF
--- a/src/app/interfaces/reporting.interface.ts
+++ b/src/app/interfaces/reporting.interface.ts
@@ -46,9 +46,7 @@ export interface AllNetworkInterfacesUpdate {
 
 export interface NetworkInterfaceUpdate {
   link_state: LinkState;
-  received_bytes: number;
   received_bytes_rate: number;
-  sent_bytes: number;
   sent_bytes_rate: number;
   speed: number;
 }

--- a/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
+++ b/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
@@ -208,18 +208,18 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
           nicInfo.out = usageUpdate.sent_bytes_rate * KiB;
 
           if (
-            usageUpdate.sent_bytes !== undefined
-            && usageUpdate.sent_bytes - nicInfo.lastSent > this.minSizeToActiveTrafficArrowIcon
+            usageUpdate.sent_bytes_rate !== undefined
+            && usageUpdate.sent_bytes_rate - nicInfo.lastSent > this.minSizeToActiveTrafficArrowIcon
           ) {
-            nicInfo.lastSent = usageUpdate.sent_bytes;
+            nicInfo.lastSent = usageUpdate.sent_bytes_rate;
             this.tableService.updateStateInfoIcon(nicName, 'sent');
           }
 
           if (
-            usageUpdate.received_bytes !== undefined
-            && usageUpdate.received_bytes - nicInfo.lastReceived > this.minSizeToActiveTrafficArrowIcon
+            usageUpdate.received_bytes_rate !== undefined
+            && usageUpdate.received_bytes_rate - nicInfo.lastReceived > this.minSizeToActiveTrafficArrowIcon
           ) {
-            nicInfo.lastReceived = usageUpdate.received_bytes;
+            nicInfo.lastReceived = usageUpdate.received_bytes_rate;
             this.tableService.updateStateInfoIcon(nicName, 'received');
           }
         }

--- a/src/app/pages/network/components/interfaces-card/interface-status-icon/interface-status-icon.component.spec.ts
+++ b/src/app/pages/network/components/interfaces-card/interface-status-icon/interface-status-icon.component.spec.ts
@@ -47,10 +47,8 @@ describe('InterfaceStatusIconComponent', () => {
     beforeEach(() => {
       spectator.setInput('update', {
         link_state: LinkState.Up,
-        sent_bytes: 100 * KiB,
         sent_bytes_rate: 100 * KiB,
-        received_bytes_rate: 20 * MiB,
-        received_bytes: 30 * MiB,
+        received_bytes_rate: 30 * MiB,
       } as NetworkInterfaceUpdate);
     });
 

--- a/src/app/pages/network/components/interfaces-card/interface-status-icon/interface-status-icon.component.ts
+++ b/src/app/pages/network/components/interfaces-card/interface-status-icon/interface-status-icon.component.ts
@@ -32,8 +32,8 @@ export class InterfaceStatusIconComponent implements OnChanges {
 
   get tooltipText(): string {
     return this.translate.instant('Sent: {sent} Received: {received}', {
-      sent: filesize(this.update.sent_bytes, { standard: 'iec' }),
-      received: filesize(this.update.received_bytes, { standard: 'iec' }),
+      sent: filesize(this.update.sent_bytes_rate, { standard: 'iec' }),
+      received: filesize(this.update.received_bytes_rate, { standard: 'iec' }),
     });
   }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 8bc2be324b29dda799ba99285e072b8fb1709c99
    git cherry-pick -x e34c6a28864739421bf796c9951a76cf6a5d5ac4

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 3ea80b4b1a510f0bba28dc0d3e5f501f662d6ccb

For testing, use the latest nightly, check the dashboard and ensure no console errors are emitted.

send_bytes/received_bytes keys were removed in https://github.com/truenas/middleware/pull/12502

Original PR: https://github.com/truenas/webui/pull/9238
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125343