### PR TITLE
NAS-127720 / 24.04.0 / Webui does not handle validation errors properly when creating SMB shares via "Add Dataset" (by AlexKarpov98)

### DIFF
--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
@@ -10,15 +10,18 @@
       <ix-name-and-options
         [existing]="existingDataset"
         [parent]="parentDataset"
+        (formValidityChange)="isNameAndOptionsValid = $event"
       ></ix-name-and-options>
       <ix-quotas-section
         *ngIf="isAdvancedMode && isNew"
         [parent]="parentDataset"
+        (formValidityChange)="isQuotaValid = $event"
       ></ix-quotas-section>
       <ix-encryption-section
         *ngIf="isNew"
         [parent]="parentDataset"
         [advancedMode]="isAdvancedMode"
+        (formValidityChange)="isEncryptionValid = $event"
       ></ix-encryption-section>
       <ix-other-options-section
         [existing]="existingDataset"
@@ -26,6 +29,7 @@
         [datasetPreset]="datasetPreset"
         [advancedMode]="isAdvancedMode"
         (advancedModeChange)="onSwitchToAdvanced()"
+        (formValidityChange)="isOtherOptionsValid = $event"
       ></ix-other-options-section>
 
       <ix-form-actions>
@@ -35,7 +39,7 @@
           type="submit"
           color="primary"
           ixTest="save"
-          [disabled]="form.invalid || isLoading || noNameProvided"
+          [disabled]="form.invalid || isLoading || !areSubFormsValid"
         >
           {{ 'Save' | translate }}
         </button>

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
@@ -35,7 +35,7 @@
           type="submit"
           color="primary"
           ixTest="save"
-          [disabled]="form.invalid || isLoading"
+          [disabled]="form.invalid || isLoading || noNameProvided"
         >
           {{ 'Save' | translate }}
         </button>

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
@@ -91,6 +91,14 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
       });
   }
 
+  get noNameProvided(): boolean {
+    if (!this.isNew || !this.nameAndOptionsSection) {
+      return false;
+    }
+
+    return !(this.nameAndOptionsSection.getPayload() as { name: string }).name;
+  }
+
   get isNew(): boolean {
     return !this.existingDataset;
   }

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
@@ -52,6 +52,11 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
 
   readonly requiredRoles = [Role.DatasetWrite];
 
+  isNameAndOptionsValid = true;
+  isQuotaValid = true;
+  isEncryptionValid = true;
+  isOtherOptionsValid = true;
+
   isLoading = false;
   isAdvancedMode = false;
   datasetPreset = DatasetPreset.Generic;
@@ -61,42 +66,8 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
   parentDataset: Dataset;
   existingDataset: Dataset;
 
