### PR TITLE
NAS-126843: Fix max concurrent calls bug

### DIFF
--- a/src/app/views/sessions/signin/signin-form/signin-form.component.ts
+++ b/src/app/views/sessions/signin/signin-form/signin-form.component.ts
@@ -6,7 +6,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import _ from 'lodash';
 import {
-  distinctUntilChanged, EMPTY, switchMap,
+  distinctUntilChanged, EMPTY, firstValueFrom, switchMap,
 } from 'rxjs';
 import { LoginResult } from 'app/enums/login-result.enum';
 import { WINDOW } from 'app/helpers/window.helper';
@@ -66,7 +66,10 @@ export class SigninFormComponent implements OnInit {
     });
   }
 
-  login(): void {
+  async login(): Promise<void> {
+    if (await firstValueFrom(this.signinStore.isLoading$)) {
+      return;
+    }
     this.isLastLoginAttemptFailed = false;
     this.signinStore.setLoadingState(true);
     const formValues = this.form.value;


### PR DESCRIPTION
**Summary**

Until login request request is finished, I've disabled sign-in form

**Testing**

On **Login** page,

1. Enter login and password (try both correct and incorrect)
2. Press **Enter** key multiple times
3. After \~20 quick subsequent presses of **Enter** key, it displays

- **Expected result:** it should not be possible to submit a new attempt to login, until there's unfinished login request .