### PR TITLE
NAS-129057 / 24.10 / Global Search | SMB Status Tabs Highlighting is wrong

### DIFF
--- a/src/app/pages/sharing/iscsi/iscsi.component.scss
+++ b/src/app/pages/sharing/iscsi/iscsi.component.scss
@@ -2,11 +2,3 @@ nav {
   margin-bottom: 16px;
   margin-top: -32px;
 }
-
-:host ::ng-deep {
-  mat-tab-nav-panel {
-    .search-element-highlighted {
-      display: block;
-    }
-  }
-}

--- a/src/app/pages/sharing/smb/smb-status/smb-status.component.scss
+++ b/src/app/pages/sharing/smb/smb-status/smb-status.component.scss
@@ -2,11 +2,3 @@ nav {
   margin-bottom: 16px;
   margin-top: -32px;
 }
-
-:host ::ng-deep {
-  mat-tab-nav-panel {
-    .search-element-highlighted {
-      display: block;
-    }
-  }
-}

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -918,3 +918,9 @@ mat-list-item {
 div.mat-mdc-autocomplete-panel.mat-mdc-autocomplete-visible {
   margin: 5px 0;
 }
+
+mat-tab-nav-panel {
+  .search-element-highlighted {
+    display: block;
+  }
+}


### PR DESCRIPTION
Before: 

https://github.com/truenas/webui/assets/22980553/2bd3c254-9bcc-4b01-8e9d-845780799b0d


Result:

https://github.com/truenas/webui/assets/22980553/327c9158-3d86-46a5-8ca0-6b588d8a86da

