### PR TITLE
NAS-128468 / 13.3 / Enclosure reports all disks as not attached to any pool

### DIFF
--- a/src/app/core/classes/system-profiler.ts
+++ b/src/app/core/classes/system-profiler.ts
@@ -213,7 +213,7 @@ export class SystemProfiler {
         v.disks[name] = -1; // no children so we use this as placeholder
       } else if (vdev.children.length > 0) {
         vdev.children.forEach((disk, dIndex) => {
-          if (disk.device && disk.status != 'REMOVED') {
+          if (disk.status != 'REMOVED') {
             const spl = disk.disk.split(/p(\d+)/g); // was disk.device
             const name = spl[0];
             v.disks[name] = dIndex;


### PR DESCRIPTION
I'll attach in the ticket the patch to mock request.

Looks like original issue happened because condition changed it's meaning over time.