### PR TITLE
NAS-125444 / 24.04 / Incorrect acl description in Permissions card

### DIFF
--- a/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.spec.ts
+++ b/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.spec.ts
@@ -76,7 +76,7 @@ describe('PermissionsCardComponent', () => {
     const websocket = spectator.inject(WebSocketService);
 
     expect(websocket.call).toHaveBeenCalledWith('filesystem.stat', ['/mnt/testpool/dataset']);
-    expect(websocket.call).toHaveBeenCalledWith('filesystem.getacl', ['/mnt/testpool/dataset', false, true]);
+    expect(websocket.call).toHaveBeenCalledWith('filesystem.getacl', ['/mnt/testpool/dataset', true, true]);
   });
 
   it('shows dataset ownership information', () => {

--- a/src/app/pages/datasets/modules/permissions/stores/permissions-card.store.ts
+++ b/src/app/pages/datasets/modules/permissions/stores/permissions-card.store.ts
@@ -39,7 +39,7 @@ export class PermissionsCardStore extends ComponentStore<PermissionsCardState> {
       switchMap((mountpoint) => {
         return forkJoin([
           this.ws.call('filesystem.stat', [mountpoint]),
-          this.ws.call('filesystem.getacl', [mountpoint, false, true]),
+          this.ws.call('filesystem.getacl', [mountpoint, true, true]),
         ]).pipe(
           tap(([stat, acl]) => {
             this.patchState({


### PR DESCRIPTION
Testing: 
see ticket, example (use m40), go to http://localhost:4200/datasets/APPS%2Fa%2Fsmbtest

see permissions card:
<img width="381" alt="Screenshot 2023-12-03 at 23 09 25" src="https://github.com/truenas/webui/assets/22980553/5987f30d-1164-4ec0-9a9b-3f1dc03c0b6e">

And edit state:
<img width="409" alt="Screenshot 2023-12-03 at 23 09 47" src="https://github.com/truenas/webui/assets/22980553/bb84dad7-fd30-450b-a529-1f027adeb0cf">

They shall be identical.