### PR TITLE
NAS-127417 / 24.10 / Lock icon for restricted elements (by undsoft)

### DIFF
--- a/src/app/directives/common/common-directives.module.ts
+++ b/src/app/directives/common/common-directives.module.ts
@@ -9,8 +9,8 @@ import { NavigateAndInteractDirective } from 'app/directives/common/navigate-and
 import { RequiresRolesWrapperComponent } from 'app/directives/common/requires-roles/requires-roles-wrapper.component';
 import { RequiresRolesDirective } from 'app/directives/common/requires-roles/requires-roles.directive';
 import { StepActivationDirective } from 'app/directives/common/step-activation.directive';
-import { LetDirective } from './app-let.directive';
 import { IxIconModule } from 'app/modules/ix-icon/ix-icon.module';
+import { LetDirective } from './app-let.directive';
 
 @NgModule({
   imports: [

--- a/src/app/directives/common/common-directives.module.ts
+++ b/src/app/directives/common/common-directives.module.ts
@@ -10,12 +10,14 @@ import { RequiresRolesWrapperComponent } from 'app/directives/common/requires-ro
 import { RequiresRolesDirective } from 'app/directives/common/requires-roles/requires-roles.directive';
 import { StepActivationDirective } from 'app/directives/common/step-activation.directive';
 import { LetDirective } from './app-let.directive';
+import { IxIconModule } from 'app/modules/ix-icon/ix-icon.module';
 
 @NgModule({
   imports: [
     CommonModule,
     MatTooltipModule,
     TranslateModule,
+    IxIconModule,
   ],
   declarations: [
     LetDirective,

--- a/src/app/directives/common/requires-roles/requires-roles-wrapper.component.html
+++ b/src/app/directives/common/requires-roles/requires-roles-wrapper.component.html
@@ -1,0 +1,8 @@
+<span
+  matTooltipPosition="above"
+  [class]="['role-missing', class]"
+  [matTooltip]="'Missing permissions for this action' | translate"
+>
+  <ng-container *ngTemplateOutlet="template"></ng-container>
+  <ix-icon name="lock" class="role-missing-icon"></ix-icon>
+</span>

--- a/src/app/directives/common/requires-roles/requires-roles-wrapper.component.scss
+++ b/src/app/directives/common/requires-roles/requires-roles-wrapper.component.scss
@@ -1,6 +1,16 @@
+:host-context(.mat-mdc-menu-panel) {
+  :host {
+    display: block;
+
+    ::ng-deep .role-missing a {
+      opacity: 1;
+    }
+  }
+}
+
 :host {
-  position: relative;
   display: inline-block;
+  position: relative;
 }
 
 :host ::ng-deep .role-missing {
@@ -12,10 +22,6 @@
     pointer-events: none;
   }
 
-  .mdc-label {
-    //text-decoration: line-through;
-  }
-
   .mat-mdc-checkbox,
   .mat-mdc-slide-toggle,
   .mdc-button__label,
@@ -23,16 +29,26 @@
   a,
   .mat-mdc-menu-item-text {
     opacity: 0.25;
-    //text-decoration: line-through;
-    position: relative;
+
+    + .role-missing-icon {
+      bottom: 5px;
+      right: 0;
+    }
   }
 
   .role-missing-icon {
-    position: absolute;
-    bottom: 4px;
-    right: 4px;
+    bottom: 6px;
+    color: var(--fg2);
     font-size: 0.9rem;
+    height: 12px;
     opacity: 1;
+    position: absolute;
+    right: 5px;
+    width: 12px;
+
+    &:only-child {
+      display: none;
+    }
   }
 }
 

--- a/src/app/directives/common/requires-roles/requires-roles-wrapper.component.scss
+++ b/src/app/directives/common/requires-roles/requires-roles-wrapper.component.scss
@@ -1,3 +1,7 @@
+:host {
+  position: relative;
+  display: inline-block;
+}
 
 :host ::ng-deep .role-missing {
   .mat-mdc-checkbox,
@@ -9,7 +13,7 @@
   }
 
   .mdc-label {
-    text-decoration: line-through;
+    //text-decoration: line-through;
   }
 
   .mat-mdc-checkbox,
@@ -18,8 +22,17 @@
   .mat-icon,
   a,
   .mat-mdc-menu-item-text {
-    opacity: 0.5;
-    text-decoration: line-through;
+    opacity: 0.25;
+    //text-decoration: line-through;
+    position: relative;
+  }
+
+  .role-missing-icon {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    font-size: 0.9rem;
+    opacity: 1;
   }
 }
 

--- a/src/app/directives/common/requires-roles/requires-roles-wrapper.component.ts
+++ b/src/app/directives/common/requires-roles/requires-roles-wrapper.component.ts
@@ -4,12 +4,7 @@ import {
 
 @Component({
   selector: 'ix-requires-roles-wrapper',
-  template: `
-<span [class]="['role-missing', class]" [matTooltip]="'Missing permissions for this action' | translate" matTooltipPosition="above">
-  <ng-container *ngTemplateOutlet="template"></ng-container>
-  <ix-icon name="lock" class="role-missing-icon"></ix-icon>
-</span>
-`,
+  templateUrl: './requires-roles-wrapper.component.html',
   styleUrls: ['./requires-roles-wrapper.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/directives/common/requires-roles/requires-roles-wrapper.component.ts
+++ b/src/app/directives/common/requires-roles/requires-roles-wrapper.component.ts
@@ -7,6 +7,7 @@ import {
   template: `
 <span [class]="['role-missing', class]" [matTooltip]="'Missing permissions for this action' | translate" matTooltipPosition="above">
   <ng-container *ngTemplateOutlet="template"></ng-container>
+  <ix-icon name="lock" class="role-missing-icon"></ix-icon>
 </span>
 `,
   styleUrls: ['./requires-roles-wrapper.component.scss'],

--- a/src/app/modules/ix-forms/components/ix-slide-in/components/ix-modal-header/ix-modal-header.component.html
+++ b/src/app/modules/ix-forms/components/ix-slide-in/components/ix-modal-header/ix-modal-header.component.html
@@ -5,11 +5,6 @@
 >
   <h3 class="ix-formtitle">
     {{ title | translate }}
-
-    <span class="readonly-badge">
-      <ix-icon name="lock" class="role-missing-icon"></ix-icon>
-      <span>readonly</span>
-    </span>
   </h3>
 
   <ng-container *ngIf="!disableClose">

--- a/src/app/modules/ix-forms/components/ix-slide-in/components/ix-modal-header/ix-modal-header.component.html
+++ b/src/app/modules/ix-forms/components/ix-slide-in/components/ix-modal-header/ix-modal-header.component.html
@@ -3,7 +3,14 @@
   fxLayout="row"
   fxLayoutAlign="space-between center"
 >
-  <h3 class="ix-formtitle">{{ title | translate }}</h3>
+  <h3 class="ix-formtitle">
+    {{ title | translate }}
+
+    <span class="readonly-badge">
+      <ix-icon name="lock" class="role-missing-icon"></ix-icon>
+      <span>readonly</span>
+    </span>
+  </h3>
 
   <ng-container *ngIf="!disableClose">
     <ix-icon

--- a/src/app/modules/ix-forms/components/ix-slide-in/components/ix-modal-header/ix-modal-header.component.scss
+++ b/src/app/modules/ix-forms/components/ix-slide-in/components/ix-modal-header/ix-modal-header.component.scss
@@ -37,3 +37,19 @@ mat-progress-bar {
   width: calc(100% + 40px);
   z-index: 10005;
 }
+
+.readonly-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 13px;
+  background-color: var(--alt-fg1);
+  border-radius: 2px;
+  padding: 1px 7px 1px 2px;
+  vertical-align: -1px;
+  margin-left: 2px;
+
+  ix-icon {
+    font-size: 16px;
+    margin-right: 2px;
+  }
+}

--- a/src/app/modules/ix-forms/components/ix-slide-in/components/ix-modal-header/ix-modal-header.component.scss
+++ b/src/app/modules/ix-forms/components/ix-slide-in/components/ix-modal-header/ix-modal-header.component.scss
@@ -37,19 +37,3 @@ mat-progress-bar {
   width: calc(100% + 40px);
   z-index: 10005;
 }
-
-.readonly-badge {
-  display: inline-flex;
-  align-items: center;
-  font-size: 13px;
-  background-color: var(--alt-fg1);
-  border-radius: 2px;
-  padding: 1px 7px 1px 2px;
-  vertical-align: -1px;
-  margin-left: 2px;
-
-  ix-icon {
-    font-size: 16px;
-    margin-right: 2px;
-  }
-}

--- a/src/app/modules/layout/components/topbar/power-menu/power-menu.component.html
+++ b/src/app/modules/layout/components/topbar/power-menu/power-menu.component.html
@@ -14,25 +14,25 @@
     {{ 'Log Out' | translate }}
   </button>
 
-  <ng-container *ixRequiresRoles="requiredRoles">
-    <button
-      name="power-restart"
-      mat-menu-item
-      ixTest="restart"
-      (click)="onReboot()"
-    >
-      <ix-icon name="replay"></ix-icon>
-      {{ 'Restart' | translate }}
-    </button>
+  <button
+    *ixRequiresRoles="requiredRoles"
+    name="power-restart"
+    mat-menu-item
+    ixTest="restart"
+    (click)="onReboot()"
+  >
+    <ix-icon name="replay"></ix-icon>
+    {{ 'Restart' | translate }}
+  </button>
 
-    <button
-      name="power-shut-down"
-      mat-menu-item
-      ixTest="shut-down"
-      (click)="onShutdown()"
-    >
-      <ix-icon name="power_settings_new"></ix-icon>
-      {{ 'Shut Down' | translate }}
-    </button>
-  </ng-container>
+  <button
+    *ixRequiresRoles="requiredRoles"
+    name="power-shut-down"
+    mat-menu-item
+    ixTest="shut-down"
+    (click)="onShutdown()"
+  >
+    <ix-icon name="power_settings_new"></ix-icon>
+    {{ 'Shut Down' | translate }}
+  </button>
 </mat-menu>

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
@@ -81,9 +81,9 @@
     </div>
   </mat-card-content>
   <mat-card-actions *ngIf="dataset.id !== dataset.pool">
-    <ng-container *ixRequiresRoles="[Role.FullAdmin]">
+    <ng-container *ngIf="canBePromoted">
       <button
-        *ngIf="canBePromoted"
+        *ixRequiresRoles="[Role.FullAdmin]"
         mat-button
         ixTest="promote-dataset"
         (click)="promoteDataset()"

--- a/src/app/pages/datasets/modules/encryption/components/zfs-encryption-card/zfs-encryption-card.component.html
+++ b/src/app/pages/datasets/modules/encryption/components/zfs-encryption-card/zfs-encryption-card.component.html
@@ -67,11 +67,15 @@
       >
         {{ 'Export All Keys' | translate }}
       </button>
+    </ng-container>
 
+    <ng-container *ixRequiresRoles="[Role.FullAdmin]">
       <button *ngIf="canExportKey" mat-button ixTest="export-key" (click)="onExportKey()">
         {{ 'Export Key' | translate }}
       </button>
+    </ng-container>
 
+    <ng-container *ixRequiresRoles="[Role.FullAdmin]">
       <button *ngIf="hasPassphrase" mat-button ixTest="lock" (click)="onLock()">
         {{ 'Lock' | translate }}
       </button>

--- a/src/app/pages/datasets/modules/snapshots/snapshot-details-row/snapshot-details-row.component.html
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-details-row/snapshot-details-row.component.html
@@ -78,25 +78,23 @@
       </button>
     </div>
 
-    <ng-container *ixRequiresRoles="[Role.FullAdmin]">
-      <button
+    <button
       *ixRequiresRoles="[Role.FullAdmin]"
       mat-button
       [ixTest]="['clone', snapshot.snapshot_name]"
       (click)="doClone(snapshot)"
     >
-        <span>{{ 'Clone To New Dataset' | translate }}</span>
-      </button>
+      <span>{{ 'Clone To New Dataset' | translate }}</span>
+    </button>
 
-      <button
+    <button
       *ixRequiresRoles="[Role.FullAdmin]"
       mat-button
       [ixTest]="['rollback', snapshot.snapshot_name]"
       (click)="doRollback(snapshot)"
     >
-        <span>{{ 'Rollback' | translate }}</span>
-      </button>
-    </ng-container>
+      <span>{{ 'Rollback' | translate }}</span>
+    </button>
   </ix-table-expandable-row>
 </td>
 

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.html
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.html
@@ -291,7 +291,7 @@
         </div>
       </div>
 
-      <div class="form-actions">
+      <ix-form-actions>
         <button
           *ixRequiresRoles="[Role.FullAdmin]"
           mat-button
@@ -318,7 +318,7 @@
             {{ 'Advanced Options' | translate }}
           </button>
         </ng-template>
-      </div>
+      </ix-form-actions>
     </form>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.scss
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.scss
@@ -1,13 +1,5 @@
 @import 'scss-imports/splitview';
 
-.form-actions {
-  padding: 0 11px;
-
-  button {
-    margin-right: 10px;
-  }
-}
-
 .card {
   margin-left: auto;
   margin-right: auto;

--- a/src/app/pages/services/components/service-nfs/service-nfs.component.html
+++ b/src/app/pages/services/components/service-nfs/service-nfs.component.html
@@ -88,7 +88,7 @@
         ></ix-checkbox>
       </ix-fieldset>
 
-      <div class="form-actions">
+      <ix-form-actions>
         <div>
           <button
             *ixRequiresRoles="requiredRoles"
@@ -119,7 +119,7 @@
             {{ 'Add SPN' | translate }}
           </button>
         </div>
-      </div>
+      </ix-form-actions>
     </form>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/services/components/service-nfs/service-nfs.component.scss
+++ b/src/app/pages/services/components/service-nfs/service-nfs.component.scss
@@ -1,15 +1,5 @@
 @import 'scss-imports/splitview';
 
-.form-actions {
-  display: flex;
-  justify-content: space-between;
-  padding: 16px 11px;
-
-  button {
-    margin-right: 5px;
-  }
-}
-
 .two-columns {
   border-bottom: 1px solid var(--lines);
   border-top: 1px solid var(--lines);

--- a/src/app/pages/services/components/service-smart/service-smart.component.html
+++ b/src/app/pages/services/components/service-smart/service-smart.component.html
@@ -45,7 +45,7 @@
         ></ix-input>
       </ix-fieldset>
 
-      <div class="form-actions">
+      <ix-form-actions>
         <button
           *ixRequiresRoles="[Role.FullAdmin]"
           mat-button
@@ -56,7 +56,7 @@
         >
           {{ 'Save' | translate }}
         </button>
-      </div>
+      </ix-form-actions>
     </form>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/services/components/service-smb/service-smb.component.html
+++ b/src/app/pages/services/components/service-smb/service-smb.component.html
@@ -116,7 +116,7 @@
         ></ix-select>
       </ix-fieldset>
 
-      <div class="form-actions">
+      <ix-form-actions>
         <button
           *ixRequiresRoles="requiredRoles"
           mat-button
@@ -135,7 +135,7 @@
               : ('Basic Settings' | translate)
           }}
         </button>
-      </div>
+      </ix-form-actions>
     </form>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/services/components/service-smb/service-smb.component.scss
+++ b/src/app/pages/services/components/service-smb/service-smb.component.scss
@@ -1,11 +1,3 @@
-.form-actions {
-  padding: 16px 11px;
-
-  button {
-    margin-right: 5px;
-  }
-}
-
 .card {
   margin-left: auto;
   margin-right: auto;

--- a/src/app/pages/services/components/service-snmp/service-snmp.component.html
+++ b/src/app/pages/services/components/service-snmp/service-snmp.component.html
@@ -92,7 +92,7 @@
         ></ix-select>
       </ix-fieldset>
 
-      <div class="form-actions">
+      <ix-form-actions>
         <button
           *ixRequiresRoles="[Role.FullAdmin]"
           mat-button
@@ -103,7 +103,7 @@
         >
           {{ 'Save' | translate }}
         </button>
-      </div>
+      </ix-form-actions>
     </form>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/services/components/service-snmp/service-snmp.component.scss
+++ b/src/app/pages/services/components/service-snmp/service-snmp.component.scss
@@ -1,13 +1,5 @@
 @import 'scss-imports/splitview';
 
-.form-actions {
-  padding: 0 11px;
-
-  button {
-    margin-right: 5px;
-  }
-}
-
 .card {
   margin-left: auto;
   margin-right: auto;

--- a/src/app/pages/services/components/service-ssh/service-ssh.component.html
+++ b/src/app/pages/services/components/service-ssh/service-ssh.component.html
@@ -82,7 +82,7 @@
         ></ix-textarea>
       </ix-fieldset>
 
-      <div class="form-actions">
+      <ix-form-actions>
         <button
           *ixRequiresRoles="[Role.FullAdmin]"
           mat-button
@@ -101,7 +101,7 @@
               : ('Basic Settings' | translate)
           }}
         </button>
-      </div>
+      </ix-form-actions>
     </form>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/services/components/service-ups/service-ups.component.html
+++ b/src/app/pages/services/components/service-ups/service-ups.component.html
@@ -151,7 +151,7 @@
         </ix-fieldset>
       </div>
 
-      <div class="form-actions">
+      <ix-form-actions>
         <button
           *ixRequiresRoles="[Role.FullAdmin]"
           mat-button
@@ -162,7 +162,7 @@
         >
           {{ 'Save' | translate }}
         </button>
-      </div>
+      </ix-form-actions>
     </form>
   </mat-card-content>
 </mat-card>

--- a/src/app/pages/services/services.component.html
+++ b/src/app/pages/services/services.component.html
@@ -59,6 +59,7 @@
         <mat-checkbox
           *ixRequiresRoles="getRolesForService(service.service)"
           color="primary"
+          class="start-automatically"
           [ixTest]="[service.service, 'service']"
           [(ngModel)]="service.enable"
           (change)="onCheckboxChange(service)"

--- a/src/app/pages/services/services.component.scss
+++ b/src/app/pages/services/services.component.scss
@@ -12,6 +12,10 @@
   justify-content: flex-end;
 }
 
+.start-automatically {
+  margin-right: 0;
+}
+
 :host ::ng-deep {
   .ix-table.cdk-table .cdk-column-actions {
     width: auto;

--- a/src/app/pages/storage/components/dashboard-pool/zfs-health-card/zfs-health-card.component.scss
+++ b/src/app/pages/storage/components/dashboard-pool/zfs-health-card/zfs-health-card.component.scss
@@ -19,10 +19,6 @@
 
       ix-requires-roles-wrapper {
         margin-left: auto;
-
-        a {
-          text-decoration: line-through;
-        }
       }
     }
   }

--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.html
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.html
@@ -25,16 +25,25 @@
   <mat-card-actions *ngIf="isDisk">
     <ng-container *ixRequiresRoles="[Role.FullAdmin]">
       <ng-container *ngIf="canExtendDisk" [ngTemplateOutlet]="extend"></ng-container>
-      <ng-container *ngIf="canRemoveDisk" [ngTemplateOutlet]="remove"></ng-container>
+    </ng-container>
 
+    <ng-container *ixRequiresRoles="[Role.FullAdmin]">
+      <ng-container *ngIf="canRemoveDisk" [ngTemplateOutlet]="remove"></ng-container>
+    </ng-container>
+
+    <ng-container *ixRequiresRoles="[Role.FullAdmin]">
       <button *ngIf="canDetachDisk" mat-button ixTest="detach" (click)="onDetach()">
         {{ 'Detach' | translate }}
       </button>
+    </ng-container>
 
+    <ng-container *ixRequiresRoles="[Role.FullAdmin]">
       <button *ngIf="canOfflineDisk" mat-button ixTest="offline" (click)="onOffline()">
         {{ 'Offline' | translate }}
       </button>
+    </ng-container>
 
+    <ng-container *ixRequiresRoles="[Role.FullAdmin]">
       <button *ngIf="canOnlineDisk" mat-button ixTest="online" (click)="onOnline()">
         {{ 'Online' | translate }}
       </button>

--- a/src/app/pages/system/update/update.component.scss
+++ b/src/app/pages/system/update/update.component.scss
@@ -81,7 +81,7 @@
 
 .update-button {
   margin-right: 3px;
-  top: 6px;
+  margin-top: 6px;
 }
 
 #update-spinner { bottom: 0;


### PR DESCRIPTION
Strike-through on restricted elements was replaced with a lock icon as per feedback we received.

Testing: check if lock icon is not looking nice somewhere.

Original PR: https://github.com/truenas/webui/pull/9708
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127417