### PR TITLE
NAS-127356 / 24.04-RC.1 / Dragonfish: data-test tag missing from Local Groups page size select and options (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-table2/components/ix-table-pager/ix-table-pager.component.html
+++ b/src/app/modules/ix-table2/components/ix-table-pager/ix-table-pager.component.html
@@ -21,7 +21,7 @@
   <div class="buttons">
     <button
       mat-icon-button
-      ixTest="left"
+      ixTest="max-left"
       [disabled]="currentPage === 1"
       (click)="goToPage(1)"
     >
@@ -45,7 +45,7 @@
     </button>
     <button
       mat-icon-button
-      ixTest="right"
+      ixTest="max-right"
       [disabled]="currentPage === totalPages || !totalPages"
       (click)="goToPage(totalPages)"
     >

--- a/src/app/modules/ix-tables/components/ix-table-paginator/ix-table-paginator-test-attributes.directive.ts
+++ b/src/app/modules/ix-tables/components/ix-table-paginator/ix-table-paginator-test-attributes.directive.ts
@@ -1,0 +1,51 @@
+import {
+  AfterViewInit, Directive, ElementRef, HostListener,
+} from '@angular/core';
+
+// This is temporary, we need to refactor components to use ix-table2.
+// It is a fix for a DragonFish release to add data-test attributes to the ix-table-paginator.
+@Directive({
+  selector: '[ixTablePaginatorTestAttributes]',
+})
+export class IxTablePaginatorTestAttributesDirective implements AfterViewInit {
+  constructor(private el: ElementRef<HTMLElement>) {}
+
+  @HostListener('click')
+  onClick(): void {
+    this.addMatOptionTestAttributes();
+  }
+
+  ngAfterViewInit(): void {
+    this.addMainTestAttributes();
+  }
+
+  private addMainTestAttributes(): void {
+    const matSelect = this.el.nativeElement.querySelector('.mat-mdc-paginator-page-size .mat-mdc-select');
+    matSelect?.setAttribute('data-test', 'select-page-size');
+
+    const maxLeftButton = this.el.nativeElement.querySelector('.mat-mdc-paginator-navigation-first');
+    maxLeftButton?.setAttribute('data-test', 'button-max-left');
+
+    const leftButton = this.el.nativeElement.querySelector('.mat-mdc-paginator-navigation-previous');
+    leftButton?.setAttribute('data-test', 'button-left');
+
+    const maxRightButton = this.el.nativeElement.querySelector('.mat-mdc-paginator-navigation-last');
+    maxRightButton?.setAttribute('data-test', 'button-max-right');
+
+    const rightButton = this.el.nativeElement.querySelector('.mat-mdc-paginator-navigation-next');
+    rightButton?.setAttribute('data-test', 'button-right');
+  }
+
+  private addMatOptionTestAttributes(): void {
+    const options = document.querySelectorAll('mat-option');
+
+    if (options) {
+      options.forEach((option) => {
+        (option as HTMLElement)?.setAttribute(
+          'data-test',
+          `option-page-size-option-${option.textContent.replace(/\s+/g, '')}`,
+        );
+      });
+    }
+  }
+}

--- a/src/app/modules/ix-tables/components/ix-table-paginator/ix-table-paginator.component.html
+++ b/src/app/modules/ix-tables/components/ix-table-paginator/ix-table-paginator.component.html
@@ -1,4 +1,5 @@
 <mat-paginator
+  ixTablePaginatorTestAttributes
   [length]="total"
   [pageIndex]="pageIndex"
   [pageSize]="pageSize"

--- a/src/app/modules/ix-tables/ix-table.module.ts
+++ b/src/app/modules/ix-tables/ix-table.module.ts
@@ -19,6 +19,7 @@ import { IxEmptyRowComponent } from 'app/modules/ix-tables/components/ix-empty-r
 import { IxExpandToggleColumnComponent } from 'app/modules/ix-tables/components/ix-expand-toggle-column/ix-expand-toggle-column.component';
 import { IxTableComponent } from 'app/modules/ix-tables/components/ix-table/ix-table.component';
 import { IxTableExpandableRowComponent } from 'app/modules/ix-tables/components/ix-table-expandable-row/ix-table-expandable-row.component';
+import { IxTablePaginatorTestAttributesDirective } from 'app/modules/ix-tables/components/ix-table-paginator/ix-table-paginator-test-attributes.directive';
 import { IxTablePaginatorComponent } from 'app/modules/ix-tables/components/ix-table-paginator/ix-table-paginator.component';
 import { IxCellDefDirective } from 'app/modules/ix-tables/directives/ix-cell-def.directive';
 import { IxDetailRowDirective } from 'app/modules/ix-tables/directives/ix-detail-row.directive';
@@ -38,6 +39,7 @@ import { TestIdModule } from 'app/modules/test-id/test-id.module';
     IxExpandToggleColumnComponent,
     IxRowDefDirective,
     IxTableComponent,
+    IxTablePaginatorTestAttributesDirective,
     IxTableEmptyDirective,
     IxEmptyRowComponent,
     IxTableExpandableRowComponent,


### PR DESCRIPTION
Testing: see ticket.

Currently we have problem because the list is not rendered as ix-table2 component, I created separate ticket for that purpose to be merged only in master later on.

But we need to fix this ticket for master & dragonfish

But we have a problem of using
`<ix-table-paginator [dataSource]="dataSource"></ix-table-paginator>`
```
<mat-paginator
  [length]="total"
  [pageIndex]="pageIndex"
  [pageSize]="pageSize"
  [pageSizeOptions]="pageSizeOptions"
  [showFirstLastButtons]="showFirstLastButtons"
  [hidePageSize]="hidePageSize"
></mat-paginator>
```
So the idea is to create a directive which will add all needed `data-test` info to the `mat-paginator`

Original PR: https://github.com/truenas/webui/pull/9701
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127356