### PR TITLE
NAS-126983 / 24.10 / Share Page: iSCSI Service Status Label and Configure button UI overlap in different browser window sizes

### DIFF
--- a/src/app/modules/entity/entity-table/entity-table.component.scss
+++ b/src/app/modules/entity/entity-table/entity-table.component.scss
@@ -378,6 +378,6 @@ div.mat-mdc-card-table {
   justify-content: space-between;
 
   h3 {
-    color: var(--primary-txt);
+    color: var(--fg2);
   }
 }

--- a/src/app/pages/credentials/backup-credentials/backup-credentials.component.scss
+++ b/src/app/pages/credentials/backup-credentials/backup-credentials.component.scss
@@ -20,8 +20,8 @@
     gap: 8px;
     grid-template-columns: 40% repeat(2, 1fr);
 
-    @media(max-width: $breakpoint-sm) {
-      grid-template-columns: 1fr;
+    @media #{$media-lt-lg} {
+      grid-template-columns: 100%;
     }
   }
 }

--- a/src/app/pages/data-protection/data-protection-dashboard.component.scss
+++ b/src/app/pages/data-protection/data-protection-dashboard.component.scss
@@ -5,7 +5,7 @@
   gap: 8px;
   grid-template-columns: 50% 50%;
 
-  @media #{$media-lt-md} {
+  @media #{$media-lt-lg} {
     grid-template-columns: 100%;
   }
 

--- a/src/app/pages/directory-service/directory-services.component.scss
+++ b/src/app/pages/directory-service/directory-services.component.scss
@@ -43,8 +43,8 @@
   grid-template-columns: 50% 50%;
   grid-template-rows: fit-content(30vh);
 
-  @media #{$media-lt-md} {
-    grid-template-columns: auto;
+  @media #{$media-lt-lg} {
+    grid-template-columns: 100%;
   }
 
   @media #{$media-lt-sm} {

