### PR TITLE
NAS-125131 / 13.1 / Always remove OAuth window event listener

### DIFF
--- a/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
+++ b/src/app/pages/system/CloudCredentials/cloudcredentials-form/cloudcredentials-form.component.ts
@@ -1245,6 +1245,7 @@ export class CloudCredentialsFormComponent {
         window.addEventListener('message', doAuth, false);
 
         function doAuth(message) {
+          window.removeEventListener('message', doAuth);
           if (message.data.oauth_portal) {
             if (message.data.error) {
               dialogService.errorReport(T('Error'), message.data.error);
@@ -1263,7 +1264,6 @@ export class CloudCredentialsFormComponent {
               getOnedriveList(message.data);
             }
           }
-          window.removeEventListener('message', doAuth);
         }
       },
     },


### PR DESCRIPTION
`cloudsync.onedrive_list_drives` was called for pCloud credential. I suppose, the component was previously used to perform a OneDrive authorization and OneDrive event listener did not remove itself due to an unhandled exception.