### PR TITLE
NAS-129438 / 24.10 / White Box surrounds iXsystems Logo in UI after Clicking enter in the Search UI

### DIFF
--- a/src/app/modules/global-search/components/global-search-results/global-search-results.component.scss
+++ b/src/app/modules/global-search/components/global-search-results/global-search-results.component.scss
@@ -98,7 +98,6 @@
 
     &.highlighted-result {
       background-color: var(--bg1);
-      opacity: 0.8;
     }
 
     &:hover {

--- a/src/app/modules/global-search/components/global-search-trigger/global-search-trigger.component.ts
+++ b/src/app/modules/global-search/components/global-search-trigger/global-search-trigger.component.ts
@@ -6,15 +6,14 @@ import {
   ChangeDetectorRef,
   Component,
   HostListener,
-  Inject,
   ViewContainerRef,
 } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { delay, take } from 'rxjs';
-import { WINDOW } from 'app/helpers/window.helper';
 import { GlobalSearchComponent } from 'app/modules/global-search/components/global-search/global-search.component';
 import { searchDelayConst } from 'app/modules/global-search/constants/delay.const';
 import { UiSearchProvider } from 'app/modules/global-search/services/ui-search.service';
+import { FocusService } from 'app/services/focus.service';
 
 @UntilDestroy()
 @Component({
@@ -31,7 +30,7 @@ export class GlobalSearchTriggerComponent implements AfterViewInit {
     private overlay: Overlay,
     private viewContainerRef: ViewContainerRef,
     private searchProvider: UiSearchProvider,
-    @Inject(WINDOW) private window: Window,
+    private focusService: FocusService,
   ) {}
 
   ngAfterViewInit(): void {
@@ -71,7 +70,7 @@ export class GlobalSearchTriggerComponent implements AfterViewInit {
       return;
     }
     this.overlayRef.detach();
-    this.window.document.querySelector<HTMLElement>('ix-logo a')?.focus();
+    this.focusService.focusFirstFocusableElement(document.querySelector<HTMLElement>('.rightside-content-hold'));
     this.cdr.markForCheck();
   }
 }

--- a/src/app/modules/global-search/components/global-search/global-search.component.ts
+++ b/src/app/modules/global-search/components/global-search/global-search.component.ts
@@ -66,6 +66,9 @@ export class GlobalSearchComponent implements OnInit {
     switch (event.key) {
       case 'ArrowDown':
         event.preventDefault();
+        if (this.isSearchInputFocused) {
+          moveToNextFocusableElement();
+        }
         moveToNextFocusableElement();
         break;
       case 'ArrowUp':

--- a/src/app/services/focus.service.ts
+++ b/src/app/services/focus.service.ts
@@ -36,4 +36,18 @@ export class FocusService {
     focusElementById(id: string): void {
       this.document.getElementById(id)?.focus();
     }
+
+    focusFirstFocusableElement(element: HTMLElement): void {
+      const focusableSelectors = [
+        'a[href]', 'area[href]', 'input:not([disabled]):not([type="hidden"])',
+        'select:not([disabled])', 'textarea:not([disabled])',
+        'button:not([disabled])', 'iframe', 'object', 'embed',
+        '[contenteditable]', '[tabindex]:not([tabindex="-1"])',
+      ];
+      const focusableElements = element.querySelectorAll(focusableSelectors.join(', '));
+      if (focusableElements.length > 0) {
+        const firstFocusable = focusableElements[0] as HTMLElement;
+        firstFocusable.focus();
+      }
+    }
 }

--- a/src/app/services/focus.service.ts
+++ b/src/app/services/focus.service.ts
@@ -38,6 +38,8 @@ export class FocusService {
     }
 
     focusFirstFocusableElement(element: HTMLElement): void {
+      if (!element) return;
+
       const focusableSelectors = [
         'a[href]', 'area[href]', 'input:not([disabled]):not([type="hidden"])',
         'select:not([disabled])', 'textarea:not([disabled])',


### PR DESCRIPTION
Testing: see ticket, now we are focusing on the first element in the sidenav content, it's needed to not loose focus.
As well search element in global search is fixed to focus from first to second if search input is focused (previously we had to double tab to move to second element)
