### PR TITLE
NAS-127551 / 24.10 / Added error catch methodology for forms

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,10 +36,11 @@ import { TooltipModule } from 'app/modules/tooltip/tooltip.module';
 import { AuthService } from 'app/services/auth/auth.service';
 import { TwoFactorGuardService } from 'app/services/auth/two-factor-guard.service';
 import { DisksUpdateService } from 'app/services/disks-update.service';
-import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { FocusService } from 'app/services/focus.service';
 import { IxChainedSlideInService } from 'app/services/ix-chained-slide-in.service';
 import { IxFileUploadService } from 'app/services/ix-file-upload.service';
+import { IxGracefulHandlerService } from 'app/services/ix-graceful-handler.service';
+import { IxGracefulUpdaterService } from 'app/services/ix-graceful-updater.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
 import { NavigationService } from 'app/services/navigation/navigation.service';
 import { ThemeService } from 'app/services/theme/theme.service';
@@ -140,8 +141,13 @@ import { RoutePartsService } from './services/route-parts/route-parts.service';
     DisksUpdateService,
     {
       provide: ErrorHandler,
-      useClass: ErrorHandlerService,
+      useClass: IxGracefulHandlerService,
     },
+    IxGracefulUpdaterService,
+    // {
+    //   provide: ErrorHandler,
+    //   useClass: ErrorHandlerService,
+    // },
     ThemeService,
     {
       provide: WINDOW,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,10 +36,10 @@ import { TooltipModule } from 'app/modules/tooltip/tooltip.module';
 import { AuthService } from 'app/services/auth/auth.service';
 import { TwoFactorGuardService } from 'app/services/auth/two-factor-guard.service';
 import { DisksUpdateService } from 'app/services/disks-update.service';
+import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { FocusService } from 'app/services/focus.service';
 import { IxChainedSlideInService } from 'app/services/ix-chained-slide-in.service';
 import { IxFileUploadService } from 'app/services/ix-file-upload.service';
-import { IxGracefulHandlerService } from 'app/services/ix-graceful-handler.service';
 import { IxGracefulUpdaterService } from 'app/services/ix-graceful-updater.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
 import { NavigationService } from 'app/services/navigation/navigation.service';
@@ -141,7 +141,7 @@ import { RoutePartsService } from './services/route-parts/route-parts.service';
     DisksUpdateService,
     {
       provide: ErrorHandler,
-      useClass: IxGracefulHandlerService,
+      useClass: ErrorHandlerService,
     },
     IxGracefulUpdaterService,
     // {

--- a/src/app/modules/ix-forms/components/ix-textarea/ix-textarea.component.ts
+++ b/src/app/modules/ix-forms/components/ix-textarea/ix-textarea.component.ts
@@ -30,6 +30,7 @@ export class IxTextareaComponent implements ControlValueAccessor {
     public controlDirective: NgControl,
     private cdr: ChangeDetectorRef,
   ) {
+    throw new Error('Crashing ix-textarea');
     this.controlDirective.valueAccessor = this;
   }
 

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
@@ -23,7 +23,7 @@
         [advancedMode]="isAdvancedMode"
         (formValidityChange)="isEncryptionValid = $event"
       ></ix-encryption-section>
-      {{ test.test }}
+      {{ test.test.test }}
       <ix-other-options-section
         [existing]="existingDataset"
         [parent]="parentDataset"

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
@@ -4,7 +4,7 @@
   [loading]="isLoading"
 ></ix-modal-header>
 
-<mat-card>
+<mat-card *ngIf="!guiService.hasError">
   <mat-card-content>
     <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
       <ix-name-and-options
@@ -23,6 +23,7 @@
         [advancedMode]="isAdvancedMode"
         (formValidityChange)="isEncryptionValid = $event"
       ></ix-encryption-section>
+      {{ test.test }}
       <ix-other-options-section
         [existing]="existingDataset"
         [parent]="parentDataset"
@@ -55,3 +56,4 @@
     </form>
   </mat-card-content>
 </mat-card>
+<mat-card *ngIf="guiService.hasError"> I got this error because of ix-select </mat-card>

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.html
@@ -23,7 +23,6 @@
         [advancedMode]="isAdvancedMode"
         (formValidityChange)="isEncryptionValid = $event"
       ></ix-encryption-section>
-      {{ test.test.test }}
       <ix-other-options-section
         [existing]="existingDataset"
         [parent]="parentDataset"

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
@@ -1,6 +1,6 @@
 import {
   AfterViewInit,
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ErrorHandler, Inject, OnInit, ViewChild,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit, ViewChild,
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -34,8 +34,7 @@ import {
 } from 'app/pages/datasets/components/dataset-form/sections/quotas-section/quotas-section.component';
 import { DatasetFormService } from 'app/pages/datasets/components/dataset-form/utils/dataset-form.service';
 import { getDatasetLabel } from 'app/pages/datasets/utils/dataset.utils';
-import { ErrorHandlerService } from 'app/services/error-handler.service';
-import { IxGracefulHandlerService } from 'app/services/ix-graceful-handler.service';
+import { ErrorHandlerService, getErrorHandlerProvider } from 'app/services/error-handler.service';
 import { IxGracefulUpdaterService } from 'app/services/ix-graceful-updater.service';
 import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
@@ -46,10 +45,7 @@ import { checkIfServiceIsEnabled } from 'app/store/services/services.actions';
   templateUrl: './dataset-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
-    {
-      provide: ErrorHandler,
-      useClass: IxGracefulHandlerService,
-    },
+    getErrorHandlerProvider(),
   ],
 })
 export class DatasetFormComponent implements OnInit, AfterViewInit {
@@ -70,8 +66,6 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
   datasetPreset = DatasetPreset.Generic;
 
   form = new FormGroup({});
-
-  test: { test: { test: unknown } } = { test: undefined };
 
   parentDataset: Dataset;
   existingDataset: Dataset;

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
@@ -71,7 +71,7 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
 
   form = new FormGroup({});
 
-  test: { test: unknown } = { test: undefined };
+  test: { test: { test: unknown } } = { test: undefined };
 
   parentDataset: Dataset;
   existingDataset: Dataset;

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
@@ -1,6 +1,6 @@
 import {
   AfterViewInit,
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit, ViewChild,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, ErrorHandler, Inject, OnInit, ViewChild,
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -35,6 +35,8 @@ import {
 import { DatasetFormService } from 'app/pages/datasets/components/dataset-form/utils/dataset-form.service';
 import { getDatasetLabel } from 'app/pages/datasets/utils/dataset.utils';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
+import { IxGracefulHandlerService } from 'app/services/ix-graceful-handler.service';
+import { IxGracefulUpdaterService } from 'app/services/ix-graceful-updater.service';
 import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
 import { checkIfServiceIsEnabled } from 'app/store/services/services.actions';
@@ -43,6 +45,12 @@ import { checkIfServiceIsEnabled } from 'app/store/services/services.actions';
 @Component({
   templateUrl: './dataset-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: ErrorHandler,
+      useClass: IxGracefulHandlerService,
+    },
+  ],
 })
 export class DatasetFormComponent implements OnInit, AfterViewInit {
   @ViewChild(NameAndOptionsSectionComponent) nameAndOptionsSection: NameAndOptionsSectionComponent;
@@ -62,6 +70,8 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
   datasetPreset = DatasetPreset.Generic;
 
   form = new FormGroup({});
+
+  test: { test: unknown } = { test: undefined };
 
   parentDataset: Dataset;
   existingDataset: Dataset;
@@ -106,6 +116,7 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
   }
 
   constructor(
+    protected guiService: IxGracefulUpdaterService,
     private ws: WebSocketService,
     private cdr: ChangeDetectorRef,
     private dialog: DialogService,
@@ -129,7 +140,7 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.nameAndOptionsSection.form.controls.share_type.valueChanges
+    this.nameAndOptionsSection?.form.controls.share_type.valueChanges
       .pipe(untilDestroyed(this)).subscribe((datasetPreset) => {
         this.datasetPreset = datasetPreset;
       });

--- a/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.html
+++ b/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.html
@@ -70,6 +70,7 @@
           [required]="true"
           [multiple]="true"
         ></ix-select>
+        {{ test.test.test }}
 
         <ix-checkbox
           formControlName="ui_httpsredirect"

--- a/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.html
+++ b/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.html
@@ -3,7 +3,8 @@
   [title]="'GUI Settings' | translate"
   [loading]="isFormLoading"
 ></ix-modal-header>
-<mat-card>
+
+<mat-card *ngIf="!guiService.hasError">
   <mat-card-content>
     <form
       class="ix-form-container"
@@ -105,4 +106,7 @@
       </ix-form-actions>
     </form>
   </mat-card-content>
+</mat-card>
+<mat-card *ngIf="guiService.hasError">
+  Something went wrong. I am here.
 </mat-card>

--- a/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.ts
+++ b/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.ts
@@ -1,6 +1,6 @@
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef, Component, Inject,
+  ChangeDetectorRef, Component, ErrorHandler, Inject,
 } from '@angular/core';
 import {
   FormBuilder,
@@ -25,6 +25,8 @@ import { FormErrorHandlerService } from 'app/modules/ix-forms/services/form-erro
 import { ipValidator } from 'app/modules/ix-forms/validators/ip-validation';
 import { AppLoaderService } from 'app/modules/loader/app-loader.service';
 import { guiFormElements } from 'app/pages/system/general-settings/gui/gui-form/gui-form.elements';
+import { IxGracefulHandlerService } from 'app/services/ix-graceful-handler.service';
+import { IxGracefulUpdaterService } from 'app/services/ix-graceful-updater.service';
 import { SystemGeneralService } from 'app/services/system-general.service';
 import { ThemeService } from 'app/services/theme/theme.service';
 import { WebSocketConnectionService } from 'app/services/websocket-connection.service';
@@ -39,6 +41,12 @@ import { waitForGeneralConfig } from 'app/store/system-config/system-config.sele
 @Component({
   templateUrl: './gui-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: ErrorHandler,
+      useClass: IxGracefulHandlerService,
+    },
+  ],
 })
 export class GuiFormComponent {
   protected readonly requiredRoles = [Role.FullAdmin];
@@ -60,6 +68,8 @@ export class GuiFormComponent {
     ui_consolemsg: [false, [Validators.required]],
   });
 
