### PR TITLE
NAS-126753 / 24.04 / Wrong seconds calculation in WebUI Sessions Settings Widget

### DIFF
--- a/src/app/pages/system/advanced/access/access-card/access-card.component.spec.ts
+++ b/src/app/pages/system/advanced/access/access-card/access-card.component.spec.ts
@@ -60,7 +60,7 @@ describe('AccessCardComponent', () => {
           {
             selector: selectPreferences,
             value: {
-              lifetime: 60,
+              lifetime: 2147482,
             },
           },
           {
@@ -93,7 +93,7 @@ describe('AccessCardComponent', () => {
 
   it('shows current token lifetime', async () => {
     const lifetime = (await loader.getAllHarnesses(MatListItemHarness))[0];
-    expect(await lifetime.getFullText()).toBe('Token Lifetime: 1 minute');
+    expect(await lifetime.getFullText()).toBe('Token Lifetime: 24 days 20 hours 31 minutes 22 seconds');
   });
 
   it('shows whether DS users are allowed access to WebUI', async () => {

--- a/src/app/pages/system/advanced/access/access-card/access-card.component.ts
+++ b/src/app/pages/system/advanced/access/access-card/access-card.component.ts
@@ -163,7 +163,7 @@ export class AccessCardComponent implements OnInit {
   asDuration(tokenLifetime: number): string {
     const duration = intervalToDuration({ start: 0, end: tokenLifetime * 1000 });
     return formatDuration(duration, {
-      format: ['hours', 'minutes', 'seconds'],
+      format: ['days', 'hours', 'minutes', 'seconds'],
     });
   }
 

--- a/src/app/pages/system/advanced/access/access-form/access-form.component.ts
+++ b/src/app/pages/system/advanced/access/access-form/access-form.component.ts
@@ -29,8 +29,8 @@ export class AccessFormComponent implements OnInit {
   form = this.fb.group({
     token_lifetime: [defaultPreferences.lifetime, [
       Validators.required,
-      Validators.min(30),
-      Validators.max(Math.floor(2 ** 31 / 1000 - 1)), // Max value for setTimeout
+      Validators.min(30), // Min value allowed is 30 seconds.
+      Validators.max(2147482), // Max value is 2147482 seconds, or 24 days, 20 hours, 31 minutes, and 22 seconds.
     ]],
     ds_auth: [false],
   });
@@ -38,6 +38,7 @@ export class AccessFormComponent implements OnInit {
   get isEnterprise(): boolean {
     return this.systemGeneralService.isEnterprise;
   }
+
   protected readonly Role = Role;
 
   constructor(


### PR DESCRIPTION
Testing: 
Go to `Advanced Settings -> Access` card
http://localhost:4200/system/advanced

Try to update `Token Lifetime`
<img width="133" alt="Screenshot 2024-01-17 at 12 08 47" src="https://github.com/truenas/webui/assets/22980553/9248ce27-8298-4ec4-9867-d353da562d8b">

Make sure that it works if seconds in total are greater then 24 hours:

Example:
<img width="457" alt="Screenshot 2024-01-17 at 12 04 13" src="https://github.com/truenas/webui/assets/22980553/0c8c51a7-1c14-448b-a9d7-8cc31c6c2188">
<img width="456" alt="Screenshot 2024-01-17 at 12 04 33" src="https://github.com/truenas/webui/assets/22980553/28913595-6b62-4910-901a-dec21d09898a">
