### PR TITLE
NAS-126976 / 24.10 / Focus service updates to correctly handle table reloading and loosing html ref & other improvements

### DIFF
--- a/src/app/pages/directory-service/components/idmap-form/idmap-form.component.ts
+++ b/src/app/pages/directory-service/components/idmap-form/idmap-form.component.ts
@@ -215,7 +215,7 @@ export class IdmapFormComponent implements OnInit {
       .subscribe({
         next: () => {
           this.isLoading = false;
-          this.slideInRef.close();
+          this.slideInRef.close(true);
         },
         error: (error: unknown) => {
           this.formErrorHandler.handleWsFormError(error, this.form);

--- a/src/app/pages/directory-service/components/idmap-list/idmap-list.component.ts
+++ b/src/app/pages/directory-service/components/idmap-list/idmap-list.component.ts
@@ -79,6 +79,7 @@ export class IdmapListComponent implements OnInit {
           onClick: (row) => {
             const slideInRef = this.slideInService.open(IdmapFormComponent, { data: row });
             slideInRef.slideInClosed$.pipe(
+              filter(Boolean),
               untilDestroyed(this),
             ).subscribe(() => this.getIdmaps());
           },
@@ -180,6 +181,7 @@ export class IdmapListComponent implements OnInit {
       if (adConfig.enable) {
         const slideInRef = this.slideInService.open(IdmapFormComponent);
         slideInRef.slideInClosed$.pipe(
+          filter(Boolean),
           untilDestroyed(this),
         ).subscribe(() => {
           this.getIdmaps();

--- a/src/app/pages/directory-service/components/kerberos-settings/kerberos-settings.component.ts
+++ b/src/app/pages/directory-service/components/kerberos-settings/kerberos-settings.component.ts
@@ -67,7 +67,7 @@ export class KerberosSettingsComponent implements OnInit {
       next: () => {
         this.isFormLoading = false;
         this.cdr.markForCheck();
-        this.slideInRef.close();
+        this.slideInRef.close(true);
       },
       error: (error: unknown) => {
         this.isFormLoading = false;

--- a/src/app/pages/directory-service/directory-services.component.ts
+++ b/src/app/pages/directory-service/directory-services.component.ts
@@ -162,7 +162,10 @@ export class DirectoryServicesComponent implements OnInit {
 
   openKerberosSettingsForm(): void {
     const slideInRef = this.slideInService.open(KerberosSettingsComponent);
-    slideInRef.slideInClosed$.pipe(untilDestroyed(this)).subscribe(() => this.refreshCards());
+    slideInRef.slideInClosed$.pipe(
+      filter(Boolean),
+      untilDestroyed(this),
+    ).subscribe(() => this.refreshCards());
   }
 
   refreshTables(): void {

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
-import { take } from 'rxjs/operators';
+import { filter, take } from 'rxjs/operators';
 import { shared, helptextSharingSmb } from 'app/helptext/sharing';
 import { helptextVolumes } from 'app/helptext/storage/volumes/volume-list';
 import { SmbShare } from 'app/interfaces/smb-share.interface';
@@ -84,14 +84,22 @@ export class SmbListComponent implements EntityTableConfig<SmbShare> {
 
   doAdd(): void {
     const slideInRef = this.slideInService.open(SmbFormComponent);
-    slideInRef.slideInClosed$.pipe(take(1), untilDestroyed(this)).subscribe(() => this.entityList.getData());
+    slideInRef.slideInClosed$.pipe(
+      take(1),
+      filter(Boolean),
+      untilDestroyed(this),
+    ).subscribe(() => this.entityList.getData());
   }
 
   doEdit(id: string | number): void {
     const slideInRef = this.slideInService.open(SmbFormComponent, {
       data: { existingSmbShare: this.entityList.rows.find((share) => share.id === id) },
     });
-    slideInRef.slideInClosed$.pipe(take(1), untilDestroyed(this)).subscribe(() => this.entityList.getData());
+    slideInRef.slideInClosed$.pipe(
+      take(1),
+      filter(Boolean),
+      untilDestroyed(this),
+    ).subscribe(() => this.entityList.getData());
   }
 
   getActions(smbShare: SmbShare): EntityTableAction[] {

--- a/src/app/services/focus.service.ts
+++ b/src/app/services/focus.service.ts
@@ -19,7 +19,7 @@ export class FocusService {
       if (this.lastFocusedElement) {
         setTimeout(() => {
           const dataTestValue = this.lastFocusedElement.getAttribute('data-test');
-          const hasOverlayWithChildren = this.document.querySelector('.cdk-overlay-container').hasChildNodes();
+          const hasOverlayWithChildren = this.document.querySelector('.cdk-overlay-container')?.hasChildNodes();
 
           if (dataTestValue && !hasOverlayWithChildren) {
             const dataTestElement = this.document.querySelector(`[data-test="${dataTestValue}"]`);

--- a/src/app/services/focus.service.ts
+++ b/src/app/services/focus.service.ts
@@ -21,7 +21,7 @@ export class FocusService {
           const dataTestValue = this.lastFocusedElement.getAttribute('data-test');
 
           if (dataTestValue) {
-            const dataTestElement = document.querySelector(`[data-test="${dataTestValue}"]`);
+            const dataTestElement = this.document.querySelector(`[data-test="${dataTestValue}"]`);
             (dataTestElement as HTMLElement)?.focus();
           } else {
             this.lastFocusedElement?.focus();

--- a/src/app/services/focus.service.ts
+++ b/src/app/services/focus.service.ts
@@ -17,8 +17,18 @@ export class FocusService {
 
     restoreFocus(): void {
       if (this.lastFocusedElement) {
-        this.lastFocusedElement.focus();
-        this.lastFocusedElement = null;
+        setTimeout(() => {
+          const dataTestValue = this.lastFocusedElement.getAttribute('data-test');
+
+          if (dataTestValue) {
+            const dataTestElement = document.querySelector(`[data-test="${dataTestValue}"]`);
+            (dataTestElement as HTMLElement)?.focus();
+          } else {
+            this.lastFocusedElement?.focus();
+          }
+
+          this.lastFocusedElement = null;
+        }, 200);
       }
     }
 

--- a/src/app/services/focus.service.ts
+++ b/src/app/services/focus.service.ts
@@ -19,8 +19,9 @@ export class FocusService {
       if (this.lastFocusedElement) {
         setTimeout(() => {
           const dataTestValue = this.lastFocusedElement.getAttribute('data-test');
+          const hasOverlayWithChildren = this.document.querySelector('.cdk-overlay-container').hasChildNodes();
 
-          if (dataTestValue) {
+          if (dataTestValue && !hasOverlayWithChildren) {
             const dataTestElement = this.document.querySelector(`[data-test="${dataTestValue}"]`);
             (dataTestElement as HTMLElement)?.focus();
           } else {

--- a/src/app/services/ix-slide-in.service.ts
+++ b/src/app/services/ix-slide-in.service.ts
@@ -79,7 +79,7 @@ export class IxSlideInService {
       this.slideInComponent.closeSlideIn();
     }
 
-    timer(10).pipe(take(1), untilDestroyed(this)).subscribe(() => this.focusService.restoreFocus());
+    this.focusService.restoreFocus();
   }
 
   private closeOnNavigation(): void {


### PR DESCRIPTION
Testing:
I noticed that focus is lost if we update form and return to the table (html element is rerendered and it's reference is lost, I got an Idea to depend on data-test attribute, since it's unchanging)
As well did some fixes for Directory Services.