### PR TITLE
NAS-126685 / 24.04 / NAS-126685: Do not do full build when only translation files were changed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,20 +108,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0 # fetch all history for all branches and tags
+          fetch-depth: 0
       - name: Commit and Push Changes
         run: |
-          # Fetch the full history and checkout the PR's head branch
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
           git checkout ${{ github.head_ref }}
           # Ensure the branch is up to date
           git pull origin ${{ github.head_ref }} --no-edit
           # Stage any changes
           git add src/assets/i18n
           # Only commit if there are changes
-          if ! git diff --quiet --cached; then
-            git commit -m "NAS-XXXXXX: Resort translation strings" || echo "No changes to commit."
-            git push origin ${{ github.head_ref }}
-          else
-            echo "No changes to commit."
-          fi
+          git commit -m "NAS-XXXXXX: Resort translation strings" || echo "No changes to commit."
+          git push origin ${{ github.head_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.check-if-only-translation-changed.outputs.only_translations == 'true' }}
     steps:
+      - name: Extract Messages
+        run: yarn run extract
+      - name: Validate Translations
+        run: yarn run validate-translations
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -113,6 +117,7 @@ jobs:
         run: |
           git config --global user.name 'Alex Karpov'
           git config --global user.email 'akarpov@ixsystems.com'
+          git pull origin ${{ github.head_ref }} --no-edit
           git add src/assets/i18n
           git commit -m "NAS-XXXXXX: Resort translation strings" || echo "No changes to commit."
           git push origin ${{ github.head_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,5 +125,5 @@ jobs:
           git config --global user.name 'Alex Karpov'
           git config --global user.email 'akarpov@ixsystems.com'
           git add src/assets/i18n
-          git commit -m "Resort translation strings"
+          git commit -m "NAS-xxxxxx: Resort translation strings"
           git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,14 +116,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         uses: ./.github/actions/prepare
-      - name: Extract Messages
-        run: yarn run extract
-      - name: Validate Translations
-        run: yarn run validate-translations
       - name: Commit and Push Changes
         run: |
           git config --global user.name 'Alex Karpov'
           git config --global user.email 'akarpov@ixsystems.com'
           git add src/assets/i18n
-          git commit -m "NAS-xxxxxx: Resort translation strings"
+          git commit -m "NAS-XXXXXX: Resort translation strings"
           git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,32 @@ jobs:
       - name: Install
         uses: ./.github/actions/prepare
 
+  resort-strings:
+    name: Resort Strings and Commit
+    needs: [install]
+    runs-on: ubuntu-latest
+    if: "contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') || contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Extract Messages
+        run: yarn extract
+      - name: Validate Translations
+        run: yarn validate-translations
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name 'Alex Karpov'
+          git config --global user.email 'akarpov@ixsystems.com'
+          git add src/assets/i18n
+          git commit -m "Resort translation strings"
+          git push
+
   build:
     name: Build
     needs: [install]
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.modified, 'src/assets/i18n/') && !contains(github.event.head_commit.added, 'src/assets/i18n/')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -83,24 +104,3 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
-  resort-strings:
-    name: Resort Strings and Commit
-    needs: [install]
-    runs-on: ubuntu-latest
-    if: "contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') || contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Extract Messages
-        run: yarn extract
-      - name: Validate Translations
-        run: yarn validate-translations
-      - name: Commit and Push Changes
-        run: |
-          git config --global user.name 'Alex Karpov'
-          git config --global user.email 'akarpov@ixsystems.com'
-          git add src/assets/i18n
-          git commit -m "Resort translation strings"
-          git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     name: Resort Strings and Commit
     needs: [install]
     runs-on: ubuntu-latest
-    if: "contains(github.event.head_commit.modified, 'src/assets/i18n/') || contains(github.event.head_commit.added, 'src/assets/i18n/')"
+    if: "contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') || contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
     name: Build
     needs: [install]
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.modified, 'src/assets/i18n/') && !contains(github.event.head_commit.added, 'src/assets/i18n/')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,6 +38,7 @@ jobs:
     name: Validate code style
     needs: [install]
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.modified, 'src/assets/i18n/') && !contains(github.event.head_commit.added, 'src/assets/i18n/')"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -63,6 +65,7 @@ jobs:
     name: Run tests
     needs: [install]
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.modified, 'src/assets/i18n/') && !contains(github.event.head_commit.added, 'src/assets/i18n/')"
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -79,3 +82,25 @@ jobs:
           name: webui
           token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: true
