### PR TITLE
NAS-128052 / 24.04.0 / Dragonfish Empty Datasets & Empty Pools - `Create Pool` button is not disabled for Readonly User

### DIFF
--- a/src/app/modules/entity/entity-empty/entity-empty.component.scss
+++ b/src/app/modules/entity/entity-empty/entity-empty.component.scss
@@ -1,3 +1,9 @@
+:host ::ng-deep {
+  ix-missing-access-wrapper {
+    width: 100%;
+  }
+}
+
 :host {
   height: 100%;
   padding: 15px;

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
@@ -6,7 +6,7 @@
   fxLayoutAlign="center center"
   fxLayoutGap="32px"
 >
-  <ix-entity-empty [conf]="entityEmptyConf"></ix-entity-empty>
+  <ix-entity-empty [conf]="entityEmptyConf" [requiredRoles]="requiredRoles"></ix-entity-empty>
 </div>
 
 <ng-template #datasetContainer>

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -34,6 +34,7 @@ import {
   switchMap,
 } from 'rxjs/operators';
 import { EmptyType } from 'app/enums/empty-type.enum';
+import { Role } from 'app/enums/role.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { DatasetDetails } from 'app/interfaces/dataset.interface';
 import { EmptyConfig } from 'app/interfaces/empty-config.interface';
@@ -58,6 +59,7 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
   @ViewChild('ixTreeHeader', { static: false }) ixTreeHeader: ElementRef<HTMLElement>;
   @ViewChild('ixTree', { static: false }) ixTree: ElementRef<HTMLElement>;
 
+  readonly requiredRoles = [Role.FullAdmin];
   isLoading$ = this.datasetStore.isLoading$;
   selectedDataset$ = this.datasetStore.selectedDataset$;
   @HostBinding('class.details-overlay') showMobileDetails = false;

--- a/src/app/pages/storage/components/pools-dashboard/pools-dashboard.component.html
+++ b/src/app/pages/storage/components/pools-dashboard/pools-dashboard.component.html
@@ -36,7 +36,7 @@
     fxLayoutAlign="center center"
     fxLayoutGap="32px"
   >
-    <ix-entity-empty [conf]="entityEmptyConf"></ix-entity-empty>
+    <ix-entity-empty [conf]="entityEmptyConf" [requiredRoles]="requiredRoles"></ix-entity-empty>
   </div>
 </ng-container>
 


### PR DESCRIPTION
Results:
<img width="514" alt="Screenshot 2024-03-27 at 11 08 34" src="https://github.com/truenas/webui/assets/22980553/5ffda705-3d36-423a-b1ff-1014139e45c2">
<img width="412" alt="Screenshot 2024-03-27 at 11 08 38" src="https://github.com/truenas/webui/assets/22980553/a7ad1d32-1a42-4cb0-ace1-fec9125104d4">
