### PR TITLE
NAS-126909 / 24.10 / Bug in the Workflows - If I created PR with translation files and with other files - it skips required steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
               echo "translations-only=true" >> $GITHUB_ENV
             else
               echo "translations-only=false" >> $GITHUB_ENV
+            fi
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 2  # Fetches the last two commits for diff
+          fetch-depth: 2
 
       - name: Determine if only translations were changed
         id: determine-changes
@@ -48,9 +48,6 @@ jobs:
 
           echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
 
-      - name: Debug translations-only
-        run: echo "The value of translations-only is ${{ steps.determine-changes.outputs.translations-only }}"
-
   build:
     name: Build
     needs: [check-files, install]
@@ -60,10 +57,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         uses: ./.github/actions/prepare
-
-      - name: Debug translations-only output
-        run: echo "The value of translations-only is ${{ needs.check-files.outputs.translations-only }}"
-
       - name: Build
         if: ${{ needs.check-files.outputs.translations-only == 'false' }}
         run: yarn build:prod:aot

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,19 +37,21 @@ jobs:
           if grep -qvE '^src/assets/i18n/' changed-files.txt; then
             echo "Other files changed"
             echo "translations-only=false" >> $GITHUB_ENV
+            echo "TRANSLATIONS_ONLY=false" >> $GITHUB_ENV
           else
             echo "Only translation files changed"
             echo "translations-only=true" >> $GITHUB_ENV
+            echo "TRANSLATIONS_ONLY=true" >> $GITHUB_ENV
           fi
 
       - name: Debug translations-only
         run: |
-          echo "The value of translations-only is ${{ $translations-only }}"
+          echo "The value of TRANSLATIONS_ONLY is $TRANSLATIONS_ONLY"
 
       - name: Set output
         id: set-output
         run: |
-          echo "::set-output name=translations-only::$translations-only"
+          echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,6 @@ jobs:
               - '**'
               - '!src/assets/i18n/**'
 
-      - name: Debug Filter Outputs
-        run: |
-          echo "Translations Filter Output: ${{ steps.filter.outputs.translations }}"
-          echo "Other Filter Output: ${{ steps.filter.outputs.other }}"
-
       - name: Set output
         id: set-output
         run: |
@@ -59,6 +54,7 @@ jobs:
     name: Build
     needs: [check-files, install]
     runs-on: ubuntu-latest
