### PR TITLE
NAS-125762 / 24.04 / Installed apps sorting unsorts itself (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -69,7 +69,6 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
     active: SortableField.Application,
     direction: SortDirection.Asc,
   };
-  ixTreeHeaderWidth: number | null = null;
   readonly sortableField = SortableField;
 
   entityEmptyConf: EmptyConfig = {
@@ -304,6 +303,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
       .pipe(untilDestroyed(this))
       .subscribe((job: Job<ChartScaleResult, ChartScaleQueryParams>) => {
         this.appJobs.set(name, job);
+        this.sortChanged(this.sortingInfo);
         this.cdr.markForCheck();
       });
   }
@@ -313,6 +313,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
       .pipe(untilDestroyed(this))
       .subscribe((job: Job<ChartScaleResult, ChartScaleQueryParams>) => {
         this.appJobs.set(name, job);
+        this.sortChanged(this.sortingInfo);
         this.cdr.markForCheck();
       });
   }
@@ -443,7 +444,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
         case SortableField.Application:
           return doSortCompare(a.name, b.name, isAsc);
         case SortableField.Status:
-          return doSortCompare(a.status, b.status, isAsc);
+          return doSortCompare(this.getAppStatus(a.name), this.getAppStatus(b.name), isAsc);
         case SortableField.Updates:
           return doSortCompare(
             (a.update_available || a.container_images_update_available) ? 1 : 0,
@@ -500,6 +501,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
       .subscribe((event) => {
         const [name] = event.fields.arguments;
         this.appJobs.set(name, event.fields);
+        this.sortChanged(this.sortingInfo);
         this.cdr.markForCheck();
       });
   }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x a598f74e956de96b74ea31e0252f1d54798eb049
    git cherry-pick -x 7ca70f0a8f562a0ab0386487b622a2868b5311b3

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x d79921ea43f12a0f4c0ded1ac825af85f0a459fa

Testing: see ticket, try start / stop apps and keep sorted by Status.

Result (sorted realtime):

https://github.com/truenas/webui/assets/22980553/58fc01f2-758b-463a-aa3f-51fb12dd8549




Original PR: https://github.com/truenas/webui/pull/9449
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125762