### PR TITLE
NAS-127062 / 24.04-RC.1 / Dragonfish: Fix Enclosure pool/disk UI info incorrect when disk is pulled

### DIFF
--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
@@ -63,7 +63,7 @@
                   "
                 ></div>
                 {{ pool }}
-                <span *ngIf="!systemState.pools[i] || !systemState.pools[i].healthy">
+                <span *ngIf="!findPoolByName(pool) || !findPoolByName(pool).healthy">
                   <ix-icon name="mdi-alert"></ix-icon>
                 </span>
               </div>

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.html
@@ -63,7 +63,7 @@
                   "
                 ></div>
                 {{ pool }}
-                <span *ngIf="!findPoolByName(pool) || !findPoolByName(pool).healthy">
+                <span *ngIf="!isPoolHealthy(pool)" class="alert">
                   <ix-icon name="mdi-alert"></ix-icon>
                 </span>
               </div>

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.scss
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.scss
@@ -187,6 +187,10 @@ nav.view-nav-bar {
   text-align: left;
   width: fit-content;
 
+  .alert {
+    display: inline-flex;
+  }
+
   ix-icon {
     font-size: 14px;
   }

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
@@ -1129,6 +1129,10 @@ export class EnclosureDisksComponent implements AfterContentInit, OnDestroy {
     return this.systemState.pools.find((pool: Pool) => pool.name === name);
   }
 
+  isPoolHealthy(poolName: string): boolean {
+    return this.findPoolByName(poolName)?.healthy;
+  }
+
   // PIXI/Chassis trigger
   toggleHighlightMode(mode: string): void {
     const enclosureView = this.selectedEnclosureView;


### PR DESCRIPTION
**Testing**

For testing machine - see ticket

**Expected result:** Enclosure page to identify sanity as the degraded pool with triangle "!"  icon in the legend on the right side