### PR TITLE
NAS-127787 / 24.04.0 / Audit advanced search syntax not filtering query (by AlexKarpov98)

### DIFF
--- a/src/app/modules/search-input/services/query-to-api/query-to-api.service.ts
+++ b/src/app/modules/search-input/services/query-to-api/query-to-api.service.ts
@@ -69,7 +69,9 @@ export class QueryToApiService<T> {
   }
 
   private buildCondition(condition: Condition): QueryFilter<T> {
-    const currentProperty = this.searchProperties.find((value) => value.label === condition.property);
+    const currentProperty = this.searchProperties.find((value) => {
+      return value.label?.toLowerCase() === condition.property?.toLowerCase();
+    });
     const mappedConditionProperty = (currentProperty?.property || condition.property);
     const mappedConditionValue = this.mapValueByPropertyType(currentProperty, condition.value);
 


### PR DESCRIPTION
column names are now case-insensitive (see ticket's comment)
`"event" != "Authentication"` will work same as `"Event" != "Authentication"` or `"EvEnT" = "Authentication"`
Testing:
<img width="1225" alt="Screenshot 2024-03-13 at 10 59 51" src="https://github.com/truenas/webui/assets/22980553/c852970d-c15e-4a30-8b6f-43683d4e7bcb">


Original PR: https://github.com/truenas/webui/pull/9809
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127787