### PR TITLE
NAS-124964 / 24.04 / Only server side pagination/sorting in ApiDataProvider

### DIFF
--- a/src/app/modules/ix-table2/classes/api-data-provider/api-data-provider.ts
+++ b/src/app/modules/ix-table2/classes/api-data-provider/api-data-provider.ts
@@ -1,13 +1,13 @@
-import { map, Observable, switchMap } from 'rxjs';
+import { Observable, switchMap } from 'rxjs';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { ApiCallDirectory, ApiCallMethod } from 'app/interfaces/api/api-call-directory.interface';
 import { QueryFilters } from 'app/interfaces/query-api.interface';
 import { WebsocketError } from 'app/interfaces/websocket-error.interface';
-import { PaginationClientSide } from 'app/modules/ix-table2/classes/api-data-provider/pagination-client-side';
-import { SortingClientSide } from 'app/modules/ix-table2/classes/api-data-provider/sorting-client-side.class';
+import { PaginationServerSide } from 'app/modules/ix-table2/classes/api-data-provider/pagination-server-side.class';
+import { SortingServerSide } from 'app/modules/ix-table2/classes/api-data-provider/sorting-server-side.class';
 import { BaseDataProvider } from 'app/modules/ix-table2/classes/base-data-provider';
-import { PaginationStrategy, TablePagination } from 'app/modules/ix-table2/interfaces/table-pagination.interface';
-import { SortingStrategy, TableSort } from 'app/modules/ix-table2/interfaces/table-sort.interface';
+import { TablePagination } from 'app/modules/ix-table2/interfaces/table-pagination.interface';
+import { TableSort } from 'app/modules/ix-table2/interfaces/table-sort.interface';
 import { WebSocketService } from 'app/services/ws.service';
 
 // TODO: Extract to separate files
@@ -17,8 +17,8 @@ export type ApiCallParams = Record<string, unknown>;
 // TODO: Narrow down the type of M to only include .query methods
 // TODO: T can be inferred from M
 export class ApiDataProvider<T, M extends ApiCallMethod> extends BaseDataProvider<T> {
-  paginationStrategy: PaginationStrategy;
-  sortingStrategy: SortingStrategy;
+  paginationStrategy: PaginationServerSide;
+  sortingStrategy: SortingServerSide;
 
   private rows: T[] = [];
 
@@ -28,8 +28,8 @@ export class ApiDataProvider<T, M extends ApiCallMethod> extends BaseDataProvide
     private params: ApiCallDirectory[M]['params'] = [],
   ) {
     super();
-    this.paginationStrategy = new PaginationClientSide();
-    this.sortingStrategy = new SortingClientSide();
+    this.paginationStrategy = new PaginationServerSide();
+    this.sortingStrategy = new SortingServerSide();
   }
 
   setParams(params: ApiCallDirectory[M]['params']): void {
@@ -44,14 +44,8 @@ export class ApiDataProvider<T, M extends ApiCallMethod> extends BaseDataProvide
           this.totalRows = count;
           return this.ws.call(this.method, this.prepareParams(this.params));
         }),
