### PR TITLE
NAS-127920 / 24.10 / Fix tree node padding on Devices & Boot Status pages

### DIFF
--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.html
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.html
@@ -49,7 +49,6 @@
         >
           <ix-tree-node
             *treeNodeDef="let topologyItem; dataSource: dataSource"
-            treeNodeToggle
             routerLinkActive="selected"
             [treeNodeDefDataSource]="dataSource"
             [class.selected]="topologyItem.guid === selectedNode?.guid"
@@ -57,7 +56,7 @@
             (click)="viewDetails(poolId, topologyItem.guid)"
             (keydown.enter)="viewDetails(poolId, topologyItem.guid)"
           >
-            <span class="spacer"></span>
+            <span class="spacer" treeNodeToggle></span>
             <ix-topology-item-node
               [topologyItem]="topologyItem | cast"
               [disk]="getDisk(topologyItem)"

--- a/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.html
+++ b/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.html
@@ -47,10 +47,9 @@
     >
       <ix-tree-node
         *treeNodeDef="let topologyItem; dataSource: dataSource"
-        treeNodeToggle
         [treeNodeDefDataSource]="dataSource"
       >
-        <span class="spacer"></span>
+        <span class="spacer" treeNodeToggle></span>
         <ix-bootenv-node-item
           [node]="topologyItem"
           [poolInstance]="poolInstance"


### PR DESCRIPTION
To test, open the Devices and Boot Status pages. Ensure tree node takes full width.

Expected no left offset outside of tree node.
![image](https://github.com/truenas/webui/assets/351613/b7efe3d4-ddf3-4afc-bafd-60cd15b95e72)

Actual:
![image](https://github.com/truenas/webui/assets/351613/c3b1ffe1-0377-48c1-8a55-081a019f8c9f)


