### PR TITLE
NAS-124602 / 13.0 / Reload UI during updates (by undsoft)

### DIFF
--- a/src/app/pages/system/update/manualupdate/manualupdate.component.ts
+++ b/src/app/pages/system/update/manualupdate/manualupdate.component.ts
@@ -85,7 +85,6 @@ export class ManualUpdateComponent extends ViewControllerComponent {
     public translate: TranslateService,
     private dialogService: DialogService,
     private systemService: SystemGeneralService,
-    private updateService: UpdateService,
   ) {
     super();
 
@@ -164,14 +163,12 @@ export class ManualUpdateComponent extends ViewControllerComponent {
         this.dialogRef.close(false);
         if (!this.isHA) {
           if (ures[0].attributes.preferences['rebootAfterManualUpdate']) {
-            this.updateService.setForHardRefresh();
             this.router.navigate(['/others/reboot'], { skipLocationChange: true });
           } else {
             this.translate.get('Restart').subscribe((reboot: string) => {
               this.translate.get(helptext.rebootAfterManualUpdate.manual_reboot_msg).subscribe((reboot_prompt: string) => {
                 this.dialogService.confirm(reboot, reboot_prompt).subscribe((reboot_res) => {
                   if (reboot_res) {
-                    this.updateService.setForHardRefresh();
                     this.router.navigate(['/others/reboot'], { skipLocationChange: true });
                   }
                 });

--- a/src/app/pages/system/update/update.component.ts
+++ b/src/app/pages/system/update/update.component.ts
@@ -105,7 +105,6 @@ export class UpdateComponent implements OnInit, OnDestroy {
     protected storage: StorageService,
     protected http: HttpClient,
     public core: CoreService,
-    private updateService: UpdateService,
   ) {
     this.sysGenService.updateRunning.subscribe((res) => {
       res === 'true' ? this.isUpdateRunning = true : this.isUpdateRunning = false;
@@ -400,7 +399,6 @@ export class UpdateComponent implements OnInit, OnDestroy {
     this.dialogRef.componentInstance.jobId = jobId;
     this.dialogRef.componentInstance.wsshow();
     this.dialogRef.componentInstance.success.subscribe((res) => {
-      this.updateService.setForHardRefresh();
       this.router.navigate(['/others/reboot'], { skipLocationChange: true });
     });
     this.dialogRef.componentInstance.failure.subscribe((err) => {

--- a/src/app/services/update.service.ts
+++ b/src/app/services/update.service.ts
@@ -1,27 +1,40 @@
 import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { WINDOW } from 'app/helpers/window.helper';
+import { ApiTimestamp } from 'app/interfaces/api-date.interface';
+import { WebSocketService } from 'app/services/ws.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UpdateService {
+  private lastSeenBuiltTime: number;
+
   constructor(
+    private ws: WebSocketService,
     @Inject(WINDOW) private window: Window,
   ) {}
 
   /**
    * Hard refresh is needed to load new html and js after the update.
    */
-  setForHardRefresh(): void {
-    this.window.localStorage.setItem('hardRefresh', 'true');
-  }
+  hardRefreshIfNeeded(): Observable<unknown> {
+    return this.ws.call('system.build_time').pipe(
+      tap((buildTime: ApiTimestamp) => {
+        if (!this.lastSeenBuiltTime) {
+          // First boot.
+          this.lastSeenBuiltTime = buildTime.$date;
+          return;
+        }
 
-  hardRefreshIfNeeded(): void {
-    if (this.window.localStorage.getItem('hardRefresh') !== 'true') {
-      return;
-    }
+        if (this.lastSeenBuiltTime === buildTime.$date) {
+          // No update.
+          return;
+        }
 
-    this.window.localStorage.removeItem('hardRefresh');
-    this.window.location.reload();
+        this.window.location.reload();
+      }),
+    );
   }
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 49f0ce51a9c205931beb27dae556708f6d49dd17
    git cherry-pick -x 78accace50af295d739c8ba877575ab7c9fefd1d
    git cherry-pick -x d7536b82ed1b1b76ca6715d5514dee82302ba256

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x abe7ac845e0aea9607c67d9167f614a2d38dab8f

Testing: update a system and see that UI reloads after update is complete.
Background tabs and tabs in other browser should also reload.

Original PR: https://github.com/truenas/webui/pull/9236
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124602