### PR TITLE
NAS-127423 / 24.04.0 / Fix login prompt after failover processed (by denysbutenko)

### DIFF
--- a/src/app/interfaces/api/api-event-directory.interface.ts
+++ b/src/app/interfaces/api/api-event-directory.interface.ts
@@ -24,7 +24,7 @@ export interface ApiEventDirectory {
   'chart.release.statistics': { response: { id: string; stats: ChartReleaseStats } };
   'core.get_jobs': { response: Job };
   'directoryservices.status': { response: DirectoryServicesState };
-  'failover.status': { response: FailoverStatus };
+  'failover.status': { response: { status: FailoverStatus } };
   'failover.disabled.reasons': { response: FailoverDisabledReasonEvent };
   'service.query': { response: Service };
   'truecommand.config': { response: TrueCommandConfig };

--- a/src/app/views/sessions/signin/store/signin.store.spec.ts
+++ b/src/app/views/sessions/signin/store/signin.store.spec.ts
@@ -179,7 +179,7 @@ describe('SigninStore', () => {
           return of();
         }
 
-        return of({ fields: FailoverStatus.Importing } as ApiEvent<FailoverStatus>);
+        return of({ fields: { status: FailoverStatus.Importing } } as ApiEvent<{ status: FailoverStatus }>);
       });
 
       spectator.service.init();


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x f8c0e082e617701ed25044e393e9cac8cfb50f55

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x a44d5578afea2f2dc8d61b4a664e8fa260e44339

For testing, ensure the `username` and `password` fields appear after failover is completed. Use m40 and try to initiate failover.

Examples of how it was and what to expect:

![image](https://github.com/truenas/webui/assets/351613/269265db-33b6-4faf-a772-c920dfc8c748)
![image](https://github.com/truenas/webui/assets/351613/586b7d80-acfc-49f1-a891-2399878507db)


Original PR: https://github.com/truenas/webui/pull/9882
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127423