### PR TITLE
NAS-128364 / 24.10 / Truncated translation on Backup Credentials panel

### DIFF
--- a/src/assets/styles/other/_fn-styles.scss
+++ b/src/assets/styles/other/_fn-styles.scss
@@ -436,11 +436,12 @@ body * {
   box-direction: normal;
   box-orient: horizontal;
   display: flex;
-  flex-align: center;
   flex-direction: row;
   height: 48px;
   padding: 0 16px 0 0;
   position: relative;
+  white-space: normal;
+  word-wrap: break-word;
   z-index: 99;
 }
 


### PR DESCRIPTION
Testing: see ticket / result:
<img width="763" alt="Screenshot 2024-07-01 at 23 49 26" src="https://github.com/truenas/webui/assets/22980553/dc3a5c2c-63e7-458e-967e-1e3cffda2d0a">
