### PR TITLE
NAS-127141 / 24.10 / Unsubscribe from API events subscriptions on logout

### DIFF
--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -211,9 +211,14 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, O
   }
 
   setUptimeUpdates(): void {
+    if (!this.systemInfo?.uptime_seconds) {
+      return;
+    }
+
     if (this.uptimeInterval) {
       clearInterval(this.uptimeInterval);
     }
+
     this.uptimeInterval = setInterval(() => {
       this.systemInfo.uptime_seconds += 1;
       this.systemInfo.datetime.$date += 1000;

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -181,6 +181,7 @@ export class AuthService {
     return this.makeRequest('auth.logout').pipe(
       tap(() => {
         this.clearAuthToken();
+        this.ws.clearSubscriptions();
         this.isLoggedIn$.next(false);
       }),
     );


### PR DESCRIPTION
The easiest way to test changes is to create a fresh nightly instance with API Tests in CI. While tests are running, multiple jobs and events are created. Then, log in and reduce session duration to lowest value (30 seconds). Navigate to different pages and check when session has ended.
 
Ensure websocket messages have no active subscriptions (except ping). 
Check if active websocket connection can be reused.
Test for any regressions.