### PR TITLE
NAS-127515 / 24.04-RC.1 / Add codename to system info widget (by denysbutenko)

### DIFF
--- a/src/app/enums/codename.enum.ts
+++ b/src/app/enums/codename.enum.ts
@@ -1,0 +1,4 @@
+export enum Codename {
+  ElectricEel = 'ElectricEel',
+  Dragonfish = 'Dragonfish',
+}

--- a/src/app/interfaces/system-info.interface.ts
+++ b/src/app/interfaces/system-info.interface.ts
@@ -1,3 +1,4 @@
+import { Codename } from 'app/enums/codename.enum';
 import { LicenseFeature } from 'app/enums/license-feature.enum';
 import { ApiDate, ApiTimestamp } from 'app/interfaces/api-date.interface';
 
@@ -23,6 +24,7 @@ export interface SystemInfo {
   uptime_seconds: number;
   version: string;
   remote_info?: SystemInfo;
+  codename: Codename;
 }
 
 export interface SystemLicense {

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
@@ -75,17 +75,11 @@
                 [ngClass]="['platform-logo-wrapper', sysGenService.getProductType()?.toLowerCase()]"
               >
                 <ng-container *ngIf="productImage || isPassive; else textOnly">
-                  <ix-icon
-                    name="ix:logo_truenas_scale_full"
-                    [id]="productModel"
-                  ></ix-icon>
+                  <ix-icon name="ix:logo_truenas_scale_full" [id]="productModel"></ix-icon>
                 </ng-container>
 
                 <ng-template #textOnly>
-                  <ix-icon
-                    name="ix:logo_truenas_scale_type"
-                    [id]="productModel"
-                  ></ix-icon>
+                  <ix-icon name="ix:logo_truenas_scale_type" [id]="productModel"></ix-icon>
                 </ng-template>
               </div>
               <div
@@ -209,12 +203,12 @@
                   <mat-list-item>
                     <strong>{{ 'Version' | translate }}:</strong>
                     <div class="copy-version">
-                      <div class="copy-version-text">
-                        <span>{{ systemInfo.version }}</span>
+                      <div class="copy-version-text" [matTooltip]="systemVersion">
+                        <span>{{ systemVersion }}</span>
                       </div>
                       <ix-copy-btn
                         class="copy-version-button"
-                        [text]="systemInfo.version"
+                        [text]="systemVersion"
                       ></ix-copy-btn>
                     </div>
                   </mat-list-item>

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.scss
@@ -213,7 +213,7 @@ img.clickable,
   align-items: center;
   display: flex;
   flex: 1;
-  margin-right: -16px;
+  margin-right: -29px;
   min-width: 0;
 
   .copy-version-text {

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -65,6 +65,14 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, O
 
   readonly ScreenType = ScreenType;
 
+  get systemVersion(): string {
+    if (this.systemInfo?.codename) {
+      return this.systemInfo.version.replace('TrueNAS-SCALE', this.systemInfo.codename);
+    }
+
+    return this.systemInfo.version;
+  }
+
   constructor(
     public router: Router,
     public translate: TranslateService,


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 0a518a8ea600e97a092dee05e49bc98ad7f42e5d
    git cherry-pick -x c227346e7a3b3714fc2575f64b09740dfa0dfac9

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x c15c57c8b62015ea2a0e77ad540c5fa09cd4233b

Changes

- Replace `TrueNAS-SCALE` with release codename (when available)
- Fix regression on standby widget when HA is disabled
- Added tooltip to see full version (no need to copy anymore)

![image](https://github.com/truenas/webui/assets/351613/f6d940be-aad7-4b4d-bf76-23149a3fc32a)



Original PR: https://github.com/truenas/webui/pull/9736
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127515