### PR TITLE
Fix typo in German translation: "Algorythmus"

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3341,7 +3341,7 @@
   "Alert": "Benachrichtigung",
   "Alert Settings": "Benachrichtigungseinstellungen",
   "Alerts": "Alarme",
-  "Algorithm": "Algorythmus",
+  "Algorithm": "Algorithmus",
   "Aliases": "Aliase",
   "Aliases must be 15 characters or less.": "Aliase dürfen maximal 15 Zeichen lang sein.",
   "All Disks": "Alle Datenträger",


### PR DESCRIPTION
See for example https://de.wikipedia.org/wiki/Algorithmus

I can remove the trailing newline if it bothers you – just tell me.