### PR TITLE
Clarify what the VM password field is for

### DIFF
--- a/src/app/helptext/vm/vm-wizard/vm-wizard.ts
+++ b/src/app/helptext/vm/vm-wizard/vm-wizard.ts
@@ -5,7 +5,7 @@ import { helptextGlobal } from 'app/helptext/global-helptext';
 export const helptextVmWizard = {
   os_tooltip: T('Choose the VM operating system type.'),
   name_tooltip: T('Enter an alphanumeric name for the virtual machine.'),
-  password_tooltip: T('Enter a password for the virtual machine.'),
+  password_tooltip: T('Enter a password for the VNC display.'),
   description_tooltip: T('Description (optional).'),
   time_tooltip: T('VM system time. Default is <i>Local</i>.'),
   bootloader_tooltip: T('Select <i>UEFI</i> for newer operating systems or\


### PR DESCRIPTION
Ideally, the New VM wizard UI should also be updated to show that the Bind and Password fields are related to the VNC display device. I'm not sure what the best way to do that is.

- Group the fields visually
- Rename the fields to "Display bind" and "Display password" and update all of the translations 