### PR TITLE
NAS-128761 / 24.10 / Use demoWidgets as initial state for new dashboard

### DIFF
--- a/src/app/pages/dashboard/services/dashboard.store.spec.ts
+++ b/src/app/pages/dashboard/services/dashboard.store.spec.ts
@@ -1,6 +1,7 @@
 import { createServiceFactory, SpectatorService, mockProvider } from '@ngneat/spectator/jest';
 import { firstValueFrom, of } from 'rxjs';
 import { mockCall, mockWebSocket } from 'app/core/testing/utils/mock-websocket.utils';
+import { demoWidgets } from 'app/pages/dashboard/services/demo-widgets.constant';
 import { WidgetGroupLayout } from 'app/pages/dashboard/types/widget-group.interface';
 import { WidgetType } from 'app/pages/dashboard/types/widget.interface';
 import { AuthService } from 'app/services/auth/auth.service';
@@ -93,6 +94,18 @@ describe('DashboardStore', () => {
     ]);
 
     expect(finalizeSpy).toHaveBeenCalledWith(false);
+  });
+
+  it('should load demoWidgets if user does not have dashState', async () => {
+    const authService = spectator.inject(AuthService);
+    Object.defineProperty(authService, 'user$', { value: of({ attributes: {} }) });
+
+    spectator.service.entered();
+
+    expect(await firstValueFrom(spectator.service.state$)).toMatchObject({
+      ...initialState,
+      groups: demoWidgets,
+    });
   });
 
   afterEach(() => {

--- a/src/app/pages/dashboard/services/dashboard.store.ts
+++ b/src/app/pages/dashboard/services/dashboard.store.ts
@@ -7,6 +7,7 @@ import {
 } from 'rxjs';
 import { WidgetName } from 'app/enums/widget-name.enum';
 import { LoggedInUser } from 'app/interfaces/ds-cache.interface';
+import { demoWidgets } from 'app/pages/dashboard/services/demo-widgets.constant';
 import { WidgetGroup, WidgetGroupLayout } from 'app/pages/dashboard/types/widget-group.interface';
 import { SomeWidgetSettings, WidgetType } from 'app/pages/dashboard/types/widget.interface';
 import { AuthService } from 'app/services/auth/auth.service';
@@ -62,10 +63,11 @@ export class DashboardStore extends ComponentStore<DashboardState> {
         map((user) => user.attributes.dashState),
       )),
       tap((dashState) => {
+        // TODO: Remove demoWidgets once active development of new dashboard is done
         this.setState({
           isLoading: false,
           globalError: '',
-          groups: this.getDashboardGroups(dashState || []),
+          groups: this.getDashboardGroups(dashState || demoWidgets),
         });
       }),
       catchError((error) => {


### PR DESCRIPTION
For testing

- create a fresh VM
- check dashboard using builtin webui - expected: `Dashboard is Empty!`
- check dashboard using this branch - expected: demo widgets are loaded