### PR TITLE
NAS-127009 / 24.04-RC.1 / Add role support for Bulk Edit Disks form (by denysbutenko)

### DIFF
--- a/src/app/pages/storage/modules/disks/components/disk-bulk-edit/disk-bulk-edit.component.html
+++ b/src/app/pages/storage/modules/disks/components/disk-bulk-edit/disk-bulk-edit.component.html
@@ -46,6 +46,7 @@
 
       <ix-form-actions>
         <button
+          *ixRequiresRoles="requiresRoles"
           mat-button
           type="submit"
           color="primary"

--- a/src/app/pages/storage/modules/disks/components/disk-bulk-edit/disk-bulk-edit.component.spec.ts
+++ b/src/app/pages/storage/modules/disks/components/disk-bulk-edit/disk-bulk-edit.component.spec.ts
@@ -5,6 +5,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockJob, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { DiskPowerLevel } from 'app/enums/disk-power-level.enum';
 import { DiskStandby } from 'app/enums/disk-standby.enum';
@@ -56,6 +57,7 @@ describe('DiskBulkEditComponent', () => {
       TooltipModule,
     ],
     providers: [
+      mockAuth(),
       mockProvider(IxSlideInRef),
       mockProvider(SnackbarService),
       mockProvider(DialogService),

--- a/src/app/pages/storage/modules/disks/components/disk-bulk-edit/disk-bulk-edit.component.ts
+++ b/src/app/pages/storage/modules/disks/components/disk-bulk-edit/disk-bulk-edit.component.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import { DiskPowerLevel } from 'app/enums/disk-power-level.enum';
 import { DiskStandby } from 'app/enums/disk-standby.enum';
 import { JobState } from 'app/enums/job-state.enum';
+import { Role } from 'app/enums/role.enum';
 import { translateOptions } from 'app/helpers/translate.helper';
 import { helptextDisks } from 'app/helptext/storage/disks/disks';
 import { Disk, DiskUpdate } from 'app/interfaces/storage.interface';
@@ -34,6 +35,7 @@ export class DiskBulkEditComponent {
   readonly helptextBulkEdit = helptextDisks.bulk_edit;
   readonly hddstandbyOptions$ = of(helptextDisks.disk_form_hddstandby_options);
   readonly advpowermgmtOptions$ = of(translateOptions(this.translate, this.helptext.disk_form_advpowermgmt_options));
+  protected readonly requiresRoles = [Role.FullAdmin];
 
   constructor(
     private fb: FormBuilder,


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 8b4334a94c826d64a882f9fba4fa530f9e7ca025

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8bcd00aa8a0e2aea8635f528cc7a4529199b416f

For testing

- Login as Readonly Administator
- Open Storage Dashboard
- Find the Manage Disks button on the screen
- Choose two disks at least to bulk actions appear
- Press the Edit Disks
- Check the Save button is disabled

Original PR: https://github.com/truenas/webui/pull/9615
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127009