### PR TITLE
NAS-126826 / 24.04-RC.1 / On the latest Dragonfish nightly build Pool Wizard all mat-option data-test  are missing the option text. (by AlexKarpov98)

### DIFF
--- a/src/app/modules/test-id/test-override/test-override.directive.ts
+++ b/src/app/modules/test-id/test-override/test-override.directive.ts
@@ -13,4 +13,5 @@ import {
 })
 export class TestOverrideDirective {
   @Input('ixTestOverride') overrideDescription: number | string | (string | number)[];
+  @Input() appendInitialDataTestLastPart?: boolean;
 }

--- a/src/app/modules/test-id/test-override/test-override.directive.ts
+++ b/src/app/modules/test-id/test-override/test-override.directive.ts
@@ -13,5 +13,5 @@ import {
 })
 export class TestOverrideDirective {
   @Input('ixTestOverride') overrideDescription: number | string | (string | number)[];
-  @Input() appendInitialDataTestLastPart?: boolean;
+  @Input() keepLastPart?: boolean;
 }

--- a/src/app/modules/test-id/test/test.directive.ts
+++ b/src/app/modules/test-id/test/test.directive.ts
@@ -36,7 +36,7 @@ export class TestDirective {
       .filter((part) => part)
       .map((part) => kebabCase(String(part)));
 
-    if (this.overrideDirective?.appendInitialDataTestLastPart) {
+    if (this.overrideDirective?.keepLastPart) {
       const normalizedInitialDescription = Array.isArray(this.description) ? this.description : [this.description];
       normalizedDescription.push(normalizedInitialDescription[normalizedInitialDescription.length - 1]);
     }

--- a/src/app/modules/test-id/test/test.directive.ts
+++ b/src/app/modules/test-id/test/test.directive.ts
@@ -30,11 +30,18 @@ export class TestDirective {
 
   get normalizedDescription(): string[] {
     const description = this.overrideDirective?.overrideDescription ?? this.description;
-    const normalizedDescription = Array.isArray(description) ? description : [description];
+    let normalizedDescription = Array.isArray(description) ? description : [description];
 
-    return normalizedDescription
+    normalizedDescription = normalizedDescription
       .filter((part) => part)
       .map((part) => kebabCase(String(part)));
+
+    if (this.overrideDirective?.appendInitialDataTestLastPart) {
+      const normalizedInitialDescription = Array.isArray(this.description) ? this.description : [this.description];
+      normalizedDescription.push(normalizedInitialDescription[normalizedInitialDescription.length - 1]);
+    }
+
+    return normalizedDescription as string[];
   }
 
   @HostBinding('attr.data-test')

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="canChangeLayout; else showLayoutInfo" class="layout-container">
   <ix-select
     [ixTestOverride]="['layout']"
-    [appendInitialDataTestLastPart]="true"
+    [keepLastPart]="true"
     [formControl]="layoutControl"
     [label]="'Layout' | translate"
     [tooltip]="'Select VDEV layout. This is the first step in setting up your VDEVs.' | translate"
@@ -13,7 +13,7 @@
   <ix-input
     *ngIf="isDataVdev || isMetadataVdev"
     [ixTestOverride]="['layout']"
-    [appendInitialDataTestLastPart]="true"
+    [keepLastPart]="true"
     [formControl]="layoutControl"
     [label]="'Layout' | translate"
     [readonly]="true"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -1,6 +1,7 @@
 <div *ngIf="canChangeLayout; else showLayoutInfo" class="layout-container">
   <ix-select
-    [ixTestOverride]="['layout', type]"
+    [ixTestOverride]="['layout']"
+    [appendInitialDataTestLastPart]="true"
     [formControl]="layoutControl"
     [label]="'Layout' | translate"
     [tooltip]="'Select VDEV layout. This is the first step in setting up your VDEVs.' | translate"
@@ -11,7 +12,8 @@
 <ng-template #showLayoutInfo>
   <ix-input
     *ngIf="isDataVdev || isMetadataVdev"
-    [ixTestOverride]="['layout', type]"
+    [ixTestOverride]="['layout']"
+    [appendInitialDataTestLastPart]="true"
     [formControl]="layoutControl"
     [label]="'Layout' | translate"
     [readonly]="true"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
@@ -94,7 +94,7 @@ describe('AutomatedDiskSelection', () => {
     expect(spectator.query(NormalSelectionComponent)).toBeNull();
   });
 
-  it('doesnt let the layout change when canChangeLayout is false', async () => {
+  it('does not let the layout change when canChangeLayout is false', async () => {
     spectator.setInput('canChangeLayout', false);
 
     layoutSelect = await loader.getHarnessOrNull(IxSelectHarness.with({ label: 'Layout' }));


### PR DESCRIPTION
Testing: 
See ticket, go to http://localhost:4200/storage/create

And see that data-test for `Layout` is now as expected, example:
**data-test="option-layout-RAIDZ1"**

So the Idea here is to append original data-test last part value to overwritten data-test attribute value.
Because for select->option - we can't get option.value from the parent component and append it dynamically via `ixTestOverride`

But with this update, we can override it:
before: **option-RAIDZ1**
with ixTestOverride: **option-layout**
with ixTestOverride && keepLastPart: **option-layout-RAIDZ1**

Original PR: https://github.com/truenas/webui/pull/9509
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126826