### PR TITLE
NAS-126701 / UI errors on Manage Devices page - Add EXTEND for single-device LOG and remove EXTEND on RAIDZ vdev member disks

### DIFF
--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
@@ -41,7 +41,7 @@ export class ZfsInfoCardComponent {
   }
 
   get isRaidzParent(): boolean {
-    return raidzItems.includes(this.topologyItem.type);
+    return raidzItems.includes(this.topologyParentItem.type);
   }
 
   get isDraidOrMirrorParent(): boolean {
@@ -62,6 +62,7 @@ export class ZfsInfoCardComponent {
       && (this.topologyCategory === VdevType.Data
         || this.topologyCategory === VdevType.Dedup
         || this.topologyCategory === VdevType.Special
+        || this.topologyCategory === VdevType.Log
       ) && this.topologyItem.status !== TopologyItemStatus.Unavail;
   }
 


### PR DESCRIPTION
Adds EXTEND button for single-device LOG vdevs and removes misleading EXTEND on RAIDZ vdev member disks

isRaidzParent function updated (was checking the passed item itself, intention is to check if the parent item is RAIDZ type) - ref #7883 

canExtendDisk function updated to add match on VdevType.Log as a single-disk LOG should still be extended