### PR TITLE
NAS-129103 / 24.04.2 / DF: Replication Page rep task enabled checkbox data-test tag not defined correctly

### DIFF
--- a/src/app/modules/entity/entity-table/entity-table.component.html
+++ b/src/app/modules/entity/entity-table/entity-table.component.html
@@ -374,7 +374,7 @@
                   color="primary"
                   class="checkbox"
                   [id]="'checkbox__' + getRowIdentifier(element)"
-                  [ixTest]="getRowIdentifier(element)"
+                  [ixTest]="[column, router.url, getRowTestAttribute(element)]"
                   [disabled]="currentColumns?.[i]?.disabled"
                   [(ngModel)]="element[column]"
                   (change)="checkboxChanged(element)"

--- a/src/app/modules/entity/entity-table/entity-table.component.ts
+++ b/src/app/modules/entity/entity-table/entity-table.component.ts
@@ -974,6 +974,10 @@ export class EntityTableComponent<Row extends SomeRow = SomeRow> implements OnIn
     return UUID.UUID();
   }
 
+  getRowTestAttribute(row: Row): string {
+    return row.name || row.path || row.description || row.title || row.id;
+  }
+
   isPaddedAway(index: number): boolean {
     return !this.shouldApplyStickyOffset(index)
       && !(this.isLeftStickyColumnNo(index) && this.isTableOverflow());


### PR DESCRIPTION
Testing: see ticket 

Now checkbox data-test attr is fixed:

example: 
`checkbox-enabled-data-protection-replication-pewl-pewl`
<img width="471" alt="Screenshot 2024-06-12 at 13 41 32" src="https://github.com/truenas/webui/assets/22980553/5ac47b0c-30bc-4a5b-8852-036bf9f11ce4">

Before:
![image](https://github.com/truenas/webui/assets/22980553/200e0894-30ac-4bba-aa65-edfc400e7a26)

On the master branch it's all right, we use our new ix-table component there everywhere.