### PR TITLE
NAS-125488 / 24.04 / Datasets: Dataset space management does not show the exact number, it shows the number as a rounded number.

### DIFF
--- a/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.html
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.html
@@ -14,7 +14,7 @@
   <h3 class="chart-header">
     <span class="chart-title">{{ 'Total Allocation' | translate }}:</span>
     <span>
-      {{ dataset.used.parsed | filesize: { standard: 'iec', round: 0 } }}
+      {{ dataset.used.parsed | filesize: { standard: 'iec', round: 2 } }}
     </span>
   </h3>
   <div class="legend-wrapper">
@@ -28,7 +28,7 @@
       </span>
       <span class="legend-value">
         {{
-          dataset.usedbydataset.parsed | filesize: { standard: 'iec', round: 0 }
+          dataset.usedbydataset.parsed | filesize: { standard: 'iec', round: 2 }
         }}
         <ng-container *ngIf="dataset.usedbydataset.parsed">
           ({{ dataset.usedbydataset.parsed / dataset.used.parsed | percent }})
@@ -47,7 +47,7 @@
         <span class="legend-value">
           {{
             dataset.usedbychildren.parsed
-              | filesize: { standard: 'iec', round: 0 }
+              | filesize: { standard: 'iec', round: 2 }
           }}
           <ng-container *ngIf="dataset.usedbychildren.parsed">
             ({{


### PR DESCRIPTION
Testing: see ticket and result 👇 :
<img width="1097" alt="Screenshot 2024-01-04 at 15 25 18" src="https://github.com/truenas/webui/assets/22980553/71153547-78c8-4509-9c23-d0620ee42ece">
