### PR TITLE
NAS-127105 / 24.10 / Update SysInfo Widget

### DIFF
--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
@@ -95,6 +95,9 @@
                 fxLayoutAlign="center center"
                 [fxFlex.xs]="sysGenService.isEnterprise && productImage === 'X10' ? 80 : 100"
               >
+                <div *ngIf="!isHaEnabled && isPassive" class="generic alert">
+                  <ix-icon name="mdi-alert" [matTooltip]="'HA is disabled' | translate"></ix-icon>
+                </div>
                 <div
                   [class]="'product-image ' + productEnclosure"
                   [class.truenas]="sysGenService.isEnterprise"
@@ -125,16 +128,13 @@
                       name="ix:logo_freenas_certified"
                     ></ix-icon>
                   </ng-template>
-                  <div *ngIf="!hasHa && isPassive" class="generic alert">
-                    <ix-icon name="mdi-alert"></ix-icon>
-                  </div>
                   <div *ngIf="productImage && isHaLicensed && !isPassive" class="ha-node-status">
                     ({{ 'Active' | translate }})
                   </div>
-                  <div *ngIf="productImage && isHaLicensed && isPassive && hasHa" class="ha-node-status">
+                  <div *ngIf="productImage && isHaLicensed && isPassive" class="ha-node-status">
                     ({{ 'Standby' | translate }})
                   </div>
-                  <div *ngIf="ready && !productImage && sysGenService.isEnterprise && hasHa" class="ha-node-status">
+                  <div *ngIf="ready && !productImage && sysGenService.isEnterprise && isHaEnabled" class="ha-node-status">
                     ({{ 'Unsupported Hardware' | translate }})
                   </div>
                 </div>
@@ -159,7 +159,7 @@
                   </button>
                   <ix-simple-failover-button
                     *ngIf="isPassive"
-                    [disabled]="!hasHa && !(hasOnlyMismatchVersionsReason$ | async)"
+                    [disabled]="!isHaEnabled && !(hasOnlyMismatchVersionsReason$ | async)"
                   ></ix-simple-failover-button>
                 </div>
               </ng-template>
@@ -168,7 +168,7 @@
             <!-- Details Section -->
             <div class="right" fxFlex.xs fxFlex.gt-xs="60" fxLayout="column">
               <div
-                *ngIf="!systemInfo && isHaLicensed && isPassive && hasHa"
+                *ngIf="!systemInfo && isHaLicensed && isPassive && isHaEnabled"
                 class="data-container ha-status"
                 fxFlex
               >
@@ -178,12 +178,12 @@
               </div>
 
               <div
-                *ngIf="!systemInfo && isHaLicensed && isPassive && !hasHa"
+                *ngIf="!systemInfo && isHaLicensed && isPassive && !isHaEnabled"
                 class="data-container ha-status"
                 fxFlex
               >
                 <h3>
-                  {{ hasHa ? ('HA Enabled' | translate) : ('HA Disabled' | translate) }}
+                  {{ isHaEnabled ? ('HA Enabled' | translate) : ('HA Disabled' | translate) }}
                 </h3>
               </div>
 
@@ -191,7 +191,11 @@
                 <mat-spinner class="spinner" [diameter]="40"></mat-spinner>
               </div>
 
-              <div *ngIf="(systemInfo && !isPassive) || (systemInfo && isPassive && hasHa)" class="data-container" fxFlex>
+              <div
+                *ngIf="systemInfo"
+                class="data-container"
+                fxFlex
+              >
                 <div fxHide.gt-xs class="list-subheader">
                   {{ isPassive ? ('System Information (Standby)' | translate) : ('System Information' | translate) }}
                 </div>
@@ -259,7 +263,7 @@
                   <ix-simple-failover-button
                     *ngIf="isPassive"
                     color="primary"
-                    [disabled]="!hasHa && !(hasOnlyMismatchVersionsReason$ | async)"
+                    [disabled]="!isHaEnabled && !(hasOnlyMismatchVersionsReason$ | async)"
                   ></ix-simple-failover-button>
                 </div>
               </div>

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
@@ -336,12 +336,14 @@ img.platform-logo {
 }
 
 div.generic.alert {
+  bottom: 4px;
+  position: absolute;
   text-align: center;
 }
 
 div.generic.alert .ix-icon {
   font-size: 48px;
-  height: auto;
+  height: 48px;
   width: auto;
 }
 

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -42,10 +42,12 @@ import { selectIsIxHardware, waitForSystemFeatures } from 'app/store/system-info
   providers: [TitleCasePipe],
 })
 export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, OnDestroy {
-  protected isHaLicensed = false;
   @Input() isPassive = false;
-  protected enclosureSupport = false;
   @Input() showReorderHandle = false;
+
+  protected isHaLicensed = false;
+  protected isHaEnabled = false;
+  protected enclosureSupport = false;
 
   hasOnlyMismatchVersionsReason$ = this.store$.select(selectHasOnlyMismatchVersionsReason);
 
@@ -58,7 +60,6 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, O
   updateAvailable = false;
   isIxHardware = false;
   isUpdateRunning = false;
-  hasHa = this.window.localStorage.getItem('ha_status') === 'true';
   updateMethod = 'update.update';
   screenType = ScreenType.Desktop;
   uptimeInterval: Interval;
@@ -158,7 +159,7 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, O
     this.store$.select(selectHaStatus)
       .pipe(filter(Boolean), untilDestroyed(this))
       .subscribe(({ hasHa }) => {
-        this.hasHa = hasHa;
+        this.isHaEnabled = hasHa;
         this.cdr.markForCheck();
       });
   }


### PR DESCRIPTION
Tested on different systems.

M60 HA is enabled:
![image](https://github.com/truenas/webui/assets/351613/24d9ed66-e313-453d-a1ec-ad94bf845c91)

M40 HA is disabled:
![image](https://github.com/truenas/webui/assets/351613/84e9f549-2ccf-4869-8428-d65153060cd2)

non-HA nightly instance:
<img width="552" alt="image" src="https://github.com/truenas/webui/assets/351613/790c44e3-679f-4e0f-96d6-dbeb7ec7a4de">

For testing, try to find edge cases where it can be broken.
