### PR TITLE
NAS-127836 / 24.04-RC.1 / Add "Netdata" button to reporting section (by william-gr)

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -682,6 +682,7 @@ export interface ApiCallDirectory {
   'reporting.exporters.update': { params: [number, UpdateReportingExporter]; response: ReportingExporter };
   'reporting.netdata_get_data': { params: ReportingQueryParams; response: ReportingData[] };
   'reporting.netdata_graphs': { params: QueryParams<ReportingGraph>; response: ReportingGraph[] };
+  'reporting.netdataweb_generate_password': { params: []; response: string };
 
   // Rsynctask
   'rsynctask.create': { params: [RsyncTaskUpdate]; response: RsyncTask };

--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.html
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.html
@@ -49,4 +49,9 @@
     ixTest="exporters-nav"
     [routerLink]="['/reportsdashboard','exporters']"
   >{{ 'Exporters' | translate }}</button>
+  <button
+    mat-button
+    ixTest="netdata-nav"
+    (click)="openNetdata()"
+  >{{ 'Netdata' | translate }}</button>
 </form>

--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.spec.ts
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.spec.ts
@@ -1,0 +1,69 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { mockProvider, Spectator, createComponentFactory } from '@ngneat/spectator/jest';
+import { provideMockStore } from '@ngrx/store/testing';
+import { of } from 'rxjs';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
+import { Preferences } from 'app/interfaces/preferences.interface';
+import { IxDynamicFormModule } from 'app/modules/ix-dynamic-form/ix-dynamic-form.module';
+import { IxFormsModule } from 'app/modules/ix-forms/ix-forms.module';
+import { FormErrorHandlerService } from 'app/modules/ix-forms/services/form-error-handler.service';
+import { ReportsGlobalControlsComponent } from 'app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component';
+import { ReportTab, ReportType } from 'app/pages/reports-dashboard/interfaces/report-tab.interface';
+import { ReportsService } from 'app/pages/reports-dashboard/reports.service';
+import { WebSocketService } from 'app/services/ws.service';
+import { selectPreferences } from 'app/store/preferences/preferences.selectors';
+
+describe('ReportsGlobalControlsComponent', () => {
+  let spectator: Spectator<ReportsGlobalControlsComponent>;
+  let loader: HarnessLoader;
+
+  const createComponent = createComponentFactory({
+    component: ReportsGlobalControlsComponent,
+    imports: [
+      IxFormsModule,
+      IxDynamicFormModule,
+      ReactiveFormsModule,
+    ],
+    providers: [
+      mockWebsocket([
+        mockCall('disk.query', []),
+        mockCall('disk.temperatures'),
+        mockCall('reporting.netdataweb_generate_password'),
+        mockCall('reporting.netdata_graphs', []),
+      ]),
+      mockAuth(),
+      mockProvider(FormErrorHandlerService),
+      mockProvider(ReportsService, {
+        getReportTabs: () => ([({ value: ReportType.System, label: 'system' } as ReportTab)] as ReportTab[]),
+        getReportGraphs: () => of([]),
+      }),
+      provideMockStore({
+        selectors: [
+          {
+            selector: selectPreferences,
+            value: {
+              autoRefreshReports: false,
+            } as Preferences,
+          },
+        ],
+      }),
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createComponent();
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+  });
+
+  it('click netdata button', async () => {
+    const netdataButton = await loader.getHarness(MatButtonHarness.with({ text: 'Netdata' }));
+
+    await netdataButton.click();
+
+    expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith('reporting.netdataweb_generate_password', []);
+  });
+});

--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.spec.ts
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.spec.ts
@@ -2,6 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { ActivatedRoute } from '@angular/router';
 import { mockProvider, Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
@@ -36,6 +37,11 @@ describe('ReportsGlobalControlsComponent', () => {
         mockCall('reporting.netdata_graphs', []),
       ]),
       mockAuth(),
+      mockProvider(ActivatedRoute, {
+        routeConfig: {
+          path: 'system',
+        },
+      }),
       mockProvider(FormErrorHandlerService),
       mockProvider(ReportsService, {
         getReportTabs: () => ([({ value: ReportType.System, label: 'system' } as ReportTab)] as ReportTab[]),

--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
@@ -10,6 +10,7 @@ import { Store } from '@ngrx/store';
 import { take } from 'rxjs';
 import { ReportTab, ReportType } from 'app/pages/reports-dashboard/interfaces/report-tab.interface';
 import { ReportsService } from 'app/pages/reports-dashboard/reports.service';
+import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
 import { autoRefreshReportsToggled } from 'app/store/preferences/preferences.actions';
 import { waitForPreferences } from 'app/store/preferences/preferences.selectors';
@@ -41,6 +42,7 @@ export class ReportsGlobalControlsComponent implements OnInit {
     private store$: Store<AppState>,
     private reportsService: ReportsService,
     private cdr: ChangeDetectorRef,
+    private ws: WebSocketService,
   ) {}
 
   ngOnInit(): void {
@@ -101,5 +103,14 @@ export class ReportsGlobalControlsComponent implements OnInit {
         this.store$.dispatch(autoRefreshReportsToggled());
       });
     });
+  }
+
+  openNetdata(): void {
+    // TODO: error handling
+    this.ws.call('reporting.netdataweb_generate_password', [])
+      .pipe(untilDestroyed(this))
+      .subscribe((password) => {
+        this.reportsService.openNetdata(password);
+      });
   }
 }

--- a/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
+++ b/src/app/pages/reports-dashboard/components/reports-global-controls/reports-global-controls.component.ts
@@ -8,8 +8,10 @@ import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { take } from 'rxjs';
+import { AppLoaderService } from 'app/modules/loader/app-loader.service';
 import { ReportTab, ReportType } from 'app/pages/reports-dashboard/interfaces/report-tab.interface';
 import { ReportsService } from 'app/pages/reports-dashboard/reports.service';
+import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
 import { autoRefreshReportsToggled } from 'app/store/preferences/preferences.actions';
@@ -40,6 +42,8 @@ export class ReportsGlobalControlsComponent implements OnInit {
     private fb: FormBuilder,
     private route: ActivatedRoute,
     private store$: Store<AppState>,
+    private loader: AppLoaderService,
+    private errorHandler: ErrorHandlerService,
     private reportsService: ReportsService,
     private cdr: ChangeDetectorRef,
     private ws: WebSocketService,
@@ -106,9 +110,12 @@ export class ReportsGlobalControlsComponent implements OnInit {
   }
 
   openNetdata(): void {
-    // TODO: error handling
     this.ws.call('reporting.netdataweb_generate_password', [])
-      .pipe(untilDestroyed(this))
+      .pipe(
+        this.loader.withLoader(),
+        this.errorHandler.catchError(),
+        untilDestroyed(this),
+      )
       .subscribe((password) => {
         this.reportsService.openNetdata(password);
       });

--- a/src/app/pages/reports-dashboard/reports.service.ts
+++ b/src/app/pages/reports-dashboard/reports.service.ts
@@ -1,8 +1,9 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import {
   map, Observable, shareReplay, BehaviorSubject, Subject,
 } from 'rxjs';
 import { ReportingGraphName } from 'app/enums/reporting.enum';
+import { WINDOW } from 'app/helpers/window.helper';
 import { Option } from 'app/interfaces/option.interface';
 import { ReportingGraph } from 'app/interfaces/reporting-graph.interface';
 import { ReportingData } from 'app/interfaces/reporting.interface';
@@ -28,6 +29,7 @@ export class ReportsService {
 
   constructor(
     private ws: WebSocketService,
+    @Inject(WINDOW) private window: Window,
   ) {
     this.ws.call('reporting.netdata_graphs').subscribe((reportingGraphs) => {
       this.hasUps = reportingGraphs.some((graph) => graph.name.startsWith(ReportingGraphName.Ups));
@@ -160,5 +162,17 @@ export class ReportsService {
         return options;
       }),
     );
+  }
+
+  openNetdata(password: string): void {
+    // Thats the only way I could manage to have the browser save the password
+    // to re-use when the new tab is opened.
+    // HttpClient seems to do it through HttpHeaders which won't cache in browser.
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', '/netdata/', true, 'root', password);
+    xhr.addEventListener('load', () => {
+      this.window.open('/netdata/');
+    });
+    xhr.send();
   }
 }

--- a/src/app/pages/reports-dashboard/reports.service.ts
+++ b/src/app/pages/reports-dashboard/reports.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import {
-  map, Observable, shareReplay, BehaviorSubject, Subject,
+  filter, map, Observable, shareReplay, BehaviorSubject, Subject,
 } from 'rxjs';
 import { ReportingGraphName } from 'app/enums/reporting.enum';
 import { WINDOW } from 'app/helpers/window.helper';
@@ -10,6 +10,7 @@ import { ReportingData } from 'app/interfaces/reporting.interface';
 import { ReportTab, reportTypeLabels, ReportType } from 'app/pages/reports-dashboard/interfaces/report-tab.interface';
 import { LegendDataWithStackedTotalHtml, Report } from 'app/pages/reports-dashboard/interfaces/report.interface';
 import { convertAggregations, optimizeLegend } from 'app/pages/reports-dashboard/utils/report.utils';
+import { AuthService } from 'app/services/auth/auth.service';
 import { WebSocketService } from 'app/services/ws.service';
 
 @Injectable({
@@ -26,8 +27,10 @@ export class ReportsService {
 
   private legendEventEmitter$ = new Subject<LegendDataWithStackedTotalHtml>();
   readonly legendEventEmitterObs$ = this.legendEventEmitter$.asObservable();
+  private loggedInUser$ = this.authService.user$.pipe(filter(Boolean));
 
   constructor(
+    private authService: AuthService,
     private ws: WebSocketService,
     @Inject(WINDOW) private window: Window,
   ) {
@@ -169,10 +172,12 @@ export class ReportsService {
     // to re-use when the new tab is opened.
     // HttpClient seems to do it through HttpHeaders which won't cache in browser.
     const xhr = new XMLHttpRequest();
-    xhr.open('GET', '/netdata/', true, 'root', password);
-    xhr.addEventListener('load', () => {
-      this.window.open('/netdata/');
+    this.loggedInUser$.subscribe((user) => {
+      xhr.open('GET', '/netdata/', true, user.pw_name, password);
+      xhr.addEventListener('load', () => {
+        this.window.open('/netdata/');
+      });
+      xhr.send();
     });
-    xhr.send();
   }
 }

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2131,6 +2131,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface Read": "",
   "Network Interface Write": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1753,6 +1753,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface Read": "",
   "Network Interface Write": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -939,6 +939,7 @@
   "NetBIOS Name of this NAS. This name must differ from the <i>Workgroup</i> name and be no greater than 15 characters.": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface Read": "",
   "Network Interface Write": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2253,6 +2253,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface": "",
   "Network Interface Read": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -168,6 +168,7 @@
   "Multiprotocol": "",
   "NFS Sessions": "",
   "NFSv4 DNS Domain": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface Read": "",
   "Network Interface Write": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2201,6 +2201,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2073,6 +2073,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface": "",
   "Network Interface Read": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1916,6 +1916,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2415,6 +2415,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -38,6 +38,7 @@
   "Maximum time a graph is stored in months (allowed values are 1-60).  Changing this value causes the <i>Confirm RRD Destroy</i>  dialog to appear. Changes do not take effect until the existing  reporting database is destroyed.": "",
   "Missing group - {gid}": "",
   "NFSv4 DNS Domain": "",
+  "Netdata": "",
   "No S.M.A.R.T. test results": "",
   "No S.M.A.R.T. tests have been performed on this disk yet.": "",
   "No SMB Shares have been configured yet": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2359,6 +2359,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2357,6 +2357,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1230,6 +1230,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface Read": "",
   "Network Interface Write": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1263,6 +1263,7 @@
   "Nameservers": "",
   "NetBIOS": "",
   "NetBIOS Name of this NAS. This name must differ from the <i>Workgroup</i> name and be no greater than 15 characters.": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface Read": "",
   "Network Interface Write": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -416,6 +416,7 @@
   "NFSv4 DNS Domain": "",
   "Name not added": "",
   "NetBIOS Name of this NAS. This name must differ from the <i>Workgroup</i> name and be no greater than 15 characters.": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface Read": "",
   "Network Interface Write": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2421,6 +2421,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network": "",
   "Network General Read": "",
   "Network Interface": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -394,6 +394,7 @@
   "NFSv4 DNS Domain": "",
   "Name not added": "",
   "NetBIOS Name of this NAS. This name must differ from the <i>Workgroup</i> name and be no greater than 15 characters.": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface Read": "",
   "Network Interface Write": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1875,6 +1875,7 @@
   "Netcat Active Side Listen Address": "",
   "Netcat Active Side Max Port": "",
   "Netcat Active Side Min Port": "",
+  "Netdata": "",
   "Network General Read": "",
   "Network Interface Read": "",
   "Network Interface Write": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 307e3d4e85649b510ccc0a6f9754b122fff0a92a
    git cherry-pick -x a87f32cea0065880305ca9ddb0a62d8af8987acd
    git cherry-pick -x 4daceb0d33557670b8fd2c4091997d6098bca6bc
    git cherry-pick -x fe30c8d5446bd92b40de20be262d85f037a4613c

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 163ff5b9ce18c0224526d2dce6f254e965f8fda4

This button will make a WS call to generate a password and make a request to /netdata/ for the browser to cache the credentials. Once that is done a new tab will be opened with netdata.

Original PR: https://github.com/truenas/webui/pull/9816
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127836