### PR TITLE
NAS-126711 / 24.04 / Fix HA enabled message when loading widget info

### DIFF
--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
@@ -179,7 +179,7 @@
               </div>
 
               <div
-                *ngIf="!systemInfo || (isHaLicensed && isPassive && !hasHa)"
+                *ngIf="!systemInfo && isHaLicensed && isPassive && !hasHa"
                 class="data-container ha-status"
                 fxFlex
               >


### PR DESCRIPTION
For testing, ensure no `HA Enabled/HA Disabled` text appears while the sys-info widget is loading. Check the non-HA system (e.g., nightly) and check on the HA system (e.g., m40).