### PR TITLE
NAS-126821 / 24.10 / Restore VMware state indication

### DIFF
--- a/src/app/interfaces/vmware.interface.ts
+++ b/src/app/interfaces/vmware.interface.ts
@@ -1,4 +1,5 @@
 import { DatasetType } from 'app/enums/dataset.enum';
+import { VmwareState } from 'app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-status-cell/vmware-status-cell.component';
 
 export interface MatchDatastoresWithDatasets {
   datastores: VmwareDatastore[];
@@ -30,6 +31,7 @@ export interface VmwareSnapshot {
   hostname: string;
   password: string;
   username: string;
+  state: VmwareState;
 }
 
 export type VmwareSnapshotUpdate = Omit<VmwareSnapshot, 'id'>;

--- a/src/app/pages/data-protection/data-protection.module.ts
+++ b/src/app/pages/data-protection/data-protection.module.ts
@@ -57,6 +57,7 @@ import { SnapshotTaskFormComponent } from 'app/pages/data-protection/snapshot-ta
 import { SnapshotTaskListComponent } from 'app/pages/data-protection/snapshot-task/snapshot-task-list/snapshot-task-list.component';
 import { VmwareSnapshotFormComponent } from 'app/pages/data-protection/vmware-snapshot/vmware-snapshot-form/vmware-snapshot-form.component';
 import { VmwareSnapshotListComponent } from 'app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-snapshot-list.component';
+import { VmwareStatusCellComponent } from 'app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-status-cell/vmware-status-cell.component';
 import { CloudsyncFormComponent } from './cloudsync/cloudsync-form/cloudsync-form.component';
 import { CloudsyncListComponent } from './cloudsync/cloudsync-list/cloudsync-list.component';
 import { CloudsyncWizardComponent } from './cloudsync/cloudsync-wizard/cloudsync-wizard.component';
@@ -84,6 +85,7 @@ import { SmartTaskListComponent } from './smart-task/smart-task-list/smart-task-
     EntityModule,
     ReactiveFormsModule,
     MatProgressBarModule,
+    MatTooltipModule,
     MatCardModule,
     TranslateModule,
     IxTable2Module,
@@ -109,6 +111,7 @@ import { SmartTaskListComponent } from './smart-task/smart-task-list/smart-task-
     SnapshotTaskFormComponent,
     VmwareSnapshotFormComponent,
     VmwareSnapshotListComponent,
+    VmwareStatusCellComponent,
     RsyncTaskListComponent,
     RsyncTaskFormComponent,
     SmartTaskListComponent,

--- a/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-snapshot-list.component.html
+++ b/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-snapshot-list.component.html
@@ -23,6 +23,17 @@
       [dataProvider]="dataProvider"
       [isLoading]="dataProvider.isLoading$ | async"
     >
+      
+      <ng-template
+        let-snapshot
+        ix-table-cell
+        [columnIndex]="4"
+        [dataProvider]="dataProvider"
+      >
+        <ix-vmware-status-cell
+          [state]="snapshot.state"
+        ></ix-vmware-status-cell>
+      </ng-template>
       <ng-template let-snapshot ix-table-details-row [dataProvider]="dataProvider">
         <div class="table-details-row-actions">
           <button

--- a/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-snapshot-list.component.ts
+++ b/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-snapshot-list.component.ts
@@ -48,6 +48,11 @@ export class VmwareSnapshotListComponent implements OnInit {
       propertyName: 'datastore',
       sortable: true,
     }),
+    textColumn({
+      title: this.translate.instant('State'),
+      propertyName: 'state',
+      sortable: true,
+    }),
   ], {
     rowTestId: (row) => 'vmware-snapshot-' + row.hostname,
   });

--- a/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-status-cell/vmware-status-cell.component.html
+++ b/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-status-cell/vmware-status-cell.component.html
@@ -1,0 +1,5 @@
+<span
+  [matTooltip]="tooltip"
+>
+  {{ state.state | translate }}
+</span>

