### PR TITLE
NAS-125411 / 24.10 / Added check for vdev capacties difference

### DIFF
--- a/src/app/services/storage.service.spec.ts
+++ b/src/app/services/storage.service.spec.ts
@@ -154,7 +154,7 @@ describe('StorageService', () => {
 
       // Check mixed VDEV when the difference is less than 2 GiB
       expect(storageService.isMixedVdevCapacity(new Set([GiB, GiB * 3 - 1]))).toBe(false);
-      expect(storageService.isMixedVdevCapacity(new Set([GiB, GiB * 3]))).toBe(true);
+      expect(storageService.isMixedVdevCapacity(new Set([GiB, GiB * 3.2]))).toBe(true);
     });
   });
 

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { GiB } from 'app/constants/bytes.constant';
 import { TopologyItemType, TopologyWarning, VdevType } from 'app/enums/v-dev-type.enum';
 import { FileSystemStat } from 'app/interfaces/filesystem-stat.interface';
 import { Option } from 'app/interfaces/option.interface';
@@ -105,8 +104,11 @@ export class StorageService {
 
   // Check to see if every VDEV has the same capacity. Best practices dictate every vdev should be uniform
   isMixedVdevCapacity(allVdevCapacities: Set<number>): boolean {
-    const diff = Math.max(...allVdevCapacities) - Math.min(...allVdevCapacities);
-    return allVdevCapacities.size > 1 && diff >= GiB * 2;
+    const max = Math.max(...allVdevCapacities);
+    const min = Math.min(...allVdevCapacities);
+    const diffPercentage = 100 - ((min / max) * 100);
+
+    return allVdevCapacities.size > 1 && diffPercentage >= 5;
   }
 
   getVdevDiskCapacities(vdevs: TopologyItem[], disks: Disk[]): Set<number>[] {

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -107,12 +107,9 @@ export class StorageService {
   isMixedVdevCapacity(allVdevCapacities: Set<number>): boolean {
     const max = Math.max(...allVdevCapacities);
     const min = Math.min(...allVdevCapacities);
-    const diffPercentage = 100 - ((min / max) * 100);
-    const diff = Math.max(...allVdevCapacities) - Math.min(...allVdevCapacities);
+    const fivePercentOfMax = max * (5 / 100);
 
-    const isDiffNoticable = diffPercentage >= 5 && diff >= GiB * 2;
-
-    return allVdevCapacities.size > 1 && isDiffNoticable;
+    return min + fivePercentOfMax + GiB * 2 < max;
   }
 
   getVdevDiskCapacities(vdevs: TopologyItem[], disks: Disk[]): Set<number>[] {

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { GiB } from 'app/constants/bytes.constant';
 import { TopologyItemType, TopologyWarning, VdevType } from 'app/enums/v-dev-type.enum';
 import { FileSystemStat } from 'app/interfaces/filesystem-stat.interface';
 import { Option } from 'app/interfaces/option.interface';
@@ -107,8 +108,11 @@ export class StorageService {
     const max = Math.max(...allVdevCapacities);
     const min = Math.min(...allVdevCapacities);
     const diffPercentage = 100 - ((min / max) * 100);
+    const diff = Math.max(...allVdevCapacities) - Math.min(...allVdevCapacities);
 
-    return allVdevCapacities.size > 1 && diffPercentage >= 5;
+    const isDiffNoticable = diffPercentage >= 5 && diff >= GiB * 2;
+
+    return allVdevCapacities.size > 1 && isDiffNoticable;
   }
 
   getVdevDiskCapacities(vdevs: TopologyItem[], disks: Disk[]): Set<number>[] {


### PR DESCRIPTION
Mixed Vdev Capacities warning should only be shown if the difference is greater than 2 Gib and the percentage difference between the highest and lowest vdev capacities is more than 5%.