+      if: ${{ needs.check-files.outputs.translations-only == 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -67,7 +63,6 @@ jobs:
       - name: Debug translations-only output
         run: echo "The value of translations-only is ${{ needs.check-files.outputs.translations-only }}"
       - name: Build
-        if: ${{ needs.check-files.outputs.translations-only == 'false' }}
         run: yarn build:prod:aot
 
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,13 +57,15 @@ jobs:
     name: Build
     needs: [check-files, install]
     runs-on: ubuntu-latest
-    if: ${{ needs.check-files.outputs.translations-only == 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install
         uses: ./.github/actions/prepare
+      - name: Debug translations-only output
+        run: echo "The value of translations-only is ${{ needs.check-files.outputs.translations-only }}"
       - name: Build
+        if: ${{ needs.check-files.outputs.translations-only == 'false' }}
         run: yarn build:prod:aot
 
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,19 +22,31 @@ jobs:
         uses: ./.github/actions/prepare
 
   check-files:
-    name: Check if translations only were changed
-    runs-on: ubuntu-latest
-    outputs:
-      translations-only: ${{ steps.filter.outputs.translations-only }}
-    steps:
-      - uses: actions/checkout@v3
+      name: Check if translations only were changed
+      runs-on: ubuntu-latest
+      outputs:
+        translations-only: ${{ steps.filter.outputs.translations-only }}
+      steps:
+        - uses: actions/checkout@v3
 
-      - id: filter
-        uses: dorny/paths-filter@v2
-        with:
-          filters: |
-            translations-only:
-              - 'src/assets/i18n/**'
+        - id: filter
+          uses: dorny/paths-filter@v2
+          with:
+            filters: |
+              translations:
+                - 'src/assets/i18n/**'
+              other:
+                - '**'
+                - '!src/assets/i18n/**'
+            list-files: shell
+
+        - name: Set output
+          id: set-output
+          run: |
+            if [ "${{ steps.filter.outputs.translations }}" == 'true' ] && [ "${{ steps.filter.outputs.other }}" == 'false' ]; then
+              echo "translations-only=true" >> $GITHUB_ENV
+            else
+              echo "translations-only=false" >> $GITHUB_ENV
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,24 +32,25 @@ jobs:
           CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
           echo "$CHANGED_FILES"
 
-          translations_only="true"
+          TRANSLATIONS_ONLY="true"
           for file in $CHANGED_FILES; do
             if [[ ! "$file" =~ ^src/assets/i18n/ ]]; then
-              translations_only="false"
+              TRANSLATIONS_ONLY="false"
               break
             fi
           done
 
-          echo "translations-only=$translations_only" >> $GITHUB_ENV
+          echo "translations-only=$TRANSLATIONS_ONLY" >> $GITHUB_ENV
+          echo "TRANSLATIONS_ONLY=$TRANSLATIONS_ONLY" >> $GITHUB_ENV
 
       - name: Debug translations-only
         run: |
-          echo "The value of translations-only is $translations_only"
+          echo "The value of TRANSLATIONS_ONLY is $TRANSLATIONS_ONLY"
 
       - name: Set output
         id: set-output
         run: |
-          echo "::set-output name=translations-only::$translations_only"
+          echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,6 @@ jobs:
         uses: ./.github/actions/prepare
 
   check-files:
-    name: Check if translations only were changed
-    runs-on: ubuntu-latest
-    outputs:
-      translations-only: ${{ steps.set-output.outputs.translations-only }}
     steps:
       - uses: actions/checkout@v3
 
@@ -33,25 +29,27 @@ jobs:
         id: check-changed
         run: |
           echo "Changed files:"
-          git diff --name-only ${{ github.event.before }} ${{ github.sha }} | tee changed-files.txt
-          if grep -qvE '^src/assets/i18n/' changed-files.txt; then
-            echo "Other files changed"
-            echo "translations-only=false" >> $GITHUB_ENV
-            echo "TRANSLATIONS_ONLY=false" >> $GITHUB_ENV
-          else
-            echo "Only translation files changed"
-            echo "translations-only=true" >> $GITHUB_ENV
-            echo "TRANSLATIONS_ONLY=true" >> $GITHUB_ENV
-          fi
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          echo "$CHANGED_FILES"
+
+          translations_only="true"
+          for file in $CHANGED_FILES; do
+            if [[ ! "$file" =~ ^src/assets/i18n/ ]]; then
+              translations_only="false"
+              break
+            fi
+          done
+
+          echo "translations-only=$translations_only" >> $GITHUB_ENV
 
       - name: Debug translations-only
         run: |
-          echo "The value of TRANSLATIONS_ONLY is $TRANSLATIONS_ONLY"
+          echo "The value of translations-only is $translations_only"
 
       - name: Set output
         id: set-output
         run: |
-          echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
+          echo "::set-output name=translations-only::$translations_only"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,9 +50,16 @@ jobs:
           echo "TRANSLATIONS_ONLY=$TRANSLATIONS_ONLY" >> $GITHUB_ENV
           echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
 
-      - name: Debug translations-only
+      - name: Set output
+        id: set-output
         run: |
-          echo "The value of translations-only is $TRANSLATIONS_ONLY"
+          echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
+
+      - name: Debug translations-only
+      run: |
+        echo "The value of TRANSLATIONS_ONLY (env) is $TRANSLATIONS_ONLY"
+        echo "The value of translations-only (output) is ${{ steps.set-output.outputs.translations-only }}"
+
 
   build:
     name: Build
@@ -63,8 +70,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install
         uses: ./.github/actions/prepare
+
       - name: Debug translations-only output
         run: echo "The value of translations-only is ${{ needs.check-files.outputs.translations-only }}"
+
       - name: Build
         if: ${{ needs.check-files.outputs.translations-only == 'false' }}
         run: yarn build:prod:aot

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,19 +39,20 @@ jobs:
               - '**'
               - '!src/assets/i18n/**'
 
-      - name: Set output
-        id: set-output
-        run: |
-          if [ "${{ steps.filter.outputs.translations }}" == 'true' ] && [ "${{ steps.filter.outputs.other }}" == 'false' ]; then
-            echo "::set-output name=translations-only::true"
-          else
-            echo "::set-output name=translations-only::false"
-          fi
-
       - name: Debug output
         run: |
           echo "Translations: ${{ steps.filter.outputs.translations }}"
           echo "Other: ${{ steps.filter.outputs.other }}"
+
+
+      - name: Set output
+        id: set-output
+        run: |
+          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.other }}" == 'false' ]]; then
+            echo "translations-only=true" >> $GITHUB_ENV
+          else
+            echo "translations-only=false" >> $GITHUB_ENV
+          fi
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Debug translations-only
         run: |
-          echo "The value of translations-only is $translations-only"
+          echo "The value of translations-only is ${{ $translations-only }}"
 
       - name: Set output
         id: set-output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,13 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED_FILES"
 
+          # Initialize translations-only as true
           TRANSLATIONS_ONLY="true"
+
+          # Check each changed file
           for file in $CHANGED_FILES; do
             if [[ "$file" != "src/assets/i18n/"* ]]; then
+              # If any file is not in the translations directory, set to false
               TRANSLATIONS_ONLY="false"
               break
             fi
@@ -48,7 +52,10 @@ jobs:
           echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
 
       - name: Debug translations-only
-        run: echo "The value of translations-only is $TRANSLATIONS_ONLY"
+        run: |
+          echo "Changed files:"
+          git diff --name-only ${{ github.event.before }} ${{ github.sha }}
+          echo "The value of translations-only is $TRANSLATIONS_ONLY"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     name: Build
     needs: [check-files, install]
     runs-on: ubuntu-latest
-      if: ${{ needs.check-files.outputs.translations-only == 'false' }}
+    if: ${{ needs.check-files.outputs.translations-only == 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,21 +28,20 @@ jobs:
       translations-only: ${{ steps.set-output.outputs.translations-only }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # Fetches the last two commits for diff
 
       - name: Check changed files
         id: check-changed
         run: |
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          echo "Comparing changes with the previous commit"
+          CHANGED_FILES=$(git diff --name-only HEAD~1 ${{ github.sha }})
           echo "Changed files:"
           echo "$CHANGED_FILES"
 
-          # Initialize translations-only as true
           TRANSLATIONS_ONLY="true"
-
-          # Check each changed file
           for file in $CHANGED_FILES; do
             if [[ "$file" != "src/assets/i18n/"* ]]; then
-              # If any file is not in the translations directory, set to false
               TRANSLATIONS_ONLY="false"
               break
             fi
@@ -53,8 +52,6 @@ jobs:
 
       - name: Debug translations-only
         run: |
-          echo "Changed files:"
-          git diff --name-only ${{ github.event.before }} ${{ github.sha }}
           echo "The value of translations-only is $TRANSLATIONS_ONLY"
 
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,6 @@ jobs:
             echo "translations-only=false" >> $GITHUB_ENV
           fi
 
-
       - name: Set output
         id: set-output
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,11 @@ jobs:
               - '**'
               - '!src/assets/i18n/**'
 
+      - name: Debug Filter Outputs
+        run: |
+          echo "Translations Filter Output: ${{ steps.filter.outputs.translations }}"
+          echo "Other Filter Output: ${{ steps.filter.outputs.other }}"
+
       - name: Set output
         id: set-output
         run: |
@@ -54,7 +59,6 @@ jobs:
     name: Build
     needs: [check-files, install]
     runs-on: ubuntu-latest
-    if: ${{ needs.check-files.outputs.translations-only == 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -63,6 +67,7 @@ jobs:
       - name: Debug translations-only output
         run: echo "The value of translations-only is ${{ needs.check-files.outputs.translations-only }}"
       - name: Build
+        if: ${{ needs.check-files.outputs.translations-only == 'false' }}
         run: yarn build:prod:aot
 
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,29 +33,13 @@ jobs:
         uses: dorny/paths-filter@v2
         with:
           filters: |
-            translations:
+            translations-only:
               - 'src/assets/i18n/**'
               - '!**/*.*'  # Exclude all other file types
-            other:
-              - '**'
 
-      - name: Set output
-        id: set-output
+      - name: Debug output
         run: |
-          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.other }}" == 'false' ]]; then
-            echo "translations-only=true" >> $GITHUB_ENV
-          else
-            echo "translations-only=false" >> $GITHUB_ENV
-          fi
-
-      - name: Set output
-        id: set-output
-        run: |
-          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.other }}" == 'false' ]]; then
-            echo "translations-only=true" >> $GITHUB_ENV
-          else
-            echo "translations-only=false" >> $GITHUB_ENV
-          fi
+          echo "Translations: ${{ steps.filter.outputs.translations-only }}"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,32 +29,26 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - id: filter
-        uses: dorny/paths-filter@v2
-        with:
-          filters: |
-            translations:
-              - 'src/assets/i18n/**'
-            other:
-              - '**'
-              - '!src/assets/i18n/**'
-
-      - name: Set output
-        id: set-output
+      - name: Check changed files
+        id: check-changed
         run: |
-          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.other }}" == 'false' ]]; then
-            echo "translations-only=true" >> $GITHUB_ENV
-            echo "::set-output name=translations-only::true"
-          else
-            echo "translations-only=false" >> $GITHUB_ENV
-            echo "::set-output name=translations-only::false"
-          fi
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
 
-      - name: Debug output
-        run: |
-          echo "Translations Filter Output: ${{ steps.filter.outputs.translations }}"
-          echo "Other Filter Output: ${{ steps.filter.outputs.other }}"
-          echo "Final translations-only: ${{ steps.set-output.outputs.translations-only }}"
+          TRANSLATIONS_ONLY="true"
+          for file in $CHANGED_FILES; do
+            if [[ "$file" != "src/assets/i18n/"* ]]; then
+              TRANSLATIONS_ONLY="false"
+              break
+            fi
+          done
+
+          echo "TRANSLATIONS_ONLY=$TRANSLATIONS_ONLY" >> $GITHUB_ENV
+          echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
+
+      - name: Debug translations-only
+        run: echo "The value of translations-only is $TRANSLATIONS_ONLY"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     name: Check if translations only were changed
     runs-on: ubuntu-latest
     outputs:
-      translations-only: ${{ steps.filter.outputs.translations-only }}
+      translations-only: ${{ steps.set-output.outputs.translations-only }}
     steps:
       - uses: actions/checkout@v3
 
@@ -33,13 +33,19 @@ jobs:
         uses: dorny/paths-filter@v2
         with:
           filters: |
-            translations-only:
+            all:
+              - '**'
+            translations:
               - 'src/assets/i18n/**'
-              - '!**/*.*'  # Exclude all other file types
 
-      - name: Debug output
+      - name: Set output
+        id: set-output
         run: |
-          echo "Translations: ${{ steps.filter.outputs.translations-only }}"
+          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.all }}" == 'src/assets/i18n/**' ]]; then
+            echo "translations-only=true" >> $GITHUB_ENV
+          else
+            echo "translations-only=false" >> $GITHUB_ENV
+          fi
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,16 +25,15 @@ jobs:
     name: Check if translations only were changed
     runs-on: ubuntu-latest
     outputs:
