### PR TITLE
NAS-127582 / 24.04.0 / Performing advanced query in webui audit form appears to submit query payload twice (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-table2/classes/api-data-provider/api-data-provider.ts
+++ b/src/app/modules/ix-table2/classes/api-data-provider/api-data-provider.ts
@@ -1,4 +1,6 @@
-import { Observable, switchMap } from 'rxjs';
+import {
+  Observable, filter, switchMap, take,
+} from 'rxjs';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { ApiCallDirectory, ApiCallMethod } from 'app/interfaces/api/api-call-directory.interface';
 import { QueryFilters } from 'app/interfaces/query-api.interface';
@@ -63,13 +65,18 @@ export class ApiDataProvider<T, M extends ApiCallMethod> extends BaseDataProvide
 
   setSorting(sorting: TableSort<T>): void {
     this.sorting = sorting;
-    this.sortingStrategy.handleCurrentPage(this.load.bind(this));
+    this.emptyType$.pipe(take(1), filter((value) => value !== EmptyType.Loading)).subscribe(() => {
+      this.sortingStrategy.handleCurrentPage(this.load.bind(this));
+    });
     this.controlsStateUpdated.emit();
   }
 
   setPagination(pagination: TablePagination): void {
     this.pagination = pagination;
-    this.paginationStrategy.handleCurrentPage(this.load.bind(this));
+
+    this.emptyType$.pipe(take(1), filter((value) => value !== EmptyType.Loading)).subscribe(() => {
+      this.paginationStrategy.handleCurrentPage(this.load.bind(this));
+    });
     this.controlsStateUpdated.emit();
   }
 

--- a/src/app/pages/account/groups/privilege/privilege-list/privilege-list.component.ts
+++ b/src/app/pages/account/groups/privilege/privilege-list/privilege-list.component.ts
@@ -92,10 +92,6 @@ export class PrivilegeListComponent implements OnInit {
     this.getPrivileges();
   }
 
-  getPrivileges(): void {
-    this.dataProvider.load();
-  }
-
   openForm(privilege?: Privilege): void {
     const slideInRef = this.slideInService.open(PrivilegeFormComponent, { data: privilege });
     slideInRef.slideInClosed$.pipe(filter(Boolean), untilDestroyed(this)).subscribe(() => {
@@ -132,5 +128,9 @@ export class PrivilegeListComponent implements OnInit {
     this.dataProvider.setRows(this.privileges.filter((privileges) => {
       return privileges.name.toLowerCase().includes(filterString);
     }));
+  }
+
+  private getPrivileges(): void {
+    this.dataProvider.load();
   }
 }

--- a/src/app/pages/audit/components/audit/audit.component.ts
+++ b/src/app/pages/audit/components/audit/audit.component.ts
@@ -121,6 +121,8 @@ export class AuditComponent implements OnInit, OnDestroy {
     this.dataProvider.sortingStrategy = new SortingServerSide();
     this.setDefaultSort();
 
+    this.getAuditLogs();
+
     this.apiAndLocalUserSuggestions$ = combineLatest(
       this.userSuggestions$,
       this.dataProvider.currentPage$.pipe(take(1), map((users) => this.mapUsersForSuggestions(users))),
@@ -174,7 +176,7 @@ export class AuditComponent implements OnInit, OnDestroy {
       );
     }
 
-    this.dataProvider.load();
+    this.getAuditLogs();
   }
 
   updateUrlOptions(): void {
@@ -345,5 +347,9 @@ export class AuditComponent implements OnInit, OnDestroy {
       label: user.username,
       value: `"${user.username}"`,
     }));
+  }
+
+  private getAuditLogs(): void {
+    this.dataProvider.load();
   }
 }


### PR DESCRIPTION
Testing: 
See that load() is not called multiple times (upon initial load request)

inside of the `load(): void {` 

you can alert `alert(this.method);` to make sure it's only called once.
Before it was called twice because of the `setSorting` and `setPagination` logic.

Original PR: https://github.com/truenas/webui/pull/9757
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127582