+
+  resort-strings:
+    name: Resort Strings and Commit
+    needs: [install]
+    runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.modified, 'src/assets/i18n/') || contains(github.event.head_commit.added, 'src/assets/i18n/')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Extract Messages
+        run: yarn extract
+      - name: Validate Translations
+        run: yarn validate-translations
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name 'Alex Karpov'
+          git config --global user.email 'akarpov@ixsystems.com'
+          git add src/assets/i18n
+          git commit -m "Resort translation strings"
+          git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,15 +104,15 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.check-if-only-translation-changed.outputs.only_translations == 'true' }}
     steps:
-      - name: Extract Messages
-        run: yarn run extract
-      - name: Validate Translations
-        run: yarn run validate-translations
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+      - name: Extract Messages
+        run: yarn run extract
+      - name: Validate Translations
+        run: yarn run validate-translations
       - name: Commit and Push Changes
         run: |
           git config --global user.name 'Alex Karpov'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,5 +119,9 @@ jobs:
           git config --global user.email 'akarpov@ixsystems.com'
           git pull origin ${{ github.head_ref }} --no-edit
           git add src/assets/i18n
-          git commit -m "NAS-XXXXXX: Resort translation strings" || echo "No changes to commit."
-          git push origin ${{ github.head_ref }}
+          if ! git diff --quiet --cached; then
+            git commit -m "NAS-XXXXXX: Resort translation strings"
+            git push origin ${{ github.head_ref }}
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,11 +111,8 @@ jobs:
           fetch-depth: 0
       - name: Commit and Push Changes
         run: |
-          git checkout ${{ github.head_ref }}
-          # Ensure the branch is up to date
-          git pull origin ${{ github.head_ref }} --no-edit
-          # Stage any changes
+          git config --global user.name 'Alex Karpov'
+          git config --global user.email 'akarpov@ixsystems.com'
           git add src/assets/i18n
-          # Only commit if there are changes
           git commit -m "NAS-XXXXXX: Resort translation strings" || echo "No changes to commit."
           git push origin ${{ github.head_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,27 @@ jobs:
       - name: Install
         uses: ./.github/actions/prepare
 
+  check-only-translation-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      only_translations: ${{ steps.only_translations.outputs.result }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check if only translation files have changed
+        id: only_translations
+        run: |
+          FILES_API_URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }}/files"
+          FILES=$(curl -s -X GET -G $FILES_API_URL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" | jq -r '.[] | .filename')
+          TRANSLATION_FILES_CHANGED=$(echo "$FILES" | grep -c "src/assets/i18n" || true)
+          TOTAL_FILES_CHANGED=$(echo "$FILES" | wc -l | xargs)
+          if [ "$TOTAL_FILES_CHANGED" == "$TRANSLATION_FILES_CHANGED" ]; then
+            echo "::set-output name=result::true"
+          else
+            echo "::set-output name=result::false"
+          fi
+
   build:
     name: Build
     needs: [install]
@@ -64,7 +85,7 @@ jobs:
     name: Run tests
     needs: [install]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') && !contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')) }}
+    if: ${{ needs.check-only-translation-changes.outputs.only_translations == 'false' }}
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -84,9 +105,9 @@ jobs:
 
   resort-strings:
     name: Resort Strings and Commit
