### PR TITLE
NAS-127273 / 24.04-RC.1 / Data Protection → Next Run shows value for disabled tasks miss-match between card and list (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component.ts
+++ b/src/app/modules/ix-table2/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { isValid } from 'date-fns';
 import { FormatDateTimePipe } from 'app/core/pipes/format-datetime.pipe';
 import { formatDistanceToNowShortened } from 'app/helpers/format-distance-to-now-shortened';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
@@ -20,17 +21,27 @@ export class IxCellRelativeDateComponent<T> extends ColumnComponent<T> {
   }
 
   get date(): string {
-    if (this.value) {
+    if (!this.value) {
+      return this.translate.instant('N/A');
+    }
+
+    if (isValid(new Date(this.value as string))) {
       return formatDistanceToNowShortened(this.value as number);
     }
-    return this.translate.instant('N/A');
+
+    return this.value as string;
   }
 
   get dateTooltip(): string {
-    if (+this.value) {
+    if (!this.value) {
+      return this.translate.instant('N/A');
+    }
+
+    if (isValid(new Date(this.value as string))) {
       return this.formatDateTime.transform(this.value as number);
     }
-    return this.translate.instant('N/A');
+
+    return this.value as string;
   }
 }
 

--- a/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.spec.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.spec.ts
@@ -108,7 +108,7 @@ describe('CloudsyncListComponent', () => {
       }),
       mockProvider(LocaleService),
       mockProvider(TaskService, {
-        getTaskNextRun: jest.fn(() => 'in about 10 hours'),
+        getTaskNextTime: jest.fn(() => new Date(new Date().getTime() + (25 * 60 * 60 * 1000))),
       }),
     ],
   });

