### PR TITLE
NAS-126036 / 24.04 / Folder selector for cloud sync task works incorrectly

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -498,7 +498,7 @@ export class CloudsyncFormComponent implements OnInit {
         encryption_salt: this.form.controls.encryption_salt.value,
         attributes: {
           bucket,
-          folder: node.path.slice(1).join('') || '/',
+          folder: node.data.path,
         },
         args: '',
       };
@@ -510,16 +510,18 @@ export class CloudsyncFormComponent implements OnInit {
       return this.ws.call('cloudsync.list_directory', [data]).pipe(
         map((listing) => {
           const nodes: ExplorerNodeData[] = [];
+
           listing.forEach((file) => {
             if (file.IsDir) {
               nodes.push({
-                path: '/' + file.Name,
+                path: `${data.attributes.folder}/${file.Name}`.replace(/\/+/g, '/'),
                 name: file.Name,
                 type: ExplorerNodeType.Directory,
                 hasChildren: true,
               });
             }
           });
+
           return nodes;
         }),
       );

--- a/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-what-and-when/cloudsync-what-and-when.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-what-and-when/cloudsync-what-and-when.component.ts
@@ -501,7 +501,7 @@ export class CloudsyncWhatAndWhenComponent implements OnInit, OnChanges {
         encryption_salt: this.form.controls.encryption_salt.value,
         attributes: {
           bucket,
-          folder: node.path.slice(1).join('') || '/',
+          folder: node.data.path,
         },
         args: '',
       };
@@ -513,16 +513,18 @@ export class CloudsyncWhatAndWhenComponent implements OnInit, OnChanges {
       return this.ws.call('cloudsync.list_directory', [data]).pipe(
         map((listing) => {
           const nodes: ExplorerNodeData[] = [];
+
           listing.forEach((file) => {
             if (file.IsDir) {
               nodes.push({
-                path: '/' + file.Name,
+                path: `${data.attributes.folder}/${file.Name}`.replace(/\/+/g, '/'),
                 name: file.Name,
                 type: ExplorerNodeType.Directory,
                 hasChildren: true,
               });
             }
           });
+
           return nodes;
         }),
       );


### PR DESCRIPTION
Testing:
See ticket, use m40 and go to `Cloudsync Task Wizard`

Try selecting folders, there should not be any limits to folder nesting and you should see full path once you selected folder.

<img width="806" alt="Screenshot 2024-01-08 at 12 07 20" src="https://github.com/truenas/webui/assets/22980553/a89de605-1533-4325-aa82-c272e295ffed">
