### PR TITLE
NAS-127603 / 24.04.0 / Added remove button for Spares for RaidZ pool

### DIFF
--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/zfs-info-card.component.ts
@@ -75,7 +75,8 @@ export class ZfsInfoCardComponent {
     && !this.isRaidzParent
     && (!this.hasTopLevelRaidz
     || this.topologyCategory === VdevType.Cache
-    || this.topologyCategory === VdevType.Log);
+    || this.topologyCategory === VdevType.Log
+    || this.topologyCategory === VdevType.Spare);
   }
 
   get canRemoveVDEV(): boolean {


### PR DESCRIPTION
Create a RaidZ pool with disks alocated for spare vdevs. You should be able to see the "Remove" button for the Spare disks.