### PR TITLE
NAS-128046 / 24.10 / Fix `include` field

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.spec.ts
@@ -170,6 +170,7 @@ describe('CloudSyncFormComponent', () => {
         enabled: true,
         encryption: false,
         exclude: [],
+        include: [],
         follow_symlinks: false,
         path: mntPath,
         post_script: '',

--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -610,7 +610,7 @@ export class CloudSyncFormComponent implements OnInit {
     const value: CloudSyncTaskUpdate = {
       ...formValue,
       attributes,
-      include: undefined,
+      include: [],
       path: undefined,
       bwlimit: formValue.bwlimit ? this.prepareBwlimit(formValue.bwlimit) : undefined,
       schedule: formValue.cloudsync_picker ? crontabToSchedule(formValue.cloudsync_picker) : {},


### PR DESCRIPTION
**Testing**

On **Data Protection** page, at **Cloud Sync Tasks** block

User views existing task, then makes a change, save, and then open again

**Expected result:**

User should be able to edit source and save changes