### PR TITLE
NAS-127829 / 24.04.0 / Disks are displayed in a random order on the Disk I/O Reporting Page

### DIFF
--- a/src/app/pages/reports-dashboard/reports-dashboard.component.ts
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.ts
@@ -190,7 +190,7 @@ export class ReportsDashboardComponent implements OnInit, OnDestroy {
       }
     });
 
-    return result;
+    return result.sort((a, b) => a.identifiers?.[0]?.localeCompare(b.identifiers?.[0]));
   }
 
   buildDiskMetrics(): void {

--- a/src/app/pages/reports-dashboard/reports.service.ts
+++ b/src/app/pages/reports-dashboard/reports.service.ts
@@ -147,7 +147,8 @@ export class ReportsService {
           .map((disk) => {
             const [value] = disk.devname.split(' ');
             return { label: disk.devname, value };
-          });
+          })
+          .sort((a, b) => a.label.localeCompare(b.label));
       }),
       shareReplay({ refCount: true, bufferSize: 1 }),
     );


### PR DESCRIPTION
Testing: see ticket.

Sorting is now in alphabetical order:
<img width="1728" alt="Screenshot 2024-03-20 at 12 05 15" src="https://github.com/truenas/webui/assets/22980553/c8084114-bae6-44cc-bea3-98520fd51ca3">
