### PR TITLE
NAS-128660 / 24.04.1 / ES24n should not have identify buttons for drives

### DIFF
--- a/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
+++ b/src/app/pages/system/view-enclosure/components/enclosure-disks/enclosure-disks.component.ts
@@ -257,7 +257,10 @@ export class EnclosureDisksComponent implements AfterContentInit, OnDestroy {
 
   get hideIdentifyDrive(): boolean {
     const selectedEnclosureView = this.selectedEnclosureView;
-    return selectedEnclosureView.model === 'TRUENAS-MINI-R';
+
+    // Stupid way until we refactor this.
+    const notSupported = ['TRUENAS-MINI-R', 'ES24N'];
+    return notSupported.includes(selectedEnclosureView.model);
   }
 
   theme: Theme;


### PR DESCRIPTION
Testing: just review the code.