### PR TITLE
NAS-126753 / 23.10.2 / Wrong seconds calculation in WebUI Sessions Settings Widget (by AlexKarpov98)

### DIFF
--- a/src/app/pages/system/advanced/sessions/sessions-card/sessions-card.component.ts
+++ b/src/app/pages/system/advanced/sessions/sessions-card/sessions-card.component.ts
@@ -134,7 +134,7 @@ export class SessionsCardComponent {
   asDuration(tokenLifetime: number): string {
     const duration = intervalToDuration({ start: 0, end: tokenLifetime * 1000 });
     return formatDuration(duration, {
-      format: ['hours', 'minutes', 'seconds'],
+      format: ['days', 'hours', 'minutes', 'seconds'],
     });
   }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x ce87d453d1361adc2c1da9b90d8c2f1113a01622

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 149716f614590c90831ab628b1a056691656427a

Testing: 
Go to `Advanced Settings -> Access` card
http://localhost:4200/system/advanced

Try to update `Token Lifetime`
<img width="133" alt="Screenshot 2024-01-17 at 12 08 47" src="https://github.com/truenas/webui/assets/22980553/9248ce27-8298-4ec4-9867-d353da562d8b">

Make sure that it works if seconds in total are greater then 24 hours:

Example:
<img width="457" alt="Screenshot 2024-01-17 at 12 04 13" src="https://github.com/truenas/webui/assets/22980553/0c8c51a7-1c14-448b-a9d7-8cc31c6c2188">
<img width="456" alt="Screenshot 2024-01-17 at 12 04 33" src="https://github.com/truenas/webui/assets/22980553/28913595-6b62-4910-901a-dec21d09898a">


Original PR: https://github.com/truenas/webui/pull/9459
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126753