### PR TITLE
NAS-127221 / 24.04-RC.1 / Missing Reboot UI Option on non-root Admin (by undsoft)

### DIFF
--- a/src/app/modules/layout/components/topbar/power-menu/power-menu.component.html
+++ b/src/app/modules/layout/components/topbar/power-menu/power-menu.component.html
@@ -14,7 +14,7 @@
     {{ 'Log Out' | translate }}
   </button>
 
-  <ng-container *ngIf="isSysAdmin$ | async">
+  <ng-container *ixRequiresRoles="requiredRoles">
     <button
       name="power-restart"
       mat-menu-item

--- a/src/app/modules/layout/components/topbar/power-menu/power-menu.component.spec.ts
+++ b/src/app/modules/layout/components/topbar/power-menu/power-menu.component.spec.ts
@@ -3,7 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { Router } from '@angular/router';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { BehaviorSubject, of } from 'rxjs';
+import { of } from 'rxjs';
 import { PowerMenuComponent } from 'app/modules/layout/components/topbar/power-menu/power-menu.component';
 import { AuthService } from 'app/services/auth/auth.service';
 import { DialogService } from 'app/services/dialog.service';
@@ -13,12 +13,11 @@ describe('PowerMenuComponent', () => {
   let spectator: Spectator<PowerMenuComponent>;
   let loader: HarnessLoader;
   let menu: MatMenuHarness;
-  const isSysAdmin$ = new BehaviorSubject(true);
   const createComponent = createComponentFactory({
     component: PowerMenuComponent,
     providers: [
       mockProvider(AuthService, {
-        isSysAdmin$,
+        hasRole: jest.fn(() => of(true)),
         logout: jest.fn(() => of()),
       }),
       mockProvider(DialogService, {
@@ -43,35 +42,23 @@ describe('PowerMenuComponent', () => {
     expect(spectator.inject(AuthService).logout).toHaveBeenCalled();
   });
 
-  describe('if logged user is a system administrator', () => {
-    it('has a Restart menu item that restarts system after confirmation', async () => {
-      const restart = await menu.getItems({ text: /Restart$/ });
-      await restart[0].click();
+  it('has a Restart menu item that restarts system after confirmation', async () => {
+    const restart = await menu.getItems({ text: /Restart$/ });
+    await restart[0].click();
 
-      expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith(expect.objectContaining({
-        message: 'Restart the system?',
-      }));
-      expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/others/reboot'], { skipLocationChange: true });
-    });
-
-    it('has a Shutdown menu item that shuts down system after confirmation', async () => {
-      const shutdown = await menu.getItems({ text: /Shut Down$/ });
-      await shutdown[0].click();
-
-      expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith(expect.objectContaining({
-        message: 'Shut down the system?',
-      }));
-      expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/others/shutdown'], { skipLocationChange: true });
-    });
+    expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Restart the system?',
+    }));
+    expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/others/reboot'], { skipLocationChange: true });
   });
 
-  it('does not have Restart or Shutdown menu items if logged user is not a system administrator', async () => {
-    isSysAdmin$.next(false);
-    spectator.detectChanges();
-    const restart = await menu.getItems({ text: /Restart$/ });
+  it('has a Shutdown menu item that shuts down system after confirmation', async () => {
     const shutdown = await menu.getItems({ text: /Shut Down$/ });
+    await shutdown[0].click();
 
-    expect(restart).toHaveLength(0);
-    expect(shutdown).toHaveLength(0);
+    expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Shut down the system?',
+    }));
+    expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/others/shutdown'], { skipLocationChange: true });
   });
 });

--- a/src/app/modules/layout/components/topbar/power-menu/power-menu.component.ts
+++ b/src/app/modules/layout/components/topbar/power-menu/power-menu.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { filter } from 'rxjs/operators';
+import { Role } from 'app/enums/role.enum';
 import { helptextTopbar } from 'app/helptext/topbar';
 import { AuthService } from 'app/services/auth/auth.service';
 import { DialogService } from 'app/services/dialog.service';
@@ -17,7 +18,7 @@ import { WebsocketConnectionService } from 'app/services/websocket-connection.se
 export class PowerMenuComponent {
   readonly tooltips = helptextTopbar.mat_tooltips;
 
-  protected isSysAdmin$ = this.authService.isSysAdmin$;
+  protected requiredRoles = [Role.FullAdmin];
 
   constructor(
     private authService: AuthService,


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x a522835ac27a991b300a2587909cebc2db25c481
    git cherry-pick -x 80fd084598d2df7620379aa7df7f2bc60cc55d58

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x afaad5220b43c1c853c76e2727ed74895d0a9657

See ticket.

Original PR: https://github.com/truenas/webui/pull/9624
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127221