### PR TITLE
NAS-127926 / 24.04.0 / Apps/UI - "Install" button remains disabled even if the form does not have validation errors (Only when selecting non-default version) (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.spec.ts
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.spec.ts
@@ -553,6 +553,7 @@ describe('ChartWizardComponent', () => {
       });
 
       const values = await form.getValues();
+      expect(spectator.component.chartSchema.groups).toEqual(appVersion120.schema.groups);
 
       expect(values).toEqual({
         'Application Name': 'ipfs',

--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.ts
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.ts
@@ -435,9 +435,14 @@ export class ChartWizardComponent implements OnInit, OnDestroy {
   }
 
   private buildDynamicForm(schema: ChartSchema['schema']): void {
+    if (this.chartSchema?.questions) {
+      this.chartSchema.questions.forEach((question) => this.form.removeControl(question.variable));
+    }
+
     this.dynamicSection = [];
     this.dynamicSection.push(...this.rootDynamicSection);
     this.chartSchema = schema;
+
     try {
       schema.groups.forEach((group) => {
         this.dynamicSection.push({ ...group, help: group.description, schema: [] });


### PR DESCRIPTION
Testing: see ticket. 
There was a problem with remaining controls which're not relevant to the selected version.

Result:

https://github.com/truenas/webui/assets/22980553/0ba26b4b-e509-4650-b0ef-d35c1061475f



Original PR: https://github.com/truenas/webui/pull/9897
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127926