-      translations-only: ${{ steps.set-output.outputs.translations-only }}
+      translations-only: ${{ steps.determine-changes.outputs.translations-only }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2  # Fetches the last two commits for diff
 
-      - name: Check changed files
-        id: check-changed
+      - name: Determine if only translations were changed
+        id: determine-changes
         run: |
-          echo "Comparing changes with the previous commit"
           CHANGED_FILES=$(git diff --name-only HEAD~1 ${{ github.sha }})
           echo "Changed files:"
           echo "$CHANGED_FILES"
@@ -47,19 +46,10 @@ jobs:
             fi
           done
 
-          echo "TRANSLATIONS_ONLY=$TRANSLATIONS_ONLY" >> $GITHUB_ENV
-          echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
-
-      - name: Set output
-        id: set-output
-        run: |
           echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
 
       - name: Debug translations-only
-      run: |
-        echo "The value of TRANSLATIONS_ONLY (env) is $TRANSLATIONS_ONLY"
-        echo "The value of translations-only (output) is ${{ steps.set-output.outputs.translations-only }}"
-
+        run: echo "The value of translations-only is ${{ steps.determine-changes.outputs.translations-only }}"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,11 @@ jobs:
             echo "::set-output name=translations-only::false"
           fi
 
+      - name: Debug output
+        run: |
+          echo "Translations: ${{ steps.filter.outputs.translations }}"
+          echo "Other: ${{ steps.filter.outputs.other }}"
+
   build:
     name: Build
     needs: [check-files, install]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,31 +29,27 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - id: filter
-        uses: dorny/paths-filter@v2
-        with:
-          filters: |
-            translations:
-              - 'src/assets/i18n/**'
-            other:
-              - '**'
-              - '!src/assets/i18n/**'
-
-      - name: Debug Filter Outputs
+      - name: Check changed files
+        id: check-changed
         run: |
-          echo "Translations Filter Output: ${{ steps.filter.outputs.translations }}"
-          echo "Other Filter Output: ${{ steps.filter.outputs.other }}"
+          echo "Changed files:"
+          git diff --name-only ${{ github.event.before }} ${{ github.sha }} | tee changed-files.txt
+          if grep -qvE '^src/assets/i18n/' changed-files.txt; then
+            echo "Other files changed"
+            echo "translations-only=false" >> $GITHUB_ENV
+          else
+            echo "Only translation files changed"
+            echo "translations-only=true" >> $GITHUB_ENV
+          fi
+
+      - name: Debug translations-only
+        run: |
+          echo "The value of translations-only is $translations-only"
 
       - name: Set output
         id: set-output
         run: |
-          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.other }}" == 'false' ]]; then
-            echo "translations-only=true" >> $GITHUB_ENV
-            echo "::set-output name=translations-only::true"
-          else
-            echo "translations-only=false" >> $GITHUB_ENV
-            echo "::set-output name=translations-only::false"
-          fi
+          echo "::set-output name=translations-only::$translations-only"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,15 +33,21 @@ jobs:
         uses: dorny/paths-filter@v2
         with:
           filters: |
