### PR TITLE
NAS-125495 / 24.04 / Enclosure management - list of drives off the screen and not scrollable

### DIFF
--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.scss
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.scss
@@ -199,6 +199,7 @@ nav.view-nav-bar {
 .view-card .dom-overlay.stage-left,
 .view-card .dom-overlay.stage-right {
   display: block;
+  overflow: auto;
   position: absolute;
   width: 25%;
 }


### PR DESCRIPTION
Testing: see ticket
<img width="1213" alt="Screenshot 2024-01-04 at 15 03 27" src="https://github.com/truenas/webui/assets/22980553/6fc36fad-1ff6-4141-996e-1dd15635f608">
