### PR TITLE
NAS-127013 / 24.10 / Fix smart result table expanding

### DIFF
--- a/src/app/interfaces/smart-test.interface.ts
+++ b/src/app/interfaces/smart-test.interface.ts
@@ -39,7 +39,6 @@ export interface SmartManualTestParams {
 }
 
 export interface SmartTestResults {
-  identifier: string;
   disk: string;
   tests: SmartTestResult[];
 }

--- a/src/app/pages/storage/modules/disks/components/smart-results/smart-results.component.ts
+++ b/src/app/pages/storage/modules/disks/components/smart-results/smart-results.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import { UUID } from 'angular2-uuid';
 import { lastValueFrom, map, tap } from 'rxjs';
 import { SmartTestResultPageType } from 'app/enums/smart-test-results-page-type.enum';
 import { QueryParams } from 'app/interfaces/query-api.interface';
@@ -12,7 +13,7 @@ import { WebSocketService } from 'app/services/ws.service';
 
 interface SmartTestResultsRow extends SmartTestResult {
   disk: string;
-  identifier: string;
+  id: string;
 }
 
 @UntilDestroy()
@@ -91,12 +92,7 @@ export class SmartResultsComponent implements EntityTableConfig {
     const rows: SmartTestResultsRow[] = [];
     data.forEach((item) => {
       item?.tests.forEach((test) => {
-        rows.push({
-          ...test,
-          identifier: `${item.identifier}_${test.num}`,
-          disk: item.disk,
-          num: test.num,
-        });
+        rows.push({ ...test, disk: item.disk, id: UUID.UUID() });
       });
     });
     return rows;


### PR DESCRIPTION
**Testing**

1. Go to **Storage \> Pool Disk Health card \> View All S.M.A.R.T. tests**
2. Select to expand the view of 1 of the results

**Expected Result** Only selected row expands, regardless of other rows 