-            all:
-              - '**'
             translations:
               - 'src/assets/i18n/**'
+            other:
+              - '**'
+              - '!src/assets/i18n/**'
+
+      - name: Debug Filter Outputs
+        run: |
+          echo "Translations Filter Output: ${{ steps.filter.outputs.translations }}"
+          echo "Other Filter Output: ${{ steps.filter.outputs.other }}"
 
       - name: Set output
         id: set-output
         run: |
-          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.all }}" == 'src/assets/i18n/**' ]]; then
+          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.other }}" == 'false' ]]; then
             echo "translations-only=true" >> $GITHUB_ENV
           else
             echo "translations-only=false" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,32 +22,31 @@ jobs:
         uses: ./.github/actions/prepare
 
   check-files:
-      name: Check if translations only were changed
-      runs-on: ubuntu-latest
-      outputs:
-        translations-only: ${{ steps.filter.outputs.translations-only }}
-      steps:
-        - uses: actions/checkout@v3
+    name: Check if translations only were changed
+    runs-on: ubuntu-latest
+    outputs:
+      translations-only: ${{ steps.set-output.outputs.translations-only }}
+    steps:
+      - uses: actions/checkout@v3
 
-        - id: filter
-          uses: dorny/paths-filter@v2
-          with:
-            filters: |
-              translations:
-                - 'src/assets/i18n/**'
-              other:
-                - '**'
-                - '!src/assets/i18n/**'
-            list-files: shell
+      - id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            translations:
+              - 'src/assets/i18n/**'
+            other:
+              - '**'
+              - '!src/assets/i18n/**'
 
