### PR TITLE
NAS-125870 / 24.04 / New endpoint for system info card on main dashboard

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -271,6 +271,8 @@ import {
  * For events from `subscribed` see ApiEventDirectory.
  */
 export interface ApiCallDirectory {
+  'webui.main.dashboard.sys_info': { params: void; response: SystemInfo };
+
   // Active Directory
   'activedirectory.config': { params: void; response: ActiveDirectoryConfig };
   'activedirectory.update': { params: [ActiveDirectoryUpdate]; response: ActiveDirectoryConfig };

--- a/src/app/interfaces/system-info.interface.ts
+++ b/src/app/interfaces/system-info.interface.ts
@@ -2,6 +2,7 @@ import { LicenseFeature } from 'app/enums/license-feature.enum';
 import { ApiDate, ApiTimestamp } from 'app/interfaces/api-date.interface';
 
 export interface SystemInfo {
+  platform: string;
   birthday: ApiTimestamp;
   boottime: ApiTimestamp;
   buildtime: ApiTimestamp;
@@ -22,6 +23,7 @@ export interface SystemInfo {
   uptime: string;
   uptime_seconds: number;
   version: string;
+  remote_info?: SystemInfo;
 }
 
 export interface SystemLicense {

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
@@ -169,7 +169,7 @@
             <!-- Details Section -->
             <div class="right" fxFlex.xs fxFlex.gt-xs="60" fxLayout="column">
               <div
-                *ngIf="!data && isHaLicensed && isPassive && hasHa"
+                *ngIf="!systemInfo && isHaLicensed && isPassive && hasHa"
                 class="data-container ha-status"
                 fxFlex
               >
@@ -179,7 +179,7 @@
               </div>
 
               <div
-                *ngIf="!data || (isHaLicensed && isPassive && !hasHa)"
+                *ngIf="!systemInfo || (isHaLicensed && isPassive && !hasHa)"
                 class="data-container ha-status"
                 fxFlex
               >
@@ -188,11 +188,11 @@
                 </h3>
               </div>
 
-              <div *ngIf="!data && !isHaLicensed" class="loader">
+              <div *ngIf="!systemInfo && !isHaLicensed" class="loader">
                 <mat-spinner class="spinner" [diameter]="40"></mat-spinner>
               </div>
 
-              <div *ngIf="(data && !isPassive) || (data && isPassive && hasHa)" class="data-container" fxFlex>
+              <div *ngIf="(systemInfo && !isPassive) || (systemInfo && isPassive && hasHa)" class="data-container" fxFlex>
                 <div fxHide.gt-xs class="list-subheader">
                   {{ isPassive ? ('System Information (Standby)' | translate) : ('System Information' | translate) }}
                 </div>
@@ -204,42 +204,42 @@
                   <mat-list-item>
                     <strong>{{ 'Platform' | translate }}:</strong>
                     <span>
-                      {{ data.system_product && isIxHardware ? data.system_product : 'Generic' }}
+                      {{ systemInfo.platform && isIxHardware ? systemInfo.platform : 'Generic' }}
                     </span>
                   </mat-list-item>
                   <mat-list-item>
                     <strong>{{ 'Version' | translate }}:</strong>
                     <div class="copy-version">
                       <div class="copy-version-text">
-                        <span>{{ data.version }}</span>
+                        <span>{{ systemInfo.version }}</span>
                       </div>
                       <ix-copy-btn
                         class="copy-version-button"
-                        [text]="data.version"
+                        [text]="systemInfo.version"
                       ></ix-copy-btn>
                     </div>
                   </mat-list-item>
 
-                  <mat-list-item *ngIf="data.license">
+                  <mat-list-item *ngIf="systemInfo.license">
                     <strong>{{ 'License' | translate }}:</strong>
                     <span>
                       {{ licenseString }}
                     </span>
                   </mat-list-item>
 
-                  <mat-list-item *ngIf="data.system_serial && isIxHardware">
+                  <mat-list-item *ngIf="systemInfo.system_serial && isIxHardware">
                     <strong>{{ 'System Serial' | translate }}:</strong>
-                    <span>{{ data.system_serial }}</span>
+                    <span>{{ systemInfo.system_serial }}</span>
                   </mat-list-item>
 
                   <mat-list-item>
                     <strong>{{ 'Hostname' | translate }}:</strong>
-                    <span>{{ data.hostname }}</span>
+                    <span>{{ systemInfo.hostname }}</span>
                   </mat-list-item>
 
                   <mat-list-item>
                     <strong>{{ 'Uptime' | translate }}:</strong>
-                    <span>{{ data.uptime_seconds | uptime: (data.datetime.$date | formatDateTime:null:' ':'HH:mm') }}</span>
+                    <span>{{ systemInfo.uptime_seconds | uptime: (systemInfo.datetime.$date | formatDateTime:null:' ':'HH:mm') }}</span>
                   </mat-list-item>
                 </mat-list>
 

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -9,9 +9,7 @@ import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import {
-  filter, repeat, skipWhile, take,
-} from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 import { JobState } from 'app/enums/job-state.enum';
 import { ScreenType } from 'app/enums/screen-type.enum';
 import { SystemUpdateStatus } from 'app/enums/system-update.enum';
@@ -27,8 +25,8 @@ import { SystemGeneralService } from 'app/services/system-general.service';
 import { ThemeService } from 'app/services/theme/theme.service';
 import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
-import { selectHasOnlyMismatchVersionsReason, selectHaStatus, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
-import { selectIsIxHardware, waitForSystemFeatures, waitForSystemInfo } from 'app/store/system-info/system-info.selectors';
+import { selectHasOnlyMismatchVersionsReason, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
+import { selectIsIxHardware, waitForSystemFeatures } from 'app/store/system-info/system-info.selectors';
 
 @UntilDestroy()
 @Component({
@@ -49,7 +47,7 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
 
   hasOnlyMismatchVersionsReason$ = this.store$.select(selectHasOnlyMismatchVersionsReason);
 
-  data: SystemInfo;
+  systemInfo: SystemInfo;
   ready = false;
   productImage = '';
   productModel = '';
@@ -95,39 +93,27 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
 
   get licenseString(): string {
     return this.translate.instant('{license} contract, expires {date}', {
-      license: this.titleCase.transform(this.data.license.contract_type.toLowerCase()),
-      date: this.data.license.contract_end.$value,
+      license: this.titleCase.transform(this.systemInfo.license.contract_type.toLowerCase()),
+      date: this.systemInfo.license.contract_end.$value,
     });
   }
 
   ngOnInit(): void {
     this.checkForUpdate();
     this.loadSystemInfo();
-    this.loadEnclosureSupport();
-    this.loadIsIxHardware();
+    this.getEnclosureSupport();
+    this.getIsIxHardware();
   }
 
   loadSystemInfo(): void {
-    this.loadSystemInfoForActive();
+    this.getSystemInfo();
+
     if (this.sysGenService.isEnterprise) {
-      this.store$
-        .select(selectIsHaLicensed)
-        .pipe(untilDestroyed(this))
-        .subscribe((isHaLicensed) => {
-          this.isHaLicensed = isHaLicensed;
-          if (isHaLicensed) {
-            this.updateMethod = 'failover.upgrade';
-          }
-          if (isHaLicensed && this.isPassive) {
-            this.loadSystemInfoForPassive();
-          }
-          this.checkForRunningUpdate();
-          this.cdr.markForCheck();
-        });
+      this.getIsHaLicensed();
     }
   }
 
-  loadIsIxHardware(): void {
+  getIsIxHardware(): void {
     this.store$
       .select(selectIsIxHardware)
       .pipe(untilDestroyed(this))
@@ -138,7 +124,7 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
       });
   }
 
-  loadEnclosureSupport(): void {
+  getEnclosureSupport(): void {
     this.store$
       .pipe(waitForSystemFeatures, untilDestroyed(this))
       .subscribe((features) => {
@@ -147,39 +133,31 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
       });
   }
 
-  loadSystemInfoForActive(): void {
-    this.store$
-      .pipe(
-        waitForSystemInfo,
-        skipWhile(() => this.isPassive),
-        untilDestroyed(this),
-      )
+  getSystemInfo(): void {
+    this.ws.call('webui.main.dashboard.sys_info')
+      .pipe(untilDestroyed(this))
       .subscribe((systemInfo) => {
-        this.processSysInfo(systemInfo);
+        if (this.isPassive) {
+          this.processSysInfo(systemInfo.remote_info);
+        } else {
+          this.processSysInfo(systemInfo);
+        }
         this.cdr.markForCheck();
       });
   }
 
-  loadSystemInfoForPassive(): void {
-    this.store$.select(selectHaStatus).pipe(
-      filter((haStatus) => !!haStatus),
-      untilDestroyed(this),
-    ).subscribe((haStatus) => {
-      if (haStatus.hasHa) {
-        this.data = null;
+  getIsHaLicensed(): void {
+    this.store$
+      .select(selectIsHaLicensed)
+      .pipe(untilDestroyed(this))
+      .subscribe((isHaLicensed) => {
+        this.isHaLicensed = isHaLicensed;
+        if (isHaLicensed) {
+          this.updateMethod = 'failover.upgrade';
+        }
+        this.checkForRunningUpdate();
         this.cdr.markForCheck();
-
-        this.ws.call('failover.call_remote', ['system.info'])
-          .pipe(repeat({ delay: 30000 }), untilDestroyed(this))
-          .subscribe((systemInfo: SystemInfo) => {
-            this.processSysInfo(systemInfo);
-            this.cdr.markForCheck();
-          });
-      } else if (!haStatus.hasHa) {
-        this.productImage = '';
-      }
-      this.hasHa = haStatus.hasHa;
-    });
+      });
   }
 
   checkForRunningUpdate(): void {
@@ -204,20 +182,20 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit {
   }
 
   processSysInfo(systemInfo: SystemInfo): void {
-    this.data = systemInfo;
+    this.systemInfo = systemInfo;
     this.setProductImage();
     this.ready = true;
   }
 
   setProductImage(): void {
-    if (!this.isIxHardware || !this.data) return;
+    if (!this.isIxHardware || !this.systemInfo) return;
 
-    if (this.data.system_product.includes('MINI')) {
-      this.setMiniImage(this.data.system_product);
-    } else if (this.data.system_product.includes('CERTIFIED')) {
+    if (this.systemInfo.platform.includes('MINI')) {
+      this.setMiniImage(this.systemInfo.platform);
+    } else if (this.systemInfo.platform.includes('CERTIFIED')) {
       this.certified = true;
     } else {
-      const product = this.productImgServ.getServerProduct(this.data.system_product);
+      const product = this.productImgServ.getServerProduct(this.systemInfo.platform);
       this.productImage = product ? `/servers/${product}.png` : 'ix-original.svg';
       this.productModel = product || '';
       this.productEnclosure = 'rackmount';


### PR DESCRIPTION
Testing: See ticket.

See that Dashboard Widget works for `HA systems` as well for the non-iX hardware system

I used: 
- Latest nightly (machine) for non-iX hardware system
- f60-146... (machine) for HA systems

<img width="1115" alt="Screenshot 2023-12-26 at 15 07 24" src="https://github.com/truenas/webui/assets/22980553/e9dace59-4d62-4fc8-8d38-7c356519a144">

These ones should have latest API on it.
As well the idea is not use `'failover.call_remote'` endpoint.