-  constructor(
-    private ws: WebSocketService,
-    private cdr: ChangeDetectorRef,
-    private dialog: DialogService,
-    private datasetFormService: DatasetFormService,
-    private router: Router,
-    private errorHandler: ErrorHandlerService,
-    private snackbar: SnackbarService,
-    private translate: TranslateService,
-    private slideInRef: IxSlideInRef<DatasetFormComponent>,
-    private store$: Store<AppState>,
-    @Inject(SLIDE_IN_DATA) private slideInData: { datasetId: string; isNew?: boolean },
-  ) {}
-
-  ngOnInit(): void {
-    if (this.slideInData?.datasetId && !this.slideInData?.isNew) {
-      this.setForEdit();
-    }
-    if (this.slideInData?.datasetId && this.slideInData?.isNew) {
-      this.setForNew();
-    }
-  }
-
-  ngAfterViewInit(): void {
-    this.nameAndOptionsSection.form.controls.share_type.valueChanges
-      .pipe(untilDestroyed(this)).subscribe((datasetPreset) => {
-        this.datasetPreset = datasetPreset;
-      });
-  }
-
-  get noNameProvided(): boolean {
-    if (!this.isNew || !this.nameAndOptionsSection) {
-      return false;
-    }
-
-    return !(this.nameAndOptionsSection.getPayload() as { name: string }).name;
+  get areSubFormsValid(): boolean {
+    return this.isNameAndOptionsValid && this.isQuotaValid && this.isEncryptionValid && this.isNameAndOptionsValid;
   }
 
   get isNew(): boolean {
@@ -132,6 +103,36 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
       this.nameAndOptionsSection,
       this.otherOptionsSection,
     ];
+  }
+
+  constructor(
+    private ws: WebSocketService,
+    private cdr: ChangeDetectorRef,
+    private dialog: DialogService,
+    private datasetFormService: DatasetFormService,
+    private router: Router,
+    private errorHandler: ErrorHandlerService,
+    private snackbar: SnackbarService,
+    private translate: TranslateService,
+    private slideInRef: IxSlideInRef<DatasetFormComponent>,
+    private store$: Store<AppState>,
+    @Inject(SLIDE_IN_DATA) private slideInData: { datasetId: string; isNew?: boolean },
+  ) {}
+
+  ngOnInit(): void {
+    if (this.slideInData?.datasetId && !this.slideInData?.isNew) {
+      this.setForEdit();
+    }
+    if (this.slideInData?.datasetId && this.slideInData?.isNew) {
+      this.setForNew();
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.nameAndOptionsSection.form.controls.share_type.valueChanges
+      .pipe(untilDestroyed(this)).subscribe((datasetPreset) => {
+        this.datasetPreset = datasetPreset;
+      });
   }
 
   setForNew(): void {

--- a/src/app/pages/datasets/components/dataset-form/sections/encryption-section/encryption-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/encryption-section/encryption-section.component.ts
@@ -1,9 +1,9 @@
 import {
-  ChangeDetectionStrategy, Component, Input, OnChanges,
+  ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnInit, Output,
 } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
-import { UntilDestroy } from '@ngneat/until-destroy';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { DatasetEncryptionType } from 'app/enums/dataset.enum';
@@ -20,9 +20,11 @@ import { WebSocketService } from 'app/services/ws.service';
   templateUrl: './encryption-section.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class EncryptionSectionComponent implements OnChanges {
+export class EncryptionSectionComponent implements OnChanges, OnInit {
   @Input() parent: Dataset;
   @Input() advancedMode: boolean;
+
+  @Output() formValidityChange = new EventEmitter<boolean>();
 
   get inheritEncryptionLabel(): string {
     return this.parent.encrypted
@@ -88,6 +90,12 @@ export class EncryptionSectionComponent implements OnChanges {
       this.setInheritValues();
       this.disableEncryptionIfParentEncrypted();
     }
+  }
+
+  ngOnInit(): void {
+    this.form.statusChanges.pipe(untilDestroyed(this)).subscribe((status) => {
+      this.formValidityChange.emit(status === 'VALID');
+    });
   }
 
   getPayload(): Partial<DatasetCreate> {

--- a/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.spec.ts
@@ -1,7 +1,7 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { DatasetCaseSensitivity, DatasetPreset } from 'app/enums/dataset.enum';
 import { ZfsPropertySource } from 'app/enums/zfs-property-source.enum';
 import { Dataset } from 'app/interfaces/dataset.interface';
@@ -12,6 +12,7 @@ import { IxFormHarness } from 'app/modules/ix-forms/testing/ix-form.harness';
 import {
   NameAndOptionsSectionComponent,
 } from 'app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component';
+import { SmbValidationService } from 'app/pages/sharing/smb/smb-form/smb-validator.service';
 
 describe('NameAndOptionsSectionComponent', () => {
   let spectator: Spectator<NameAndOptionsSectionComponent>;
@@ -34,6 +35,9 @@ describe('NameAndOptionsSectionComponent', () => {
     imports: [
       ReactiveFormsModule,
       IxFormsModule,
+    ],
+    providers: [
+      mockProvider(SmbValidationService),
     ],
   });
 

--- a/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.ts
@@ -1,10 +1,10 @@
 import {
-  ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnInit, Output,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, OnInit, Output,
 } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
-import { of } from 'rxjs';
+import { delay, merge, of } from 'rxjs';
 import { DatasetCaseSensitivity, DatasetPreset, datasetPresetLabels } from 'app/enums/dataset.enum';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextDatasetForm } from 'app/helptext/storage/volumes/datasets/dataset-form';
@@ -13,6 +13,7 @@ import {
   forbiddenValues,
 } from 'app/modules/ix-forms/validators/forbidden-values-validation/forbidden-values-validation';
 import { datasetNameTooLong } from 'app/pages/datasets/components/dataset-form/utils/name-length-validation';
+import { SmbValidationService } from 'app/pages/sharing/smb/smb-form/smb-validator.service';
 import { NameValidationService } from 'app/services/name-validation.service';
 
 @UntilDestroy()
@@ -60,7 +61,9 @@ export class NameAndOptionsSectionComponent implements OnInit, OnChanges {
   constructor(
     private formBuilder: FormBuilder,
     private translate: TranslateService,
+    private smbValidationService: SmbValidationService,
     private nameValidationService: NameValidationService,
+    private cdr: ChangeDetectorRef,
   ) {}
 
   ngOnChanges(): void {
@@ -76,15 +79,11 @@ export class NameAndOptionsSectionComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     this.form.controls.parent.disable();
 
-    this.form.controls.name.valueChanges.pipe(untilDestroyed(this)).subscribe((name) => {
-      this.datasetPresetForm.patchValue({
-        smb_name: name,
-      });
-    });
+    this.listenForSmbNameValidation();
 
-    this.form.statusChanges.pipe(untilDestroyed(this)).subscribe((status) => {
-      this.formValidityChange.emit(status === 'VALID');
-    });
+    merge(this.form.statusChanges, this.datasetPresetForm.statusChanges)
+      .pipe(untilDestroyed(this))
+      .subscribe((status) => this.formValidityChange.emit(status === 'VALID'));
   }
 
   getPayload(): Partial<DatasetCreate> | Partial<DatasetUpdate> {
@@ -134,5 +133,29 @@ export class NameAndOptionsSectionComponent implements OnInit, OnChanges {
       datasetNameTooLong(this.parent.name),
       forbiddenValues(namesInUse, isNameCaseSensitive),
     ]);
+  }
+
+  private listenForSmbNameValidation(): void {
+    merge(
+      this.form.controls.share_type.valueChanges,
+      this.datasetPresetForm.controls.create_smb.valueChanges,
+    )
+      .pipe(delay(0), untilDestroyed(this))
+      .subscribe(() => {
+        const smbNameControl = this.datasetPresetForm.controls.smb_name;
+
+        if (this.canCreateSmb && !!this.datasetPresetForm.controls.create_smb.value) {
+          smbNameControl.addValidators(Validators.required);
+          smbNameControl.addAsyncValidators(this.smbValidationService.validate());
+          smbNameControl.patchValue(this.form.controls.name.value);
+          smbNameControl.markAsTouched();
+        } else {
+          smbNameControl.clearAsyncValidators();
+          smbNameControl.clearValidators();
+          smbNameControl.patchValue(null);
+        }
+
+        this.cdr.markForCheck();
+      });
   }
 }

--- a/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.ts
@@ -91,7 +91,7 @@ export class NameAndOptionsSectionComponent implements OnInit, OnChanges {
 
     return {
       ...payload,
-      name: `${this.parent.name}/${payload.name}`,
+      name: payload.name && this.form.controls.name.valid ? `${this.parent.name}/${payload.name}` : null,
     };
   }
 

--- a/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.ts
@@ -1,5 +1,5 @@
 import {
-  ChangeDetectionStrategy, Component, Input, OnChanges, OnInit,
+  ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnInit, Output,
 } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -25,6 +25,8 @@ import { NameValidationService } from 'app/services/name-validation.service';
 export class NameAndOptionsSectionComponent implements OnInit, OnChanges {
   @Input() existing: Dataset;
   @Input() parent: Dataset;
+
+  @Output() formValidityChange = new EventEmitter<boolean>();
 
   datasetPresetOptions$ = of(mapToOptions(datasetPresetLabels, this.translate));
 
@@ -78,6 +80,10 @@ export class NameAndOptionsSectionComponent implements OnInit, OnChanges {
       this.datasetPresetForm.patchValue({
         smb_name: name,
       });
+    });
+
+    this.form.statusChanges.pipe(untilDestroyed(this)).subscribe((status) => {
+      this.formValidityChange.emit(status === 'VALID');
     });
   }
 

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
@@ -68,7 +68,9 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
   @Input() existing: Dataset;
   @Input() datasetPreset: DatasetPreset;
   @Input() advancedMode: boolean;
+
   @Output() advancedModeChange = new EventEmitter<void>();
+  @Output() formValidityChange = new EventEmitter<boolean>();
 
   hasDeduplication = false;
   hasDedupWarning = false;
@@ -172,6 +174,10 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
 
     this.form.controls.acltype.valueChanges.pipe(untilDestroyed(this)).subscribe(() => {
       this.updateAclMode();
+    });
+
+    this.form.statusChanges.pipe(untilDestroyed(this)).subscribe((status) => {
+      this.formValidityChange.emit(status === 'VALID');
     });
   }
 

--- a/src/app/pages/datasets/components/dataset-form/sections/quotas-section/quotas-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/quotas-section/quotas-section.component.ts
@@ -1,5 +1,5 @@
 import {
-  ChangeDetectionStrategy, Component, Input, OnInit,
+  ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output,
 } from '@angular/core';
 import { AbstractControl, FormBuilder, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -23,6 +23,8 @@ const critical = 95;
 })
 export class QuotasSectionComponent implements OnInit {
   @Input() parent: Dataset;
+
+  @Output() formValidityChange = new EventEmitter<boolean>();
 
   readonly form = this.formBuilder.group({
     refquota: [null as number, this.validators.withMessage(
@@ -56,6 +58,10 @@ export class QuotasSectionComponent implements OnInit {
 
   ngOnInit(): void {
     this.setFormRelations();
+
+    this.form.statusChanges.pipe(untilDestroyed(this)).subscribe((status) => {
+      this.formValidityChange.emit(status === 'VALID');
+    });
   }
 
   getPayload(): Partial<DatasetCreate> {

--- a/src/app/pages/sharing/smb/smb-form/smb-validator.service.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-validator.service.ts
@@ -21,7 +21,7 @@ export class SmbValidationService {
     private translate: TranslateService,
   ) { }
 
-  validate = (originalName: string) => {
+  validate = (originalName?: string) => {
     return (control: AbstractControl<string>): Observable<ValidationErrors | null> => {
       return control.valueChanges.pipe(
         debounceTime(300),


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x c9e63b226d26df4b07cda50280006deffdbd4259
    git cherry-pick -x 940727476b5c0c2eb5aff46bd27afffb30ca0434

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~2
    git cherry-pick -x 54b6031f4d84a863c679533c6b8cda45aae3be9f

Testing:

See ticket, try to create dataset.
You should not be able to submit with invalid name or empty name now.

<img width="812" alt="Screenshot 2024-03-13 at 10 11 49" src="https://github.com/truenas/webui/assets/22980553/ebd51dc8-2b17-477f-9b58-5a1984f64400">


Original PR: https://github.com/truenas/webui/pull/9808
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127720