-        - name: Set output
-          id: set-output
-          run: |
-            if [ "${{ steps.filter.outputs.translations }}" == 'true' ] && [ "${{ steps.filter.outputs.other }}" == 'false' ]; then
-              echo "translations-only=true" >> $GITHUB_ENV
-            else
-              echo "translations-only=false" >> $GITHUB_ENV
-            fi
+      - name: Set output
+        id: set-output
+        run: |
+          if [ "${{ steps.filter.outputs.translations }}" == 'true' ] && [ "${{ steps.filter.outputs.other }}" == 'false' ]; then
+            echo "::set-output name=translations-only::true"
+          else
+            echo "::set-output name=translations-only::false"
+          fi
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,29 +29,31 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Check changed files
-        id: check-changed
+      - id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            translations:
+              - 'src/assets/i18n/**'
+            other:
+              - '**'
+              - '!src/assets/i18n/**'
+
+      - name: Debug filter results
         run: |
-          echo "Changed files:"
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
-          echo "$CHANGED_FILES"
-
-          TRANSLATIONS_ONLY="true"
-          for file in $CHANGED_FILES; do
-            if [[ ! $file =~ ^src/assets/i18n/ ]]; then
-              TRANSLATIONS_ONLY="false"
-              break
-            fi
-          done
-
-          echo "TRANSLATIONS_ONLY=$TRANSLATIONS_ONLY" >> $GITHUB_ENV
-
-      - name: Debug translations-only
-        run: echo "The value of translations-only is $TRANSLATIONS_ONLY"
+          echo "Translations Filter Output: ${{ steps.filter.outputs.translations }}"
+          echo "Other Filter Output: ${{ steps.filter.outputs.other }}"
 
       - name: Set output
         id: set-output
