### PR TITLE
NAS-129198 / 24.04.2 / Share "enabled" checkbox on edit right panel not matched share page

### DIFF
--- a/src/app/helpers/operators/accumulate-loading-state.helper.ts
+++ b/src/app/helpers/operators/accumulate-loading-state.helper.ts
@@ -1,0 +1,19 @@
+import {
+  BehaviorSubject, OperatorFunction, pipe, map, tap,
+  filter,
+} from 'rxjs';
+import { toLoadingState } from 'app/helpers/operators/to-loading-state.helper';
+
+export type LoadingMap = Map<number | string, boolean>;
+
+export function accumulateLoadingState<T>(
+  id: number | string,
+  container$: BehaviorSubject<LoadingMap>,
+): OperatorFunction<T, T> {
+  return pipe(
+    toLoadingState(),
+    tap((state) => container$.next(container$.getValue().set(id, state.isLoading))),
+    filter((state) => !state.isLoading),
+    map((state) => (state.value)),
+  );
+}

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
@@ -7,10 +7,11 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  tap, map, filter, switchMap,
+  tap, map, filter, switchMap, BehaviorSubject,
 } from 'rxjs';
 import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
+import { LoadingMap, accumulateLoadingState } from 'app/helpers/operators/accumulate-loading-state.helper';
 import { helptextSharingSmb } from 'app/helptext/sharing/smb/smb';
 import { SmbShare, SmbSharesec } from 'app/interfaces/smb-share.interface';
 import { AsyncDataProvider } from 'app/modules/ix-table2/classes/async-data-provider/async-data-provider';
@@ -37,6 +38,7 @@ import { selectService } from 'app/store/services/services.selectors';
 })
 export class SmbCardComponent implements OnInit {
   requiredRoles = [Role.SharingSmbWrite, Role.SharingWrite];
+  loadingMap$ = new BehaviorSubject<LoadingMap>(new Map());
 
   service$ = this.store$.select(selectService(ServiceName.Cifs));
 
@@ -81,6 +83,7 @@ export class SmbCardComponent implements OnInit {
         {
           iconName: 'edit',
           tooltip: this.translate.instant('Edit'),
+          disabled: (row) => this.loadingMap$.pipe(map((ids) => ids.get(row.id))),
           onClick: (row) => this.openForm(row),
         },
         {
@@ -191,7 +194,10 @@ export class SmbCardComponent implements OnInit {
   private onChangeEnabledState(row: SmbShare): void {
     const param = 'enabled';
 
-    this.ws.call('sharing.smb.update', [row.id, { [param]: !row[param] }]).pipe(untilDestroyed(this)).subscribe({
+    this.ws.call('sharing.smb.update', [row.id, { [param]: !row[param] }]).pipe(
+      accumulateLoadingState(row.id, this.loadingMap$),
+      untilDestroyed(this),
+    ).subscribe({
       next: () => {
         this.getSmbShares();
       },

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
@@ -7,7 +7,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  tap, map, filter, switchMap, BehaviorSubject,
+  tap, map, filter, switchMap,
 } from 'rxjs';
 import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
@@ -37,7 +37,6 @@ import { selectService } from 'app/store/services/services.selectors';
 })
 export class SmbCardComponent implements OnInit {
   requiredRoles = [Role.SharingSmbWrite, Role.SharingWrite];
-  changeEnabledIds$ = new BehaviorSubject<Set<number>>(new Set());
 
   service$ = this.store$.select(selectService(ServiceName.Cifs));
 
@@ -83,7 +82,6 @@ export class SmbCardComponent implements OnInit {
           iconName: 'edit',
           tooltip: this.translate.instant('Edit'),
           onClick: (row) => this.openForm(row),
-          disabled: (row) => this.changeEnabledIds$.pipe(map((ids) => ids.has(row.id))),
         },
         {
           iconName: 'delete',
@@ -191,16 +189,13 @@ export class SmbCardComponent implements OnInit {
   }
 
   private onChangeEnabledState(row: SmbShare): void {
-    this.changeEnabledIds$.next(this.changeEnabledIds$.getValue().add(row.id));
     const param = 'enabled';
 
     this.ws.call('sharing.smb.update', [row.id, { [param]: !row[param] }]).pipe(untilDestroyed(this)).subscribe({
       next: () => {
-        this.changeEnabledIds$.getValue().delete(row.id);
         this.getSmbShares();
       },
       error: (error: unknown) => {
-        this.changeEnabledIds$.getValue().delete(row.id);
         this.getSmbShares();
         this.dialogService.error(this.errorHandler.parseError(error));
       },

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
@@ -7,7 +7,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  tap, map, filter, switchMap,
+  tap, map, filter, switchMap, BehaviorSubject,
 } from 'rxjs';
 import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
@@ -37,7 +37,7 @@ import { selectService } from 'app/store/services/services.selectors';
 })
 export class SmbCardComponent implements OnInit {
   requiredRoles = [Role.SharingSmbWrite, Role.SharingWrite];
-  changedEnabled = new Map<number, boolean>([]);
+  changeEnabledIds$ = new BehaviorSubject<Set<number>>(new Set());
 
   service$ = this.store$.select(selectService(ServiceName.Cifs));
 
@@ -83,6 +83,7 @@ export class SmbCardComponent implements OnInit {
           iconName: 'edit',
           tooltip: this.translate.instant('Edit'),
           onClick: (row) => this.openForm(row),
+          disabled: (row) => this.changeEnabledIds$.pipe(map((ids) => ids.has(row.id))),
         },
         {
           iconName: 'delete',
@@ -190,27 +191,20 @@ export class SmbCardComponent implements OnInit {
   }
 
   private onChangeEnabledState(row: SmbShare): void {
+    this.changeEnabledIds$.next(this.changeEnabledIds$.getValue().add(row.id));
     const param = 'enabled';
-    this.changedEnabled.set(row.id, !row[param]);
-    this.updateEnabledFields();
 
     this.ws.call('sharing.smb.update', [row.id, { [param]: !row[param] }]).pipe(untilDestroyed(this)).subscribe({
       next: () => {
-        this.changedEnabled.delete(row.id);
+        this.changeEnabledIds$.getValue().delete(row.id);
         this.getSmbShares();
       },
       error: (error: unknown) => {
-        this.changedEnabled.delete(row.id);
+        this.changeEnabledIds$.getValue().delete(row.id);
         this.getSmbShares();
         this.dialogService.error(this.errorHandler.parseError(error));
       },
     });
-  }
-
-  private updateEnabledFields(): void {
-    this.dataProvider.setRows(this.smbShares.map((smbShare) => (
-      this.changedEnabled.has(smbShare.id) ? { ...smbShare, enabled: this.changedEnabled.get(smbShare.id) } : smbShare
-    )));
   }
 
   private updateEnabledFieldVisibility(hidden: boolean): void {


### PR DESCRIPTION
Restored as a backport. 
Original PR: https://github.com/truenas/webui/pull/10218

**Testing**

**Steps to Reproduce**



        
1. Navigate to Shares page

        
2. toggle share 'enabled' slider to 'disabled'

        
3. At this share click 'pencil' icon


**Expected Result**

right panel displays and 'enabled' checkbox is disabled