### PR TITLE
NAS-125484 / 23.10.2 / Incorrect When time displayed on periodic snapshot tasks screen (by AlexKarpov98)

### DIFF
--- a/src/app/modules/scheduler/utils/schedule-to-crontab.spec.ts
+++ b/src/app/modules/scheduler/utils/schedule-to-crontab.spec.ts
@@ -1,5 +1,5 @@
 import { Schedule } from 'app/interfaces/schedule.interface';
-import { scheduleToCrontab } from 'app/modules/scheduler/utils/schedule-to-crontab.utils';
+import { extractActiveHoursFromCron, scheduleToCrontab } from 'app/modules/scheduler/utils/schedule-to-crontab.utils';
 
 describe('scheduleToCrontab', () => {
   it('converts schedule with minutes to crontab', () => {
@@ -23,5 +23,13 @@ describe('scheduleToCrontab', () => {
     };
 
     expect(scheduleToCrontab(schedule)).toBe('0 10 * 2-5 6');
+  });
+
+  it('extracts start and end value from crontab', () => {
+    expect(extractActiveHoursFromCron('15 10 * 2-5 6')).toEqual({ start: '10:15', end: '10:15' });
+    expect(extractActiveHoursFromCron('15,25,35 10 * 2-5 6')).toEqual({ start: '10:15,25,35', end: '10:15,25,35' });
+    expect(extractActiveHoursFromCron('0 08-18 * * mon,tue,wed,thu,fri,sat')).toEqual({ start: '08:00', end: '18:00' });
+    expect(extractActiveHoursFromCron('0 08,10 * * *')).toEqual({ start: '08:00', end: '10:00' });
+    expect(extractActiveHoursFromCron('0 0 * * *')).toEqual({ start: '00:00', end: '23:59' });
   });
 });

--- a/src/app/modules/scheduler/utils/schedule-to-crontab.utils.ts
+++ b/src/app/modules/scheduler/utils/schedule-to-crontab.utils.ts
@@ -7,3 +7,36 @@ export function scheduleToCrontab(schedule: Schedule): string {
 
   return `0 ${schedule.hour} ${schedule.dom} ${schedule.month} ${schedule.dow}`;
 }
+
+export function extractActiveHoursFromCron(crontab: string): { start: string; end: string } {
+  const parts = crontab.split(' ');
+  const [minutes, hours] = parts;
+
+  const formatTime = (hour: string, minute: string): string => `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}`;
+
+  if ((hours === '0' || hours === '00') && (minutes === '0' || minutes === '00')) {
+    return { start: '00:00', end: '23:59' };
+  }
+
+  const processRange = (range: string[], minute: string): { start: string; end: string } => {
+    if (range.length === 2) {
+      return { start: formatTime(range[0], minute), end: formatTime(range[1], minute) };
+    }
+    return { start: formatTime(range[0], minute), end: formatTime(range[0], minute) };
+  };
+
+  if (hours.includes('-')) {
+    const hourRange = hours.split('-');
+    return processRange(hourRange, minutes);
+  }
+
+  if (hours.includes(',')) {
+    const hourList = hours.split(',');
+    return {
+      start: formatTime(hourList[0], minutes),
+      end: formatTime(hourList[hourList.length - 1], minutes),
+    };
+  }
+
+  return processRange([hours], minutes);
+}

--- a/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
@@ -12,6 +12,7 @@ import { WebsocketError } from 'app/interfaces/websocket-error.interface';
 import { EntityTableComponent } from 'app/modules/entity/entity-table/entity-table.component';
 import { EntityTableConfig } from 'app/modules/entity/entity-table/entity-table.interface';
 import { extractActiveHoursFromCron, scheduleToCrontab } from 'app/modules/scheduler/utils/schedule-to-crontab.utils';
+import { SnapshotTaskComponent } from 'app/pages/data-protection/snapshot/snapshot-task/snapshot-task.component';
 import { DialogService } from 'app/services/dialog.service';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';

--- a/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/data-protection/snapshot/snapshot-list/snapshot-list.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { JobState } from 'app/enums/job-state.enum';
 import {
@@ -12,15 +11,13 @@ import {
 import { WebsocketError } from 'app/interfaces/websocket-error.interface';
 import { EntityTableComponent } from 'app/modules/entity/entity-table/entity-table.component';
 import { EntityTableConfig } from 'app/modules/entity/entity-table/entity-table.interface';
-import { scheduleToCrontab } from 'app/modules/scheduler/utils/schedule-to-crontab.utils';
-import { SnapshotTaskComponent } from 'app/pages/data-protection/snapshot/snapshot-task/snapshot-task.component';
+import { extractActiveHoursFromCron, scheduleToCrontab } from 'app/modules/scheduler/utils/schedule-to-crontab.utils';
 import { DialogService } from 'app/services/dialog.service';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
 import { StorageService } from 'app/services/storage.service';
 import { TaskService } from 'app/services/task.service';
 import { WebSocketService } from 'app/services/ws.service';
-import { AppState } from 'app/store';
 
 @UntilDestroy()
 @Component({
@@ -80,7 +77,6 @@ export class SnapshotListComponent implements EntityTableConfig<PeriodicSnapshot
     private slideInService: IxSlideInService,
     private route: ActivatedRoute,
     private router: Router,
-    private store$: Store<AppState>,
   ) {
     this.filterValue = this.route.snapshot.paramMap.get('dataset') || '';
   }
@@ -91,11 +87,17 @@ export class SnapshotListComponent implements EntityTableConfig<PeriodicSnapshot
 
   resourceTransformIncomingRestData(tasks: PeriodicSnapshotTask[]): PeriodicSnapshotTaskUi[] {
     return tasks.map((task) => {
+      const cronSchedule = scheduleToCrontab(task.schedule);
+      const activeHours = extractActiveHoursFromCron(cronSchedule);
+
       const transformedTask = {
         ...task,
         keepfor: `${task.lifetime_value} ${task.lifetime_unit}(S)`,
-        when: this.translate.instant('From {task_begin} to {task_end}', { task_begin: task.schedule.begin, task_end: task.schedule.end }),
-        cron_schedule: scheduleToCrontab(task.schedule),
+        when: this.translate.instant('From {task_begin} to {task_end}', {
+          task_begin: activeHours.start,
+          task_end: activeHours.end,
+        }),
+        cron_schedule: cronSchedule,
       } as PeriodicSnapshotTaskUi;
 
       return {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b75a00037e80ac00d34adc49063a1441bb7bbb6c
    git cherry-pick -x 5c38d6f036532bbbb774df27e738c927c7cc2e7c

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x f1547cfac9253d612245c0aa53e13c6ffa621eba

Testing: 
See ticket and result and test case: 👇 
<img width="1109" alt="Screenshot 2023-12-07 at 17 38 22" src="https://github.com/truenas/webui/assets/22980553/db08942f-726e-4162-81f0-1b27eabccf8d">


Original PR: https://github.com/truenas/webui/pull/9294
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125484