### PR TITLE
NAS-129329: DF: Self-Encrypting Drive card doesn't display on System->Advanced page for Read Only Admin

### DIFF
--- a/src/app/pages/system/advanced/advanced-settings.component.html
+++ b/src/app/pages/system/advanced/advanced-settings.component.html
@@ -14,7 +14,7 @@
   <ix-replication-settings-card></ix-replication-settings-card>
   <ix-access-card></ix-access-card>
   <ix-allowed-addresses-card></ix-allowed-addresses-card>
-  <ix-self-encrypting-drive-card *ixHasRole="[Role.FullAdmin]"></ix-self-encrypting-drive-card>
+  <ix-self-encrypting-drive-card></ix-self-encrypting-drive-card>
   <ix-isolated-gpus-card></ix-isolated-gpus-card>
   <ix-global-two-factor-card></ix-global-two-factor-card>
   <ix-system-security-card *ngIf="!!(isSystemLicensed$ | async)"></ix-system-security-card>


### PR DESCRIPTION
Testing: see ticket.