### PR TITLE
NAS-127051 / 24.04-RC.1 / Read only user : SMB Share > Edit Share ACL > Save button enabled (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
@@ -77,6 +77,7 @@
 
       <ix-form-actions>
         <button
+          *ixRequiresRoles="requiresRoles"
           mat-button
           type="submit"
           color="primary"

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
@@ -5,6 +5,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { User } from '@sentry/angular';
 import { of } from 'rxjs';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { NfsAclTag } from 'app/enums/nfs-acl.enum';
 import { SmbSharesecPermission, SmbSharesecType } from 'app/enums/smb-sharesec.enum';
@@ -66,6 +67,7 @@ describe('SmbAclComponent', () => {
       IxFormsModule,
     ],
     providers: [
+      mockAuth(),
       mockWebsocket([
         mockCall('sharing.smb.getacl', mockAcl),
         mockCall('sharing.smb.setacl'),

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
@@ -8,6 +8,7 @@ import {
   concatMap, forkJoin, from, Observable, of,
 } from 'rxjs';
 import { NfsAclTag, smbAclTagLabels } from 'app/enums/nfs-acl.enum';
+import { Role } from 'app/enums/role.enum';
 import { SmbSharesecPermission, SmbSharesecType } from 'app/enums/smb-sharesec.enum';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextSharingSmb } from 'app/helptext/sharing';
@@ -49,7 +50,7 @@ export class SmbAclComponent implements OnInit {
   private shareAclName: string;
 
   readonly tags$ = of(mapToOptions(smbAclTagLabels, this.translate));
-
+  readonly requiresRoles = [Role.SharingSmbWrite, Role.SharingWrite];
   readonly permissions$ = of([
     {
       label: 'FULL',


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 43fe86e81aa08d6a9e3c080c510e59de1ed8719c

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 484c4ce285839aa53c2016a8a2fca25d11a11627

Testing:
You should see  👇  for the `readonly` user:
<img width="494" alt="Screenshot 2024-01-31 at 14 55 30" src="https://github.com/truenas/webui/assets/22980553/019ae43d-ce0f-4f3f-9d4e-a6a3d9174381">


Original PR: https://github.com/truenas/webui/pull/9568
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127051