### PR TITLE
NAS-127503 / 24.10 / Fix Standby card cannot be hidden on main dashboard

### DIFF
--- a/src/app/pages/dashboard/components/dashboard-form/dashboard-form.component.ts
+++ b/src/app/pages/dashboard/components/dashboard-form/dashboard-form.component.ts
@@ -92,6 +92,10 @@ export class DashboardFormComponent implements OnInit {
 
     const clone: DashConfigItem[] = [...this.dashState].map((widget) => {
       let identifier: string = widget.name;
+      if (widget.name === WidgetName.SystemInformationStandby || widget?.identifier === 'passive,true') {
+        // TODO: This is a hack to handle the standby widget. Make it better.
+        return { ...widget, rendered: this.form.value[WidgetName.SystemInformation] as boolean };
+      }
       if (widget.identifier) {
         identifier = widget.identifier.split(',')[1];
       }

--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
@@ -292,6 +292,7 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
   }
 
   private applyState(newState: DashConfigItem[]): void {
+    // TODO: Remove this method and use the store to update the state
     // This reconciles current state with saved dashState
 
     if (!this.dashState) {
@@ -312,6 +313,7 @@ export class DashboardComponent implements AfterViewInit, OnDestroy {
   }
 
   private setDashState(dashState: DashConfigItem[]): void {
+    // TODO: Remove this method and use the store to update the state
     this.dashState = dashState;
     if (!this.reorderMode) {
       this.renderedWidgets = this.dashState.filter((widget) => widget.rendered);

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
@@ -395,6 +395,7 @@ div.generic.alert {
   bottom: 4px;
   position: absolute;
   text-align: center;
+  width: 100%;
 }
 
 div.generic.alert .ix-icon {


### PR DESCRIPTION
Fixed visibility of the system info standby widget. It relies on the visibility of the active widget now. Also, this PR has a fix for icon regression on the standby widget when HA is disabled.