### PR TITLE
NAS-127719 / 24.10 / Do not offer service dialogs if user does not have access (by undsoft)

### DIFF
--- a/src/app/helpers/operators/filter-async.operator.ts
+++ b/src/app/helpers/operators/filter-async.operator.ts
@@ -1,15 +1,19 @@
 import {
-  filter, map, Observable, OperatorFunction, switchMap,
+  filter, map, Observable, OperatorFunction, switchMap, take,
 } from 'rxjs';
 
 /**
  * Similar to filter(), but accepts an observable.
  */
-export function filterAsync<T>(asyncPredicate$: Observable<boolean>): OperatorFunction<T, T> {
+export function filterAsync<T>(predicateFactory: (value: T) => Observable<boolean>): OperatorFunction<T, T> {
   return (source$: Observable<T>) => source$.pipe(
-    switchMap((item) => asyncPredicate$.pipe(
-      filter((result) => result),
-      map(() => item),
-    )),
+    switchMap((value) => {
+      const predicate$ = predicateFactory(value);
+      return predicate$.pipe(
+        take(1),
+        filter((result) => result),
+        map(() => value),
+      );
+    }),
   );
 }

--- a/src/app/modules/dialog/components/start-service-dialog/start-service-dialog.component.html
+++ b/src/app/modules/dialog/components/start-service-dialog/start-service-dialog.component.html
@@ -21,7 +21,6 @@
   >{{ 'No' | translate }}</button>
 
   <button
-    *ixRequiresRoles="requiredRoles"
     mat-button
     color="primary"
     ixTest="enable-service"

--- a/src/app/modules/dialog/components/start-service-dialog/start-service-dialog.component.ts
+++ b/src/app/modules/dialog/components/start-service-dialog/start-service-dialog.component.ts
@@ -7,7 +7,6 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, forkJoin } from 'rxjs';
-import { Role } from 'app/enums/role.enum';
 import { ServiceName, serviceNames } from 'app/enums/service-name.enum';
 import { Service } from 'app/interfaces/service.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -28,8 +27,6 @@ export interface StartServiceDialogResult {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StartServiceDialogComponent implements OnInit {
