### PR TITLE
Fix typo dataset-form.ts form translation

### DIFF
--- a/src/app/helptext/storage/volumes/datasets/dataset-form.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-form.ts
@@ -2,7 +2,7 @@ import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
 
 export default {
   dataset_parent_name_tooltip: T('Parent dataset path (read-only).'),
-  dataset_form_name_tooltip: T('Enter a unique name for the dataset. The dataset name length is calculated by adding the length of this field\'s value and the length of the parent path field value. The length of \'Parent Path\' and \'Name\' added together cannot exceed 200 characters. Because of this length validation on this field accounts for the parent path as well. Furthermore, the maximum nested directory levels allowed is 50. You can\'t create a dataset that\'s at the 51st level in the directory hierarchy after you account for the nested levels in the parent path.'),
+  dataset_form_name_tooltip: T(`Enter a unique name for the dataset. The dataset name length is calculated by adding the length of this field's value and the length of the parent path field value. The length of 'Parent Path' and 'Name' added together cannot exceed 200 characters. Because of this length validation on this field accounts for the parent path as well. Furthermore, the maximum nested directory levels allowed is 50. You can't create a dataset that's at the 51st level in the directory hierarchy after you account for the nested levels in the parent path.`),
   dataset_form_comments_tooltip: T('Enter any notes about this dataset.'),
   dataset_form_sync_tooltip: T('<i>Standard</i> uses the sync settings that have been\
  requested by the client software, <i>Always</i> waits for\


### PR DESCRIPTION
Hi guys, the translation of dataset_form_name_tooltip tooltip does not work. (French translate OK in json). I think it's because there are the characters \\' several times in the sentence. I hope this will fix the bug.

![translate1](https://github.com/truenas/webui/assets/4472695/99d101f2-dc90-484e-a7fb-0119a55899cf)
