### PR TITLE
NAS-127589 / 24.04.0 / Use new download VM logs endpoint in WebUI (by denysbutenko)

### DIFF
--- a/src/app/pages/vm/vm-list/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list/vm-list.component.ts
@@ -460,9 +460,8 @@ export class VmListComponent implements EntityTableConfig<VirtualMachineRow> {
       label: this.translate.instant('Download Logs'),
       disabled: !this.hasRolesAccess,
       onClick: (vm: VirtualMachineRow) => {
-        const path = `/var/log/libvirt/qemu/${vm.id}_${vm.name}.log`;
         const filename = `${vm.id}_${vm.name}.log`;
-        this.ws.call('core.download', ['filesystem.get', [path], filename]).pipe(
+        this.ws.call('core.download', ['vm.log_file_download', [vm.id], filename]).pipe(
           switchMap(([, url]) => {
             const mimetype = 'text/plain';
             return this.storageService.downloadUrl(url, filename, mimetype);


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 2dc8285440330eaccf52897de51a5f36d06f3225
    git cherry-pick -x b3d4263a601d584e5c28efe5d2c6b3c2b84bce62
    git cherry-pick -x 71afcf53edce248e9df1ad106fdf84f874068c65
    git cherry-pick -x 5f3fc941f1e9b22007af4f92ec99f65c71b3f31a

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8423bade9dec6b6c052a4315e70e3c775f5b0b1d

M40 is ready for testing this PR. Try to download logs on the VM page.

Original PR: https://github.com/truenas/webui/pull/9773
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127589