### PR TITLE
NAS-127505 / 24.04-RC.1 / UI submitting duplicate issue reports

### DIFF
--- a/src/app/modules/oauth-button/components/oauth-button/oauth-button.component.ts
+++ b/src/app/modules/oauth-button/components/oauth-button/oauth-button.component.ts
@@ -1,5 +1,5 @@
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Inject, Input, Output,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Inject, Input, OnDestroy, Output,
 } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { WINDOW } from 'app/helpers/window.helper';
@@ -16,7 +16,7 @@ import { DialogService } from 'app/services/dialog.service';
   styleUrls: ['./oauth-button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class OauthButtonComponent {
+export class OauthButtonComponent implements OnDestroy {
   @Input() oauthType: OauthButtonType;
   @Input() isLoggedIn = false;
   @Input() disabled = false;
@@ -24,6 +24,11 @@ export class OauthButtonComponent {
   @Input() testId: string;
 
   @Output() loggedIn = new EventEmitter();
+
+  private readonly jiraAuthFn = (message: OauthJiraMessage): void => this.onLogInWithJiraSuccess(message);
+  private readonly gmailAuthFn = (message: OauthMessage<GmailOauthConfig>): void => {
+    this.onLogInWithGmailSuccess(message);
+  };
 
   get buttonText(): string {
     switch (this.oauthType) {
@@ -56,6 +61,11 @@ export class OauthButtonComponent {
     @Inject(WINDOW) private window: Window,
   ) {}
 
+  ngOnDestroy(): void {
+    this.window.removeEventListener('message', this.jiraAuthFn, false);
+    this.window.removeEventListener('message', this.gmailAuthFn, false);
+  }
+
   onOauthClicked(): void {
     switch (this.oauthType) {
       case OauthButtonType.Jira:
@@ -70,8 +80,7 @@ export class OauthButtonComponent {
   }
 
   onLoginWithJira(): void {
-    const authFn = (message: OauthJiraMessage): void => this.onLogInWithJiraSuccess(message);
-    this.doCommonOauthLoginLogic(authFn);
+    this.doCommonOauthLoginLogic(this.jiraAuthFn);
   }
 
   onLogInWithJiraSuccess(message: OauthJiraMessage): void {
@@ -84,8 +93,7 @@ export class OauthButtonComponent {
   }
 
   onLoginWithGmail(): void {
-    const authFn = (message: OauthMessage<GmailOauthConfig>): void => this.onLogInWithGmailSuccess(message);
-    this.doCommonOauthLoginLogic(authFn);
+    this.doCommonOauthLoginLogic(this.gmailAuthFn);
   }
 
   onLogInWithGmailSuccess(message: OauthMessage<GmailOauthConfig>): void {

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
@@ -72,7 +72,7 @@ export class SupportCardComponent implements OnInit {
     this.store$.pipe(waitForSystemInfo, untilDestroyed(this)).subscribe((systemInfo) => {
       this.systemInfo = { ...systemInfo };
       this.systemInfo.memory = (systemInfo.physmem / GiB).toFixed(0) + ' GiB';
-      if (systemInfo.system_product.includes('MINI')) {
+      if (systemInfo.system_product?.includes('MINI')) {
         const getImage = this.productImageService.getMiniImagePath(systemInfo.system_product);
         if (this.productImageService.isRackmount(systemInfo.system_product)) {
           this.isProductImageRack = true;

--- a/src/app/services/error-handler.service.spec.ts
+++ b/src/app/services/error-handler.service.spec.ts
@@ -66,6 +66,7 @@ describe('ErrorHandlerService', () => {
   });
 
   beforeEach(() => {
+    jest.resetAllMocks();
     spectator = createService();
 
     const dialogService = spectator.inject(DialogService);
@@ -94,7 +95,6 @@ describe('ErrorHandlerService', () => {
   describe('handleError', () => {
     it('logs normal error to console and sentry', () => {
       jest.spyOn(spectator.service, 'parseError');
-      jest.spyOn(console, 'error');
       spectator.service.handleError(error);
 
       expect(console.error).toHaveBeenCalledWith(error);
@@ -103,6 +103,12 @@ describe('ErrorHandlerService', () => {
         message: 'Dummy Error',
         title: 'Error',
       });
+    });
+
+    it('does not log Websocket CloseEvent to Sentry', () => {
+      spectator.service.handleError(new CloseEvent('close'));
+
+      expect(spectator.service.logToSentry).not.toHaveBeenCalled();
     });
 
     it('logs websocket error', () => {

--- a/src/app/services/error-handler.service.ts
+++ b/src/app/services/error-handler.service.ts
@@ -39,6 +39,11 @@ export class ErrorHandlerService implements ErrorHandler {
     if (parsedError) {
       error = parsedError;
     }
+
+    if (!this.shouldLogToSentry(error)) {
+      return;
+    }
+
     this.logToSentry(error);
   }
 
@@ -235,5 +240,13 @@ export class ErrorHandlerService implements ErrorHandler {
         };
       }
     }
+  }
+
+  private shouldLogToSentry(error: unknown): boolean {
+    if (error instanceof CloseEvent) {
+      return false;
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
Previously, oauth subscriptions were incorrectly cleared, which lead to possible duplicate ticket submittions.
Also, filters out websocket close events from Sentry.

Testing:
1. Update `addTicket` in `FeedbackService` to not create actual tickets:
```
   return of(ticket).pipe(
      map(() => {
        console.log('creating ticket');
        return { } as NewTicketResponse;
      }),
    );
```

2. Open feedback form on an non-enterprise system and fill in a bug report.
3. Click Login To Jira.
4. Close the window.
5. Click Login to Jira again and submit the ticket.

You should only see one `create ticket` message in console.