### PR TITLE
NAS-127701 / 24.04.0 / Fix SysInfo widget on failover reconnect (by denysbutenko)

### DIFF
--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.html
@@ -128,7 +128,7 @@
                   <div *ngIf="productImage && isHaLicensed && isPassive && hasHa" class="ha-node-status">
                     ({{ 'Standby' | translate }})
                   </div>
-                  <div *ngIf="ready && !productImage && sysGenService.isEnterprise && hasHa" class="ha-node-status">
+                  <div *ngIf="ready && !productImage && sysGenService.isEnterprise && !isIxHardware" class="ha-node-status">
                     ({{ 'Unsupported Hardware' | translate }})
                   </div>
                 </div>
@@ -162,7 +162,7 @@
             <!-- Details Section -->
             <div class="right" fxFlex.xs fxFlex.gt-xs="60" fxLayout="column">
               <div
-                *ngIf="!systemInfo && isHaLicensed && isPassive && hasHa"
+                *ngIf="ready && !systemInfo && isHaLicensed && isPassive && hasHa"
                 class="data-container ha-status"
                 fxFlex
               >
@@ -172,7 +172,7 @@
               </div>
 
               <div
-                *ngIf="!systemInfo && isHaLicensed && isPassive && !hasHa"
+                *ngIf="ready && !systemInfo && isHaLicensed && isPassive && !hasHa"
                 class="data-container ha-status"
                 fxFlex
               >
@@ -181,7 +181,7 @@
                 </h3>
               </div>
 
-              <div *ngIf="!systemInfo && !isHaLicensed" class="loader">
+              <div *ngIf="!ready && !systemInfo" class="loader">
                 <mat-spinner class="spinner" [diameter]="40"></mat-spinner>
               </div>
 

