### PR TITLE
NAS-124814 / 24.04 / Handling case for no disks for a specific pool (by RehanY147)

### DIFF
--- a/src/app/pages/storage/components/pools-dashboard/pools-dashboard.component.ts
+++ b/src/app/pages/storage/components/pools-dashboard/pools-dashboard.component.ts
@@ -100,6 +100,6 @@ export class PoolsDashboardComponent implements OnInit {
   }
 
   getDisksForPool(pool: Pool): StorageDashboardDisk[] {
-    return this.allDisksByPool[pool.name];
+    return this.allDisksByPool[pool.name] || [];
   }
 }


### PR DESCRIPTION
Handling case where missing disks for a specific pool make the topology card fail on the Storage page for pools.

Original PR: https://github.com/truenas/webui/pull/9396
Jira URL: https://ixsystems.atlassian.net/browse/NAS-124814