### PR TITLE
NAS-127086 / 24.04-RC.1 / Missing permission checks in Apps (by undsoft)

### DIFF
--- a/src/app/directives/common/requires-roles/requires-roles-wrapper.component.scss
+++ b/src/app/directives/common/requires-roles/requires-roles-wrapper.component.scss
@@ -7,11 +7,6 @@
     pointer-events: none;
   }
 
-  .mat-mdc-button,
-  .mdc-button {
-    margin-right: 8px;
-  }
-
   .mdc-label {
     text-decoration: line-through;
   }

--- a/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.html
+++ b/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.html
@@ -11,15 +11,17 @@
   <div class="app-image-holder">
     <ix-app-card-logo [url]="app?.icon_url"></ix-app-card-logo>
   </div>
-  <button
-    *ngIf="!(kubernetesStore.selectedPool$ | async)"
-    mat-button
-    color="primary"
-    ixTest="setup-pool"
-    (click)="showChoosePoolModal()"
-  >
-    {{ 'Setup Pool To Install' | translate }}
-  </button>
+  <ng-container *ngIf="!(kubernetesStore.selectedPool$ | async)">
+    <button
+      *ixRequiresRoles="setupPoolRequiredRoles"
+      mat-button
+      color="primary"
+      ixTest="setup-pool"
+      (click)="showChoosePoolModal()"
+    >
+      {{ 'Setup Pool To Install' | translate }}
+    </button>
+  </ng-container>
   <button
     *ngIf="!!(kubernetesStore.selectedPool$ | async)"
     mat-button

--- a/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.ts
+++ b/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.ts
@@ -8,6 +8,7 @@ import { TranslateService } from '@ngx-translate/core';
 import {
   filter, map, Observable, of, switchMap, take,
 } from 'rxjs';
+import { Role } from 'app/enums/role.enum';
 import { AvailableApp } from 'app/interfaces/available-app.interface';
 import { SelectPoolDialogComponent } from 'app/pages/apps/components/select-pool-dialog/select-pool-dialog.component';
 import { InstalledAppsStore } from 'app/pages/apps/store/installed-apps-store.service';