-  readonly requiredRoles = [Role.ServiceWrite];
-
   startAutomaticallyControl = new FormControl(true);
   protected isLoading = false;
   private service: Service;

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.ts
@@ -178,7 +178,7 @@ export class WidgetSysInfoComponent extends WidgetComponent implements OnInit, O
   getIsHaLicensed(): void {
     this.store$
       .select(selectIsHaLicensed)
-      .pipe(filterAsync(this.sysGenService.isEnterprise$), untilDestroyed(this))
+      .pipe(filterAsync(() => this.sysGenService.isEnterprise$), untilDestroyed(this))
       .subscribe((isHaLicensed) => {
         this.isHaLicensed = isHaLicensed;
         if (isHaLicensed) {

--- a/src/app/pages/services/services.component.html
+++ b/src/app/pages/services/services.component.html
@@ -37,7 +37,7 @@
 
         <ng-template #slider>
           <mat-slide-toggle
-            *ixRequiresRoles="getRolesForService(service.service)"
+            *ixRequiresRoles="servicesService.getRolesRequiredToManage(service.service)"
             color="primary"
             matTooltipPosition="right"
             [checked]="service.state === ServiceStatus.Running"
@@ -55,7 +55,7 @@
       </th>
       <td *matCellDef="let service; dataSource: dataSource" mat-cell>
         <mat-checkbox
-          *ixRequiresRoles="getRolesForService(service.service)"
+          *ixRequiresRoles="servicesService.getRolesRequiredToManage(service.service)"
           color="primary"
           class="start-automatically"
           [ixTest]="[service.service, 'service']"

--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -28,6 +28,7 @@ import { ServiceUpsComponent } from 'app/pages/services/components/service-ups/s
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { IscsiService } from 'app/services/iscsi.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
+import { ServicesService } from 'app/services/services.service';
 import { UrlOptionsService } from 'app/services/url-options.service';
 import { WebSocketService } from 'app/services/ws.service';
 import { serviceChanged } from 'app/store/services/services.actions';
@@ -79,6 +80,7 @@ export class ServicesComponent implements OnInit {
     private store$: Store<ServicesState>,
     private urlOptions: UrlOptionsService,
     private errorHandler: ErrorHandlerService,
+    protected servicesService: ServicesService,
   ) {}
 
   ngOnInit(): void {
@@ -87,19 +89,6 @@ export class ServicesComponent implements OnInit {
 
   get shouldShowEmpty(): boolean {
     return !this.dataSource.filteredData.length;
-  }
-
-  getRolesForService(serviceName: ServiceName): Role[] {
-    switch (serviceName) {
-      case ServiceName.Cifs:
-        return [Role.SharingSmbWrite, Role.ServiceWrite];
-      case ServiceName.Iscsi:
-        return [Role.SharingIscsiWrite, Role.ServiceWrite];
-      case ServiceName.Nfs:
-        return [Role.SharingNfsWrite, Role.ServiceWrite];
-      default:
-        return [Role.ServiceWrite];
-    }
   }
 
   getData(): void {

--- a/src/app/pages/system/update/components/train-card/train-card.component.ts
+++ b/src/app/pages/system/update/components/train-card/train-card.component.ts
@@ -127,7 +127,7 @@ export class TrainCardComponent implements OnInit {
     });
 
     this.form.controls.auto_check.valueChanges.pipe(
-      filterAsync(this.authService.hasRole(Role.FullAdmin)),
+      filterAsync(() => this.authService.hasRole(Role.FullAdmin)),
       untilDestroyed(this),
     ).subscribe(() => {
       this.trainService.toggleAutoCheck();

--- a/src/app/services/services.service.ts
+++ b/src/app/services/services.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { Role } from 'app/enums/role.enum';
+import { ServiceName } from 'app/enums/service-name.enum';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ServicesService {
+  /**
+   * Roles required to manage a service.
+   */
+  getRolesRequiredToManage(serviceName: ServiceName): Role[] {
+    switch (serviceName) {
+      case ServiceName.Cifs:
+        return [Role.SharingSmbWrite, Role.ServiceWrite];
+      case ServiceName.Iscsi:
+        return [Role.SharingIscsiWrite, Role.ServiceWrite];
+      case ServiceName.Nfs:
+        return [Role.SharingNfsWrite, Role.ServiceWrite];
+      default:
+        return [Role.ServiceWrite];
+    }
+  }
+}

--- a/src/app/store/eula/eula.effects.ts
+++ b/src/app/store/eula/eula.effects.ts
@@ -3,7 +3,7 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 import {
-  filter, mergeMap, switchMap, take,
+  filter, mergeMap, switchMap,
 } from 'rxjs/operators';
 import { Role } from 'app/enums/role.enum';
 import { filterAsync } from 'app/helpers/operators/filter-async.operator';
@@ -19,7 +19,7 @@ export class EulaEffects {
   checkEula$ = createEffect(() => this.actions$.pipe(
     ofType(adminUiInitialized),
     filter(() => this.systemGeneralService.isEnterprise),
-    filterAsync(this.authService.hasRole([Role.FullAdmin]).pipe(take(1))),
+    filterAsync(() => this.authService.hasRole([Role.FullAdmin])),
     mergeMap(() => {
       return this.ws.call('truenas.is_eula_accepted').pipe(
         filter((isEulaAccepted) => !isEulaAccepted),

--- a/src/app/store/network-interfaces/network-interfaces.effects.ts
+++ b/src/app/store/network-interfaces/network-interfaces.effects.ts
@@ -26,7 +26,7 @@ import {
 export class NetworkInterfacesEffects {
   loadCheckinStatus$ = createEffect(() => this.actions$.pipe(
     ofType(adminUiInitialized, networkInterfacesChanged),
-    filterAsync(this.authService.hasRole([Role.NetworkInterfaceWrite])),
+    filterAsync(() => this.authService.hasRole([Role.NetworkInterfaceWrite])),
     mergeMap(() => {
       return forkJoin([
         this.ws.call('interface.has_pending_changes'),

--- a/src/app/store/services/services.effects.spec.ts
+++ b/src/app/store/services/services.effects.spec.ts
@@ -5,6 +5,7 @@ import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import {
   BehaviorSubject, firstValueFrom, of, ReplaySubject, throwError,
 } from 'rxjs';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockCall, mockWebSocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { ServiceStatus } from 'app/enums/service-status.enum';
@@ -62,6 +63,7 @@ describe('ServicesEffects', () => {
           },
         ],
       }),
+      mockAuth(),
     ],
   });
 

--- a/src/app/store/services/services.effects.ts
+++ b/src/app/store/services/services.effects.ts
@@ -3,11 +3,14 @@ import { MatDialog } from '@angular/material/dialog';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import {
-  mergeMap, map, switchMap, filter, EMPTY, catchError, of, take,
+  mergeMap, map, switchMap, filter, EMPTY, catchError, of, take, Observable,
 } from 'rxjs';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { ServiceStatus } from 'app/enums/service-status.enum';
+import { filterAsync } from 'app/helpers/operators/filter-async.operator';
 import { StartServiceDialogComponent, StartServiceDialogResult } from 'app/modules/dialog/components/start-service-dialog/start-service-dialog.component';
+import { AuthService } from 'app/services/auth/auth.service';
+import { ServicesService } from 'app/services/services.service';
 import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
 import { adminUiInitialized } from 'app/store/admin-panel/admin.actions';
@@ -50,6 +53,7 @@ export class ServicesEffects {
   checkIfServiceIsEnabled$ = createEffect(() => this.actions$.pipe(
     ofType(checkIfServiceIsEnabled),
     filter(({ serviceName }) => Boolean(serviceName)),
+    filterAsync(({ serviceName }) => this.canUserManageService(serviceName)),
     switchMap(({ serviceName }) => this.store$.select(selectService(serviceName)).pipe(take(1))),
     switchMap((service) => {
       if (service.state === ServiceStatus.Stopped) {
@@ -88,5 +92,12 @@ export class ServicesEffects {
     private actions$: Actions,
     private ws: WebSocketService,
     private matDialog: MatDialog,
+    private authService: AuthService,
+    private servicesService: ServicesService,
   ) {}
+
+  private canUserManageService(serviceName: ServiceName): Observable<boolean> {
+    const requiredRoles = this.servicesService.getRolesRequiredToManage(serviceName);
+    return this.authService.hasRole(requiredRoles);
+  }
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e5c4678c50fb2dc190585a7cbd1ca9234c61f1a1
    git cherry-pick -x 6b9a941c59e5fa0848fee89e3916f09ab5d641cb
    git cherry-pick -x 592ac0353211ea17ed0d42467a57fb10020fdb92
    git cherry-pick -x cedfa1c09f7d0a559aac92d2d3ccc876b5c50495

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 40859e19b6a7e3074eea2b7cec44604bcc6f3827

Testing: see ticket. Start service dialog will no longer be shown is user won't be able to do anything in it.

Original PR: https://github.com/truenas/webui/pull/9793
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127719