### PR TITLE
NAS-127022 / 24.04-RC.1 / Fix `Identify Drive` visible

### DIFF
--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
@@ -254,7 +254,7 @@ export class EnclosureDisksComponent implements AfterContentInit, OnDestroy {
 
   get hideIdentifyDrive(): boolean {
     const selectedEnclosureView = this.selectedEnclosureView;
-    return selectedEnclosureView.model === 'TRUENAS-MINI-R';
+    return !['R10', 'R20', 'R30', 'R40', 'R50'].includes(selectedEnclosureView.model);
   }
 
   theme: Theme;

--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
@@ -254,7 +254,7 @@ export class EnclosureDisksComponent implements AfterContentInit, OnDestroy {
 
   get hideIdentifyDrive(): boolean {
     const selectedEnclosureView = this.selectedEnclosureView;
-    return !['R10', 'R20', 'R30', 'R40', 'R50'].includes(selectedEnclosureView.model);
+    return selectedEnclosureView.model === 'R20';
   }
 
   theme: Theme;


### PR DESCRIPTION
**Summary**

Implemented as per request https://github.com/truenas/webui/pull/9630#pullrequestreview-1866069657 , which references https://ixsystems.atlassian.net/browse/NAS-127022?focusedCommentId=241103

**Testing**

Go to **Enclosure** page, when connected to the box specified in the ticket

Check visibility of **Identity Drive** button , it should not be visible on this box

