### PR TITLE
TE-1399 Adding a 10 second before the trigger of Failover

### DIFF
--- a/tests/bdd/ha-bhyve02/test_NAS_T0962.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0962.py
@@ -215,6 +215,8 @@ def click_initiate_failover_click_the_confirm_checkbox_and_press_failover(driver
     """click INITIATE FAILOVER, click the confirm checkbox, and press FAILOVER."""
     # Make sure HA is enable before going forward
     assert wait_on_element(driver, 180, xpaths.toolbar.ha_Enabled)
+    # this sleep is to let the system catch up.
+    # In a real world scenario a system does not get on a failover after few seconds of setting AD.
     time.sleep(10)
     rsc.Trigger_Failover(driver)
 

--- a/tests/bdd/ha-bhyve02/test_NAS_T0962.py
+++ b/tests/bdd/ha-bhyve02/test_NAS_T0962.py
@@ -213,6 +213,9 @@ def after_go_to_the_dashboard(driver):
 @then('click INITIATE FAILOVER, click the confirm checkbox, and press FAILOVER')
 def click_initiate_failover_click_the_confirm_checkbox_and_press_failover(driver):
     """click INITIATE FAILOVER, click the confirm checkbox, and press FAILOVER."""
+    # Make sure HA is enable before going forward
+    assert wait_on_element(driver, 180, xpaths.toolbar.ha_Enabled)
+    time.sleep(10)
     rsc.Trigger_Failover(driver)
 
     rsc.Confirm_Failover(driver)
@@ -232,7 +235,7 @@ def at_the_login_page_enter_user_and_password(driver, user, password):
 
 
 @then('on the Dashboard, wait for the Active Directory service')
-def on_the_dashboard_wait_for_the_active_Directory_service(driver):
+def on_the_dashboard_wait_for_the_active_directory_service(driver):
     """on the Dashboard, wait for the Active Directory service."""
     assert wait_on_element(driver, 60, xpaths.dashboard.title)
     assert wait_on_element(driver, 120, xpaths.dashboard.system_Info_Card_Title)


### PR DESCRIPTION
This sleep is to let the system catch up. In a real-world scenario, a system does not get on a failover after a few seconds of setting AD.