@@ -26,6 +27,8 @@ import { WebSocketService } from 'app/services/ws.service';
 export class AppDetailsHeaderComponent {
   @Input() app: AvailableApp;
   @Input() isLoading$: Observable<boolean>;
+
+  protected readonly setupPoolRequiredRoles = [Role.KubernetesWrite];
 
   constructor(
     public kubernetesStore: KubernetesStore,

--- a/src/app/pages/apps/components/catalogs/catalog-add-form/catalog-add-form.component.html
+++ b/src/app/pages/apps/components/catalogs/catalog-add-form/catalog-add-form.component.html
@@ -42,6 +42,7 @@
 
       <ix-form-actions>
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-button
           type="submit"
           color="primary"

--- a/src/app/pages/apps/components/catalogs/catalog-add-form/catalog-add-form.component.spec.ts
+++ b/src/app/pages/apps/components/catalogs/catalog-add-form/catalog-add-form.component.spec.ts
@@ -5,6 +5,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
 import { IxSlideInRef } from 'app/modules/ix-forms/components/ix-slide-in/ix-slide-in-ref';
@@ -47,6 +48,7 @@ describe('CatalogAddFormComponent', () => {
       mockProvider(MatDialog, {
         open: jest.fn(() => mockDialogRef),
       }),
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/catalogs/catalog-add-form/catalog-add-form.component.ts
+++ b/src/app/pages/apps/components/catalogs/catalog-add-form/catalog-add-form.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import { Role } from 'app/enums/role.enum';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { CatalogCreate } from 'app/interfaces/catalog.interface';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
@@ -34,6 +35,8 @@ export class CatalogAddFormComponent {
     preferred_trains: helptextApps.catalogForm.preferredTrains.tooltip,
     branch: helptextApps.catalogForm.branch.tooltip,
   };
+
+  protected readonly requiredRoles = [Role.CatalogWrite];
 
   constructor(
     private slideInRef: IxSlideInRef<CatalogAddFormComponent>,

--- a/src/app/pages/apps/components/catalogs/catalog-edit-form/catalog-edit-form.component.html
+++ b/src/app/pages/apps/components/catalogs/catalog-edit-form/catalog-edit-form.component.html
@@ -25,6 +25,7 @@
 
       <ix-form-actions>
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-button
           type="submit"
           color="primary"

--- a/src/app/pages/apps/components/catalogs/catalog-edit-form/catalog-edit-form.component.spec.ts
+++ b/src/app/pages/apps/components/catalogs/catalog-edit-form/catalog-edit-form.component.spec.ts
@@ -3,6 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { Catalog, CatalogTrain } from 'app/interfaces/catalog.interface';
 import { IxSlideInRef } from 'app/modules/ix-forms/components/ix-slide-in/ix-slide-in-ref';
@@ -30,6 +31,7 @@ describe('CatalogEditFormComponent', () => {
       ]),
       mockProvider(IxSlideInRef),
       mockProvider(FormErrorHandlerService),
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/catalogs/catalog-edit-form/catalog-edit-form.component.ts
+++ b/src/app/pages/apps/components/catalogs/catalog-edit-form/catalog-edit-form.component.ts
@@ -4,6 +4,7 @@ import {
 import { FormBuilder, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { of } from 'rxjs';
+import { Role } from 'app/enums/role.enum';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { Catalog, CatalogUpdate } from 'app/interfaces/catalog.interface';
 import { Option } from 'app/interfaces/option.interface';
@@ -31,6 +32,8 @@ export class CatalogEditFormComponent implements OnInit {
     label: helptextApps.catalogForm.name.tooltip,
     preferred_trains: helptextApps.catalogForm.preferredTrains.tooltip,
   };
+
+  protected readonly requiredRoles = [Role.CatalogWrite];
 
   constructor(
     private ws: WebSocketService,

--- a/src/app/pages/apps/components/catalogs/catalogs.component.html
+++ b/src/app/pages/apps/components/catalogs/catalogs.component.html
@@ -2,7 +2,12 @@
   <ix-page-title-header>
     <ix-search-input (search)="onListFiltered($event)"></ix-search-input>
 
-    <button mat-button ixTest="refresh-all" (click)="onRefreshAll()">
+    <button
+      *ixRequiresRoles="requiredRoles"
+      mat-button
+      ixTest="refresh-all"
+      (click)="onRefreshAll()"
+    >
       {{ 'Refresh All' | translate }}
     </button>
 
@@ -36,6 +41,7 @@
             (click)="showSummary(catalog)"
           >{{ 'Summary' | translate }}</button>
           <button
+            *ixRequiresRoles="requiredRoles"
             mat-button
             [ixTest]="[catalog.label, 'refresh']"
             (click)="refreshRow(catalog)"
@@ -45,12 +51,15 @@
             [ixTest]="[catalog.label, 'edit']"
             (click)="doEdit(catalog)"
           >{{ 'Edit' | translate }}</button>
-          <button
-            *ngIf="!catalog.builtin"
-            mat-button
-            [ixTest]="[catalog.label, 'delete']"
-            (click)="doDelete(catalog)"
-          >{{ 'Delete' | translate }}</button>
+          <ng-container *ngIf="!catalog.builtin">
+            <button
+              *ixRequiresRoles="requiredRoles"
+              mat-button
+              [ixTest]="[catalog.label, 'delete']"
+              (click)="doDelete(catalog)"
+            >{{ 'Delete' | translate }}
+            </button>
+          </ng-container>
         </div>
       </ng-template>
     </tbody>

--- a/src/app/pages/apps/components/catalogs/catalogs.component.ts
+++ b/src/app/pages/apps/components/catalogs/catalogs.component.ts
@@ -6,6 +6,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { filter, tap } from 'rxjs/operators';
 import { JobState } from 'app/enums/job-state.enum';
+import { Role } from 'app/enums/role.enum';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { Catalog } from 'app/interfaces/catalog.interface';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
@@ -62,6 +63,8 @@ export class CatalogsComponent implements OnInit {
   ], {
     rowTestId: (row) => 'catalog-' + row.label,
   });
+
+  protected readonly requiredRoles = [Role.CatalogWrite];
 
   constructor(
     private matDialog: MatDialog,

--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.html
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.html
@@ -26,6 +26,7 @@
 
       <div class="actions">
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-button
           type="submit"
           color="primary"

--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.spec.ts
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.spec.ts
@@ -7,6 +7,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Spectator } from '@ngneat/spectator';
 import { mockProvider, createComponentFactory } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockEntityJobComponentRef } from 'app/core/testing/utils/mock-entity-job-component-ref.utils';
 import { mockCall, mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { CatalogApp, CatalogAppVersion } from 'app/interfaces/catalog.interface';
@@ -384,6 +385,7 @@ describe('ChartWizardComponent', () => {
       }),
       mockProvider(IxSlideInRef),
       mockProvider(Router),
+      mockAuth(),
       { provide: SLIDE_IN_DATA, useValue: undefined },
     ],
   });

--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.ts
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.ts
@@ -21,6 +21,7 @@ import {
 } from 'rxjs/operators';
 import { ixChartApp } from 'app/constants/catalog.constants';
 import { DynamicFormSchemaType } from 'app/enums/dynamic-form-schema-type.enum';
+import { Role } from 'app/enums/role.enum';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { AppDetailsRouteParams } from 'app/interfaces/app-details-route-params.interface';
 import { CatalogApp } from 'app/interfaces/catalog.interface';
@@ -95,6 +96,8 @@ export class ChartWizardComponent implements OnInit, OnDestroy {
       return `${this.titlePrefix} ${name}`;
     }),
   );
+
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   get titlePrefix(): string {
     return this.isNew ? this.translate.instant('Install') : this.translate.instant('Edit');

--- a/src/app/pages/apps/components/docker-images/docker-images-list/docker-images-list.component.html
+++ b/src/app/pages/apps/components/docker-images/docker-images-list/docker-images-list.component.html
@@ -13,6 +13,7 @@
 
   <div class="actions">
     <button
+      *ixRequiresRoles="requiredRoles"
       mat-button
       ixTest="update-selected"
       [disabled]="!selectionHasUpdates"
@@ -21,7 +22,12 @@
       <ix-icon name="update"></ix-icon>
       {{ 'Update' | translate }}
     </button>
-    <button mat-button ixTest="delete-selected" (click)="doDelete(checkboxColumn?.selection.selected)">
+    <button
+      *ixRequiresRoles="requiredRoles"
+      mat-button
+      ixTest="delete-selected"
+      (click)="doDelete(checkboxColumn?.selection.selected)"
+    >
       <ix-icon name="delete"></ix-icon>
       {{ 'Delete' | translate }}
     </button>
@@ -101,6 +107,7 @@
       </button>
       <mat-menu #actionsMenu="matMenu">
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-menu-item
           [ixTest]="['update', image.repo_tags.join(', ')]"
           [disabled]="!image.update_available"
@@ -109,7 +116,7 @@
           {{ image.update_available ? ('Update available' | translate) : ('Up to date' | translate) }}
         </button>
         <button
-          *ixRequiresRoles="[Role.FullAdmin]"
+          *ixRequiresRoles="requiredRoles"
           mat-menu-item
           [ixTest]="['delete', image.repo_tags.join(', ')]"
           (click)="doDelete([image])"

--- a/src/app/pages/apps/components/docker-images/docker-images-list/docker-images-list.component.ts
+++ b/src/app/pages/apps/components/docker-images/docker-images-list/docker-images-list.component.ts
@@ -31,7 +31,6 @@ import { IxSlideInService } from 'app/services/ix-slide-in.service';
 export class DockerImagesListComponent implements OnInit, AfterViewInit {
   dataSource = new MatTableDataSource<ContainerImage>([]);
 
-  Role = Role;
   displayedColumns = ['select', 'id', 'repo_tags', 'size', 'update', 'actions'];
 
   @ViewChild(MatSort, { static: false }) sort: MatSort;
@@ -62,6 +61,8 @@ export class DockerImagesListComponent implements OnInit, AfterViewInit {
       return of(EmptyType.NoSearchResults);
     }),
   );
+
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   get selectionHasUpdates(): boolean {
     return this.checkboxColumn.selection.selected.some((image) => image.update_available);

--- a/src/app/pages/apps/components/docker-images/pull-image-form/pull-image-form.component.html
+++ b/src/app/pages/apps/components/docker-images/pull-image-form/pull-image-form.component.html
@@ -40,6 +40,7 @@
 
       <ix-form-actions>
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-button
           type="submit"
           color="primary"

--- a/src/app/pages/apps/components/docker-images/pull-image-form/pull-image-form.component.spec.ts
+++ b/src/app/pages/apps/components/docker-images/pull-image-form/pull-image-form.component.spec.ts
@@ -3,6 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { EntityModule } from 'app/modules/entity/entity.module';
 import { IxSlideInRef } from 'app/modules/ix-forms/components/ix-slide-in/ix-slide-in-ref';
@@ -35,6 +36,7 @@ describe('PullImageFormComponent', () => {
       { provide: SLIDE_IN_DATA, useValue: undefined },
       mockProvider(FormErrorHandlerService),
       mockProvider(DialogService),
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/docker-images/pull-image-form/pull-image-form.component.ts
+++ b/src/app/pages/apps/components/docker-images/pull-image-form/pull-image-form.component.ts
@@ -4,6 +4,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { latestVersion } from 'app/constants/catalog.constants';
+import { Role } from 'app/enums/role.enum';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { PullContainerImageParams } from 'app/interfaces/container-image.interface';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
@@ -33,6 +34,8 @@ export class PullImageFormComponent {
     username: helptextApps.pullImageForm.username.tooltip,
     password: helptextApps.pullImageForm.password.tooltip,
   };
+
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   constructor(
     private slideInRef: IxSlideInRef<PullImageFormComponent>,

--- a/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.html
@@ -89,6 +89,7 @@
 
   <div class="form-actions">
     <button
+      *ixRequiresRoles="requiredRoles"
       mat-button
       type="submit"
       color="primary"

--- a/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.spec.ts
@@ -8,6 +8,7 @@ import { ImgFallbackModule } from 'ngx-img-fallback';
 import { BulkListItemComponent } from 'app/core/components/bulk-list-item/bulk-list-item.component';
 import { FakeFormatDateTimePipe } from 'app/core/testing/classes/fake-format-datetime.pipe';
 import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockCall, mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { UpgradeSummary } from 'app/interfaces/application.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
@@ -121,6 +122,7 @@ describe('AppBulkUpgradeComponent', () => {
         mockCall('chart.release.upgrade_summary', fakeUpgradeSummary),
         mockJob('chart.release.upgrade', fakeSuccessfulJob(fakeAppOne)),
       ]),
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.ts
@@ -16,6 +16,7 @@ import {
 } from 'rxjs';
 import { appImagePlaceholder } from 'app/constants/catalog.constants';
 import { BulkListItem, BulkListItemState } from 'app/core/components/bulk-list-item/bulk-list-item.interface';
+import { Role } from 'app/enums/role.enum';
 import { UpgradeSummary } from 'app/interfaces/application.interface';
 import { ChartRelease, ChartReleaseUpgradeParams } from 'app/interfaces/chart-release.interface';
 import { Option } from 'app/interfaces/option.interface';
@@ -40,6 +41,7 @@ export class AppBulkUpgradeComponent {
 
   readonly trackByKey: TrackByFunction<KeyValue<string, BulkListItem<ChartRelease>>> = (_, entry) => entry.key;
   readonly imagePlaceholder = appImagePlaceholder;
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   constructor(
     private formBuilder: FormBuilder,

--- a/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.html
@@ -62,6 +62,7 @@
                   class="container-action"
                 >
                   <button
+                    *ixRequiresRoles="requiredRoles"
                     mat-icon-button
                     matTooltipPosition="above"
                     [attr.aria-label]="'Shell' | translate"

--- a/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.spec.ts
@@ -7,6 +7,7 @@ import { createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 import { of } from 'rxjs';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
 import { ChartContainerImage, ChartRelease } from 'app/interfaces/chart-release.interface';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
@@ -57,6 +58,7 @@ describe('AppContainersCardComponent', () => {
       mockProvider(MatDialog, {
         open: jest.fn(() => of(true)),
       }),
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-containers-card/app-containers-card.component.ts
@@ -8,6 +8,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { map } from 'rxjs';
 import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
 import { PodSelectDialogType } from 'app/enums/pod-select-dialog.enum';
+import { Role } from 'app/enums/role.enum';
 import { ChartContainerImage, ChartRelease } from 'app/interfaces/chart-release.interface';
 import { PodDialogFormValue } from 'app/interfaces/pod-select-dialog.interface';
 import { PodSelectDialogComponent } from 'app/pages/apps/components/pod-select-dialog/pod-select-dialog.component';
@@ -27,6 +28,8 @@ export class AppContainersCardComponent implements OnChanges {
   readonly chartReleaseStatus = ChartReleaseStatus;
 
   containerImages: Record<string, ChartContainerImage>;
+
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   constructor(
     private appService: ApplicationsService,

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -158,6 +158,7 @@
       {{ 'Roll Back' | translate }}
     </button>
     <button
+      *ixRequiresRoles="requiredRoles"
       mat-button
       [ixTest]="[app.name, 'delete']"
       (click)="deleteButtonPressed()"

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -10,6 +10,7 @@ import { MockComponents, MockDirective } from 'ng-mocks';
 import { ImgFallbackDirective } from 'ngx-img-fallback';
 import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 import { of } from 'rxjs';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { UpgradeSummary } from 'app/interfaces/application.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
 import { AppCardLogoComponent } from 'app/pages/apps/components/app-card-logo/app-card-logo.component';
@@ -87,6 +88,7 @@ describe('AppInfoCardComponent', () => {
         open: jest.fn(() => mockDialogRef),
       }),
       mockProvider(RedirectService),
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -8,6 +8,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { startCase, isEmpty } from 'lodash';
 import { filter, map, take } from 'rxjs';
 import { appImagePlaceholder, ixChartApp } from 'app/constants/catalog.constants';
+import { Role } from 'app/enums/role.enum';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { UpgradeSummary } from 'app/interfaces/application.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
@@ -50,6 +51,8 @@ export class AppInfoCardComponent {
   get isStartingOrStopping(): boolean {
     return [AppStatus.Starting, AppStatus.Stopping].includes(this.status);
   }
+
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   constructor(
     private loader: AppLoaderService,

--- a/src/app/pages/apps/components/installed-apps/app-rollback-modal/app-rollback-modal.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-rollback-modal/app-rollback-modal.component.html
@@ -19,6 +19,7 @@
 <div mat-dialog-actions class="buttons">
   <button mat-button matDialogClose ixTest="cancel">{{ 'Cancel' | translate }}</button>
   <button
+    *ixRequiresRoles="requiredRoles"
     mat-button
     color="primary"
     ixTest="roll-back"

--- a/src/app/pages/apps/components/installed-apps/app-rollback-modal/app-rollback-modal.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-rollback-modal/app-rollback-modal.component.spec.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockEntityJobComponentRef } from 'app/core/testing/utils/mock-entity-job-component-ref.utils';
 import { ChartRelease, ChartReleaseVersion } from 'app/interfaces/chart-release.interface';
 import { IxSelectHarness } from 'app/modules/ix-forms/components/ix-select/ix-select.harness';
@@ -35,6 +36,7 @@ describe('AppRollbackModalComponent', () => {
           } as ChartRelease['history'],
         } as ChartRelease,
       },
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-rollback-modal/app-rollback-modal.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-rollback-modal/app-rollback-modal.component.ts
@@ -5,6 +5,7 @@ import { FormBuilder, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Observable, of } from 'rxjs';
+import { Role } from 'app/enums/role.enum';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { ChartRollbackParams } from 'app/interfaces/chart-release-event.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
@@ -27,6 +28,7 @@ export class AppRollbackModalComponent {
   versionOptions$: Observable<Option[]>;
 
   readonly helptext = helptextApps.charts.rollback_dialog.version.tooltip;
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   constructor(
     private dialogRef: MatDialogRef<AppRollbackModalComponent>,

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
@@ -54,7 +54,7 @@
     ></ix-icon>
   </ng-container>
 </div>
-<div class="cell cell-action">
+<div *ixRequiresRoles="requiredRoles" class="cell cell-action">
   <button
     *ngIf="isAppStopped"
     mat-icon-button

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.spec.ts
@@ -2,6 +2,7 @@ import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { MockComponents } from 'ng-mocks';
 import { ImgFallbackModule } from 'ngx-img-fallback';
 import { officialCatalog } from 'app/constants/catalog.constants';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
 import { AppRowComponent } from 'app/pages/apps/components/installed-apps/app-row/app-row.component';
@@ -33,6 +34,9 @@ describe('AppRowComponent', () => {
     imports: [ImgFallbackModule, AppCatalogPipe],
     declarations: [
       MockComponents(AppStatusCellComponent),
+    ],
+    providers: [
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
@@ -3,6 +3,7 @@ import {
   Component, EventEmitter, Input, Output,
 } from '@angular/core';
 import { appImagePlaceholder } from 'app/constants/catalog.constants';
+import { Role } from 'app/enums/role.enum';
 import { ChartScaleQueryParams, ChartScaleResult } from 'app/interfaces/chart-release-event.interface';
 import { ChartRelease } from 'app/interfaces/chart-release.interface';
 import { Job } from 'app/interfaces/job.interface';
@@ -25,6 +26,8 @@ export class AppRowComponent {
   @Output() selectionChange = new EventEmitter<void>();
 
   readonly imagePlaceholder = appImagePlaceholder;
+
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   get hasUpdates(): boolean {
     return this.app.update_available || this.app.container_images_update_available;

--- a/src/app/pages/apps/components/installed-apps/app-settings-button/app-settings-button.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-settings-button/app-settings-button.component.html
@@ -4,20 +4,27 @@
 </button>
 
 <mat-menu #menu="matMenu" overlapTrigger="false">
-  <button mat-menu-item ixTest="choose-pool" (click)="onChoosePool()">
+  <button
+    *ixRequiresRoles="requiredRoles"
+    mat-menu-item
+    ixTest="choose-pool"
+    (click)="onChoosePool()"
+  >
     {{ 'Choose Pool' | translate }}
   </button>
   <button mat-menu-item ixTest="advanced-settings" (click)="onAdvancedSettings()">
     {{ 'Advanced Settings' | translate }}
   </button>
-  <button
-    *ngIf="!!(kubernetesStore.selectedPool$ | async)"
-    mat-menu-item
-    ixTest="unset-pool"
-    (click)="onUnsetPool()"
-  >
-    {{ 'Unset Pool' | translate }}
-  </button>
+  <ng-container *ngIf="!!(kubernetesStore.selectedPool$ | async)">
+    <button
+      *ixRequiresRoles="requiredRoles"
+      mat-menu-item
+      ixTest="unset-pool"
+      (click)="onUnsetPool()"
+    >
+      {{ 'Unset Pool' | translate }}
+    </button>
+  </ng-container>
   <button mat-menu-item ixTest="container-images" [routerLink]="['/apps', 'installed', 'manage-container-images']">
     {{ 'Manage Container Images' | translate }}
   </button>

--- a/src/app/pages/apps/components/installed-apps/app-settings-button/app-settings-button.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-settings-button/app-settings-button.component.spec.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { AppSettingsButtonComponent } from 'app/pages/apps/components/installed-apps/app-settings-button/app-settings-button.component';
 import { KubernetesSettingsComponent } from 'app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component';
 import { SelectPoolDialogComponent } from 'app/pages/apps/components/select-pool-dialog/select-pool-dialog.component';
@@ -33,6 +34,7 @@ describe('AppSettingsButtonComponent', () => {
       mockProvider(KubernetesStore, {
         selectedPool$: of('pool'),
       }),
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-settings-button/app-settings-button.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-settings-button/app-settings-button.component.ts
@@ -5,6 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { officialCatalog } from 'app/constants/catalog.constants';
+import { Role } from 'app/enums/role.enum';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { EntityJobComponent } from 'app/modules/entity/entity-job/entity-job.component';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
@@ -24,6 +25,8 @@ import { IxSlideInService } from 'app/services/ix-slide-in.service';
 })
 export class AppSettingsButtonComponent {
   readonly officialCatalog = officialCatalog;
+
+  protected readonly requiredRoles = [Role.KubernetesWrite];
 
   constructor(
     private slideInService: IxSlideInService,

--- a/src/app/pages/apps/components/installed-apps/app-upgrade-dialog/app-upgrade-dialog.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-upgrade-dialog/app-upgrade-dialog.component.html
@@ -90,24 +90,26 @@
       </div>
     </mat-expansion-panel>
   </mat-accordion>
-</div>
 
-<div class="button-bar" mat-dialog-actions align="end">
-  <button
-    mat-button
-    class="mat-mdc-button mat-button mat-secondary"
-    ixTest="close"
-    (click)="dialogRef.close(false)"
-  >
-    {{ 'Close' | translate }}
-  </button>
-  <button
-    mat-button
-    class="mat-mdc-button mat-button"
-    color="primary"
-    ixTest="upgrade"
-    (click)="dialogRef.close(selectedVersionKey)"
-  >
-    {{ 'Upgrade' | translate }}
-  </button>
+  <ix-form-actions>
+    <button
+      mat-button
+      class="mat-mdc-button mat-button mat-secondary"
+      ixTest="close"
+      (click)="dialogRef.close(false)"
+    >
+      {{ 'Close' | translate }}
+    </button>
+    <button
+      *ixRequiresRoles="requiredRoles"
+      mat-button
+      class="mat-mdc-button mat-button"
+      color="primary"
+      ixTest="upgrade"
+      (click)="dialogRef.close(selectedVersionKey)"
+    >
+      {{ 'Upgrade' | translate }}
+    </button>
+  </ix-form-actions>
+
 </div>

--- a/src/app/pages/apps/components/installed-apps/app-upgrade-dialog/app-upgrade-dialog.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-upgrade-dialog/app-upgrade-dialog.component.ts
@@ -6,6 +6,7 @@ import {
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { appImagePlaceholder } from 'app/constants/catalog.constants';
+import { Role } from 'app/enums/role.enum';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { UpgradeSummary } from 'app/interfaces/application.interface';
 import { ChartContainerImage } from 'app/interfaces/chart-release.interface';
@@ -30,6 +31,8 @@ export class AppUpgradeDialogComponent {
   versionOptions = new Map<string, Version>();
   selectedVersionKey: string;
   selectedVersion: Version;
+
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   constructor(
     public dialogRef: MatDialogRef<AppUpgradeDialogComponent>,

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.html
@@ -40,6 +40,7 @@
         <div class="bulk-button-wrapper">
           <label>{{ 'Bulk Actions' | translate }}</label>
           <button
+            *ixRequiresRoles="requiredRoles"
             mat-button
             ixTest="bulk-actions-menu"
             [matMenuTriggerFor]="menu"

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.spec.ts
@@ -11,6 +11,7 @@ import {
 import { MockComponents } from 'ng-mocks';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { of } from 'rxjs';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockEntityJobComponentRef } from 'app/core/testing/utils/mock-entity-job-component-ref.utils';
 import { mockCall, mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { AvailableApp } from 'app/interfaces/available-app.interface';
@@ -38,6 +39,7 @@ import { KubernetesStore } from 'app/pages/apps/store/kubernetes-store.service';
 import { AppCatalogPipe } from 'app/pages/apps/utils/app-catalog.pipe';
 import { AuthService } from 'app/services/auth/auth.service';
 
+// TODO: Clean up
 const existingCatalogApp = {
   name: 'webdav',
   versions: {
@@ -546,6 +548,7 @@ describe('Finding app', () => {
         searchedApps$: of([{ apps: appsResponse }]),
         searchQuery$: of('webdav'),
       }),
+      mockAuth(),
     ],
   });
 
@@ -633,6 +636,7 @@ describe('Redirect to install app', () => {
   });
 });
 
+// TODO: Why is this here?
 describe('Install app', () => {
   let spectator: Spectator<ChartWizardComponent>;
   let loader: HarnessLoader;
@@ -681,6 +685,7 @@ describe('Install app', () => {
           routeConfig: { path: 'install' },
         },
       },
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -21,6 +21,7 @@ import {
 import { ChartReleaseStatus } from 'app/enums/chart-release-status.enum';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { JobState } from 'app/enums/job-state.enum';
+import { Role } from 'app/enums/role.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { ChartScaleResult, ChartScaleQueryParams } from 'app/interfaces/chart-release-event.interface';
@@ -133,6 +134,8 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
       (app) => app.status === ChartReleaseStatus.Stopped && this.selection.isSelected(app.id),
     );
   }
+
+  protected readonly requiredRoles = [Role.AppsWrite];
 
   constructor(
     private appService: ApplicationsService,

--- a/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.html
+++ b/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.html
@@ -75,6 +75,7 @@
 
       <ix-form-actions>
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-button
           type="submit"
           color="primary"

--- a/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.spec.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockCall, mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { ContainerConfig } from 'app/interfaces/container-config.interface';
@@ -61,6 +62,7 @@ describe('KubernetesSettingsComponent', () => {
       }),
       mockProvider(IxSlideInRef),
       mockProvider(FormErrorHandlerService),
+      mockAuth(),
     ],
   });
 

--- a/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.ts
+++ b/src/app/pages/apps/components/installed-apps/kubernetes-settings/kubernetes-settings.component.ts
@@ -10,6 +10,7 @@ import {
   catchError, filter, map, switchMap, tap,
 } from 'rxjs/operators';
 import { JobState } from 'app/enums/job-state.enum';
+import { Role } from 'app/enums/role.enum';
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { KubernetesConfig, KubernetesConfigUpdate } from 'app/interfaces/kubernetes-config.interface';
@@ -58,6 +59,8 @@ export class KubernetesSettingsComponent implements OnInit {
       }));
     }),
   );
+
+  protected readonly requiredRoles = [Role.KubernetesWrite];
 
   private oldConfig: KubernetesConfig;
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 2956dcbb2184c564dea3d7568a03e7ce7a5c8b73
    git cherry-pick -x 0838e083348bfafb29060f1504e708d9e87ba0ca

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x af0b5d9f88002e18812beba582d2891125b6002a

Testing:
Check permissions in Apps section as a readonly user.

Note:
- installed apps may not load because of a middleware issue. In this case login as full admin and mock AuthService.hasRole to return false.
- pod logs button is not working, but I believe it should. I have created a middleware ticket for it.

Original PR: https://github.com/truenas/webui/pull/9560
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127086