### PR TITLE
NAS-129716 / 24.10 / Search UI takes User to Wrong Category for Shutdown Scripts

### DIFF
--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.elements.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.elements.ts
@@ -10,6 +10,7 @@ export const cloudBackupListElements = {
     },
     add: {
       hierarchy: [T('Add')],
+      anchor: 'add-cloud-backup',
       synonyms: [
         T('Add TrueCloud Backup Task'),
         T('Add Cloud Backup'),

--- a/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.elements.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-list/cloudsync-list.elements.ts
@@ -38,6 +38,7 @@ export const cloudSyncListElements = {
         T('New Cloud Sync Task'),
         T('Task'),
       ],
+      anchor: 'add-cloudsync',
     },
   },
 } satisfies UiSearchableElement;

--- a/src/app/pages/data-protection/replication/replication-list/replication-list.elements.ts
+++ b/src/app/pages/data-protection/replication/replication-list/replication-list.elements.ts
@@ -16,6 +16,7 @@ export const replicationListElements = {
         T('New Replication Task'),
         T('Task'),
       ],
+      anchor: 'add-replication',
     },
   },
 } satisfies UiSearchableElement;

--- a/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.elements.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-list/rsync-task-list.elements.ts
@@ -16,6 +16,7 @@ export const rsyncTaskListElements = {
         T('New Rsync Task'),
         T('Task'),
       ],
+      anchor: 'add-rsync',
     },
   },
 } satisfies UiSearchableElement;

--- a/src/app/pages/data-protection/scrub-task/scrub-list/scrub-list.elements.ts
+++ b/src/app/pages/data-protection/scrub-task/scrub-list/scrub-list.elements.ts
@@ -16,6 +16,7 @@ export const scrubListElements = {
         T('New Scrub Task'),
         T('Task'),
       ],
+      anchor: 'add-scrub',
     },
   },
 } satisfies UiSearchableElement;

