### PR TITLE
NAS-127798 / 24.04.0 / Unable to save "Enable S.M.A.R.T." settings in Storage > Edit Disk page

### DIFF
--- a/src/app/pages/storage/modules/disks/components/disk-list/disk-list.component.ts
+++ b/src/app/pages/storage/modules/disks/components/disk-list/disk-list.component.ts
@@ -227,15 +227,6 @@ export class DiskListComponent implements EntityTableConfig<Disk>, OnDestroy {
     });
     this.diskUpdateSubscriptionId = this.disksUpdate.addSubscriber(disksUpdateTrigger$);
     this.entityList = entityList;
-
-    this.entityList.dataSource$.pipe(untilDestroyed(this)).subscribe((data) => {
-      this.entityList.dataSource.data = data.map((item) => {
-        return {
-          ...item,
-          togglesmart: this.yesNoPipe.transform(item.togglesmart) as unknown as boolean,
-        };
-      });
-    });
   }
 
   resourceTransformIncomingRestData(disks: Disk[]): Disk[] {
@@ -243,7 +234,6 @@ export class DiskListComponent implements EntityTableConfig<Disk>, OnDestroy {
       ...disk,
       pool: this.getPoolColumn(disk),
       readable_size: buildNormalizedFileSize(disk.size),
-      togglesmart: this.yesNoPipe.transform(disk.togglesmart) as unknown as boolean,
     }));
   }
 


### PR DESCRIPTION
Only exists on dragonfish, I assume it was somehow accidentally backported to dragonfish. 
(on Dragonfish table details row - we show true/false for all of the tables instead of Yes/No as on Electric Eel)