### PR TITLE
NAS-127966 / 24.10 / Doing actions colapses the Dataset Tree

### DIFF
--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -21,7 +21,6 @@ import {
   ActivatedRoute, NavigationStart, Router,
 } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { ResizedEvent } from 'angular-resize-event';
 import { uniqBy } from 'lodash';
@@ -46,7 +45,6 @@ import { DatasetTreeStore } from 'app/pages/datasets/store/dataset-store.service
 import { datasetNameSortComparer } from 'app/pages/datasets/utils/dataset.utils';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { WebSocketService } from 'app/services/ws.service';
-import { AppState } from 'app/store';
 
 @UntilDestroy()
 @Component({
@@ -91,6 +89,7 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
   treeControl = new FlatTreeControl<DatasetDetails>(
     this.getLevel,
     this.isExpandable,
+    { trackBy: (dataset: DatasetDetails) => dataset.id as unknown as DatasetDetails },
   );
   treeFlattener = new TreeFlattener<DatasetDetails, DatasetDetails>(
     (dataset) => dataset,
@@ -112,7 +111,6 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
     private errorHandler: ErrorHandlerService,
     private dialogService: DialogService,
     private breakpointObserver: BreakpointObserver,
-    private store$: Store<AppState>,
     @Inject(WINDOW) private window: Window,
   ) {
     this.router.events


### PR DESCRIPTION
Testing: see ticket. When we do some update - opened datasets shall not collapse.

Result: 

https://github.com/truenas/webui/assets/22980553/e927c232-510e-491d-9a7d-d465bfa28e39


