### PR TITLE
Don't force-capitalize every word on button labels

### DIFF
--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -247,7 +247,6 @@ ix-tooltip button {
 .mat-flat-button {
   border-radius: 0 !important;
   font-weight: 400 !important;
-  text-transform: capitalize !important;
 
   &:focus-visible {
     outline: 1.5px solid var(--alt-fg2) !important;

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -709,7 +709,6 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
     @include variable(font-family, --font-family-body, $font-family-body, !important);
     background: var(--btn-default-bg);
     font-weight: 700 !important;
-    text-transform: capitalize !important;
   }
 
   .mdc-button--outlined {


### PR DESCRIPTION
While adding some German translations (#9899) I noticed that the labels on all the buttons in the WebUI have the first letter of every single word capitalized due to the use of the CSS filter `text-transform: capitalize`. 

This isn't really grammatically correct, and having every single word on a button capitalized looks weird, in my opinion. At least in German, maybe it's different in english. I'm not sure why the capitalization is even there in the first place (in the CSS) when it might as well be solved by capitalizing these words in the translation files. 

Looking at the english translation file, nearly every button label is already included in the translation file with all words capitalized

With this PR, the CSS for the buttons is changed to remove that auto-capitalization. For the english language this probably won't change anything since all/most of the button labels have every single word capitalized in the i18n file anyways, but it allows other languages to follow proper grammar rules with regards to case-sensitivity and have some words on a button label that aren't capitalized. 

Or am I missing something and there's a good reason why these buttons have CSS that auto-capitalizes every single word?