### PR TITLE
NAS-127582 / 24.10 / Performing advanced query in webui audit form appears to submit query payload twice

### DIFF
--- a/src/app/modules/ix-table2/classes/api-data-provider/api-data-provider.ts
+++ b/src/app/modules/ix-table2/classes/api-data-provider/api-data-provider.ts
@@ -1,4 +1,6 @@
-import { Observable, switchMap } from 'rxjs';
+import {
+  Observable, filter, switchMap, take,
+} from 'rxjs';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { ApiCallParams, ApiCallResponseType, QueryMethods } from 'app/interfaces/api/api-call-directory.interface';
 import { QueryFilters } from 'app/interfaces/query-api.interface';
@@ -57,13 +59,18 @@ export class ApiDataProvider<T extends QueryMethods> extends BaseDataProvider<Ap
 
   setSorting(sorting: TableSort<ApiCallResponseType<T>>): void {
     this.sorting = sorting;
-    this.sortingStrategy.handleCurrentPage(this.load.bind(this));
+    this.emptyType$.pipe(take(1), filter((value) => value !== EmptyType.Loading)).subscribe(() => {
+      this.sortingStrategy.handleCurrentPage(this.load.bind(this));
+    });
     this.controlsStateUpdated.emit();
   }
 
   setPagination(pagination: TablePagination): void {
     this.pagination = pagination;
-    this.paginationStrategy.handleCurrentPage(this.load.bind(this));
+
+    this.emptyType$.pipe(take(1), filter((value) => value !== EmptyType.Loading)).subscribe(() => {
+      this.paginationStrategy.handleCurrentPage(this.load.bind(this));
+    });
     this.controlsStateUpdated.emit();
   }
 

--- a/src/app/pages/account/groups/privilege/privilege-list/privilege-list.component.ts
+++ b/src/app/pages/account/groups/privilege/privilege-list/privilege-list.component.ts
@@ -125,10 +125,6 @@ export class PrivilegeListComponent implements OnInit {
     this.setSearchProperties();
   }
 
-  getPrivileges(): void {
-    this.dataProvider.load();
-  }
-
   openForm(privilege?: Privilege): void {
     const slideInRef = this.slideInService.open(PrivilegeFormComponent, { data: privilege });
     slideInRef.slideInClosed$.pipe(filter(Boolean), untilDestroyed(this)).subscribe(() => {
@@ -193,5 +189,9 @@ export class PrivilegeListComponent implements OnInit {
       textProperty('ds_groups.*.name', this.translate.instant('DS Groups Name'), this.groupsSuggestions$),
       textProperty('roles', this.translate.instant('Roles'), this.rolesSuggestions$, roleNames),
     ]);
+  }
+
+  private getPrivileges(): void {
+    this.dataProvider.load();
   }
 }

--- a/src/app/pages/audit/components/audit/audit.component.ts
+++ b/src/app/pages/audit/components/audit/audit.component.ts
@@ -122,6 +122,8 @@ export class AuditComponent implements OnInit, OnDestroy {
     this.dataProvider.sortingStrategy = new SortingServerSide();
     this.setDefaultSort();
 
+    this.getAuditLogs();
+
     this.apiAndLocalUserSuggestions$ = combineLatest(
       this.userSuggestions$,
       this.dataProvider.currentPage$.pipe(take(1), map((users) => this.mapUsersForSuggestions(users))),
@@ -175,7 +177,7 @@ export class AuditComponent implements OnInit, OnDestroy {
       );
     }
 
-    this.dataProvider.load();
+    this.getAuditLogs();
   }
 
   updateUrlOptions(): void {
@@ -346,5 +348,9 @@ export class AuditComponent implements OnInit, OnDestroy {
       label: user.username,
       value: `"${user.username}"`,
     }));
+  }
+
+  private getAuditLogs(): void {
+    this.dataProvider.load();
   }
 }


### PR DESCRIPTION
Testing: 
See that load() is not called multiple times (upon initial load request)

inside of the `load(): void {` 

you can alert `alert(this.method);` to make sure it's only called once.
Before it was called twice because of the `setSorting` and `setPagination` logic.