### PR TITLE
NAS-125696 / 24.04 / ix-chips options are transparent at some point

### DIFF
--- a/src/assets/styles/other/_root-variables.scss
+++ b/src/assets/styles/other/_root-variables.scss
@@ -74,6 +74,7 @@
   --mdc-snackbar-supporting-text-size: 1rem;
   --mdc-list-list-item-one-line-container-height: 48px;
   --mdc-list-list-item-selected-container-color: var(--bg2);
+  --mat-option-selected-state-layer-color: var(--bg2);
   --mat-mdc-slider-hover-ripple-color: rgba(0, 149, 213, 0.05);
   --mat-mdc-slider-focus-ripple-color: rgba(0, 149, 213, 0.2);
   --mat-mdc-button-persistent-ripple-color: rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
Testing: 👇 

Before: _(notice Readonly Administrators background)_
<img width="479" alt="Screenshot 2023-12-14 at 18 16 16" src="https://github.com/truenas/webui/assets/22980553/0d44d757-472f-4118-aa34-ea7c398c612e">

After:
<img width="489" alt="Screenshot 2023-12-14 at 18 17 10" src="https://github.com/truenas/webui/assets/22980553/0c6cbbf9-8e87-4625-93b1-b45ccc2badb5">
