### PR TITLE
Prevent text overflow in entity-table-row-details

### DIFF
--- a/src/app/modules/entity/entity-table/entity-table-row-details/entity-table-row-details.component.scss
+++ b/src/app/modules/entity/entity-table/entity-table-row-details/entity-table-row-details.component.scss
@@ -14,6 +14,7 @@
   p {
     line-height: 24px;
     margin: 0;
+    word-break: break-word;
   }
 
   .mat-icon.widget-icon {


### PR DESCRIPTION
Currently, if the text in the right column of `entity-table-row-details` is too long and doesn't contain enouch characters that usually allow line breaks (like spaces and hyphens) the text will overflow. Because the text is in a table this also messes with the layout of the columns of the `entity-table`:

![](https://github.com/truenas/webui/assets/77448526/e89c2fff-6dbb-4fb9-8dde-9845147ed45c)

This PR fixes this by adding the `word-break: break-word` CSS property to the `p`-element:

![](https://github.com/truenas/webui/assets/77448526/6655dd13-8943-4245-8934-587b6d318fa3)