### PR TITLE
NAS-128054 / 24.10 / Add `detailsRowIdentifier` for the snapshot list

### DIFF
--- a/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.html
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.html
@@ -63,7 +63,7 @@
   ></thead>
   <tbody
     ix-table-body
-    detailsRowIdentifier="snapshot_name"
+    detailsRowIdentifier="name"
     [columns]="columns"
     [dataProvider]="dataProvider"
     [isLoading]="isLoading$ | async"

--- a/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.html
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.html
@@ -63,6 +63,7 @@
   ></thead>
   <tbody
     ix-table-body
+    detailsRowIdentifier="snapshot_name"
     [columns]="columns"
     [dataProvider]="dataProvider"
     [isLoading]="isLoading$ | async"


### PR DESCRIPTION
Go to /ui/datasets/snapshots

**Expected result:** user can see the page without any errors, especially with no `Maximum number of concurrent calls (20) has exceeded.` error, which was mentioned in the ticket