### PR TITLE
NAS-128481 / 24.10 / Datapoint widget quarters incorrectly renders widget size

### DIFF
--- a/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.scss
+++ b/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.scss
@@ -22,7 +22,7 @@ mat-card {
     .container {
       align-items: center;
       display: flex;
-      height: calc($widget-group-height * 0.3);
+      height: calc($widget-group-height * 0.3125);
       justify-content: center;
       line-height: normal;
       margin: 12px 0;
@@ -30,6 +30,11 @@ mat-card {
       padding: 0 12px;
       text-align: center;
       width: 100%;
+
+      > div {
+        word-break: break-word;
+        word-wrap: break-word;
+      }
 
       &.full {
         height: calc($widget-group-height * 0.8);

--- a/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.ts
+++ b/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.ts
@@ -16,14 +16,15 @@ export class WidgetDatapointComponent {
   subText = input<string>();
 
   get maxFontSize(): number {
-    let fontSize = this.size() === SlotSize.Quarter ? 18 : 20;
+    const isQuarter = this.size() === SlotSize.Quarter;
+    let fontSize = isQuarter ? 18 : 20;
 
     if (this.text().length <= 15) {
-      fontSize = this.size() === SlotSize.Quarter ? 35 : 49;
+      fontSize = isQuarter ? 35 : 49;
     } else if (this.text().length <= 30) {
-      fontSize = this.size() === SlotSize.Quarter ? 25 : 30;
+      fontSize = isQuarter ? 25 : 30;
     } else if (this.text().length <= 40) {
-      fontSize = this.size() === SlotSize.Quarter ? 20 : 22;
+      fontSize = isQuarter ? 20 : 22;
     }
 
     return fontSize;

--- a/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.ts
+++ b/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.ts
@@ -16,14 +16,14 @@ export class WidgetDatapointComponent {
   subText = input<string>();
 
   get maxFontSize(): number {
-    let fontSize = 20;
+    let fontSize = this.size() === SlotSize.Quarter ? 18 : 20;
 
     if (this.text().length <= 15) {
-      fontSize = 49;
+      fontSize = this.size() === SlotSize.Quarter ? 35 : 49;
     } else if (this.text().length <= 30) {
-      fontSize = 30;
+      fontSize = this.size() === SlotSize.Quarter ? 25 : 30;
     } else if (this.text().length <= 40) {
-      fontSize = 22;
+      fontSize = this.size() === SlotSize.Quarter ? 20 : 22;
     }
 
     return fontSize;


### PR DESCRIPTION
Testing: see ticket & result 👇 

Before:
![image](https://github.com/truenas/webui/assets/22980553/27c8e373-3ab9-4e18-9a3f-f6c407fced9d)

After:
<img width="1728" alt="Screenshot 2024-04-24 at 11 11 17" src="https://github.com/truenas/webui/assets/22980553/4595d465-7b6f-46cc-944c-c53b797af099">
