### PR TITLE
NAS-125066 / 24.10 / Missing explaination for "System Settings / Advanced / Allowed IP Addresses"

### DIFF
--- a/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-card/allowed-addresses-card.component.html
+++ b/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-card/allowed-addresses-card.component.html
@@ -1,8 +1,16 @@
 <mat-card>
   <mat-toolbar-row>
-    <h3 class="card-title">
-      {{ 'Allowed IP Addresses' | translate }}
-    </h3>
+    <div fxFlex fxLayoutAlign="start center">
+      <h3 class="card-title">
+        {{ 'Allowed IP Addresses' | translate }}
+      </h3>
+
+      <ix-tooltip
+        class="tooltip"
+        [header]="'Allowed IP Addresses' | translate"
+        [message]="'IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.' | translate"
+      ></ix-tooltip>
+    </div>
 
     <div class="actions action-icon">
       <button

--- a/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-card/allowed-addresses-card.component.scss
+++ b/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-card/allowed-addresses-card.component.scss
@@ -1,0 +1,3 @@
+ix-tooltip {
+  margin: 2px 0 0 5px;
+}

--- a/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-card/allowed-addresses-card.component.ts
+++ b/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-card/allowed-addresses-card.component.ts
@@ -28,7 +28,7 @@ interface AllowedAddressRow {
 @UntilDestroy()
 @Component({
   selector: 'ix-allowed-addresses-card',
-  styleUrls: ['../../common-card.scss'],
+  styleUrls: ['../../common-card.scss', './allowed-addresses-card.component.scss'],
   templateUrl: './allowed-addresses-card.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1648,6 +1648,7 @@
   "IP": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1315,6 +1315,7 @@
   "IP": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Events": "",
   "IPMI Password Reset": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -657,6 +657,7 @@
   "INFO": "",
   "INTERNAL": "",
   "IP": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Events": "",
   "IPMI Read": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1725,6 +1725,7 @@
   "IP": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Events": "",
   "IPMI Password Reset": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -115,6 +115,7 @@
   "Hubic": "",
   "I would like to": "",
   "IP": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI Events": "",
   "IPMI Read": "",
   "IPMI Write": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1654,6 +1654,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1554,6 +1554,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1369,6 +1369,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1868,6 +1868,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -271,6 +271,7 @@
   "Hubic": "",
   "I would like to": "",
   "IP": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI Events": "",
   "IPMI Read": "",
   "IPMI Write": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1812,6 +1812,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1811,6 +1811,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1084,6 +1084,7 @@
   "IP": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -941,6 +941,7 @@
   "INFO": "",
   "INTERNAL": "",
   "IP": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Events": "",
   "IPMI Read": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -284,6 +284,7 @@
   "Hubic": "",
   "I would like to": "",
   "IP": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI Events": "",
   "IPMI Read": "",
   "IPMI Write": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1874,6 +1874,7 @@
   "IP Addresses": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Configuration": "",
   "IPMI Events": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -332,6 +332,7 @@
   "I would like to": "",
   "INTERNAL": "",
   "IP": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI Events": "",
   "IPMI Read": "",
   "IPMI Write": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1436,6 +1436,7 @@
   "IP": "",
   "IP address of the remote system with <i>UPS Mode</i> set as <i>Master</i>. Enter a valid IP address in the format <i>192.168.0.1</i>.": "",
   "IP address on which the connection <b>Active Side</b> listens. Defaults to <i>0.0.0.0</i>.": "",
+  "IP addresses and networks that are allowed to use API and UI. If this list is empty, then all IP addresses are allowed to use API and UI.": "",
   "IPMI": "",
   "IPMI Events": "",
   "IPMI Read": "",


### PR DESCRIPTION
Testing:
<img width="755" alt="Screenshot 2024-01-24 at 11 44 41" src="https://github.com/truenas/webui/assets/22980553/0e193879-f51b-4e2b-8fdc-f5e56764f09c">

<img width="748" alt="Screenshot 2024-01-24 at 11 44 38" src="https://github.com/truenas/webui/assets/22980553/40a4c9cd-be2f-4022-8364-df9d609b42af">