--- a/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.component.ts
@@ -90,9 +90,14 @@ export class CloudsyncListComponent implements OnInit {
       title: this.translate.instant('Next Run'),
       propertyName: 'next_run',
       hidden: true,
-      getValue: (task) => (task.enabled
-        ? this.taskService.getTaskNextRun(scheduleToCrontab(task.schedule))
-        : this.translate.instant('Disabled')),
+      getValue: (task) => {
+        if (task.enabled) {
+          return task.schedule
+            ? formatDistanceToNowShortened(this.taskService.getTaskNextTime(scheduleToCrontab(task.schedule)))
+            : this.translate.instant('N/A');
+        }
+        return this.translate.instant('Disabled');
+      },
     }),
     textColumn({
       title: this.translate.instant('Last Run'),

--- a/src/app/pages/data-protection/cloudsync/cloudsync-task-card/cloudsync-task-card.component.spec.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-task-card/cloudsync-task-card.component.spec.ts
@@ -156,7 +156,7 @@ describe('CloudSyncTaskCardComponent', () => {
   it('should show table rows', async () => {
     const expectedRows = [
       ['Description', 'Frequency', 'Next Run', 'Last Run', 'Enabled', 'State', ''],
-      ['custom-cloudsync', 'Every hour, every day', 'in 1 day', '1 min. ago', '', 'FINISHED', ''],
+      ['custom-cloudsync', 'Every hour, every day', 'Disabled', '1 min. ago', '', 'FINISHED', ''],
     ];
 
     const cells = await table.getCellTexts();

--- a/src/app/pages/data-protection/cloudsync/cloudsync-task-card/cloudsync-task-card.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-task-card/cloudsync-task-card.component.ts
@@ -60,7 +60,9 @@ export class CloudSyncTaskCardComponent implements OnInit {
     }),
     relativeDateColumn({
       title: this.translate.instant('Next Run'),
-      getValue: (row) => this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule)),
+      getValue: (row) => (row.enabled
+        ? this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule))
+        : this.translate.instant('Disabled')),
     }),
     relativeDateColumn({
       title: this.translate.instant('Last Run'),

--- a/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.spec.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.spec.ts
@@ -129,7 +129,7 @@ describe('RsyncTaskCardComponent', () => {
   it('should show table rows', async () => {
     const expectedRows = [
       ['Path', 'Remote Host', 'Frequency', 'Next Run', 'Last Run', 'Enabled', 'State', ''],
-      ['/mnt/APPS', 'asd', 'Every hour, every day', 'in 1 day', '1 min. ago', '', 'FINISHED', ''],
+      ['/mnt/APPS', 'asd', 'Every hour, every day', 'Disabled', '1 min. ago', '', 'FINISHED', ''],
     ];
 
     const cells = await table.getCellTexts();

--- a/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
@@ -58,7 +58,9 @@ export class RsyncTaskCardComponent implements OnInit {
     }),
     relativeDateColumn({
       title: this.translate.instant('Next Run'),
-      getValue: (row) => this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule)),
+      getValue: (row) => (row.enabled
+        ? this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule))
+        : this.translate.instant('Disabled')),
     }),
     relativeDateColumn({
       title: this.translate.instant('Last Run'),

--- a/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.spec.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.spec.ts
@@ -141,7 +141,7 @@ describe('RsyncTaskListComponent', () => {
         '',
         'PUSH',
         'At 12:00 AM, on day 1 of the month',
-        'N/A',
+        'Disabled',
         'Second task',
         'peter',
         'FINISHED',

--- a/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.component.ts
@@ -14,9 +14,7 @@ import { AsyncDataProvider } from 'app/modules/ix-table2/classes/async-data-prov
 import {
   actionsColumn,
 } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component';
-import {
-  relativeDateColumn,
-} from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component';
+import { relativeDateColumn } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component';
 import {
   scheduleColumn,
 } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-schedule/ix-cell-schedule.component';
@@ -91,11 +89,12 @@ export class RsyncTaskListComponent implements OnInit {
     }),
     relativeDateColumn({
       title: this.translate.instant('Next Run'),
-      getValue: (row) => this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule)),
+      getValue: (row) => (row.enabled
+        ? this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule))
+        : this.translate.instant('Disabled')),
     }),
     relativeDateColumn({
       title: this.translate.instant('Last Run'),
-      propertyName: 'job',
       getValue: (row) => row.job?.time_finished?.$date,
       hidden: true,
     }),

--- a/src/app/pages/data-protection/scrub-task/scrub-list/scrub-list.component.spec.ts
+++ b/src/app/pages/data-protection/scrub-task/scrub-list/scrub-list.component.spec.ts
@@ -119,7 +119,7 @@ describe('ScrubListComponent', () => {
         'Second task',
         '00 00 * * 7',
         'At 12:00 AM, only on Sunday',
-        'N/A',
+        'Disabled',
         'No',
         '',
       ],

--- a/src/app/pages/data-protection/scrub-task/scrub-list/scrub-list.component.ts
+++ b/src/app/pages/data-protection/scrub-task/scrub-list/scrub-list.component.ts
@@ -10,9 +10,7 @@ import { AsyncDataProvider } from 'app/modules/ix-table2/classes/async-data-prov
 import {
   actionsColumn,
 } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component';
-import {
-  relativeDateColumn,
-} from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component';
+import { relativeDateColumn } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component';
 import {
   scheduleColumn,
 } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-schedule/ix-cell-schedule.component';
@@ -67,7 +65,9 @@ export class ScrubListComponent implements OnInit {
     }),
     relativeDateColumn({
       title: this.translate.instant('Next Run'),
-      getValue: (row) => this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule)),
+      getValue: (row) => (row.enabled
+        ? this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule))
+        : this.translate.instant('Disabled')),
     }),
     yesNoColumn({
       title: this.translate.instant('Enabled'),

--- a/src/app/pages/data-protection/scrub-task/scrub-task-card/scrub-task-card.component.spec.ts
+++ b/src/app/pages/data-protection/scrub-task/scrub-task-card/scrub-task-card.component.spec.ts
@@ -100,7 +100,7 @@ describe('ScrubTaskCardComponent', () => {
   it('should show table rows', async () => {
     const expectedRows = [
       ['Pool', 'Description', 'Frequency', 'Next Run', 'Enabled', ''],
-      ['APPS', 'cccc', 'At 00:00, only on Sunday', 'in 1 day', '', ''],
+      ['APPS', 'cccc', 'At 00:00, only on Sunday', 'Disabled', '', ''],
     ];
 
     const cells = await table.getCellTexts();

--- a/src/app/pages/data-protection/scrub-task/scrub-task-card/scrub-task-card.component.ts
+++ b/src/app/pages/data-protection/scrub-task/scrub-task-card/scrub-task-card.component.ts
@@ -44,7 +44,9 @@ export class ScrubTaskCardComponent implements OnInit {
     }),
     relativeDateColumn({
       title: this.translate.instant('Next Run'),
-      getValue: (task) => this.taskService.getTaskNextTime(scheduleToCrontab(task.schedule)) as unknown,
+      getValue: (row) => (row.enabled
+        ? this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule))
+        : this.translate.instant('Disabled')),
     }),
     toggleColumn({
       title: this.translate.instant('Enabled'),

--- a/src/app/pages/data-protection/snapshot-task/snapshot-task-card/snapshot-task-card.component.spec.ts
+++ b/src/app/pages/data-protection/snapshot-task/snapshot-task-card/snapshot-task-card.component.spec.ts
@@ -116,7 +116,7 @@ describe('SnapshotTaskCardComponent', () => {
   it('should show table rows', async () => {
     const expectedRows = [
       ['Pool/Dataset', 'Keep for', 'Frequency', 'Next Run', 'Last Run', 'Enabled', 'State', ''],
-      ['APPS/test2', '2 week(s)', 'At 00:00, every day', 'in 1 day', '1 min. ago', '', 'PENDING', ''],
+      ['APPS/test2', '2 week(s)', 'At 00:00, every day', 'Disabled', '1 min. ago', '', 'PENDING', ''],
     ];
 
     const cells = await table.getCellTexts();

--- a/src/app/pages/data-protection/snapshot-task/snapshot-task-card/snapshot-task-card.component.ts
+++ b/src/app/pages/data-protection/snapshot-task/snapshot-task-card/snapshot-task-card.component.ts
@@ -48,7 +48,9 @@ export class SnapshotTaskCardComponent implements OnInit {
     }),
     relativeDateColumn({
       title: this.translate.instant('Next Run'),
-      getValue: (row) => this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule)),
+      getValue: (row) => (row.enabled
+        ? this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule))
+        : this.translate.instant('Disabled')),
     }),
     relativeDateColumn({
       title: this.translate.instant('Last Run'),

--- a/src/app/pages/system/advanced/cron/cron-card/cron-card.component.ts
+++ b/src/app/pages/system/advanced/cron/cron-card/cron-card.component.ts
@@ -63,7 +63,9 @@ export class CronCardComponent implements OnInit {
     }),
     relativeDateColumn({
       title: this.translate.instant('Next Run'),
-      getValue: (row) => this.taskService.getTaskNextTime(row.cron_schedule) as unknown,
+      getValue: (row) => (row.enabled
+        ? this.taskService.getTaskNextTime(row.cron_schedule)
+        : this.translate.instant('Disabled')),
     }),
     actionsColumn({
       cssClass: 'tight-actions',

--- a/src/app/pages/system/advanced/cron/cron-list/cron-list.component.html
+++ b/src/app/pages/system/advanced/cron/cron-list/cron-list.component.html
@@ -30,7 +30,7 @@
       <dl *ngIf="hiddenColumns.length" class="table-hidden-columns">
         <div *ngFor="let column of hiddenColumns">
           <b>{{ column.title }}:</b>
-          <span>{{ cronjob[column.propertyName] }}</span>
+          <span>{{ column?.getValue?.(cronjob) || cronjob[column.propertyName] }}</span>
         </div>
         <mat-divider></mat-divider>
       </dl>

--- a/src/app/pages/system/advanced/cron/cron-list/cron-list.component.spec.ts
+++ b/src/app/pages/system/advanced/cron/cron-list/cron-list.component.spec.ts
@@ -81,7 +81,7 @@ describe('CronListComponent', () => {
       }),
       mockProvider(LocaleService),
       mockProvider(TaskService, {
-        getTaskNextRun: jest.fn(() => 'in about 10 hours'),
+        getTaskNextTime: jest.fn(() => new Date(new Date().getTime() + (25 * 60 * 60 * 1000))),
       }),
       mockAuth(),
     ],

--- a/src/app/pages/system/advanced/cron/cron-list/cron-list.component.ts
+++ b/src/app/pages/system/advanced/cron/cron-list/cron-list.component.ts
@@ -8,11 +8,9 @@ import {
   filter, map, switchMap, tap,
 } from 'rxjs';
 import { Role } from 'app/enums/role.enum';
+import { formatDistanceToNowShortened } from 'app/helpers/format-distance-to-now-shortened';
 import { AsyncDataProvider } from 'app/modules/ix-table2/classes/async-data-provider/async-data-provider';
-import { relativeDateColumn } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component';
-import { scheduleColumn } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-schedule/ix-cell-schedule.component';
 import { textColumn } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
-import { yesNoColumn } from 'app/modules/ix-table2/components/ix-table-body/cells/ix-cell-yesno/ix-cell-yesno.component';
 import { Column, ColumnComponent } from 'app/modules/ix-table2/interfaces/table-column.interface';
 import { createTable } from 'app/modules/ix-table2/utils';
 import { EmptyService } from 'app/modules/ix-tables/services/empty.service';
@@ -49,27 +47,38 @@ export class CronListComponent implements OnInit {
       title: this.translate.instant('Description'),
       propertyName: 'description',
     }),
-    scheduleColumn({
+    textColumn({
       title: this.translate.instant('Schedule'),
       propertyName: 'schedule',
+      getValue: (task) => (task.enabled ? scheduleToCrontab(task.schedule) : this.translate.instant('Disabled')),
     }),
-    yesNoColumn({
+    textColumn({
       title: this.translate.instant('Enabled'),
       propertyName: 'enabled',
+      getValue: (task) => (task.enabled ? this.translate.instant('Yes') : this.translate.instant('No')),
     }),
-    relativeDateColumn({
+    textColumn({
       title: this.translate.instant('Next Run'),
       hidden: true,
-      getValue: (row) => this.taskService.getTaskNextTime(scheduleToCrontab(row.schedule)),
+      getValue: (task) => {
+        if (task.enabled) {
+          return task.schedule
+            ? formatDistanceToNowShortened(this.taskService.getTaskNextTime(scheduleToCrontab(task.schedule)))
+            : this.translate.instant('N/A');
+        }
+        return this.translate.instant('Disabled');
+      },
     }),
-    yesNoColumn({
+    textColumn({
       title: this.translate.instant('Hide Stdout'),
       propertyName: 'stdout',
+      getValue: (task) => (task.stdout ? this.translate.instant('Yes') : this.translate.instant('No')),
       hidden: true,
     }),
-    yesNoColumn({
+    textColumn({
       title: this.translate.instant('Hide Stderr'),
       propertyName: 'stderr',
+      getValue: (task) => (task.stderr ? this.translate.instant('Yes') : this.translate.instant('No')),
       hidden: true,
     }),
   ], {

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -83,6 +83,11 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
     @include variable(color, --fg1, $fg1);
   }
 
+  .mat-mdc-menu-item .mat-icon {
+    align-items: center;
+    display: flex;
+  }
+
   .mat-mdc-menu-item .mat-icon:not([color]),
   .mat-mdc-menu-item .theme-picker-swatch .mat-icon:not([color]),
   .mat-mdc-menu-item-submenu-trigger::after {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 3af9bc02657045d337aa2ab428ad6d5bd4eaa763
    git cherry-pick -x d74faa30bac4e52ee135599ecfe5ada836bb3028

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 7f2fea9f77722c89c094198cf17f1bb24950657a

Testing: see ticket.
Main idea is to make SAME behaviour across `Enabled & Next Run` - to show `Disabled` for Next Run if task is NOT Enabled.

As well in this ticket I fixed some issues with LIST components in Data Protection & Cron, to show same value for table's column and expandable details.

More fixes on listing & expandable rows issue will be done here: https://ixsystems.atlassian.net/browse/NAS-127279

Original PR: https://github.com/truenas/webui/pull/9652
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127273