### PR TITLE
NAS-128625 / 24.10 / Recent searches in global search shows unusual results

### DIFF
--- a/src/app/modules/global-search/components/global-search/global-search.component.spec.ts
+++ b/src/app/modules/global-search/components/global-search/global-search.component.spec.ts
@@ -137,7 +137,7 @@ describe('GlobalSearchComponent', () => {
     spectator.component.resetInput();
     spectator.detectChanges();
 
-    expect(spectator.component.searchControl.value).toBeNull();
+    expect(spectator.component.searchControl.value).toBe('');
     expect(document.activeElement).toBe(spectator.query('input'));
   });
 });

--- a/src/app/modules/global-search/components/global-search/global-search.component.ts
+++ b/src/app/modules/global-search/components/global-search/global-search.component.ts
@@ -82,7 +82,7 @@ export class GlobalSearchComponent implements OnInit {
   }
 
   resetInput(): void {
-    this.searchControl.reset();
+    this.searchControl.setValue('');
   }
 
   private listenForSearchChanges(): void {

--- a/src/app/modules/global-search/services/global-search-sections.service.spec.ts
+++ b/src/app/modules/global-search/services/global-search-sections.service.spec.ts
@@ -87,7 +87,6 @@ describe('GlobalSearchSectionsProvider', () => {
         targetHref: 'url2',
       },
     ];
-    mockLocalStorage.getItem.mockReturnValue(JSON.stringify(recentSearches));
 
     const results = spectator.service.getRecentSearchesSectionResults();
 

--- a/src/app/modules/global-search/services/global-search-sections.service.spec.ts
+++ b/src/app/modules/global-search/services/global-search-sections.service.spec.ts
@@ -17,7 +17,7 @@ jest.mock('app/../assets/ui-searchable-elements.json', () => ([
     triggerAnchor: null,
     section: GlobalSearchSection.Ui,
   },
-]), { virtual: true });
+]));
 
 describe('GlobalSearchSectionsProvider', () => {
   let spectator: SpectatorService<GlobalSearchSectionsProvider>;
@@ -87,6 +87,8 @@ describe('GlobalSearchSectionsProvider', () => {
         targetHref: 'url2',
       },
     ];
+
+    mockLocalStorage.getItem.mockReturnValue(JSON.stringify(recentSearches));
 
     const results = spectator.service.getRecentSearchesSectionResults();
 

--- a/src/app/modules/global-search/services/global-search-sections.service.ts
+++ b/src/app/modules/global-search/services/global-search-sections.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import UiElementsJson from 'app/../assets/ui-searchable-elements.json';
 import { Observable } from 'rxjs';
 import { WINDOW } from 'app/helpers/window.helper';
 import { GlobalSearchSection } from 'app/modules/global-search/enums/global-search-section.enum';
@@ -41,6 +42,17 @@ export class GlobalSearchSectionsProvider {
   }
 
   getRecentSearchesSectionResults(): UiSearchableElement[] {
-    return JSON.parse(this.window.localStorage.getItem('recentSearches') || '[]');
+    const recentSearches = JSON.parse(this.window.localStorage.getItem('recentSearches') || '[]') as UiSearchableElement[];
+    const exitingHierarchies = new Set(UiElementsJson.map((item) => JSON.stringify(item.hierarchy)));
+
+    const validRecentSearches = recentSearches.filter((item) => {
+      return exitingHierarchies.has(JSON.stringify(item.hierarchy)) || item.hierarchy[0].startsWith('Search Documentation for');
+    });
+
+    if (recentSearches.length !== validRecentSearches.length) {
+      this.window.localStorage.setItem('recentSearches', JSON.stringify(validRecentSearches));
+    }
+
+    return validRecentSearches;
   }
 }


### PR DESCRIPTION
Testing: see ticket, try to update local storage`recentSearches`, add unexisting search result. (update hierarchy item)

You should only see items which are available in `ui-searchable-elements.json`.