--- a/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-status-cell/vmware-status-cell.component.scss
+++ b/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-status-cell/vmware-status-cell.component.scss
@@ -1,0 +1,25 @@
+:host {
+  border: 2px solid transparent;
+  border-radius: 20px;
+  box-sizing: border-box;
+  display: flex;
+  font-weight: bold;
+  gap: 6px;
+  justify-content: center;
+  padding: 3px 8px;
+
+  &.success {
+    border-color: var(--green);
+    color: var(--green);
+  }
+
+  &.pending {
+    border-color: var(--yellow);
+    color: var(--yellow);
+  }
+
+  &.error {
+    border-color: var(--red);
+    color: var(--red);
+  }
+}

--- a/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-status-cell/vmware-status-cell.component.ts
+++ b/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-list/vmware-status-cell/vmware-status-cell.component.ts
@@ -1,0 +1,42 @@
+import {
+  ChangeDetectionStrategy,
+  Component, HostBinding, Input,
+} from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+export enum VmwareSnapshotStatus {
+  Pending = 'PENDING',
+  Error = 'ERROR',
+  Success = 'SUCCESS',
+}
+
+export interface VmwareState {
+  state: VmwareSnapshotStatus;
+  error?: string;
+  datetime?: { $time: number };
+}
+
+@Component({
+  selector: 'ix-vmware-status-cell',
+  templateUrl: './vmware-status-cell.component.html',
+  styleUrls: ['./vmware-status-cell.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class VmwareStatusCellComponent {
+  @Input() state: VmwareState;
+  protected VmwareStates = VmwareSnapshotStatus;
+
+  get tooltip(): string {
+    if (this.state.state === VmwareSnapshotStatus.Error) {
+      return this.state.error ? this.translate.instant(this.state.error) : this.translate.instant('Error');
+    }
+    return this.state.state === VmwareSnapshotStatus.Pending
+      ? this.translate.instant('Pending')
+      : this.translate.instant('Success');
+  }
+
+  @HostBinding('class') get hostClasses(): string[] {
+    return ['status', this.state?.state.toLowerCase()];
+  }
+  constructor(private translate: TranslateService) { }
+}

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2346,6 +2346,7 @@
   "Pause Scrub": "",
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
+  "Pending": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",
   "Pending Upgrade": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1954,6 +1954,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1052,6 +1052,7 @@
   "Pattern of naming custom  snapshots to include in the replication with the periodic snapshot  schedule. Enter the  <a href=\"https://man7.org/linux/man-pages/man3/strftime.3.html\"  target=\"_blank\">strftime(3)</a> strings that match the snapshots to  include in the replication.<br><br>  When a periodic snapshot is not linked to the replication, enter the  naming schema for manually created snapshots. Has the same <i>&percnt;Y</i>,  <i>&percnt;m</i>, <i>&percnt;d</i>, <i>&percnt;H</i>, and <i>&percnt;M</i> string requirements as  the <b>Naming Schema</b> in a <b>Periodic Snapshot Task</b>. Separate  entries by pressing <code>Enter</code>.": "",
   "Pattern of naming custom snapshots to be  replicated. Enter the name and  <a href=\"https://man7.org/linux/man-pages/man3/strftime.3.html\" target=\"_blank\">strftime(3)</a>  <i>&percnt;Y</i>, <i>&percnt;m</i>, <i>&percnt;d</i>, <i>&percnt;H</i>, and <i>&percnt;M</i> strings that  match the snapshots to include in the replication. Separate entries by  pressing <code>Enter</code>. The number of snapshots matching the  patterns are shown.": "",
   "Pause Scrub": "",
+  "Pending": "",
   "Pending Sync Keys Cleared": "",
   "Percentage of total core utilization": "",
   "Percentage used of dataset quota at which to generate a critical alert.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2481,6 +2481,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -181,6 +181,7 @@
   "OpenStack Swift": "",
   "Opened at": "",
   "Password Login": "",
+  "Pending": "",
   "Periodic S.M.A.R.T. Tests": "",
   "Photo Library API client secret generated from the  <a href=\"https://developers.google.com/identity/protocols/oauth2\" target=\"_blank\">Google API Console</a>": "",
   "Privileges": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2443,6 +2443,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2288,6 +2288,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2158,6 +2158,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2657,6 +2657,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -370,6 +370,7 @@
   "Password Login": "",
   "Password login enabled": "",
   "Pause Scrub": "",
+  "Pending": "",
   "Percentage of total core utilization": "",
   "Percentage used of dataset quota at which to generate a critical alert.": "",
   "Percentage used of dataset quota at which to generate a warning alert.": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2599,6 +2599,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2599,6 +2599,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1623,6 +1623,7 @@
   "Pattern of naming custom snapshots to be  replicated. Enter the name and  <a href=\"https://man7.org/linux/man-pages/man3/strftime.3.html\" target=\"_blank\">strftime(3)</a>  <i>&percnt;Y</i>, <i>&percnt;m</i>, <i>&percnt;d</i>, <i>&percnt;H</i>, and <i>&percnt;M</i> strings that  match the snapshots to include in the replication. Separate entries by  pressing <code>Enter</code>. The number of snapshots matching the  patterns are shown.": "",
   "Pause Scrub": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1419,6 +1419,7 @@
   "Pattern of naming custom  snapshots to include in the replication with the periodic snapshot  schedule. Enter the  <a href=\"https://man7.org/linux/man-pages/man3/strftime.3.html\"  target=\"_blank\">strftime(3)</a> strings that match the snapshots to  include in the replication.<br><br>  When a periodic snapshot is not linked to the replication, enter the  naming schema for manually created snapshots. Has the same <i>&percnt;Y</i>,  <i>&percnt;m</i>, <i>&percnt;d</i>, <i>&percnt;H</i>, and <i>&percnt;M</i> string requirements as  the <b>Naming Schema</b> in a <b>Periodic Snapshot Task</b>. Separate  entries by pressing <code>Enter</code>.": "",
   "Pattern of naming custom snapshots to be  replicated. Enter the name and  <a href=\"https://man7.org/linux/man-pages/man3/strftime.3.html\" target=\"_blank\">strftime(3)</a>  <i>&percnt;Y</i>, <i>&percnt;m</i>, <i>&percnt;d</i>, <i>&percnt;H</i>, and <i>&percnt;M</i> strings that  match the snapshots to include in the replication. Separate entries by  pressing <code>Enter</code>. The number of snapshots matching the  patterns are shown.": "",
   "Pause Scrub": "",
+  "Pending": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",
   "Percentage of total core utilization": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -401,6 +401,7 @@
   "Password Login Groups": "",
   "Password login enabled": "",
   "Pause Scrub": "",
+  "Pending": "",
   "Percentage of total core utilization": "",
   "Percentage used of dataset quota at which to generate a critical alert.": "",
   "Percentage used of dataset quota at which to generate a warning alert.": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2663,6 +2663,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -444,6 +444,7 @@
   "Password Login Groups": "",
   "Password login enabled": "",
   "Pause Scrub": "",
+  "Pending": "",
   "Percentage of total core utilization": "",
   "Percentage used of dataset quota at which to generate a critical alert.": "",
   "Percentage used of dataset quota at which to generate a warning alert.": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2082,6 +2082,7 @@
   "Peer Secret": "",
   "Peer Secret (Confirm)": "",
   "Peer User": "",
+  "Pending": "",
   "Pending Network Changes": "",
   "Pending Sync": "",
   "Pending Sync Keys Cleared": "",


### PR DESCRIPTION
**Summary**

Restored functionality that was added here:  [NAS-118320 / 23.10 / Added state to the vmware snapshots table by RehanY147 · Pull Request #8478 · truenas/webui](https://github.com/truenas/webui/pull/8478/files)  but then accidentally removed

**Testing**

Test that VMWare snapshots table displays states: Pending, Error, Success
- with mocks on JSON provided in the description of [this ticket](https://ixsystems.atlassian.net/browse/NAS-118320)