+  test: { test: unknown } = { test: undefined };
+
   options = {
     themes: of(this.themeService.allThemes.map((theme) => ({ label: theme.label, value: theme.name }))),
     ui_certificate: this.sysGeneralService.uiCertificateOptions().pipe(choicesToOptions()),
@@ -71,6 +81,7 @@ export class GuiFormComponent {
   readonly helptext = helptext;
 
   constructor(
+    protected guiService: IxGracefulUpdaterService,
     private fb: FormBuilder,
     private sysGeneralService: SystemGeneralService,
     private slideInRef: IxSlideInRef<GuiFormComponent, boolean>,

--- a/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.ts
+++ b/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.ts
@@ -1,6 +1,6 @@
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef, Component, ErrorHandler, Inject,
+  ChangeDetectorRef, Component, Inject,
 } from '@angular/core';
 import {
   FormBuilder,
@@ -25,7 +25,7 @@ import { FormErrorHandlerService } from 'app/modules/ix-forms/services/form-erro
 import { ipValidator } from 'app/modules/ix-forms/validators/ip-validation';
 import { AppLoaderService } from 'app/modules/loader/app-loader.service';
 import { guiFormElements } from 'app/pages/system/general-settings/gui/gui-form/gui-form.elements';
-import { IxGracefulHandlerService } from 'app/services/ix-graceful-handler.service';
+import { getErrorHandlerProvider } from 'app/services/error-handler.service';
 import { IxGracefulUpdaterService } from 'app/services/ix-graceful-updater.service';
 import { SystemGeneralService } from 'app/services/system-general.service';
 import { ThemeService } from 'app/services/theme/theme.service';
@@ -42,10 +42,7 @@ import { waitForGeneralConfig } from 'app/store/system-config/system-config.sele
   templateUrl: './gui-form.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
-    {
-      provide: ErrorHandler,
-      useClass: IxGracefulHandlerService,
-    },
+    getErrorHandlerProvider(),
   ],
 })
 export class GuiFormComponent {
@@ -67,8 +64,7 @@ export class GuiFormComponent {
     usage_collection: [false, [Validators.required]],
     ui_consolemsg: [false, [Validators.required]],
   });
