### PR TITLE
NAS-128046 / 24.04.0 / Fix `include` field (by bvasilenko)

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.spec.ts
@@ -168,6 +168,7 @@ describe('CloudsyncFormComponent', () => {
         enabled: true,
         encryption: false,
         exclude: [],
+        include: [],
         follow_symlinks: false,
         path: mntPath,
         post_script: '',

--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -608,7 +608,7 @@ export class CloudsyncFormComponent implements OnInit {
     const value: CloudSyncTaskUpdate = {
       ...formValue,
       attributes,
-      include: undefined,
+      include: [],
       path: undefined,
       bwlimit: formValue.bwlimit ? this.prepareBwlimit(formValue.bwlimit) : undefined,
       schedule: formValue.cloudsync_picker ? crontabToSchedule(formValue.cloudsync_picker) : {},


### PR DESCRIPTION
**Testing**

On **Data Protection** page, at **Cloud Sync Tasks** block

User views existing task, then makes a change, save, and then open again

**Expected result:**

User should be able to edit source and save changes

Original PR: https://github.com/truenas/webui/pull/9895
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128046