### PR TITLE
NAS-127201 / 24.04-RC.1 / Removing element when component gets destroyed (by RehanY147)

### DIFF
--- a/src/app/modules/ix-forms/components/ix-slide-in/components/ix-chained-slide-in/ix-chained-slide-in.component.ts
+++ b/src/app/modules/ix-forms/components/ix-slide-in/components/ix-chained-slide-in/ix-chained-slide-in.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, ElementRef, Input, OnInit, TrackByFunction, ViewChild,
+  Component, ElementRef, Input, OnDestroy, OnInit, TrackByFunction, ViewChild,
 } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import {
@@ -13,7 +13,7 @@ import {
   templateUrl: './ix-chained-slide-in.component.html',
   styleUrls: ['./ix-chained-slide-in.component.scss'],
 })
-export class IxChainedSlideInComponent implements OnInit {
+export class IxChainedSlideInComponent implements OnInit, OnDestroy {
   @Input() id: string;
   @ViewChild('componentWrapper') container: HTMLElement;
   protected components: ChainedComponentSerialized[];
@@ -40,5 +40,9 @@ export class IxChainedSlideInComponent implements OnInit {
     this.ixChainedSlideInService.components$.pipe(untilDestroyed(this)).subscribe((components) => {
       this.components = components;
     });
+  }
+
+  ngOnDestroy(): void {
+    this.element.remove();
   }
 }

--- a/src/app/modules/ix-forms/components/ix-slide-in/components/ix-slide-in2/ix-slide-in2.component.ts
+++ b/src/app/modules/ix-forms/components/ix-slide-in/components/ix-slide-in2/ix-slide-in2.component.ts
@@ -1,4 +1,3 @@
-import { Location } from '@angular/common';
 import {
   Component,
   ElementRef,
@@ -12,11 +11,8 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
-import { NavigationEnd, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import {
-  Observable, Subscription, filter, merge, timer,
-} from 'rxjs';
+import { Subscription, timer } from 'rxjs';
 import { CHAINED_SLIDE_IN_REF, SLIDE_IN_DATA } from 'app/modules/ix-forms/components/ix-slide-in/ix-slide-in.token';
 import {
   ChainedComponentSerialized, ChainedComponentResponse, ChainedComponentRef, IxChainedSlideInService,
@@ -52,11 +48,8 @@ export class IxSlideIn2Component implements OnInit, OnDestroy {
   constructor(
     private el: ElementRef,
     private renderer: Renderer2,
-    private location: Location,
-    private router: Router,
     private chainedSlideInService: IxChainedSlideInService,
   ) {
-    this.closeOnNavigation();
     this.element = this.el.nativeElement as HTMLElement;
   }
 
@@ -81,6 +74,8 @@ export class IxSlideIn2Component implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.componentInfo.close$.complete();
+    this.chainedSlideInService.popComponent(this.componentInfo.id);
     this.element.remove();
   }
 
@@ -160,20 +155,5 @@ export class IxSlideIn2Component implements OnInit, OnDestroy {
       ],
     });
     this.slideInBody.createComponent<T>(componentType, { injector });
-  }
-
-  private closeOnNavigation(): void {
-    merge(
-      new Observable((observer) => {
-        this.location.subscribe((event) => {
-          observer.next(event);
-        });
-      }),
-      this.router.events.pipe(filter((event) => event instanceof NavigationEnd)),
-    )
-      .pipe(untilDestroyed(this))
-      .subscribe(() => {
-        this.componentInfo.close$.next(null);
-      });
   }
 }


### PR DESCRIPTION
To test, go to the `Data Protection` dashboard and click the `Add` button for `Cloud Sync Tasks`. Leave the form open and let the web session expire so UI goes to the sign in page automatically. Once that happens, you should be able to interact with the sign in page and continue using the UI. On `master` that was not possible.

Original PR: https://github.com/truenas/webui/pull/9606
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127201