### PR TITLE
NAS-126077 / 23.10.2 / The directories don't reset when credentials are changed on the Cloudsync Task Form (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-forms/components/ix-explorer/ix-explorer.component.ts
+++ b/src/app/modules/ix-forms/components/ix-explorer/ix-explorer.component.ts
@@ -92,6 +92,7 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
 
     if ('nodeProvider' in changes || 'root' in changes) {
       this.setInitialNode();
+      this.cdr.markForCheck();
     }
   }
 

--- a/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
+++ b/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
@@ -261,6 +261,10 @@ export class ReplicationFormComponent implements OnInit {
         untilDestroyed(this),
       )
       .subscribe(() => this.updateExplorers());
+
+    this.transportSection.form.controls.ssh_credentials.valueChanges.pipe(untilDestroyed(this)).subscribe(() => {
+      this.targetSection.form.controls.target_dataset.reset();
+    });
   }
 
   private updateExplorers(): void {

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.html
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.html
@@ -31,7 +31,7 @@
         [multiple]="true"
         [required]="true"
         [root]="isRemoteSource ? '' : mntPath"
-        [nodeProvider]="isRemoteSource ? remoteSourceNodeProvider : datasetNodeProvider"
+        [nodeProvider]="sourceNodeProvider"
       ></ix-explorer>
 
       <ix-checkbox
@@ -92,7 +92,7 @@
         [tooltip]="helptext.target_dataset_tooltip | translate"
         [required]="true"
         [root]="isRemoteTarget ? '' : mntPath"
-        [nodeProvider]="isRemoteTarget ? remoteTargetNodeProvider : datasetNodeProvider"
+        [nodeProvider]="targetNodeProvider"
       ></ix-explorer>
       <ix-checkbox
         *ngIf="form.controls.encryption.enabled"


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e6501003c99f776a1fb547c6301f8986b4a269d1
    git cherry-pick -x 418068c8cdd30c5540ec975d50a5f520f41e8ab8
    git cherry-pick -x b3e02d759019e6ac7aa5f17d3d8f1948ae7eee08

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x c4063896c0edd0542afc1d1a9a98cea57f288100

Testing: see ticket, you should be able to see `<ix-explorer>` values updated once trigger is called.
Test for any regressions.

Example:
`Cloud Sync Tasks` - Credential -> Folder (as well I reset folder value once Credential is changed)

see:

https://github.com/truenas/webui/assets/22980553/982fe4ee-205a-4aad-bdba-21685c5a5242

as well check how it worked before, to see the difference. As well some optimisations done.

Cloud Sync Task ✅ 

Replication Task ✅ (As well added missing logic for the Wizard)
```
sourceNodeProvider: TreeNodeProvider;
targetNodeProvider: TreeNodeProvider;
```
⬆️ these two were defined but value was not set..

Rsync Task ✔️ 

@RehanY147  as well mentioned `Rsync Task` but I didn't find such logic there.

Original PR: https://github.com/truenas/webui/pull/9420
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126077