--- a/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.spec.ts
+++ b/src/app/pages/dashboard/components/widget-sys-info/widget-sys-info.component.spec.ts
@@ -1,0 +1,219 @@
+import { HarnessLoader, parallel } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { fakeAsync } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { MatListItemHarness } from '@angular/material/list/testing';
+import { Router } from '@angular/router';
+import { Spectator } from '@ngneat/spectator';
+import { createHostFactory, mockProvider } from '@ngneat/spectator/jest';
+import { provideMockStore } from '@ngrx/store/testing';
+import { MockComponent } from 'ng-mocks';
+import { ImgFallbackModule } from 'ngx-img-fallback';
+import { of } from 'rxjs';
+import { DragHandleComponent } from 'app/core/components/drag-handle/drag-handle.component';
+import { FakeFormatDateTimePipe } from 'app/core/testing/classes/fake-format-datetime.pipe';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { mockCall, mockWebsocket } from 'app/core/testing/utils/mock-websocket.utils';
+import { Codename } from 'app/enums/codename.enum';
+import { ProductType } from 'app/enums/product-type.enum';
+import { SystemUpdateStatus } from 'app/enums/system-update.enum';
+import { SystemInfo, SystemLicense } from 'app/interfaces/system-info.interface';
+import { SystemUpdate } from 'app/interfaces/system-update.interface';
+import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
+import { SimpleFailoverBtnComponent } from 'app/pages/dashboard/components/widget-sys-info/simple-failover-btn.component';
+import { WidgetSysInfoComponent } from 'app/pages/dashboard/components/widget-sys-info/widget-sys-info.component';
+import { DialogService } from 'app/services/dialog.service';
+import { SystemGeneralService } from 'app/services/system-general.service';
+import { selectHaStatus, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
+import { PreferencesState } from 'app/store/preferences/preferences.reducer';
+import { selectPreferencesState } from 'app/store/preferences/preferences.selectors';
+import { selectSystemInfo, selectSystemFeatures, selectIsIxHardware } from 'app/store/system-info/system-info.selectors';
+
+describe('WidgetSysInfoComponent', () => {
+  let spectator: Spectator<WidgetSysInfoComponent>;
+  let loader: HarnessLoader;
+
+  const systemInfo = {
+    platform: 'TRUENAS-TEST-HA',
+    version: 'TrueNAS-SCALE-24.10.0-MASTER-20240301-233006',
+    codename: Codename.ElectricEel,
+    license: {
+      contract_type: 'BEST',
+      contract_end: {
+        $type: 'date',
+        $value: '2025-01-01',
+      },
+    } as SystemLicense,
+    system_serial: 'AA-00001',
+    hostname: 'test-hostname-a',
+    uptime_seconds: 83532.938532175,
+    datetime: {
+      $date: 1710491651000,
+    },
+    remote_info: {
+      platform: 'TRUENAS-TEST-HA',
+      version: 'TrueNAS-SCALE-24.10.0-MASTER-20240301-233006',
+      codename: Codename.ElectricEel,
+      license: {
+        contract_type: 'BEST',
+        contract_end: {
+          $type: 'date',
+          $value: '2025-01-01',
+        },
+      } as SystemLicense,
+      system_serial: 'AA-00002',
+      hostname: 'test-hostname-b',
+      uptime_seconds: 77.915545062,
+      datetime: {
+        $date: 1710491651000,
+      },
+    } as SystemInfo,
+  } as SystemInfo;
+
+  const createHost = createHostFactory({
+    component: WidgetSysInfoComponent,
+    imports: [
+      MatGridListModule,
+      ImgFallbackModule,
+    ],
+    declarations: [
+      MockComponent(DragHandleComponent),
+      MockComponent(SimpleFailoverBtnComponent),
+      MockComponent(IxIconComponent),
+      FakeFormatDateTimePipe,
+    ],
+    providers: [
+      mockAuth(),
+      mockWebsocket([
+        mockCall('webui.main.dashboard.sys_info', systemInfo),
+        mockCall('update.check_available', { status: SystemUpdateStatus.Unavailable } as SystemUpdate),
+        mockCall('core.get_jobs'),
+      ]),
+      mockProvider(SystemGeneralService, {
+        isEnterprise: () => true,
+        getProductType: () => ProductType.ScaleEnterprise,
+        isEnterprise$: of(true),
+        updateRunning: of(false),
+      }),
+      provideMockStore({
+        selectors: [
+          {
+            selector: selectPreferencesState,
+            value: {
+              areLoaded: true,
+              preferences: {
+                timeFormat: 'timeFormat',
+              },
+              dashboardState: [],
+            } as PreferencesState,
+          },
+          {
+            selector: selectSystemInfo,
+            value: {
+              cores: 6,
+            } as SystemInfo,
+          },
+          {
+            selector: selectSystemFeatures,
+            value: {
+              enclosure: true,
+            },
+          },
+          {
+            selector: selectIsHaLicensed,
+            value: false,
+          },
+          {
+            selector: selectIsIxHardware,
+            value: true,
+          },
+          {
+            selector: selectHaStatus,
+            value: { hasHa: true },
+          },
+        ],
+      }),
+    ],
+  });
+
+  function setupTest(isPassive = false): void {
+    spectator = createHost('<ix-widget-sysinfo></ix-widget-sysinfo>', {
+      props: { isPassive },
+    });
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+  }
+
+  describe('check active mode', () => {
+    beforeEach(() => {
+      setupTest(false);
+    });
+
+    it('checks title', () => {
+      expect(spectator.query('.card-title-text')).toHaveText('System Information');
+    });
+
+    it('checks system info rows', fakeAsync(async () => {
+      spectator.tick(1000);
+
+      const matListItems = await loader.getAllHarnesses(MatListItemHarness);
+      const items = await parallel(() => matListItems.map((item) => item.getFullText()));
+      expect(items).toEqual([
+        'Platform: TRUENAS-TEST-HA',
+        'Version:ElectricEel-24.10.0-MASTER-20240301-233006',
+        'License: Best contract, expires 2025-01-01',
+        'System Serial:AA-00001',
+        'Hostname:test-hostname-a',
+        'Uptime:23 hours 12 minutes 12 seconds as of 2024-03-15 10:34:11',
+      ]);
+    }));
+
+    it.skip('checks update button label', fakeAsync(async () => {
+      const router = spectator.inject(Router);
+      jest.spyOn(router, 'navigate').mockResolvedValue(true);
+      spectator.tick(1000);
+
+      const updateButton = await loader.getHarness(MatButtonHarness.with({ text: 'Check for Updates' }));
+      await updateButton.click();
+
+      expect(router.navigate).toHaveBeenCalledWith(['/system', 'update']);
+    }));
+
+    // TODO: Add more tests for active mode
+  });
+
+  describe('check standby mode', () => {
+    beforeEach(() => {
+      setupTest(true);
+    });
+
+    it('checks title', () => {
+      expect(spectator.query('.card-title-text')).toHaveText('System Information Standby');
+    });
+
+    it('checks system info rows', fakeAsync(async () => {
+      jest.resetAllMocks();
+      spectator.tick(1000);
+
+      const matListItems = await loader.getAllHarnesses(MatListItemHarness);
+      const items = await parallel(() => matListItems.map((item) => item.getFullText()));
+      expect(items).toEqual([
+        'Platform: TRUENAS-TEST-HA',
+        'Version:ElectricEel-24.10.0-MASTER-20240301-233006',
+        'License: Best contract, expires 2025-01-01',
+        'System Serial:AA-00002',
+        'Hostname:test-hostname-b',
+        'Uptime:1 minute 17 seconds',
+      ]);
+    }));
+
+    it.skip('checks initiate failover button', async () => {
+      const failoverButton = await loader.getHarness(MatButtonHarness.with({ text: 'Initiate Failover' }));
+      await failoverButton.click();
+
+      expect(spectator.inject(DialogService).confirm).toHaveBeenCalled();
+    });
+
+    // TODO: Add more tests standby mode
+  });
+});


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x a09dc4aacef6cdfaa8a7b65319b18535277dc5ae
    git cherry-pick -x 8fd97558c9e009039514fd0e0e858fa761e2341a
    git cherry-pick -x bbcb24f8bfaafe573109463a4f616306006009fc
    git cherry-pick -x f18081f276f254b4c72f31f4dba798ab677bcfea

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x aadf819cbc43adf615a4cb22035c9a693e646874

Changes:
- Fixed condition for `Unsupported Hardware`
- Added listener for failover reconnect to update system info data.
- ~Cleaned up unused code.~

For testing, it is best to use the HA system from CI. Check the ticket for bug details.

Original PR: https://github.com/truenas/webui/pull/9819
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127701