### PR TITLE
NAS-125832 / 23.10.1.1 / Reverting changes (by RehanY147)

### DIFF
--- a/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
+++ b/src/app/pages/dashboard/components/widget-network/widget-network.component.ts
@@ -12,6 +12,7 @@ import { Subscription, timer } from 'rxjs';
 import {
   filter, map, take, throttleTime,
 } from 'rxjs/operators';
+import { KiB } from 'app/constants/bytes.constant';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { LinkState, NetworkInterfaceAliasType } from 'app/enums/network-interface.enum';
 import { deepCloneState } from 'app/helpers/state-select.helper';
@@ -363,7 +364,7 @@ export class WidgetNetworkComponent extends WidgetComponent implements OnInit, A
           }
           (updatedResponse.data as number[][]).forEach((row, index) => {
             // remove first column and convert kilobits/s to bytes
-            (updatedResponse.data as number[][])[index] = [...row.slice(1)];
+            (updatedResponse.data as number[][])[index] = row.slice(1).map((value) => value * KiB);
           });
           return updatedResponse;
         }),


### PR DESCRIPTION
This PR reverts changes mistakenly made. The values returned by `reporting.netdata_get_data` are in Kbps so they need to be converted to bytes before UI can use it. Meaning, this multiplication was needed.

Original PR: https://github.com/truenas/webui/pull/9395
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125832