--- a/src/app/pages/data-protection/smart-task/smart-task-list/smart-task-list.elements.ts
+++ b/src/app/pages/data-protection/smart-task/smart-task-list/smart-task-list.elements.ts
@@ -17,6 +17,7 @@ export const smartTaskListElements = {
     },
     add: {
       hierarchy: [T('Add')],
+      anchor: 'add-smart-test',
       synonyms: [
         T('Add Periodic S.M.A.R.T. Test'),
         T('Add Smart Test'),

--- a/src/app/pages/data-protection/snapshot-task/snapshot-task-list/snapshot-task-list.elements.ts
+++ b/src/app/pages/data-protection/snapshot-task/snapshot-task-list/snapshot-task-list.elements.ts
@@ -10,6 +10,7 @@ export const snapshotTaskListElements = {
     },
     add: {
       hierarchy: [T('Add')],
+      anchor: 'add-snapshot-task',
       synonyms: [
         T('Add Periodic Snapshot Task'),
         T('Create Periodic Snapshot Task'),

--- a/src/app/pages/reports-dashboard/components/exporters/reporting-exporters-list/reporting-exporters-list.elements.ts
+++ b/src/app/pages/reports-dashboard/components/exporters/reporting-exporters-list/reporting-exporters-list.elements.ts
@@ -8,6 +8,7 @@ export const reportingExportersElements = {
     exporters: {},
     add: {
       hierarchy: [T('Add')],
+      anchor: 'add-reporting-exporter',
       synonyms: [
         T('Add Exporter'),
         T('New Exporter'),

--- a/src/app/pages/system/advanced/cron/cron-card/cron-card.component.html
+++ b/src/app/pages/system/advanced/cron/cron-card/cron-card.component.html
@@ -9,7 +9,6 @@
     <div class="actions">
       <button
         *ixRequiresRoles="requiredRoles"
-        id="add-cron"
         mat-button
         [ixTest]="['cron', 'add']"
         [ixUiSearch]="searchableElements.elements.addCronJob"

--- a/src/app/pages/system/advanced/cron/cron-card/cron-card.elements.ts
+++ b/src/app/pages/system/advanced/cron/cron-card/cron-card.elements.ts
@@ -8,6 +8,7 @@ export const cronCardElements = {
   elements: {
     addCronJob: {
       hierarchy: [T('Add')],
+      anchor: 'add-cron-job',
       synonyms: [
         T('Add Cron Job'),
         T('Create Cron Job'),

--- a/src/app/pages/system/advanced/init-shutdown/init-shutdown-card/init-shutdown-card.component.html
+++ b/src/app/pages/system/advanced/init-shutdown/init-shutdown-card/init-shutdown-card.component.html
@@ -9,7 +9,6 @@
     <div class="actions">
       <button
         *ixRequiresRoles="requiredRoles"
-        id="add-init-shutdown-script"
         mat-button
         [ixTest]="['init-shutdown', 'add']"
         [ixUiSearch]="searchableElements.elements.addInitShutdownScript"

--- a/src/app/pages/system/advanced/init-shutdown/init-shutdown-card/init-shutdown-card.elements.ts
+++ b/src/app/pages/system/advanced/init-shutdown/init-shutdown-card/init-shutdown-card.elements.ts
@@ -8,6 +8,7 @@ export const initShutdownCardElements = {
   elements: {
     addInitShutdownScript: {
       hierarchy: [T('Add')],
+      anchor: 'add-init-shutdown-script',
       synonyms: [
         T('Add Init/Shutdown Script'),
         T('Create Init/Shutdown Script'),

--- a/src/app/pages/system/advanced/sysctl/sysctl-card/sysctl-card.elements.ts
+++ b/src/app/pages/system/advanced/sysctl/sysctl-card/sysctl-card.elements.ts
@@ -11,6 +11,7 @@ export const sysctlCardElements = {
     },
     addSysctl: {
       hierarchy: [T('Add')],
+      anchor: 'add-sysctl',
       synonyms: [
         T('Add Sysctl'),
         T('Create Sysctl'),

--- a/src/app/pages/system/alert-service/alert-service-list/alert-service-list.elements.ts
+++ b/src/app/pages/system/alert-service/alert-service-list/alert-service-list.elements.ts
@@ -9,6 +9,7 @@ export const alertServiceListElements = {
     alertServiceList: {},
     add: {
       hierarchy: [T('Add')],
+      anchor: 'add-alert-service',
       synonyms: [
         T('Alerts'),
         T('Configure Alerts'),

--- a/src/app/pages/system/general-settings/ntp-server/ntp-server-card/ntp-server-card.component.html
+++ b/src/app/pages/system/general-settings/ntp-server/ntp-server-card/ntp-server-card.component.html
@@ -4,7 +4,6 @@
     <div class="actions action-icon">
       <button
         *ixRequiresRoles="requiredRoles"
-        id="add-ntp-server"
         mat-button
         color="default"
         ixTest="add-ntp"

--- a/src/app/pages/system/general-settings/ntp-server/ntp-server-card/ntp-server-card.elements.ts
+++ b/src/app/pages/system/general-settings/ntp-server/ntp-server-card/ntp-server-card.elements.ts
@@ -11,6 +11,7 @@ export const ntpServerElements = {
     },
     addNtpServer: {
       hierarchy: [T('Add')],
+      anchor: 'add-ntp-server',
       synonyms: [
         T('Add NTP Server'),
         T('Create NTP Server'),

--- a/src/app/pages/vm/vm-list/vm-list.elements.ts
+++ b/src/app/pages/vm/vm-list/vm-list.elements.ts
@@ -10,6 +10,7 @@ export const vmListElements = {
     },
     add: {
       hierarchy: [T('Add')],
+      anchor: 'add-vm',
       synonyms: [
         T('Add VM'),
         T('Create VM'),

--- a/src/assets/ui-searchable-elements.json
+++ b/src/assets/ui-searchable-elements.json
@@ -1001,7 +1001,7 @@
       "cloud-backup"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-cloud-backup",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -1044,7 +1044,7 @@
       "cloudsync"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-cloudsync",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -1122,7 +1122,7 @@
       "replication"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-replication",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -1164,7 +1164,7 @@
       "rsync"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-rsync",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -1224,7 +1224,7 @@
       "scrub"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-scrub",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -1298,7 +1298,7 @@
       "smart"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-smart-test",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -1369,7 +1369,7 @@
       "snapshot"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-snapshot-task",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -2135,7 +2135,7 @@
       "exporters"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-reporting-exporter",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -3496,7 +3496,7 @@
       "advanced"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-cron-job",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -3616,7 +3616,7 @@
       "advanced"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-init-shutdown-script",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -3897,7 +3897,7 @@
       "advanced"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-sysctl",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -4071,7 +4071,7 @@
       "services"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-alert-service",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -4761,7 +4761,7 @@
       "general"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-ntp-server",
     "triggerAnchor": null,
     "section": "ui"
   },
@@ -4982,7 +4982,7 @@
       "/vm"
     ],
     "routerLink": null,
-    "anchor": "add",
+    "anchor": "add-vm",
     "triggerAnchor": null,
     "section": "ui"
   },


### PR DESCRIPTION
Testing: see ticket.
It's recommended to add custom `id` attributes to the ADD buttons, if we don't add them we'll generate from hierarchy - and it's just `add` -> leading to duplicate ids.

Result:

https://github.com/truenas/webui/assets/22980553/4fe68d17-f756-4407-b48f-6bfb839e41c0

