### PR TITLE
NAS-127110 / 24.10 / ix-table-columns-selector columns -> reset to default hides all columns/rows values & Select/Unselect all works with glitches

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest",
     "test:commit": "node scripts/run_related_tests.js",
     "test:watch": "jest --watch",
-    "test:ci": "jest --runInBand",
+    "test:ci": "jest --testPathPattern=src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts",
     "test:pr": "yarn run check-env -s && echo 'Setting up temporary environment file...\\n' && yarn run ui remote -i 'headless.local' && jest --coverage --maxWorkers=2",
     "lint": "ng lint && stylelint 'src/**/*.scss' && markuplint 'src/**/*.html'",
     "lint:fix": "ng lint --fix && stylelint --fix 'src/**/*.scss' && markuplint --fix 'src/**/*.html'",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "jest",
     "test:commit": "node scripts/run_related_tests.js",
     "test:watch": "jest --watch",
-    "test:ci": "jest --testPathPattern=src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts",
+    "test:ci": "jest --runInBand",
     "test:pr": "yarn run check-env -s && echo 'Setting up temporary environment file...\\n' && yarn run ui remote -i 'headless.local' && jest --coverage --maxWorkers=2",
     "lint": "ng lint && stylelint 'src/**/*.scss' && markuplint 'src/**/*.html'",
     "lint:fix": "ng lint --fix && stylelint --fix 'src/**/*.scss' && markuplint --fix 'src/**/*.html'",

--- a/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.html
+++ b/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.html
@@ -14,9 +14,9 @@
       [ixTest]="['toggle-all-columns']"
       (click)="toggleAll()"
     >
-      <ix-icon [name]="isAllChecked ? 'remove' : 'check_circle'"></ix-icon>
-      <span *ngIf="!isAllChecked">{{ 'Unselect All' | translate }}</span>
-      <span *ngIf="isAllChecked">{{ 'Select All' | translate }}</span>
+      <ix-icon [name]="!isAllSelected ? 'remove' : 'check_circle'"></ix-icon>
+      <span *ngIf="isAllSelected">{{ 'Unselect All' | translate }}</span>
+      <span *ngIf="!isAllSelected">{{ 'Select All' | translate }}</span>
     </button>
   </div>
 

--- a/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
+++ b/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
@@ -62,9 +62,7 @@ describe('IxTableColumnsSelectorComponent', () => {
 
   beforeEach(async () => {
     spectator = createComponent({
-      props: {
-        columns: testColumns,
-      },
+      props: { columns: testColumns },
     });
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     menu = await loader.getHarness(MatMenuHarness);

--- a/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
+++ b/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
@@ -73,10 +73,24 @@ describe('IxTableColumnsSelectorComponent', () => {
     await menu.open();
   });
 
-  it('checks when "Unselect All" is pressed', async () => {
-    await menu.clickItem({ text: 'Unselect All' });
+  it('initializes with the correct default and hidden columns', () => {
+    const hiddenColumnsTitles = spectator.component.hiddenColumns.selected.map((col) => col.title);
+    const selectedColumnsTitles = spectator.component.columns.filter((col) => !col.hidden).map((col) => col.title);
 
-    expect(spectator.component.hiddenColumns.selected).toHaveLength(spectator.component.columns.length - 1);
+    expect(hiddenColumnsTitles).toEqual(expect.arrayContaining(['Description', 'Enabled']));
+    expect(selectedColumnsTitles).toEqual(expect.arrayContaining(['Users', 'Command', 'Schedule']));
+  });
+
+  it('checks when "Select All" / "Unselect All" is pressed', async () => {
+    const columnsChangeSpy = jest.spyOn(spectator.component.columnsChange, 'emit');
+
+    await menu.clickItem({ text: 'Select All' });
+    expect(spectator.component.hiddenColumns.selected).toHaveLength(0);
+    expect(columnsChangeSpy).toHaveBeenCalled();
+
+    await menu.clickItem({ text: 'Unselect All' });
+    expect(spectator.component.hiddenColumns.selected).toHaveLength(4);
+    expect(columnsChangeSpy).toHaveBeenCalled();
   });
 
   it('checks when "Reset to Defaults" is pressed', async () => {
@@ -85,5 +99,15 @@ describe('IxTableColumnsSelectorComponent', () => {
 
     expect(spectator.component.hiddenColumns.selected).toHaveLength(2);
     expect(spectator.component.resetToDefaults).toHaveBeenCalled();
+  });
+
+  it('toggles an individual column correctly', async () => {
+    expect(spectator.component.hiddenColumns.selected).toHaveLength(2);
+
+    await menu.clickItem({ text: 'Users' });
+    expect(spectator.component.hiddenColumns.selected).toHaveLength(3);
+
+    await menu.clickItem({ text: 'Enabled' });
+    expect(spectator.component.hiddenColumns.selected).toHaveLength(2);
   });
 });

--- a/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
+++ b/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
@@ -4,15 +4,11 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory } from '@ngneat/spectator/jest';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { EntityModule } from 'app/modules/entity/entity.module';
 import { textColumn } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { yesNoColumn } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-yesno/ix-cell-yesno.component';
 import { IxTableColumnsSelectorComponent } from 'app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
-import { IxTable2Module } from 'app/modules/ix-table2/ix-table2.module';
 import { createTable } from 'app/modules/ix-table2/utils';
-import { AppLoaderModule } from 'app/modules/loader/app-loader.module';
 import { CronjobRow } from 'app/pages/system/advanced/cron/cron-list/cronjob-row.interface';
 
 describe('IxTableColumnsSelectorComponent', () => {
@@ -49,20 +45,13 @@ describe('IxTableColumnsSelectorComponent', () => {
 
   const createComponent = createComponentFactory({
     component: IxTableColumnsSelectorComponent,
-    imports: [
-      AppLoaderModule,
-      EntityModule,
-      IxTable2Module,
-      TranslateModule,
-    ],
-    providers: [
-      TranslateService,
-    ],
   });
 
   beforeEach(async () => {
     spectator = createComponent({
-      props: { columns: testColumns },
+      props: {
+        columns: testColumns,
+      },
     });
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     menu = await loader.getHarness(MatMenuHarness);

--- a/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
@@ -30,7 +30,7 @@ export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges {
 
   ngOnChanges(changes: IxSimpleChanges<this>): void {
     if (changes.columns.firstChange) {
-      this.defaultColumns = changes.columns.currentValue.filter((column) => !!column.title);
+      this.defaultColumns = changes.columns.currentValue;
       this.setInitialState();
     }
   }

--- a/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
@@ -21,10 +21,6 @@ export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges {
   private defaultColumns: Column<T, ColumnComponent<T>>[];
 
   get isAllChecked(): boolean {
-    return this.isOnlyOneColumnSelected;
-  }
-
-  get isOnlyOneColumnSelected(): boolean {
     return this.columns.filter((column) => !column.hidden && !!column.title).length === 1;
   }
 
@@ -62,7 +58,7 @@ export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges {
   }
 
   toggle(column: Column<T, ColumnComponent<T>>): void {
-    if (this.isOnlyOneColumnSelected && !this.isSelected(column)) {
+    if (this.isAllChecked && !this.isSelected(column)) {
       return;
     }
     this.hiddenColumns.toggle(column);


### PR DESCRIPTION
Testing: (see ticket & videos inside the ticket - for the bugs I've found)
See results 👇 



https://github.com/truenas/webui/assets/22980553/a8512a23-5d4c-4c5c-ad0d-88791e88517b

