### PR TITLE
NAS-129391 / 24.10 / Can't edit iSCSI Target on SCALE (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/iscsi/target/target-form/target-form.component.html
+++ b/src/app/pages/sharing/iscsi/target/target-form/target-form.component.html
@@ -106,7 +106,7 @@
           type="submit"
           color="primary"
           ixTest="save"
-          [disabled]="form.invalid || isLoading || (form.statusChanges | async) === 'PENDING'"
+          [disabled]="form.invalid || isLoading || ((form.statusChanges | async) === 'PENDING' && form.controls.name.touched)"
         >
           {{ 'Save' | translate }}
         </button>

--- a/src/app/pages/sharing/iscsi/target/target-form/target-form.component.html
+++ b/src/app/pages/sharing/iscsi/target/target-form/target-form.component.html
@@ -106,7 +106,7 @@
           type="submit"
           color="primary"
           ixTest="save"
-          [disabled]="form.invalid || isLoading || ((form.statusChanges | async) === 'PENDING' && form.controls.name.touched)"
+          [disabled]="form.invalid || isLoading || isAsyncValidatorPending"
         >
           {{ 'Save' | translate }}
         </button>

--- a/src/app/pages/sharing/iscsi/target/target-form/target-form.component.ts
+++ b/src/app/pages/sharing/iscsi/target/target-form/target-form.component.ts
@@ -32,6 +32,10 @@ export class TargetFormComponent implements OnInit {
     return !this.editingTarget;
   }
 
+  get isAsyncValidatorPending(): boolean {
+    return this.form.controls.name.status === 'PENDING' && this.form.controls.name.touched;
+  }
+
   get title(): string {
     return this.isNew
       ? this.translate.instant('Add ISCSI Target')

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.html
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.html
@@ -191,7 +191,7 @@
           type="submit"
           color="primary"
           ixTest="save"
-          [disabled]="form.invalid || isLoading || ((form.statusChanges | async) === 'PENDING' && form.controls.name.touched)"
+          [disabled]="form.invalid || isLoading || isAsyncValidatorPending"
         >
           {{ 'Save' | translate }}
         </button>

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.html
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.html
@@ -191,7 +191,7 @@
           type="submit"
           color="primary"
           ixTest="save"
-          [disabled]="form.invalid || isLoading || (form.statusChanges | async) === 'PENDING'"
+          [disabled]="form.invalid || isLoading || ((form.statusChanges | async) === 'PENDING' && form.controls.name.touched)"
         >
           {{ 'Save' | translate }}
         </button>

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -86,6 +86,10 @@ export class SmbFormComponent implements OnInit, AfterViewInit {
     return !this.existingSmbShare;
   }
 
+  get isAsyncValidatorPending(): boolean {
+    return this.form.controls.name.status === 'PENDING' && this.form.controls.name.touched;
+  }
+
   readonly treeNodeProvider = this.filesystemService.getFilesystemNodeProvider({
     directoriesOnly: true,
     includeSnapshots: false,


### PR DESCRIPTION
Testing: see ticket.

Try to edit some field on a iSCSI Target except name, it should not block 

Original PR: https://github.com/truenas/webui/pull/10205
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129391