### PR TITLE
NAS-127177 / 24.10 / System Audit > Event Data, "Copy JSON" option is not in JSON format

### DIFF
--- a/src/app/core/components/copy-btn/copy-btn.component.ts
+++ b/src/app/core/components/copy-btn/copy-btn.component.ts
@@ -25,16 +25,13 @@ export class CopyButtonComponent {
     this.snackbar.success(this.translate.instant('Copied to clipboard'));
   }
 
-  private copyViaDeprecatedExecCommand(): Promise<void> {
-    const textArea = document.createElement('textarea');
-    textArea.value = this.text;
-    textArea.style.position = 'fixed';
-    textArea.style.left = '-9999px';
-    textArea.style.top = '-9999px';
-    document.body.appendChild(textArea);
-    textArea.focus();
-    textArea.select();
+  private copyViaDeprecatedExecCommand(text: string): Promise<void> {
     return new Promise((resolve) => {
+      const textArea = document.createElement('textarea');
+      Object.assign(textArea.style, { position: 'fixed', left: '-9999px', top: '-9999px' });
+      textArea.value = text;
+      document.body.appendChild(textArea);
+      textArea.select();
       document.execCommand('copy');
       textArea.remove();
       resolve();
@@ -46,7 +43,7 @@ export class CopyButtonComponent {
       return navigator.clipboard.writeText(text);
     }
 
-    return this.copyViaDeprecatedExecCommand();
+    return this.copyViaDeprecatedExecCommand(text);
   }
 
   copyToClipboard(): void {


### PR DESCRIPTION
Testing: see ticket.
Problem was with the `copyViaDeprecatedExecCommand` - it always received plain text instead of desired value.

https://github.com/truenas/webui/assets/22980553/3c5bab73-fedf-4ebd-809d-1fa14c7bf64b

