### PR TITLE
NAS-129644 / 24.10 / Fix MockStorageScenario.FillSomeSlots for multiple enclosures

### DIFF
--- a/src/app/core/testing/mock-enclosure/enclosure-templates/utils/disk.utils.ts
+++ b/src/app/core/testing/mock-enclosure/enclosure-templates/utils/disk.utils.ts
@@ -6,12 +6,12 @@ import { DashboardEnclosure, DashboardEnclosureSlot } from 'app/interfaces/enclo
 export function addDisksToSlots(enclosures: DashboardEnclosure[], percentageToAdd: number): DashboardEnclosure[] {
   const totalSlots = countSlots(enclosures);
 
-  return mapSlots(enclosures, (slot, i) => {
-    if (i > totalSlots * percentageToAdd) {
+  return mapSlots(enclosures, ({ slot, index }) => {
+    if (index > totalSlots * percentageToAdd) {
       return slot;
     }
 
-    return addDisk(slot, i);
+    return addDisk(slot, index);
   });
 }
 

--- a/src/app/core/testing/mock-enclosure/enclosure-templates/utils/pool.utils.ts
+++ b/src/app/core/testing/mock-enclosure/enclosure-templates/utils/pool.utils.ts
@@ -5,10 +5,10 @@ import { DashboardEnclosure } from 'app/interfaces/enclosure.interface';
 
 // TODO: Only creates single disk vdevs in the same pool. Improve.
 export function addPoolsToDisks(enclosures: DashboardEnclosure[], percentageToAdd: number): DashboardEnclosure[] {
-  const totalDisks = countSlotsBy(enclosures, (slot) => Boolean(slot.dev));
+  return mapSlots(enclosures, ({ slot, enclosure, index }) => {
+    const totalDisks = countSlotsBy([enclosure], ({ dev }) => Boolean(dev));
 
-  return mapSlots(enclosures, (slot, i) => {
-    if (i > totalDisks * percentageToAdd) {
+    if (index >= totalDisks * percentageToAdd) {
       return slot;
     }
 

--- a/src/app/core/testing/mock-enclosure/enclosure-templates/utils/slots.utils.ts
+++ b/src/app/core/testing/mock-enclosure/enclosure-templates/utils/slots.utils.ts
@@ -2,15 +2,21 @@ import { mapValues } from 'lodash';
 import { EnclosureElementType } from 'app/enums/enclosure-slot-status.enum';
 import { DashboardEnclosure, DashboardEnclosureSlot } from 'app/interfaces/enclosure.interface';
 
+interface SlotMappingFunction {
+  slot: DashboardEnclosureSlot;
+  enclosure: DashboardEnclosure;
+  index: number;
+}
+
 export function mapSlots(
   enclosures: DashboardEnclosure[],
-  mappingFunction: (slot: DashboardEnclosureSlot, index: number) => DashboardEnclosureSlot,
+  mappingFunction: ({ slot, enclosure, index }: SlotMappingFunction) => DashboardEnclosureSlot,
 ): DashboardEnclosure[] {
   return enclosures.map((enclosure) => {
     let i = -1;
     const slots = mapValues(enclosure.elements[EnclosureElementType.ArrayDeviceSlot], (slot) => {
       i = i + 1;
-      return mappingFunction(slot, i);
+      return mappingFunction({ slot, enclosure, index: i });
     });
 
     return {


### PR DESCRIPTION
Testing: see ticket.

Update your env config, 
<img width="466" alt="Screenshot 2024-06-26 at 15 27 44" src="https://github.com/truenas/webui/assets/22980553/656c5026-9387-4283-ac17-bcf3775343f5">

or run `yarn ui mock-enclosure` and configure it to have `FillSomeSlots` and with `expansionModels`

Result:
Right now it correctly occupies slots.

https://github.com/truenas/webui/assets/22980553/b27005a8-f1aa-4a6c-ab0b-edca905af1c0

