### PR TITLE
NAS-127893 / 24.04.1 / Fix `hasMultipleEnclosuresAfterFirstStep$` selector (by bvasilenko)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/create-pool.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/create-pool.spec.ts
@@ -83,6 +83,10 @@ describe('PoolManagerComponent – create pool', () => {
             devname: 'sda0',
             size: 20 * GiB,
             type: DiskType.Hdd,
+            enclosure: {
+              number: 4,
+              slot: 0,
+            },
           },
           {
             devname: 'sda1',

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/draid-pool-creation.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/draid-pool-creation.spec.ts
@@ -81,6 +81,10 @@ describe('PoolManagerComponent – creating dRAID pool', () => {
             devname: 'sda0',
             size: 20 * GiB,
             type: DiskType.Hdd,
+            enclosure: {
+              number: 4,
+              slot: 0,
+            },
           },
           {
             devname: 'sda1',

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/unsetting-on-fewer-disks.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/unsetting-on-fewer-disks.spec.ts
@@ -78,6 +78,10 @@ describe('PoolManagerComponent – unsetting on fewer disks', () => {
             devname: 'sda0',
             size: 20 * GiB,
             type: DiskType.Hdd,
+            enclosure: {
+              number: 4,
+              slot: 0,
+            },
           },
           {
             devname: 'sda1',

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/wizard-reset-step.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/wizard-reset-step.spec.ts
@@ -78,6 +78,10 @@ describe('PoolManagerComponent – wizard step reset', () => {
             devname: 'sda0',
             size: 20 * GiB,
             type: DiskType.Hdd,
+            enclosure: {
+              number: 4,
+              slot: 0,
+            },
           },
           {
             devname: 'sda1',

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/wizard-start-over.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/wizard-start-over.spec.ts
@@ -78,6 +78,10 @@ describe('PoolManagerComponent – start over functionality', () => {
             devname: 'sda0',
             size: 20 * GiB,
             type: DiskType.Hdd,
+            enclosure: {
+              number: 4,
+              slot: 0,
+            },
           },
           {
             devname: 'sda1',

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
@@ -45,6 +45,10 @@ describe('PoolManagerStore', () => {
       devname: 'sdc',
       type: DiskType.Hdd,
       size: 2 * TiB,
+      enclosure: {
+        number: 2,
+        slot: 1,
+      },
     },
   ] as UnusedDisk[];
   const enclosures = [

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -159,7 +159,11 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
         limitToSingleEnclosure: null,
       });
       const uniqueEnclosures = new Set<number>();
-      disksAfterFirstStep.forEach((disk) => uniqueEnclosures.add(disk.enclosure?.number));
+      disksAfterFirstStep.forEach((disk) => {
+        if (disk.enclosure) {
+          uniqueEnclosures.add(disk.enclosure.number);
+        }
+      });
       return uniqueEnclosures.size > 1;
     },
   );


### PR DESCRIPTION
**Testing**

Use the machine from the ticket, or setup mocks from the data provided in the attachments of this ticket.

On the **Storage > Create Pool** page,

When user fills **Name** and clicks **Next**
      
- **Expected result:** it should not display **Enclosure Options** , and this step should never appear at pool creation wizard

Original PR: https://github.com/truenas/webui/pull/9952
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127893