-        run: echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
+        run: |
+          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.other }}" == 'false' ]]; then
+            echo "translations-only=true" >> $GITHUB_ENV
+            echo "::set-output name=translations-only::true"
+          else
+            echo "translations-only=false" >> $GITHUB_ENV
+            echo "::set-output name=translations-only::false"
+          fi
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,14 +35,18 @@ jobs:
           filters: |
             translations:
               - 'src/assets/i18n/**'
+              - '!**/*.*'  # Exclude all other file types
             other:
               - '**'
-              - '!src/assets/i18n/**'
 
-      - name: Debug output
+      - name: Set output
+        id: set-output
         run: |
-          echo "Translations: ${{ steps.filter.outputs.translations }}"
-          echo "Other: ${{ steps.filter.outputs.other }}"
+          if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.other }}" == 'false' ]]; then
+            echo "translations-only=true" >> $GITHUB_ENV
+          else
+            echo "translations-only=false" >> $GITHUB_ENV
+          fi
 
 
       - name: Set output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     name: Check if translations only were changed
     runs-on: ubuntu-latest
     outputs:
-      translations-only: ${{ steps.set-output.outputs.translations-only }}
+      translations-only: ${{ steps.filter.outputs.translations-only }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,10 @@ jobs:
         run: |
           if [[ "${{ steps.filter.outputs.translations }}" == 'true' ]] && [[ "${{ steps.filter.outputs.other }}" == 'false' ]]; then
             echo "translations-only=true" >> $GITHUB_ENV
+            echo "::set-output name=translations-only::true"
           else
             echo "translations-only=false" >> $GITHUB_ENV
+            echo "::set-output name=translations-only::false"
           fi
 
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,6 @@ jobs:
               - '**'
               - '!src/assets/i18n/**'
 
-      - name: Debug filter results
-        run: |
-          echo "Translations Filter Output: ${{ steps.filter.outputs.translations }}"
-          echo "Other Filter Output: ${{ steps.filter.outputs.other }}"
-
       - name: Set output
         id: set-output
         run: |
@@ -54,6 +49,12 @@ jobs:
             echo "translations-only=false" >> $GITHUB_ENV
             echo "::set-output name=translations-only::false"
           fi
+
+      - name: Debug output
+        run: |
+          echo "Translations Filter Output: ${{ steps.filter.outputs.translations }}"
+          echo "Other Filter Output: ${{ steps.filter.outputs.other }}"
+          echo "Final translations-only: ${{ steps.set-output.outputs.translations-only }}"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
         uses: ./.github/actions/prepare
 
   check-files:
+    name: Check if translations only were changed
+    runs-on: ubuntu-latest
+    outputs:
+      translations-only: ${{ steps.set-output.outputs.translations-only }}
     steps:
       - uses: actions/checkout@v3
 
@@ -34,23 +38,20 @@ jobs:
 
           TRANSLATIONS_ONLY="true"
           for file in $CHANGED_FILES; do
-            if [[ ! "$file" =~ ^src/assets/i18n/ ]]; then
+            if [[ ! $file =~ ^src/assets/i18n/ ]]; then
               TRANSLATIONS_ONLY="false"
               break
             fi
           done
 
-          echo "translations-only=$TRANSLATIONS_ONLY" >> $GITHUB_ENV
           echo "TRANSLATIONS_ONLY=$TRANSLATIONS_ONLY" >> $GITHUB_ENV
 
       - name: Debug translations-only
-        run: |
-          echo "The value of TRANSLATIONS_ONLY is $TRANSLATIONS_ONLY"
+        run: echo "The value of translations-only is $TRANSLATIONS_ONLY"
 
       - name: Set output
         id: set-output
-        run: |
-          echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
+        run: echo "::set-output name=translations-only::$TRANSLATIONS_ONLY"
 
   build:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,13 @@ jobs:
     name: Build
     needs: [check-files, install]
     runs-on: ubuntu-latest
+    if: ${{ needs.check-files.outputs.translations-only == 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install
         uses: ./.github/actions/prepare
       - name: Build
-        if: ${{ needs.check-files.outputs.translations-only == 'false' }}
         run: yarn build:prod:aot
 
   lint:

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "ngx-skeleton-loader": "~5.0.0",
     "ngx-translate-messageformat-compiler": "~5.0.1",
     "ngx-webstorage": "~12.0.0",
-    "paths-filter": "dorny/paths-filter",
     "pixi-filters": "~2.7.1",
     "pixi.js": "~4.7.1",
     "popmotion": "~8.7.1",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -6,7 +6,7 @@
   " When the <b>UPS Mode</b> is set to <i>slave</i>. Enter the open network port number of the UPS <i>Master</i> system. The default port is <i>3493</i>.": "",
   " as of {dateTime}": "",
   " bytes.": "",
-  " cores at ": "",
+  " cores at ": "ttt",
   " seconds.": "",
   " threads at ": "",
   "% of all cores": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -6,7 +6,7 @@
   " When the <b>UPS Mode</b> is set to <i>slave</i>. Enter the open network port number of the UPS <i>Master</i> system. The default port is <i>3493</i>.": "",
   " as of {dateTime}": "",
   " bytes.": "",
-  " cores at ": "ttt",
+  " cores at ": "",
   " seconds.": "",
   " threads at ": "",
   "% of all cores": "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12492,16 +12492,6 @@ path@^0.12.7:
     process "^0.11.1"
     util "^0.10.3"
 
-paths-filter@dorny/paths-filter:
-  version "1.0.0"
-  resolved "https://codeload.github.com/dorny/paths-filter/tar.gz/3c49e64ca26115121162fb767bc6af9e8d059f1a"
-  dependencies:
-    "@actions/core" "^1.10.0"
-    "@actions/exec" "^1.1.1"
-    "@actions/github" "^2.2.0"
-    "@octokit/webhooks" "^7.6.2"
-    picomatch "^2.2.2"
-
 perf-marks@^1.13.4:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/perf-marks/-/perf-marks-1.14.2.tgz#7511c24239b9c2071717993a33ec3057f387b8c7"


### PR DESCRIPTION
Testing:
Create new temporary PR based on this branch (like I did here https://github.com/truenas/webui/pull/9488) and make sure that if translation files were changed together with any other files, we should NOT skip build, test and other workflow steps.

<img width="930" alt="Screenshot 2024-01-23 at 03 12 19" src="https://github.com/truenas/webui/assets/22980553/5884dffe-a4a6-405b-a9d0-1715deace745">

If only translation files were changed - then we skip build, test and so on.