### PR TITLE
NAS-128344 / 24.04.0 / Calculation for estimated storage capacity is incorrect in pool manager and dashboard when capacity is > 999TiB (by bvasilenko)

### DIFF
--- a/src/app/helpers/file-size.utils.spec.ts
+++ b/src/app/helpers/file-size.utils.spec.ts
@@ -1,0 +1,53 @@
+import { buildNormalizedFileSize } from 'app/helpers/file-size.utils';
+
+describe('buildNormalizedFileSize with base 2', () => {
+  it('converts 1000 bytes to 1000 B with base 2', () => {
+    expect(buildNormalizedFileSize(1000)).toBe('1000 B');
+  });
+
+  it('converts 1024 bytes to 1 KiB with base 2', () => {
+    expect(buildNormalizedFileSize(1024)).toBe('1 KiB');
+  });
+
+  it('converts 1024^2 bytes to 1 MiB with base 2', () => {
+    expect(buildNormalizedFileSize(1024 ** 2)).toBe('1 MiB');
+  });
+
+  it('converts 1024^3 bytes to 1 GiB with base 2', () => {
+    expect(buildNormalizedFileSize(1024 ** 3)).toBe('1 GiB');
+  });
+
+  it('converts 1024^4 bytes to 1 TiB with base 2', () => {
+    expect(buildNormalizedFileSize(1024 ** 4)).toBe('1 TiB');
+  });
+
+  it('converts 1024^5 bytes to 1 PiB with base 2', () => {
+    expect(buildNormalizedFileSize(1024 ** 5)).toBe('1 PiB');
+  });
+});
+
+describe('buildNormalizedFileSize with base 10', () => {
+  it('converts 500 bits to 500 b with base 10', () => {
+    expect(buildNormalizedFileSize(500, 'b', 10)).toBe('500 b');
+  });
+
+  it('converts 1000 bits to 1 kb with base 10', () => {
+    expect(buildNormalizedFileSize(1000, 'b', 10)).toBe('1 kb');
+  });
+
+  it('converts 1000^2 bits to 1 Mb with base 10', () => {
+    expect(buildNormalizedFileSize(1000 ** 2, 'b', 10)).toBe('1 Mb');
+  });
+
+  it('converts 1000^3 bits to 1 Gb with base 10', () => {
+    expect(buildNormalizedFileSize(1000 ** 3, 'b', 10)).toBe('1 Gb');
+  });
+
+  it('converts 1000^4 bits to 1 Tb with base 10', () => {
+    expect(buildNormalizedFileSize(1000 ** 4, 'b', 10)).toBe('1 Tb');
+  });
+
+  it('converts 1000^5 bits to 1 Pb with base 10', () => {
+    expect(buildNormalizedFileSize(1000 ** 5, 'b', 10)).toBe('1 Pb');
+  });
+});

--- a/src/app/helpers/file-size.utils.ts
+++ b/src/app/helpers/file-size.utils.ts
@@ -2,7 +2,7 @@ import {
   Gb, kb, Mb, Tb,
 } from 'app/constants/bits.constant';
 import {
-  GiB, KiB, MiB, TiB,
+  GiB, KiB, MiB, PiB, TiB,
 } from 'app/constants/bytes.constant';
 
 export function normalizeFileSize(
@@ -39,6 +39,8 @@ function normalizeFileSizeBase2(value: number, baseUnit: 'b' | 'B'): [formatted:
       return [formatted, 'Gi' + baseUnit];
     case TiB:
       return [formatted, 'Ti' + baseUnit];
+    case PiB:
+      return [formatted, 'Pi' + baseUnit];
     default:
       return [formatted, baseUnit];
   }

--- a/src/app/helpers/file-size.utils.ts
+++ b/src/app/helpers/file-size.utils.ts
@@ -1,5 +1,5 @@
 import {
-  Gb, kb, Mb, Tb,
+  Gb, kb, Mb, Tb, Pb,
 } from 'app/constants/bits.constant';
 import {
   GiB, KiB, MiB, PiB, TiB,
@@ -63,6 +63,8 @@ function normalizeFileSizeBase10(value: number, baseUnit: 'b' | 'B'): [formatted
       return [formatted, 'G' + baseUnit];
     case Tb:
       return [formatted, 'T' + baseUnit];
+    case Pb:
+      return [formatted, 'P' + baseUnit];
     default:
       return [formatted, baseUnit];
   }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 926c5a833a7a6af03393308786294e55465c32a2

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~2
    git cherry-pick -x ec59c4bc8c088a5713aa2ee9b9f6936d1cb0abda

**Testing**

Setup mocks to emulate total pool capacity > 999TiB

**Expected result:**

At Create Pool wizard, At the review stage of the wizard,

Display correct units of measurement (PiB) for **Est. Usable Raw Capacity** field at **Topology Summary** block



Original PR: https://github.com/truenas/webui/pull/9969
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128344