### PR TITLE
NAS-127276 / 24.10 / guard user.privilege access when processing login results to prevent undefined property read

### DIFF
--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -205,7 +205,7 @@ export class AuthService {
         // Check if user has access to webui.
         return this.getLoggedInUserInformation().pipe(
           switchMap((user) => {
-            if (!user.privilege.webui_access) {
+            if (!user.privilege || !user.privilege.webui_access) {
               this.isLoggedIn$.next(false);
               return of(LoginResult.NoAccess);
             }


### PR DESCRIPTION
An error dialog with `Cannot read properties of undefined (reading 'webui_access')` prompt when login successful but without privilege field:

![image](https://github.com/truenas/webui/assets/11081491/fde59bac-7710-4e73-853f-ebba1c384f95)

The correct implementation should respond users with `User is lacking permissions to access WebUI.` when have no permissions or failed to authenticate:

![image](https://github.com/truenas/webui/assets/11081491/28bd8606-0bac-4ccf-b21b-f81e5619af43)

## Notes

1. I am not quite sure why the field `privilege` is `undefined` when the authentication process has been done. Did I missed something about environment configurations?
2. I have also checked the unit test spec files that located at `src/app/services/auth/auth.service.spec.ts`, and found that there are no current possibilities to add unit tests for such case since the `processLoginResult` method is private, how do you folks usually do with it when it comes to black box testing?
