### PR TITLE
NAS-125616 / 24.04 / An Internally Signed Certificate Requires a Page Reload To Display After Creation On The Certificates Page

### DIFF
--- a/src/app/pages/credentials/certificates-dash/certificate-authority-list/certificate-authority-list.component.ts
+++ b/src/app/pages/credentials/certificates-dash/certificate-authority-list/certificate-authority-list.component.ts
@@ -260,7 +260,9 @@ export class CertificateAuthorityListComponent implements OnInit {
         }),
         untilDestroyed(this),
       )
-      .subscribe();
+      .subscribe(() => {
+        this.getCertificates();
+      });
   }
 
   doSignCsr(certificate: CertificateAuthority): void {

--- a/src/app/pages/credentials/certificates-dash/certificate-authority-list/certificate-authority-list.component.ts
+++ b/src/app/pages/credentials/certificates-dash/certificate-authority-list/certificate-authority-list.component.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit,
+  ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output,
 } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -37,6 +37,8 @@ import { WebSocketService } from 'app/services/ws.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CertificateAuthorityListComponent implements OnInit {
+  @Output() certificateSigned = new EventEmitter<void>();
+
   filterString = '';
   dataProvider: AsyncDataProvider<CertificateAuthority>;
   authorities: CertificateAuthority[] = [];
@@ -97,7 +99,6 @@ export class CertificateAuthorityListComponent implements OnInit {
     private ws: WebSocketService,
     private slideInService: IxSlideInService,
     private translate: TranslateService,
-    private cdr: ChangeDetectorRef,
     protected emptyService: EmptyService,
     private storageService: StorageService,
     private dialogService: DialogService,
@@ -269,6 +270,7 @@ export class CertificateAuthorityListComponent implements OnInit {
       .pipe(filter(Boolean), untilDestroyed(this))
       .subscribe(() => {
         this.getCertificates();
+        this.certificateSigned.emit();
       });
   }
 }

--- a/src/app/pages/credentials/certificates-dash/certificate-list/certificate-list.component.ts
+++ b/src/app/pages/credentials/certificates-dash/certificate-list/certificate-list.component.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit,
+  ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output,
 } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -37,6 +37,8 @@ import { WebSocketService } from 'app/services/ws.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CertificateListComponent implements OnInit {
+  @Output() certificateDeleted = new EventEmitter<void>();
+
   filterString = '';
   dataProvider: AsyncDataProvider<Certificate>;
   certificates: Certificate[] = [];
@@ -96,7 +98,6 @@ export class CertificateListComponent implements OnInit {
     private ws: WebSocketService,
     private slideInService: IxSlideInService,
     private translate: TranslateService,
-    private cdr: ChangeDetectorRef,
     protected emptyService: EmptyService,
     private storageService: StorageService,
     private dialogService: DialogService,
@@ -169,6 +170,7 @@ export class CertificateListComponent implements OnInit {
         jobDialogRef.componentInstance.success.pipe(untilDestroyed(this)).subscribe(() => {
           jobDialogRef.close(true);
           this.getCertificates();
+          this.certificateDeleted.emit();
         });
         jobDialogRef.componentInstance.failure.pipe(untilDestroyed(this)).subscribe((err) => {
           this.dialogService.error(this.errorHandler.parseJobError(err));

--- a/src/app/pages/credentials/certificates-dash/certificates-dash.component.html
+++ b/src/app/pages/credentials/certificates-dash/certificates-dash.component.html
@@ -1,6 +1,15 @@
 <div class="layout">
-  <ix-certificate-list></ix-certificate-list>
+  <ix-certificate-list
+    #certificateList
+    (certificateDeleted)="authorityList.dataProvider.load()"
+  ></ix-certificate-list>
+
   <ix-csr-list></ix-csr-list>
-  <ix-certificate-authority-list></ix-certificate-authority-list>
+
+  <ix-certificate-authority-list
+    #authorityList
+    (certificateSigned)="certificateList.dataProvider.load()"
+  ></ix-certificate-authority-list>
+
   <ix-acme-dns-authenticator-list></ix-acme-dns-authenticator-list>
 </div>

--- a/src/app/pages/credentials/certificates-dash/sign-csr-dialog/sign-csr-dialog.component.ts
+++ b/src/app/pages/credentials/certificates-dash/sign-csr-dialog/sign-csr-dialog.component.ts
@@ -51,7 +51,7 @@ export class SignCsrDialogComponent {
       .subscribe({
         next: () => {
           this.snackbar.success(this.translate.instant('Certificate request signed'));
-          this.dialogRef.close();
+          this.dialogRef.close(true);
         },
         error: (error) => {
           this.errorHandler.handleWsFormError(error, this.form);


### PR DESCRIPTION
Testing: see ticket (there is video)

Additional:

I tried to update tests to include checks of API calls and value `emit`, but was not able to find `DELETE` button after I open modal, and can't find any working test with same conditions.

```    
    expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(ConfirmForceDeleteCertificateComponent, {
      data: certificates[0],
    });
```

```
ailed to find element matching one of the following queries:
    (_MatButtonHarness with host element matching selector: "[mat-button], [mat-raised-button], [mat-flat-button],
                             [mat-icon-button], [mat-stroked-button], [mat-fab], [mat-mini-fab]" satisfying the constraints: text = "Delete")
```