### PR TITLE
NAS-127966 / 24.04.0 / Doing actions colapses the Dataset Tree (by AlexKarpov98)

### DIFF
--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -21,7 +21,6 @@ import {
   ActivatedRoute, NavigationStart, Router,
 } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { ResizedEvent } from 'angular-resize-event';
 import { uniqBy } from 'lodash';
@@ -47,7 +46,6 @@ import { datasetNameSortComparer } from 'app/pages/datasets/utils/dataset.utils'
 import { DialogService } from 'app/services/dialog.service';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { WebSocketService } from 'app/services/ws.service';
-import { AppState } from 'app/store';
 
 @UntilDestroy()
 @Component({
@@ -93,6 +91,7 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
   treeControl = new FlatTreeControl<DatasetDetails>(
     this.getLevel,
     this.isExpandable,
+    { trackBy: (dataset: DatasetDetails) => dataset.id as unknown as DatasetDetails },
   );
   treeFlattener = new TreeFlattener<DatasetDetails, DatasetDetails>(
     (dataset) => dataset,
@@ -114,7 +113,6 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
     private errorHandler: ErrorHandlerService,
     private dialogService: DialogService,
     private breakpointObserver: BreakpointObserver,
-    private store$: Store<AppState>,
     @Inject(WINDOW) private window: Window,
   ) {
     this.router.events


### PR DESCRIPTION
Testing: see ticket. When we do some update - opened datasets shall not collapse.

Result: 

https://github.com/truenas/webui/assets/22980553/e927c232-510e-491d-9a7d-d465bfa28e39




Original PR: https://github.com/truenas/webui/pull/9893
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127966