### PR TITLE
NAS-125570 / 24.04 / Allow privilege to be attached in group form (fix)

### DIFF
--- a/src/app/pages/account/groups/group-form/group-form.component.ts
+++ b/src/app/pages/account/groups/group-form/group-form.component.ts
@@ -213,20 +213,18 @@ export class GroupFormComponent implements OnInit {
   }
 
   private getPrivilegesList(): void {
-    if (this.editingGroup?.id) {
-      this.ws.call('privilege.query', [])
-        .pipe(untilDestroyed(this)).subscribe((privileges) => {
-          this.initialGroupRelatedPrivilegesList = privileges.filter((privilege) => {
-            return privilege.local_groups.map((group) => group.gid).includes(this.editingGroup.gid);
-          });
-
-          this.privilegesList = privileges;
-
-          this.form.controls.privileges.patchValue(
-            this.initialGroupRelatedPrivilegesList.map((privilege) => privilege.id),
-          );
+    this.ws.call('privilege.query', [])
+      .pipe(untilDestroyed(this)).subscribe((privileges) => {
+        this.initialGroupRelatedPrivilegesList = privileges.filter((privilege) => {
+          return privilege.local_groups.map((group) => group.gid).includes(this.editingGroup?.gid);
         });
-    }
+
+        this.privilegesList = privileges;
+
+        this.form.controls.privileges.patchValue(
+          this.initialGroupRelatedPrivilegesList.map((privilege) => privilege.id),
+        );
+      });
   }
 
   private setNamesInUseValidator(currentName?: string): void {


### PR DESCRIPTION
Contains fix for correct work.
There's incorrect check added

`if (this.editingGroup?.id) {}`

But we call method on init for both edit & create mode. `getPrivilegesList`