### PR TITLE
NAS-129744: Switch to system.boot_id

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -787,6 +787,7 @@ export interface ApiCallDirectory {
   'system.advanced.update': { params: [Partial<AdvancedConfigUpdate>]; response: AdvancedConfig };
   'system.advanced.update_gpu_pci_ids': { params: [isolated_gpu_pci_ids: string[]]; response: void };
   'system.build_time': { params: void; response: ApiTimestamp };
+  'system.boot_id': { params: void; response: string };
   'system.environment': { params: void; response: SystemEnvironment };
   'system.general.config': { params: void; response: SystemGeneralConfig };
   'system.general.kbdmap_choices': { params: void; response: Choices };

--- a/src/app/services/update.service.ts
+++ b/src/app/services/update.service.ts
@@ -2,14 +2,13 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { WINDOW } from 'app/helpers/window.helper';
-import { ApiTimestamp } from 'app/interfaces/api-date.interface';
 import { WebSocketService } from 'app/services/ws.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UpdateService {
-  private lastSeenBuiltTime: number;
+  private lastSeenBootId: string;
 
   constructor(
     private ws: WebSocketService,
@@ -19,16 +18,16 @@ export class UpdateService {
   /**
    * Hard refresh is needed to load new html and js after the update.
    */
-  hardRefreshIfNeeded(): Observable<unknown> {
-    return this.ws.call('system.build_time').pipe(
-      tap((buildTime: ApiTimestamp) => {
-        if (!this.lastSeenBuiltTime) {
+  hardRefreshIfNeeded(): Observable<string> {
+    return this.ws.call('system.boot_id').pipe(
+      tap((bootId) => {
+        if (!this.lastSeenBootId) {
           // First boot.
-          this.lastSeenBuiltTime = buildTime.$date;
+          this.lastSeenBootId = bootId;
           return;
         }
 
-        if (this.lastSeenBuiltTime === buildTime.$date) {
+        if (this.lastSeenBootId === bootId) {
           // No update.
           return;
         }

--- a/src/app/views/sessions/signin/store/signin.store.ts
+++ b/src/app/views/sessions/signin/store/signin.store.ts
@@ -87,8 +87,7 @@ export class SigninStore extends ComponentStore<SigninState> {
         this.checkIfAdminPasswordSet(),
         this.checkIfManagedByTrueCommand(),
         this.loadFailoverStatus(),
-        // TODO: Temporarily disabled https://ixsystems.atlassian.net/browse/NAS-129710
-        // this.updateService.hardRefreshIfNeeded(),
+        this.updateService.hardRefreshIfNeeded(),
       ]).pipe(
         switchMap(() => this.authService.loginWithToken()),
         tap((loginResult) => {
@@ -179,7 +178,7 @@ export class SigninStore extends ComponentStore<SigninState> {
   }
 
   private checkIfManagedByTrueCommand(): Observable<boolean> {
-    return of(false).pipe(
+    return this.ws.call('truenas.managed_by_truecommand').pipe(
       tap((managedByTrueCommand) => this.patchState({ managedByTrueCommand })),
     );
   }


### PR DESCRIPTION
There were middleware changes that prevent us from relying on `system.build_time` on public pages. We can use `system.boot_id` instead.
Testing: check login page.