### PR TITLE
NAS-126760 / 13.3 / Replace 'SED Password' with 'SED Key'

### DIFF
--- a/src/app/helptext/storage/disks/disks.ts
+++ b/src/app/helptext/storage/disks/disks.ts
@@ -83,9 +83,9 @@ export default {
   disk_form_informational_tooltip: T('Report if drive temperature is at or\
  above this temperature in Celsius. <i>0</i> disables the report.'),
 
-  disk_form_passwd_placeholder: T('SED Password'),
-  disk_form_passwd_tooltip: T('Set or change the password of this SED. \
- This password is used instead of the global SED password.'),
+  disk_form_passwd_placeholder: T('SED Key'),
+  disk_form_passwd_tooltip: T('Set or change the key of this SED. \
+ This key is used instead of the global SED key.'),
 
   bulk_edit: {
     title: T('Disks'),
@@ -103,8 +103,8 @@ export default {
   dialog_error: T('Error updating disks'),
 
   clear_pw: {
-    placeholder: T('Clear SED Password'),
-    tooltip: T('Clear the SED password for this disk.'),
+    placeholder: T('Clear SED Key'),
+    tooltip: T('Clear the SED key for this disk.'),
   },
 
   dw_disk_name_placeholder: T('Name'),

--- a/src/app/helptext/system/advanced.ts
+++ b/src/app/helptext/system/advanced.ts
@@ -99,10 +99,10 @@ simultaneously.'),
   sed_user_tooltip: T('User passed to <i>camcontrol security -u</i> to unlock\
  SEDs'),
 
-  sed_passwd_placeholder: T('SED Password'),
-  sed_passwd_tooltip: T('Global password to unlock SEDs.'),
+  sed_passwd_placeholder: T('SED Key'),
+  sed_passwd_tooltip: T('Global key to unlock SEDs.'),
 
-  sed_passwd2_placeholder: T('Confirm SED Password'),
+  sed_passwd2_placeholder: T('Confirm SED Key'),
   sed_passwd2_tooltip: T(''),
 
   swapondrive_warning: T('A swap size of 0 is STRONGLY DISCOURAGED.'),

--- a/src/app/helptext/system/kmip.ts
+++ b/src/app/helptext/system/kmip.ts
@@ -31,11 +31,11 @@ export const helptext_system_kmip = {
   },
 
   manage_sed_disks: {
-    placeholder: T('Manage SED Passwords'),
+    placeholder: T('Manage SED Keys'),
     tooltip: T('Self-Encrypting Drive (SED) passwords can be managed with KMIP. Enabling this\
- option allows the key server to manage creating or updating the global SED password, creating or\
- updating individual SED passwords, and retrieving SED passwords when SEDs are unlocked. Disabling\
- this option leaves SED password management with the local system.'),
+ option allows the key server to manage creating or updating the global SED key, creating or\
+ updating individual SED keys, and retrieving SED keys when SEDs are unlocked. Disabling\
+ this option leaves SED key management with the local system.'),
   },
 
   manage_zfs_keys: {


### PR DESCRIPTION
There is no concrete way to stop password manager extensions like Bitwarden from forcefully filling in a field that has any mention of a "password". Setting autocomplete off or other solutions from scale don't work. On scale this problem doesn't exist because we handle forms completely differently from core (slide-ins instead of full-page forms).