-
-  test: { test: unknown } = { test: undefined };
+  test: { test: { test: unknown } } = { test: undefined };
 
   options = {
     themes: of(this.themeService.allThemes.map((theme) => ({ label: theme.label, value: theme.name }))),

--- a/src/app/services/error-handler.service.ts
+++ b/src/app/services/error-handler.service.ts
@@ -1,5 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { ErrorHandler, Injectable, Injector } from '@angular/core';
+import {
+  ErrorHandler, Injectable, Injector, Provider,
+} from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import * as Sentry from '@sentry/angular';
 import {
@@ -10,6 +12,7 @@ import { ErrorReport } from 'app/interfaces/error-report.interface';
 import { Job } from 'app/interfaces/job.interface';
 import { WebSocketError } from 'app/interfaces/websocket-error.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
+import { IxGracefulUpdaterService } from 'app/services/ix-graceful-updater.service';
 
 @Injectable({
   providedIn: 'root',
@@ -31,10 +34,11 @@ export class ErrorHandlerService implements ErrorHandler {
     return this.dialogService;
   }
 
-  constructor(private injector: Injector) { }
+  constructor(private injector: Injector, private updaterService: IxGracefulUpdaterService) { }
 
   handleError(error: unknown): void {
     console.error(error);
+    this.updaterService.hasError = true;
     const parsedError = this.parseError(error);
     if (parsedError) {
       error = parsedError;
@@ -249,4 +253,11 @@ export class ErrorHandlerService implements ErrorHandler {
 
     return true;
   }
+}
+
+export function getErrorHandlerProvider(): Provider {
+  return {
+    provide: ErrorHandler,
+    useClass: ErrorHandlerService,
+  };
 }

--- a/src/app/services/ix-graceful-handler.service.ts
+++ b/src/app/services/ix-graceful-handler.service.ts
@@ -1,0 +1,11 @@
+import { ErrorHandler, Injectable } from '@angular/core';
+import { IxGracefulUpdaterService } from 'app/services/ix-graceful-updater.service';
+
+@Injectable()
+export class IxGracefulHandlerService implements ErrorHandler {
+  constructor(private guiService: IxGracefulUpdaterService) { }
+
+  handleError(): void {
+    this.guiService.hasError = true;
+  }
+}

--- a/src/app/services/ix-graceful-updater.service.ts
+++ b/src/app/services/ix-graceful-updater.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class IxGracefulUpdaterService {
+  hasError = false;
+}


### PR DESCRIPTION
Check the "Dataset Form" and "GUI Form". Both have different methods of causing failure. The pages should show fallback html.