### PR TITLE
NAS-127022 / 24.10 / Fix `Identify Drive` visible

### DIFF
--- a/src/app/interfaces/enclosure.interface.ts
+++ b/src/app/interfaces/enclosure.interface.ts
@@ -64,6 +64,7 @@ export interface EnclosureSlot {
 export interface EnclosureView {
   isController: boolean;
   isRackmount: boolean;
+  hasSlotStatus: boolean;
   slots: EnclosureSlot[];
   number: number;
   model: string;

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
@@ -254,7 +254,7 @@ export class EnclosureDisksComponent implements AfterContentInit, OnDestroy {
 
   get hideIdentifyDrive(): boolean {
     const selectedEnclosureView = this.selectedEnclosureView;
-    return selectedEnclosureView.model === 'TRUENAS-MINI-R';
+    return selectedEnclosureView.model === 'TRUENAS-MINI-R' || !selectedEnclosureView.hasSlotStatus;
   }
 
   theme: Theme;

--- a/src/app/pages/system/view-enclosure/stores/enclosure-store.service.ts
+++ b/src/app/pages/system/view-enclosure/stores/enclosure-store.service.ts
@@ -233,6 +233,9 @@ export class EnclosureStore extends ComponentStore<EnclosureState> {
         expanders: (enclosure.elements as EnclosureElementsGroup[]).find((item) => {
           return item.name === 'SAS Expander';
         })?.elements,
+        hasSlotStatus: (enclosure.elements as EnclosureElementsGroup[]).find((item) => {
+          return item.name === 'Array Device Slot';
+        })?.has_slot_status,
       } as EnclosureView;
     });
     enclosureViews.sort((a, b) => a.number - b.number);


### PR DESCRIPTION
**Testing**

On **Enclosure** page, when connected to the box specified in the ticket,

The visibility of **Identify Drive** button should depend on the `has_slot_status` property of the response from **enclosure.query** endpoint. `false` - hidden, `true` - visible.