### PR TITLE
NAS-127948 / 24.10 / Dragonfish: Restore Snapshot dialog rendering not consistent with other dialogs

### DIFF
--- a/src/app/pages/datasets/modules/snapshots/snapshot-rollback-dialog/snapshot-rollback-dialog.component.html
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-rollback-dialog/snapshot-rollback-dialog.component.html
@@ -61,12 +61,13 @@
     </div>
   </form>
 </ng-template>
+
 <ng-template #successMessage>
-  <p>
+  <p mat-dialog-content>
     {{ 'Dataset rolled back to snapshot {name}.' | translate: { name: publicSnapshot.snapshot_name } }}
   </p>
 
-  <div class="form-actions">
+  <ix-form-actions mat-dialog-actions class="form-actions">
     <div class="form-buttons">
       <a
         mat-button
@@ -74,7 +75,7 @@
         color="primary"
         ixTest="go-to-storage"
         matDialogClose
-        [routerLink]="['/storage/snapshots']"
+        [routerLink]="['/storage']"
       >
         {{ 'Go to Storage' | translate }}
       </a>
@@ -83,5 +84,5 @@
         {{ 'Close' | translate }}
       </button>
     </div>
-  </div>
+  </ix-form-actions>
 </ng-template>


### PR DESCRIPTION
Testing: see result 👇 

<img width="450" alt="Screenshot 2024-04-01 at 19 39 08" src="https://github.com/truenas/webui/assets/22980553/199fe7f8-89a7-4d05-818e-81b7bf7605ee">
