### PR TITLE
NAS-127882 / 24.10 / Fix GPU endpoint usage

### DIFF
--- a/src/app/interfaces/advanced-config.interface.ts
+++ b/src/app/interfaces/advanced-config.interface.ts
@@ -35,4 +35,4 @@ export interface AdvancedConfig {
   legacy_ui?: boolean;
 }
 
-export type AdvancedConfigUpdate = Omit<AdvancedConfig, 'id'>;
+export type AdvancedConfigUpdate = Omit<AdvancedConfig, 'id' | 'isolated_gpu_pci_ids'>;


### PR DESCRIPTION
**Summary**

The middleware team have just updated the API endpoints, as described below

> Removed ability to update isolated GPU config from system.advanced.update
>
> Additionally, a separate endpoint system.advanced.update_gpu_pci_ids already exists to configure and validate isolated GPUs.

**Testing**

No functional changes, code review should be enough.

_Explanation:_ All existing calls to `system.advanced.update` in the project do not attempt to change the `isolated_gpu_pci_ids` field