### PR TITLE
NAS-129063 / 24.04.1 / Initiate Failover button is inactive but HA is up

### DIFF
--- a/src/app/store/ha-info/ha-info.selectors.ts
+++ b/src/app/store/ha-info/ha-info.selectors.ts
@@ -24,6 +24,10 @@ export const selectIsUpgradePending = createSelector(
 export const selectCanFailover = createSelector(
   selectHaInfoState,
   ({ haStatus }) => {
+    if (!haStatus) {
+      return false;
+    }
+
     if (haStatus.hasHa) {
       return true;
     }


### PR DESCRIPTION
Original issue can be reproduced by adding a delay to network code in `loadHaStatus` in `HaInfoEffects`.