### PR TITLE
NAS-129528 / 24.10 / ACL forms are broken when directory services cache is dis… (by undsoft)

### DIFF
--- a/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.harness.ts
+++ b/src/app/modules/ix-forms/components/ix-combobox/ix-combobox.harness.ts
@@ -49,7 +49,7 @@ export class IxComboboxHarness extends ComponentHarness implements IxFormControl
    * @param optionLabel label of the option that is to be assigned
    */
   async setValue(optionLabel: string): Promise<void> {
-    const harness = (await this.getAutoCompleteHarness());
+    const harness = await this.getAutoCompleteHarness();
     await harness.focus();
     await harness.selectOption({ text: optionLabel });
   }

--- a/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.html
+++ b/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.html
@@ -17,6 +17,7 @@
       [label]="'User' | translate"
       [tooltip]="tooltips.user | translate"
       [provider]="userProvider"
+      [allowCustomValue]="true"
       [required]="true"
     ></ix-combobox>
 
@@ -26,6 +27,7 @@
       [label]="'Group' | translate"
       [tooltip]="tooltips.group | translate"
       [provider]="groupProvider"
+      [allowCustomValue]="true"
       [required]="true"
     ></ix-combobox>
 

--- a/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.spec.ts
+++ b/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.spec.ts
@@ -115,22 +115,54 @@ describe('EditNfsAceComponent', () => {
     expect(spectator.inject(DatasetAclEditorStore).updateSelectedAceValidation).toHaveBeenCalled();
   });
 
-  it('shows user combobox when Who is user', async () => {
-    await form.fillForm({
-      Who: 'User',
+  describe('user ace', () => {
+    it('shows user combobox when Who is user', async () => {
+      await form.fillForm({
+        Who: 'User',
+      });
+
+      const userSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'User' }));
+      expect(userSelect).toExist();
     });
 
-    const userSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'User' }));
-    expect(userSelect).toExist();
+    it('allows custom values in User combobox', async () => {
+      await form.fillForm({
+        Who: 'User',
+      });
+
+      const userCombobox = await form.getControl('User') as IxComboboxHarness;
+      await userCombobox.writeCustomValue('AD\\administrator');
+
+      expect(spectator.inject(DatasetAclEditorStore).updateSelectedAce).toHaveBeenLastCalledWith(
+        expect.objectContaining({ who: 'AD\\administrator' }),
+      );
+      expect(spectator.inject(DatasetAclEditorStore).updateSelectedAceValidation).toHaveBeenLastCalledWith(true);
+    });
   });
 
-  it('shows group combobox when Who is group', async () => {
-    await form.fillForm({
-      Who: 'Group',
+  describe('group ace', () => {
+    it('shows group combobox when Who is group', async () => {
+      await form.fillForm({
+        Who: 'Group',
+      });
+
+      const groupSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'Group' }));
+      expect(groupSelect).toExist();
     });
 
-    const groupSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'Group' }));
-    expect(groupSelect).toExist();
+    it('allows custom values in Group combobox', async () => {
+      await form.fillForm({
+        Who: 'Group',
+      });
+
+      const userCombobox = await form.getControl('Group') as IxComboboxHarness;
+      await userCombobox.writeCustomValue('AD\\domain users');
+
+      expect(spectator.inject(DatasetAclEditorStore).updateSelectedAce).toHaveBeenLastCalledWith(
+        expect.objectContaining({ who: 'AD\\domain users' }),
+      );
+      expect(spectator.inject(DatasetAclEditorStore).updateSelectedAceValidation).toHaveBeenLastCalledWith(true);
+    });
   });
 
   it('shows basic permissions select when permission type is basic', async () => {

--- a/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.html
+++ b/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.html
@@ -14,6 +14,7 @@
       [label]="'User' | translate"
       [tooltip]="tooltips.user | translate"
       [provider]="userProvider"
+      [allowCustomValue]="true"
       [required]="true"
     ></ix-combobox>
 
@@ -23,6 +24,7 @@
       [label]="'Group' | translate"
       [tooltip]="tooltips.group | translate"
       [provider]="groupProvider"
+      [allowCustomValue]="true"
       [required]="true"
     ></ix-combobox>
 

--- a/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.spec.ts
+++ b/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.spec.ts
@@ -91,24 +91,56 @@ describe('EditPosixAceComponent', () => {
         [PosixPermission.Write]: false,
       },
     });
-    expect(spectator.inject(DatasetAclEditorStore).updateSelectedAceValidation).toHaveBeenCalled();
+    expect(spectator.inject(DatasetAclEditorStore).updateSelectedAceValidation).toHaveBeenLastCalledWith(true);
   });
 
-  it('shows user combobox when Who is user', async () => {
-    await form.fillForm({
-      Who: 'User',
+  describe('group ace', () => {
+    it('shows group combobox when Who is group', async () => {
+      await form.fillForm({
+        Who: 'Group',
+      });
+
+      const groupSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'Group' }));
+      expect(groupSelect).toExist();
     });
 
-    const userSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'User' }));
-    expect(userSelect).toExist();
+    it('allows custom values in Group combobox', async () => {
+      await form.fillForm({
+        Who: 'Group',
+      });
+
+      const userCombobox = await form.getControl('Group') as IxComboboxHarness;
+      await userCombobox.writeCustomValue('AD\\domain users');
+
+      expect(spectator.inject(DatasetAclEditorStore).updateSelectedAce).toHaveBeenLastCalledWith(
+        expect.objectContaining({ who: 'AD\\domain users' }),
+      );
+      expect(spectator.inject(DatasetAclEditorStore).updateSelectedAceValidation).toHaveBeenLastCalledWith(true);
+    });
   });
 
-  it('shows group combobox when Who is group', async () => {
-    await form.fillForm({
-      Who: 'Group',
+  describe('user ace', () => {
+    it('shows user combobox when Who is user', async () => {
+      await form.fillForm({
+        Who: 'User',
+      });
+
+      const userSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'User' }));
+      expect(userSelect).toExist();
     });
 
-    const groupSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'Group' }));
-    expect(groupSelect).toExist();
+    it('allows custom values in User combobox', async () => {
+      await form.fillForm({
+        Who: 'User',
+      });
+
+      const userCombobox = await form.getControl('User') as IxComboboxHarness;
+      await userCombobox.writeCustomValue('AD\\administrator');
+
+      expect(spectator.inject(DatasetAclEditorStore).updateSelectedAce).toHaveBeenLastCalledWith(
+        expect.objectContaining({ who: 'AD\\administrator' }),
+      );
+      expect(spectator.inject(DatasetAclEditorStore).updateSelectedAceValidation).toHaveBeenLastCalledWith(true);
+    });
   });
 });


### PR DESCRIPTION
…abled.

See ticket for testing instructions.

Original PR: https://github.com/truenas/webui/pull/10178
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129528