### PR TITLE
NAS-125547 / 24.04 / The Disks Are Displayed In A Random Order On The Disk I/O Reporting Page

### DIFF
--- a/src/app/pages/reports-dashboard/reports-dashboard.component.ts
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.ts
@@ -190,7 +190,7 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy {
       }
     });
 
-    return result;
+    return result.sort((a, b) => a.identifiers?.[0].localeCompare(b.identifiers?.[0]));
   }
 
   buildDiskMetrics(): void {

--- a/src/app/pages/reports-dashboard/reports-dashboard.component.ts
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.ts
@@ -190,7 +190,7 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy {
       }
     });
 
-    return result.sort((a, b) => a.identifiers?.[0].localeCompare(b.identifiers?.[0]));
+    return result.sort((a, b) => a.identifiers?.[0]?.localeCompare(b.identifiers?.[0]));
   }
 
   buildDiskMetrics(): void {

--- a/src/app/pages/reports-dashboard/reports.service.ts
+++ b/src/app/pages/reports-dashboard/reports.service.ts
@@ -136,7 +136,8 @@ export class ReportsService {
           .map((disk) => {
             const [value] = disk.devname.split(' ');
             return { label: disk.devname, value };
-          });
+          })
+          .sort((a, b) => a.label.localeCompare(b.label));
       }),
       shareReplay({ refCount: true, bufferSize: 1 }),
     );


### PR DESCRIPTION
Testing: 
go to Disk Reporting
http://localhost:4200/reportsdashboard/disk

See that Disks are sorted in alphabetical order in the `Select` and In `Cards`

Example:
<img width="1728" alt="Screenshot 2024-01-17 at 12 33 24" src="https://github.com/truenas/webui/assets/22980553/80f8a250-daf3-44ac-b954-f3dc9152d155">