--- a/src/app/pages/network/components/network-configuration-card/network-configuration-card.component.scss
+++ b/src/app/pages/network/components/network-configuration-card/network-configuration-card.component.scss
@@ -10,6 +10,7 @@
 .columns {
   display: flex;
   min-height: 100px;
+  overflow: auto;
 
   .first-column {
     flex-grow: 1;

--- a/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.html
@@ -1,29 +1,35 @@
 <mat-card>
   <mat-toolbar-row>
-    <a [ixTest]="['iscsi-share', 'open-in-new']" [routerLink]="['/sharing', 'iscsi', 'target']">
-      <h3 class="card-title">
-        {{ 'Block (iSCSI) Shares Targets' | translate }}
-        <ix-icon name="open_in_new" class="title-icon"></ix-icon>
-      </h3>
-    </a>
+    <div class="toolbar-row-title">
+      <a [ixTest]="['iscsi-share', 'open-in-new']" [routerLink]="['/sharing', 'iscsi', 'target']">
+        <h3 class="card-title">
+          {{ 'Block (iSCSI) Shares Targets' | translate }}
+          <ix-icon name="open_in_new" class="title-icon"></ix-icon>
+        </h3>
+      </a>
 
-    <ix-service-state-button
-      [service]="service$ | async"
-      [count]="dataProvider.currentPageCount$ | async"
-    ></ix-service-state-button>
+      <ix-service-state-button
+        [service]="service$ | async"
+        [count]="dataProvider.currentPageCount$ | async"
+      ></ix-service-state-button>
+    </div>
 
     <div class="actions">
       <button
         mat-button
         [ixTest]="['iscsi-share', 'configure']"
         [routerLink]="['/sharing', 'iscsi', 'configuration']"
-      >{{ 'Configure' | translate }}</button>
+      >
+        {{ 'Configure' | translate }}
+      </button>
 
       <button
         mat-button
         [ixTest]="['iscsi-share', 'wizard']"
         (click)="openForm(null, true)"
-      >{{ 'Wizard' | translate }}</button>
+      >
+        {{ 'Wizard' | translate }}
+      </button>
 
       <ix-service-extra-actions
         [service]="service$ | async"

--- a/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.html
@@ -1,16 +1,18 @@
 <mat-card>
   <mat-toolbar-row>
-    <a [ixTest]="['nfs-share', 'open-in-new']" [routerLink]="['/sharing', 'nfs']">
-      <h3 class="card-title">
-        {{ 'UNIX (NFS) Shares' | translate }}
-        <ix-icon name="open_in_new" class="title-icon"></ix-icon>
-      </h3>
-    </a>
+    <div class="toolbar-row-title">
+      <a [ixTest]="['nfs-share', 'open-in-new']" [routerLink]="['/sharing', 'nfs']">
+        <h3 class="card-title">
+          {{ 'UNIX (NFS) Shares' | translate }}
+          <ix-icon name="open_in_new" class="title-icon"></ix-icon>
+        </h3>
+      </a>
 
-    <ix-service-state-button
-      [service]="service$ | async"
-      [count]="dataProvider.currentPageCount$ | async"
-    ></ix-service-state-button>
+      <ix-service-state-button
+        [service]="service$ | async"
+        [count]="dataProvider.currentPageCount$ | async"
+      ></ix-service-state-button>
+    </div>
 
     <div class="actions">
       <button

--- a/src/app/pages/sharing/components/shares-dashboard/service-state-button/service-state-button.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/service-state-button/service-state-button.component.scss
@@ -1,3 +1,4 @@
 :host {
-  margin-left: 15px;
+  margin-left: 8px;
+  margin-right: 8px;
 }

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.html
@@ -1,16 +1,18 @@
 <mat-card>
   <mat-toolbar-row>
-    <a [ixTest]="['smb-share', 'open-in-new']" [routerLink]="['/sharing', 'smb']">
-      <h3 class="card-title">
-        {{ title | translate }}
-        <ix-icon name="open_in_new" class="title-icon"></ix-icon>
-      </h3>
-    </a>
+    <div class="toolbar-row-title">
+      <a [ixTest]="['smb-share', 'open-in-new']" [routerLink]="['/sharing', 'smb']">
+        <h3 class="card-title">
+          {{ title | translate }}
+          <ix-icon name="open_in_new" class="title-icon"></ix-icon>
+        </h3>
+      </a>
 
-    <ix-service-state-button
-      [service]="service$ | async"
-      [count]="dataProvider.currentPageCount$ | async"
-    ></ix-service-state-button>
+      <ix-service-state-button
+        [service]="service$ | async"
+        [count]="dataProvider.currentPageCount$ | async"
+      ></ix-service-state-button>
+    </div>
 
     <div class="actions">
       <button

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -455,6 +455,7 @@ body .mdc-card__actions,
   display: flex;
   gap: 8px;
   justify-content: flex-end;
+  margin-left: auto;
 }
 
 .mat-mdc-card .mat-mdc-card-footer .actions button {

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -423,8 +423,27 @@ body .mdc-card__actions,
 
 .mat-mdc-card .mat-toolbar-row {
   border-bottom: solid 1px var(--lines);
-  height: 56px;
-  min-height: 48px !important;
+  flex-wrap: wrap;
+  gap: 8px;
+  height: initial;
+  justify-content: space-between;
+  padding: 8px 16px;
+
+  .toolbar-row-title {
+    align-items: center;
+    display: flex;
+
+    > a {
+      -webkit-box-orient: vertical;
+      display: inline-box;
+      -webkit-line-clamp: 2;
+      max-width: 75%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: normal;
+      word-break: break-word;
+    }
+  }
 
   .mat-card-title-text {
     margin: 0;
@@ -436,8 +455,6 @@ body .mdc-card__actions,
   display: flex;
   gap: 8px;
   justify-content: flex-end;
-  position: absolute;
-  right: 16px;
 }
 
 .mat-mdc-card .mat-mdc-card-footer .actions button {
@@ -887,7 +904,7 @@ ix-table2,
 table {
   overflow: auto;
 
-  @media(max-width: $breakpoint-sm) {
+  @media(max-width: $breakpoint-md) {
     tr th {
       width: 78px;
     }

--- a/src/assets/styles/other/_root-variables.scss
+++ b/src/assets/styles/other/_root-variables.scss
@@ -94,6 +94,7 @@
   --mat-tab-header-inactive-label-text-color: var(--fg2);
   --mat-tab-header-inactive-hover-label-text-color: var(--fg1);
   --mat-tab-header-inactive-focus-label-text-color: var(--fg1);
-  --mat-table-row-item-label-text-color: var(--primary-txt);
-  --mat-table-header-headline-color: var(--primary-txt);
+  --mat-table-row-item-label-text-color: var(--fg2);
+  --mat-table-header-headline-color: var(--fg2);
+  --mdc-filled-text-field-input-text-color: var(--alt-fg2);
 }


### PR DESCRIPTION
Testing:
See Shares page on smaller screens and test other cards with toolbar headers.
As well some colouring fixes were made, I switched theme and detected them.



**Result:**
<img width="1165" alt="Screenshot 2024-01-31 at 11 24 47" src="https://github.com/truenas/webui/assets/22980553/ffff330f-89e6-4ba0-a0c3-0b136c806c2f">

<img width="377" alt="Screenshot 2024-01-31 at 11 24 15" src="https://github.com/truenas/webui/assets/22980553/7c17e8fe-c46e-479e-a4b3-699e96344281">

**Before, it was like 👇 :**
<img width="379" alt="Screenshot 2024-01-30 at 10 24 25" src="https://github.com/truenas/webui/assets/22980553/59f23246-b3cd-43b0-9ac8-a7c6cd6c48af">
