### PR TITLE
NAS-127170 / 24.04-RC.1 / ix-table2 jumps when something is updated because of data hiding and spinner (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-table2/classes/async-data-provider/async-data-provider.ts
+++ b/src/app/modules/ix-table2/classes/async-data-provider/async-data-provider.ts
@@ -12,7 +12,6 @@ export class AsyncDataProvider<T> extends BaseDataProvider<T> {
   }
 
   load(): void {
-    this.emptyType$.next(EmptyType.Loading);
     this.subscription.add(
       this.request$.subscribe({
         next: (rows) => {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 608a2815a88dfa7670b0415f6f6290299baedfcf

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 65d3398f33a5923479bfb4d13c4824cb10298523

Testing: 
See ticket

Result:

https://github.com/truenas/webui/assets/22980553/363a1f5a-4639-414e-bd4a-ff569adb86e2



Original PR: https://github.com/truenas/webui/pull/9598
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127170