### PR TITLE
NAS-129598: Fix Cloud Sync Bandwidth Limit is not an integer

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.spec.ts
@@ -240,8 +240,8 @@ describe('CloudsyncFormComponent', () => {
       expect(spectator.inject(WebSocketService).call).toHaveBeenLastCalledWith('cloudsync.update', [1, {
         attributes: { folder: mntPath },
         bwlimit: [
-          { time: '9:00' },
-          { bandwidth: 2097152, time: '12:30' },
+          { bandwidth: undefined, time: '9:00' },
+          { bandwidth: '2097152', time: '12:30' },
         ],
         create_empty_src_dirs: true,
         credentials: 2,

--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -589,7 +589,7 @@ export class CloudsyncFormComponent implements OnInit {
           sublimitArr[1] = sublimitArr[1].substring(0, sublimitArr[1].length - 2);
         }
         if (this.cloudCredentialService.getByte(sublimitArr[1]) !== -1) {
-          (sublimitArr[1] as number | string) = this.cloudCredentialService.getByte(sublimitArr[1]);
+          (sublimitArr[1] as number | string) = this.cloudCredentialService.getByte(sublimitArr[1]).toFixed(0);
         }
       }
       const subLimit = {

--- a/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-what-and-when/cloudsync-what-and-when.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-what-and-when/cloudsync-what-and-when.component.ts
@@ -522,7 +522,7 @@ export class CloudsyncWhatAndWhenComponent implements OnInit, OnChanges {
           sublimitArr[1] = sublimitArr[1].substring(0, sublimitArr[1].length - 2);
         }
         if (this.cloudCredentialService.getByte(sublimitArr[1]) !== -1) {
-          (sublimitArr[1] as number | string) = this.cloudCredentialService.getByte(sublimitArr[1]);
+          (sublimitArr[1] as number | string) = this.cloudCredentialService.getByte(sublimitArr[1]).toFixed(0);
         }
       }
       const subLimit = {


### PR DESCRIPTION
Manual backport of workaround from https://github.com/truenas/webui/pull/10071
The goal is to allow users to edit the cloud sync tasks.

There is another issue with conversion limits between `buildNormalizedFileSize` and `CloudCredentialService.getByte` that increases limits on every save. It'll be addressed [separately](https://ixsystems.atlassian.net/browse/NAS-129624).