### PR TITLE
NAS-129063 / 24.04.2 / Initiate Failover button is inactive but HA is up (by undsoft)

### DIFF
--- a/src/app/store/ha-info/ha-info.selectors.ts
+++ b/src/app/store/ha-info/ha-info.selectors.ts
@@ -24,6 +24,10 @@ export const selectIsUpgradePending = createSelector(
 export const selectCanFailover = createSelector(
   selectHaInfoState,
   ({ haStatus }) => {
+    if (!haStatus) {
+      return false;
+    }
+
     if (haStatus.hasHa) {
       return true;
     }


### PR DESCRIPTION
Original issue can be reproduced by adding a delay to network code in `loadHaStatus` in `HaInfoEffects`.

Original PR: https://github.com/truenas/webui/pull/10081
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129063