### PR TITLE
Ensure multiline App "Section help" can be rendered

### DIFF
--- a/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.html
+++ b/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.html
@@ -20,7 +20,9 @@
       </div>
       <div class="help" [hidden]="!section.help">
         <div class="title">{{ 'Section Help' | translate }}</div>
-        <div class="value"> {{ section.help }}</div>
+        <div class="value">
+          <pre>{{ section.help }}</pre>
+        </div>
       </div>
     </div>
   </ix-fieldset>

--- a/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.html
+++ b/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.html
@@ -20,7 +20,8 @@
       </div>
       <div class="help" [hidden]="!section.help">
         <div class="title">{{ 'Section Help' | translate }}</div>
-        <div class="value"> {{ section.help }}</div>
+        <div class="value">
+          <pre>{{ section.help }}</pre>
       </div>
     </div>
   </ix-fieldset>

--- a/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.html
+++ b/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.html
@@ -20,8 +20,7 @@
       </div>
       <div class="help" [hidden]="!section.help">
         <div class="title">{{ 'Section Help' | translate }}</div>
-        <div class="value">
-          <pre>{{ section.help }}</pre>
+        <div class="value">{{ section.help }}</div>
       </div>
     </div>
   </ix-fieldset>

--- a/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.html
+++ b/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.html
@@ -20,9 +20,7 @@
       </div>
       <div class="help" [hidden]="!section.help">
         <div class="title">{{ 'Section Help' | translate }}</div>
-        <div class="value">
-          <pre>{{ section.help }}</pre>
-        </div>
+        <div class="value"> {{ section.help }}</div>
       </div>
     </div>
   </ix-fieldset>

--- a/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.scss
+++ b/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.scss
@@ -64,7 +64,6 @@
     .value {
       font-size: 1rem;
       white-space: pre-wrap;
-      font-family: var(--font-family-body);
     }
   }
 }

--- a/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.scss
+++ b/src/app/modules/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.scss
@@ -63,6 +63,8 @@
 
     .value {
       font-size: 1rem;
+      white-space: pre-wrap;
+      font-family: var(--font-family-body);
     }
   }
 }

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -564,6 +564,9 @@ thead.ui-treetable-thead tr {
 
 .value,
 .mat-mdc-list-item .value {
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  word-break: break-word;
   font-weight: 500;
 }
 

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -564,9 +564,6 @@ thead.ui-treetable-thead tr {
 
 .value,
 .mat-mdc-list-item .value {
-  word-wrap: break-word;
-  white-space: pre-wrap;
-  word-break: break-word;
   font-weight: 500;
 }
 


### PR DESCRIPTION
Currently we cannot write multi-line section-help for the App install/edit GUI.
As those get removed, leading to one big blob of text.

This fix, ensures that multiline descriptions get respected accordingly.

Fixes the following issue:

![image](https://github.com/truenas/webui/assets/89483932/2d4c4308-7425-4d56-b1d4-1f05b21b4b0a)

To render as:

![image](https://github.com/truenas/webui/assets/89483932/552e1dc1-eca3-4f36-8e83-6cb2c5a6473d)

Thanks for your attention!