-        map((rows: T[]) => {
-          return this.paginationStrategy.paginate<T>(
-            this.sortingStrategy.sort<T>(rows, this.sorting),
-            this.pagination,
-          );
-        }),
       ).subscribe({
-        next: (rows) => {
+        next: (rows: T[]) => {
           this.rows = rows;
           this.currentPage$.next(this.rows);
           this.emptyType$.next(rows.length ? EmptyType.NoSearchResults : EmptyType.NoPageData);
@@ -69,19 +63,13 @@ export class ApiDataProvider<T, M extends ApiCallMethod> extends BaseDataProvide
 
   setSorting(sorting: TableSort<T>): void {
     this.sorting = sorting;
-    this.sortingStrategy.handleCurrentPage(
-      () => this.load(),
-      () => this.updateCurrentPage(this.rows),
-    );
+    this.sortingStrategy.handleCurrentPage(this.load.bind(this));
     this.controlsStateUpdated.emit();
   }
 
   setPagination(pagination: TablePagination): void {
     this.pagination = pagination;
-    this.paginationStrategy.handleCurrentPage(
-      () => this.load(),
-      () => this.updateCurrentPage(this.rows),
-    );
+    this.paginationStrategy.handleCurrentPage(this.load.bind(this));
     this.controlsStateUpdated.emit();
   }
 

--- a/src/app/modules/ix-table2/classes/api-data-provider/pagination-client-side.ts
+++ b/src/app/modules/ix-table2/classes/api-data-provider/pagination-client-side.ts
@@ -1,17 +1,12 @@
-import { ApiCallParams } from 'app/modules/ix-table2/classes/api-data-provider/api-data-provider';
 import { paginate } from 'app/modules/ix-table2/classes/base-data-provider';
-import { PaginationStrategy, TablePagination } from 'app/modules/ix-table2/interfaces/table-pagination.interface';
+import { TablePagination } from 'app/modules/ix-table2/interfaces/table-pagination.interface';
 
-export class PaginationClientSide implements PaginationStrategy {
-  getParams(): ApiCallParams {
-    return {};
-  }
-
+export class PaginationClientSide {
   paginate<T>(rows: T[], pagination: TablePagination): T[] {
     return paginate(rows, pagination);
   }
 
-  handleCurrentPage(loadRowsAndUpdatePage: () => void, updatePage: () => void): void {
+  handleCurrentPage(updatePage: () => void): void {
     updatePage();
   }
 }

--- a/src/app/modules/ix-table2/classes/api-data-provider/pagination-server-side.class.ts
+++ b/src/app/modules/ix-table2/classes/api-data-provider/pagination-server-side.class.ts
@@ -1,7 +1,7 @@
 import { ApiCallParams } from 'app/modules/ix-table2/classes/api-data-provider/api-data-provider';
-import { PaginationStrategy, TablePagination } from 'app/modules/ix-table2/interfaces/table-pagination.interface';
+import { TablePagination } from 'app/modules/ix-table2/interfaces/table-pagination.interface';
 
-export class PaginationServerSide implements PaginationStrategy {
+export class PaginationServerSide {
   getParams(pagination: TablePagination): ApiCallParams {
     if (pagination.pageNumber === null || pagination.pageSize === null) {
       return {};
@@ -11,10 +11,6 @@ export class PaginationServerSide implements PaginationStrategy {
       offset: (pagination.pageNumber - 1) * pagination.pageSize,
       limit: pagination.pageSize,
     };
-  }
-
-  paginate<T>(rows: T[]): T[] {
-    return rows;
   }
 
   handleCurrentPage(loadRowsAndUpdatePage: () => void): void {

--- a/src/app/modules/ix-table2/classes/api-data-provider/sorting-client-side.class.ts
+++ b/src/app/modules/ix-table2/classes/api-data-provider/sorting-client-side.class.ts
@@ -1,12 +1,7 @@
-import { ApiCallParams } from 'app/modules/ix-table2/classes/api-data-provider/api-data-provider';
 import { sort } from 'app/modules/ix-table2/classes/base-data-provider';
-import { SortingStrategy, TableSort } from 'app/modules/ix-table2/interfaces/table-sort.interface';
+import { TableSort } from 'app/modules/ix-table2/interfaces/table-sort.interface';
 
-export class SortingClientSide implements SortingStrategy {
-  getParams(): ApiCallParams {
-    return {};
-  }
-
+export class SortingClientSide {
   sort<T>(rows: T[], sorting: TableSort<T>): T[] {
     return sort(rows, sorting);
   }

--- a/src/app/modules/ix-table2/classes/api-data-provider/sorting-server-side.class.ts
+++ b/src/app/modules/ix-table2/classes/api-data-provider/sorting-server-side.class.ts
@@ -1,8 +1,8 @@
 import { ApiCallParams } from 'app/modules/ix-table2/classes/api-data-provider/api-data-provider';
 import { SortDirection } from 'app/modules/ix-table2/enums/sort-direction.enum';
-import { SortingStrategy, TableSort } from 'app/modules/ix-table2/interfaces/table-sort.interface';
+import { TableSort } from 'app/modules/ix-table2/interfaces/table-sort.interface';
 
-export class SortingServerSide implements SortingStrategy {
+export class SortingServerSide {
   getParams<T>(sorting: TableSort<T>): ApiCallParams {
     if (sorting.propertyName === null || sorting.direction === null) {
       return {};
@@ -11,10 +11,6 @@ export class SortingServerSide implements SortingStrategy {
     return {
       order_by: [(sorting.direction === SortDirection.Desc ? '-' : '') + (sorting.propertyName as string)],
     };
-  }
-
-  sort<T>(rows: T[]): T[] {
-    return rows;
   }
 
   handleCurrentPage(loadRowsAndUpdatePage: () => void): void {

--- a/src/app/modules/ix-table2/classes/async-data-provider/async-data-provider.spec.ts
+++ b/src/app/modules/ix-table2/classes/async-data-provider/async-data-provider.spec.ts
@@ -1,4 +1,6 @@
-import { firstValueFrom, of, tap } from 'rxjs';
+import {
+  firstValueFrom, of, tap,
+} from 'rxjs';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { AsyncDataProvider } from 'app/modules/ix-table2/classes/async-data-provider/async-data-provider';
 
@@ -55,5 +57,17 @@ describe('AsyncDataProvider', () => {
     dataProvider.load();
 
     expect(await firstValueFrom(dataProvider.emptyType$)).toBe(EmptyType.Errors);
+  });
+
+  it('filters rows based on query and columns', async () => {
+    const request$ = of(testTableData);
+    const dataProvider = new AsyncDataProvider<TestTableData>(request$);
+    dataProvider.load();
+
+    dataProvider.setFilter({ query: 'c', columns: ['stringField'] });
+    expect(dataProvider.totalRows).toBe(1);
+    expect(
+      await firstValueFrom(dataProvider.currentPage$),
+    ).toEqual([{ numberField: 2, stringField: 'c', booleanField: false }]);
   });
 });

--- a/src/app/modules/ix-table2/classes/async-data-provider/async-data-provider.ts
+++ b/src/app/modules/ix-table2/classes/async-data-provider/async-data-provider.ts
@@ -3,6 +3,8 @@ import { EmptyType } from 'app/enums/empty-type.enum';
 import { BaseDataProvider } from 'app/modules/ix-table2/classes/base-data-provider';
 
 export class AsyncDataProvider<T> extends BaseDataProvider<T> {
+  private loadedRows: T[] = [];
+
   constructor(
     private request$: Observable<T[]>,
   ) {
@@ -14,14 +16,34 @@ export class AsyncDataProvider<T> extends BaseDataProvider<T> {
     this.subscription.add(
       this.request$.subscribe({
         next: (rows) => {
+          this.loadedRows = rows;
           this.setRows(rows);
           this.emptyType$.next(rows.length ? EmptyType.NoSearchResults : EmptyType.NoPageData);
         },
         error: () => {
+          this.loadedRows = [];
           this.setRows([]);
           this.emptyType$.next(EmptyType.Errors);
         },
       }),
     );
+  }
+
+  setFilter(filter: { query: string; columns: (keyof T)[] }): void {
+    if (!filter) {
+      this.totalRows = this.loadedRows.length;
+      this.setRows(this.loadedRows);
+    }
+    const filteredRows = this.loadedRows.filter((row) => {
+      for (const column of filter.columns) {
+        if (row[column].toString().trim().toLowerCase().includes(filter.query.trim().toLowerCase())) {
+          return true;
+        }
+      }
+      return false;
+    });
+    this.totalRows = filteredRows.length;
+    this.setRows(filteredRows);
+    this.emptyType$.next(!filteredRows.length ? EmptyType.NoSearchResults : EmptyType.NoPageData);
   }
 }

--- a/src/app/modules/ix-table2/interfaces/table-pagination.interface.ts
+++ b/src/app/modules/ix-table2/interfaces/table-pagination.interface.ts
@@ -1,14 +1,4 @@
-import { ApiCallParams } from 'app/modules/ix-table2/classes/api-data-provider/api-data-provider';
-
 export interface TablePagination {
   pageNumber: number;
   pageSize: number;
-}
-
-export interface PaginationStrategy {
-  getParams(pagination: TablePagination): ApiCallParams;
-
-  paginate<T>(rows: T[], pagination: TablePagination): T[];
-
-  handleCurrentPage(loadRowsAndUpdatePage: () => void, updatePage: () => void): void;
 }

--- a/src/app/modules/ix-table2/interfaces/table-sort.interface.ts
+++ b/src/app/modules/ix-table2/interfaces/table-sort.interface.ts
@@ -1,4 +1,3 @@
-import { ApiCallParams } from 'app/modules/ix-table2/classes/api-data-provider/api-data-provider';
 import { SortDirection } from 'app/modules/ix-table2/enums/sort-direction.enum';
 
 export interface TableSort<T> {
@@ -6,12 +5,4 @@ export interface TableSort<T> {
   direction: SortDirection;
   active: number;
   sortBy?: (row: T) => string | number;
-}
-
-export interface SortingStrategy {
-  getParams<T>(sorting: TableSort<T>): ApiCallParams;
-
-  sort<T>(rows: T[], sorting: TableSort<T>): T[];
-
-  handleCurrentPage(loadRowsAndUpdatePage: () => void, updatePage: () => void): void;
 }


### PR DESCRIPTION
Separate `ApiDataProvider` from `AsyncDataProvider`

This PR separates responsibilities of `ApiDataProvider` from `AsyncDataProvider`. `AsyncDataProvider` will be responsible for handling the pagination, sorting and filtering on the front-end.

`ApiDataProvider` will be responsible for handling the pagination, sorting and filtering on the back-end. `AsyncDataProvider` already has default sorting and pagination from `BaseDataProvider`