-    needs: [install]
+    needs: [check-only-translation-changes, install]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && contains(join(github.event.commits.*.added, '\n'), 'src/assets/i18n/') || contains(join(github.event.commits.*.modified, '\n'), 'src/assets/i18n/') || github.event_name == 'pull_request' && github.event.pull_request.head.ref != null }}
+    if: ${{ needs.check-only-translation-changes.outputs.only_translations == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,15 +21,16 @@ jobs:
       - name: Install
         uses: ./.github/actions/prepare
 
-  check-only-translation-changes:
+  check-if-only-translation-changed:
     runs-on: ubuntu-latest
+    name: 'Check if only translation files were changed'
     outputs:
       only_translations: ${{ steps.only_translations.outputs.result }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Check if only translation files have changed
+      - name: Check if only translation files were changed
         id: only_translations
         run: |
           FILES_API_URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.number }}/files"
@@ -44,8 +45,9 @@ jobs:
 
   build:
     name: Build
-    needs: [install]
+    needs: [check-if-only-translation-changed, install]
     runs-on: ubuntu-latest
+    if: ${{ needs.check-if-only-translation-changed.outputs.only_translations == 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -56,9 +58,9 @@ jobs:
 
   lint:
     name: Validate code style
-    needs: [install]
+    needs: [check-if-only-translation-changed, install]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') && !contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')) }}
+    if: ${{ needs.check-if-only-translation-changed.outputs.only_translations == 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -71,7 +73,8 @@ jobs:
 
   lint-translations:
     name: Validate translation strings
-    needs: [install]
+    needs: [check-if-only-translation-changed, install]
+    if: ${{ needs.check-if-only-translation-changed.outputs.only_translations == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -83,9 +86,9 @@ jobs:
 
   test:
     name: Run tests
-    needs: [install]
+    needs: [check-if-only-translation-changed, install]
     runs-on: ubuntu-latest
-    if: ${{ needs.check-only-translation-changes.outputs.only_translations == 'false' }}
+    if: ${{ needs.check-if-only-translation-changed.outputs.only_translations == 'false' }}
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -104,19 +107,19 @@ jobs:
           fail_ci_if_error: true
 
   resort-strings:
-    name: Resort Strings and Commit
-    needs: [check-only-translation-changes, install]
+    name: Resort Strings and Commit if only translations were added
+    needs: [check-if-only-translation-changed, install]
     runs-on: ubuntu-latest
-    if: ${{ needs.check-only-translation-changes.outputs.only_translations == 'true' }}
+    if: ${{ needs.check-if-only-translation-changed.outputs.only_translations == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
+      - name: Install
+        uses: ./.github/actions/prepare
       - name: Extract Messages
-        run: yarn extract
+        run: yarn run extract
       - name: Validate Translations
-        run: yarn validate-translations
+        run: yarn run validate-translations
       - name: Commit and Push Changes
         run: |
           git config --global user.name 'Alex Karpov'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,32 +21,11 @@ jobs:
       - name: Install
         uses: ./.github/actions/prepare
 
-  resort-strings:
-    name: Resort Strings and Commit
-    needs: [install]
-    runs-on: ubuntu-latest
-    if: "contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') || contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Extract Messages
-        run: yarn extract
-      - name: Validate Translations
-        run: yarn validate-translations
-      - name: Commit and Push Changes
-        run: |
-          git config --global user.name 'Alex Karpov'
-          git config --global user.email 'akarpov@ixsystems.com'
-          git add src/assets/i18n
-          git commit -m "Resort translation strings"
-          git push
-
   build:
     name: Build
     needs: [install]
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') && !contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,7 +38,7 @@ jobs:
     name: Validate code style
     needs: [install]
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.modified, 'src/assets/i18n/') && !contains(github.event.head_commit.added, 'src/assets/i18n/')"
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') && !contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -86,7 +65,7 @@ jobs:
     name: Run tests
     needs: [install]
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.modified, 'src/assets/i18n/') && !contains(github.event.head_commit.added, 'src/assets/i18n/')"
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') && !contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')) }}
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -104,3 +83,24 @@ jobs:
           token: ${{ env.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
+  resort-strings:
+    name: Resort Strings and Commit
+    needs: [install]
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && contains(join(github.event.commits.*.added, '\n'), 'src/assets/i18n/') || contains(join(github.event.commits.*.modified, '\n'), 'src/assets/i18n/') || github.event_name == 'pull_request' && github.event.pull_request.head.ref != null }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Extract Messages
+        run: yarn extract
+      - name: Validate Translations
+        run: yarn validate-translations
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name 'Alex Karpov'
+          git config --global user.email 'akarpov@ixsystems.com'
+          git add src/assets/i18n
+          git commit -m "Resort translation strings"
+          git push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,8 +51,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install
-        uses: ./.github/actions/prepare
       - name: Build
         run: yarn build:prod:aot
 
@@ -64,8 +62,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install
-        uses: ./.github/actions/prepare
       - name: Generate default environment file
         run: yarn run check-env
       - name: Build
@@ -79,8 +75,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install
-        uses: ./.github/actions/prepare
       - name: Build
         run: yarn run extract
 
@@ -94,8 +88,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install
-        uses: ./.github/actions/prepare
       - name: Run tests
         run: yarn test:pr
       - if: ${{ env.CODECOV_TOKEN }}
@@ -114,12 +106,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install
-        uses: ./.github/actions/prepare
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0 # fetch all history for all branches and tags
       - name: Commit and Push Changes
         run: |
-          git config --global user.name 'Alex Karpov'
-          git config --global user.email 'akarpov@ixsystems.com'
+          # Fetch the full history and checkout the PR's head branch
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
           git checkout ${{ github.head_ref }}
           # Ensure the branch is up to date
           git pull origin ${{ github.head_ref }} --no-edit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Check if only translation files were changed
         id: only_translations
         run: |
@@ -51,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install
+        uses: ./.github/actions/prepare
       - name: Build
         run: yarn build:prod:aot
 
@@ -62,6 +63,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install
+        uses: ./.github/actions/prepare
       - name: Generate default environment file
         run: yarn run check-env
       - name: Build
@@ -75,6 +78,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install
+        uses: ./.github/actions/prepare
       - name: Build
         run: yarn run extract
 
@@ -88,6 +93,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install
+        uses: ./.github/actions/prepare
       - name: Run tests
         run: yarn test:pr
       - if: ${{ env.CODECOV_TOKEN }}
@@ -109,6 +116,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+      - name: Install
+        uses: ./.github/actions/prepare
       - name: Extract Messages
         run: yarn run extract
       - name: Validate Translations

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,15 @@ jobs:
         run: |
           git config --global user.name 'Alex Karpov'
           git config --global user.email 'akarpov@ixsystems.com'
-          git checkout ${{ github.head_ref }} || git checkout -b ${{ github.head_ref }}
+          git checkout ${{ github.head_ref }}
+          # Ensure the branch is up to date
+          git pull origin ${{ github.head_ref }} --no-edit
+          # Stage any changes
           git add src/assets/i18n
-          git commit -m "NAS-XXXXXX: Resort translation strings" || echo "No changes to commit."
-          git push origin ${{ github.head_ref }}
+          # Only commit if there are changes
+          if ! git diff --quiet --cached; then
+            git commit -m "NAS-XXXXXX: Resort translation strings" || echo "No changes to commit."
+            git push origin ${{ github.head_ref }}
+          else
+            echo "No changes to commit."
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
     name: Build
     needs: [install]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(join(github.event.pull_request.head_commit.modified, '\n'), 'src/assets/i18n/') && !contains(join(github.event.pull_request.head_commit.added, '\n'), 'src/assets/i18n/')) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,9 +115,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Install
         uses: ./.github/actions/prepare
