### PR TITLE
NAS-126744 / 24.04 / Dataset tree collapses after new dataset is created

### DIFF
--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -234,7 +234,10 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
       .pipe(filter(Boolean), untilDestroyed(this))
       .subscribe({
         next: (selectedBranch: DatasetDetails[]) => {
-          selectedBranch.forEach((dataset) => this.treeControl.expand(dataset));
+          selectedBranch.forEach((datasetFromSelectedBranch) => {
+            const expandedDataset = this.dataSource.data.find((dataset) => dataset.id === datasetFromSelectedBranch.id);
+            this.treeControl.expand(expandedDataset);
+          });
         },
         error: this.handleError,
       });

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -235,7 +235,8 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
       .subscribe({
         next: (selectedBranch: DatasetDetails[]) => {
           selectedBranch.forEach((datasetFromSelectedBranch) => {
-            const expandedDataset = this.dataSource.data.find((dataset) => dataset.id === datasetFromSelectedBranch.id);
+            const expandedDataset = this.treeControl.dataNodes
+              .find((dataset) => dataset.id === datasetFromSelectedBranch.id);
             this.treeControl.expand(expandedDataset);
           });
         },


### PR DESCRIPTION
**Testing**

On the **Datasets** page, prepare a top-level dataset with a sub-dataset. 
1. Expand top-level dataset
2. Select sub-dataset
3. Reload the page

- **Expected result:** expansion and selection is persisted