### PR TITLE
NAS-126992 / 24.04-RC.1 / Mini-R image missing from dashboard widget (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
@@ -88,7 +88,6 @@
                   ></ix-icon>
                 </ng-template>
               </div>
-
               <div
                 class="content-left"
                 fxFlex.gt-xs="60"
@@ -109,7 +108,7 @@
                     [id]="productModel"
                     [class.clickable]="enclosureSupport"
                     [matTooltipDisabled]="!enclosureSupport"
-                    [src]="'assets/images' + productImage"
+                    [src]="productImageSrc"
                     [src-fallback]="'assets/images/truenas_scale_ondark_favicon.png'"
                     (click)="goToEnclosure()"
                   />

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -99,6 +99,17 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, O
     });
   }
 
+  get updateBtnLabel(): string {
+    if (this.updateAvailable) {
+      return this.translate.instant('Updates Available');
+    }
+    return this.translate.instant('Check for Updates');
+  }
+
+  get productImageSrc(): string {
+    return 'assets/images' + (this.productImage.startsWith('/') ? this.productImage : ('/' + this.productImage));
+  }
+
   ngOnInit(): void {
     this.checkForUpdate();
     this.getSystemInfo();
@@ -178,13 +189,6 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, O
         console.error(err);
       },
     });
-  }
-
-  get updateBtnLabel(): string {
-    if (this.updateAvailable) {
-      return this.translate.instant('Updates Available');
-    }
-    return this.translate.instant('Check for Updates');
   }
 
   processSysInfo(systemInfo: SystemInfo): void {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 0c0dfe9760181bd1c16c063ea01db8ee36588d37
    git cherry-pick -x 72e77b3766e65057d63ae407299a2336cb42b631
    git cherry-pick -x d1d78872a292769512a313d7aa60e22924806772
    git cherry-pick -x 12cfa7be90e9e9009a6daaca3a85560eb2a5e532

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 7ceac3b4f922dc216ba332358e97f714e743c05e

Testing:
you may need to mock **isIxHardware** to be **true** (see `loadIsIxHardware`)
Only in this case you will be able to see image.
<img width="582" alt="Screenshot 2024-01-26 at 17 03 51" src="https://github.com/truenas/webui/assets/22980553/14a74a6a-26aa-4b77-b07f-47d8e4613fc8">


Original PR: https://github.com/truenas/webui/pull/9538
Jira URL: https://ixsystems.atlassian.net/browse/NAS-126992