### PR TITLE
NAS-125368: App Details Card is updating Workloads card many times - it is not possible to click "shell" or "view logs" sometimes because of it

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.html
@@ -3,6 +3,8 @@
     <h3 mat-card-title>
       {{ 'Workloads' | translate }}
     </h3>
+
+    <mat-spinner *ngIf="isLoading" [diameter]="20"></mat-spinner>
   </mat-card-header>
   <mat-card-content>
     <div class="details-list">
@@ -42,10 +44,10 @@
     <div class="containers">
       <h4>{{ 'Containers' | translate }}</h4>
       <div class="container-list">
-        <ng-container *ngIf="!isLoading; else loader">
-          <ng-container *ngIf="app?.resources?.container_images; else noContainers">
+        <ng-container *ngIf="!isLoading || containerImages; else loader">
+          <ng-container *ngIf="containerImages; else noContainers">
             <div
-              *ngFor="let containerImage of app.resources.container_images | keyvalue;"
+              *ngFor="let containerImage of containerImages | keyvalue;"
               class="container-item"
             >
               <div class="container-name">{{ containerImage.key }}</div>

--- a/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.ts
@@ -8,7 +8,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { map } from 'rxjs';
 import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
 import { PodSelectDialogType } from 'app/enums/pod-select-dialog.enum';
-import { ChartRelease } from 'app/interfaces/chart-release.interface';
+import { ChartContainerImage, ChartRelease } from 'app/interfaces/chart-release.interface';
 import { PodDialogFormValue } from 'app/interfaces/pod-select-dialog.interface';
 import { PodSelectDialogComponent } from 'app/pages/apps/components/pod-select-dialog/pod-select-dialog.component';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
@@ -26,13 +26,17 @@ export class AppContainersCardComponent implements OnChanges {
   isLoading = false;
   readonly chartReleaseStatus = ChartReleaseStatus;
 
+  containerImages: { [key: string]: ChartContainerImage };
+
   constructor(
     private appService: ApplicationsService,
     private cdr: ChangeDetectorRef,
     private matDialog: MatDialog,
     private router: Router,
     private translate: TranslateService,
-  ) {}
+  ) {
+    this.containerImages = this.app?.resources?.container_images;
+  }
 
   ngOnChanges(): void {
     this.getResources();
@@ -77,6 +81,7 @@ export class AppContainersCardComponent implements OnChanges {
       next: (app) => {
         this.app = app;
         this.isLoading = false;
+        this.containerImages = this.app?.resources?.container_images;
         this.cdr.markForCheck();
       },
       error: () => {


### PR DESCRIPTION
**Testing:** see ticket and result:

https://github.com/truenas/webui/assets/22980553/72dfe5b4-1e68-4af0-898c-19624d86a2cd

Now there are no more containers disappearing each time we reload data - what is much better for the user.

Before: Each time on reload card became smaller and skeleton appeared - which is really annoying for the end user I suppose.
<img width="395" alt="Screenshot 2023-11-27 at 12 02 58" src="https://github.com/truenas/webui/assets/22980553/9bc34406-aa19-464b-a159-3b4209f26a26">