+      - name: Extract Messages
+        run: yarn run extract
+      - name: Validate Translations
+        run: yarn run validate-translations
       - name: Commit and Push Changes
         run: |
           git config --global user.name 'BugClerk'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,7 @@ jobs:
         run: |
           git config --global user.name 'Alex Karpov'
           git config --global user.email 'akarpov@ixsystems.com'
+          git checkout ${{ github.head_ref }} || git checkout -b ${{ github.head_ref }}
           git add src/assets/i18n
-          git commit -m "NAS-XXXXXX: Resort translation strings"
-          git push
+          git commit -m "NAS-XXXXXX: Resort translation strings" || echo "No changes to commit."
+          git push origin ${{ github.head_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,18 +118,14 @@ jobs:
           fetch-depth: 0
       - name: Install
         uses: ./.github/actions/prepare
-      - name: Extract Messages
-        run: yarn run extract
-      - name: Validate Translations
-        run: yarn run validate-translations
       - name: Commit and Push Changes
         run: |
-          git config --global user.name 'Alex Karpov'
-          git config --global user.email 'akarpov@ixsystems.com'
+          git config --global user.name 'BugClerk'
+          git config --global user.email 'bugclerk@ixsystems.com'
           git pull origin ${{ github.head_ref }} --no-edit
           git add src/assets/i18n
           if ! git diff --quiet --cached; then
-            git commit -m "NAS-XXXXXX: Resort translation strings"
+            git commit -m "NAS-XXXXXX: Auto resort translation strings"
             git push origin ${{ github.head_ref }}
           else
             echo "No changes to commit."

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -4,7 +4,7 @@
   " as of {dateTime}": "",
   "(Optional)": "",
   "...": "",
-  "2 days ago": "2 дні тому",
+  "2 days ago": "",
   "2 months ago": "",
   "2 weeks ago": "",
   "2FA has been configured for this account. Enter the OTP to continue.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -4,7 +4,7 @@
   " as of {dateTime}": "",
   "(Optional)": "",
   "...": "",
-  "2 days ago": "",
+  "2 days ago": "2 дні тому",
   "2 months ago": "",
   "2 weeks ago": "",
   "2FA has been configured for this account. Enter the OTP to continue.": "",


### PR DESCRIPTION
For testing -- see this PR, which is based on this branch in order to test pipeline:

https://github.com/truenas/webui/pull/9433

You should see that if only translation files were updated - we skip some of the steps and run only `Resort Strings and Commit if only translations were added` Step.

<img width="853" alt="Screenshot 2024-01-11 at 15 52 35" src="https://github.com/truenas/webui/assets/22980553/46c52b0d-54de-4954-97bf-eb8f93b6bba0">

As well you can go ahead and update some other non i18n file, to see that the pipeline will now skip `Resort Strings and Commit if only translations were added` Step and will only run previous steps we had.

<img width="848" alt="Screenshot 2024-01-11 at 15 53 33" src="https://github.com/truenas/webui/assets/22980553/ae4dc8c6-6798-495b-9317-d6f4e42d4a48">

