### PR TITLE
NAS-129686 / 24.04.3 / Fix SMB ACL form (by bvasilenko)

### DIFF
--- a/src/app/enums/nfs-acl.enum.ts
+++ b/src/app/enums/nfs-acl.enum.ts
@@ -6,7 +6,7 @@ export enum NfsAclTag {
   Everyone = 'everyone@',
   User = 'USER',
   UserGroup = 'GROUP',
-  Both = 'BOTH',
+  Both = 'BOTH', // middleware returns `ID_TYPE_BOTH` when it is not possible to determine whether an AD entity is a user or a group
 }
 
 export const nfsAclTagLabels = new Map<NfsAclTag, string>([

--- a/src/app/enums/nfs-acl.enum.ts
+++ b/src/app/enums/nfs-acl.enum.ts
@@ -6,6 +6,7 @@ export enum NfsAclTag {
   Everyone = 'everyone@',
   User = 'USER',
   UserGroup = 'GROUP',
+  Both = 'BOTH',
 }
 
 export const nfsAclTagLabels = new Map<NfsAclTag, string>([

--- a/src/app/interfaces/smb-share.interface.ts
+++ b/src/app/interfaces/smb-share.interface.ts
@@ -63,7 +63,7 @@ export interface SmbSharesecAce {
   ae_perm: SmbSharesecPermission;
   ae_type: SmbSharesecType;
   ae_who_id: {
-    id_type: NfsAclTag.Everyone | NfsAclTag.UserGroup | NfsAclTag.User | null;
+    id_type: NfsAclTag.Everyone | NfsAclTag.UserGroup | NfsAclTag.User | NfsAclTag.Both | null;
     id: number;
   };
   ae_who_sid?: string;

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
@@ -39,6 +39,7 @@
                 formControlName="user"
                 [label]="'User' | translate"
                 [provider]="userProvider"
+                [allowCustomValue]="true"
                 [required]="true"
               ></ix-combobox>
 
@@ -47,6 +48,7 @@
                 formControlName="group"
                 [label]="'Group' | translate"
                 [provider]="groupProvider"
+                [allowCustomValue]="true"
                 [required]="true"
               ></ix-combobox>
             </div>

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
@@ -109,26 +109,80 @@ describe('SmbAclComponent', () => {
     expect(title).toHaveText('Share ACL for myshare');
   });
 
-  it('shows user combobox when Who is user', async () => {
-    await entriesList.pressAddButton();
-    const newListItem = await entriesList.getLastListItem();
-    await newListItem.fillForm({
-      Who: 'User',
+  describe('user ace', () => {
+    it('shows user combobox when Who is user', async () => {
+      await entriesList.pressAddButton();
+      const newListItem = await entriesList.getLastListItem();
+      await newListItem.fillForm({
+        Who: 'User',
+      });
+
+      const userSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'User' }));
+      expect(userSelect).toExist();
+
+      const entries = spectator.component.form.value.entries;
+      expect(entries[entries.length - 1]).toEqual(
+        expect.not.objectContaining({ user: 0 }),
+      );
     });
 
-    const userSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'User' }));
-    expect(userSelect).toExist();
+    it('allows custom values in User combobox', async () => {
+      const newListItem = await entriesList.getLastListItem();
+      await newListItem.fillForm({
+        Who: 'User',
+      });
+
+      const fields = await newListItem.getControlHarnessesDict();
+
+      const userCombobox = fields['User'] as IxComboboxHarness;
+      await userCombobox.writeCustomValue('root');
+
+      const userSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'User' }));
+      expect(userSelect).toExist();
+
+      const entries = spectator.component.form.value.entries;
+      expect(entries[entries.length - 1]).toEqual(
+        expect.objectContaining({ user: 0 }),
+      );
+    });
   });
 
-  it('shows group combobox when Who is group', async () => {
-    await entriesList.pressAddButton();
-    const newListItem = await entriesList.getLastListItem();
-    await newListItem.fillForm({
-      Who: 'Group',
+  describe('group ace', () => {
+    it('shows group combobox when Who is group', async () => {
+      await entriesList.pressAddButton();
+      const newListItem = await entriesList.getLastListItem();
+      await newListItem.fillForm({
+        Who: 'Group',
+      });
+
+      const groupSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'Group' }));
+      expect(groupSelect).toExist();
+
+      const entries = spectator.component.form.value.entries;
+      expect(entries[entries.length - 1]).toEqual(
+        expect.not.objectContaining({ group: 1 }),
+      );
     });
 
-    const groupSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'Group' }));
-    expect(groupSelect).toExist();
+    it('allows custom values in Group combobox', async () => {
+      const newListItem = await entriesList.getLastListItem();
+      await newListItem.fillForm({
+        Who: 'Group',
+      });
+
+      const fields = await newListItem.getControlHarnessesDict();
+
+      const groupCombobox = fields['Group'] as IxComboboxHarness;
+      await groupCombobox.writeCustomValue('wheel');
+
+      const groupSelect = await loader.getHarness(IxComboboxHarness.with({ label: 'Group' }));
+      expect(groupSelect).toExist();
+
+      const entries = spectator.component.form.value.entries;
+      expect(entries[entries.length - 1]).toEqual(
+        expect.objectContaining({ group: 1 }),
+      );
+    });
   });
 
   it('loads and shows current acl for a share', async () => {

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
@@ -121,10 +121,11 @@ export class SmbAclComponent implements OnInit {
     this.form.controls.entries.removeAt(index);
   }
 
-  async onSubmit(): Promise<void> {
+  onSubmit(): void {
     this.isLoading = true;
 
-    of(await this.getAclEntriesFromForm())
+    of(undefined)
+      .pipe(mergeMap(() => this.getAclEntriesFromForm()))
       .pipe(mergeMap((acl) => this.ws.call('sharing.smb.setacl', [{ share_name: this.shareAclName, share_acl: acl }])))
       .pipe(untilDestroyed(this))
       .subscribe({

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.ts
@@ -4,8 +4,9 @@ import {
 import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import _ from 'lodash';
 import {
-  concatMap, forkJoin, from, map, Observable, of,
+  concatMap, firstValueFrom, forkJoin, map, mergeMap, Observable, of, from,
 } from 'rxjs';
 import { NfsAclTag, smbAclTagLabels } from 'app/enums/nfs-acl.enum';
 import { Role } from 'app/enums/role.enum';
@@ -30,8 +31,8 @@ interface FormAclEntry {
   ae_who: NfsAclTag.Everyone | NfsAclTag.UserGroup | NfsAclTag.User | null;
   ae_perm: SmbSharesecPermission;
   ae_type: SmbSharesecType;
-  user: number | null;
-  group: number | null;
+  user: string | number | null;
+  group: string | number | null;
 }
 
 @UntilDestroy()
@@ -120,11 +121,11 @@ export class SmbAclComponent implements OnInit {
     this.form.controls.entries.removeAt(index);
   }
 
-  onSubmit(): void {
+  async onSubmit(): Promise<void> {
     this.isLoading = true;
-    const acl = this.getAclEntriesFromForm();
 
-    this.ws.call('sharing.smb.setacl', [{ share_name: this.shareAclName, share_acl: acl }])
+    of(await this.getAclEntriesFromForm())
+      .pipe(mergeMap((acl) => this.ws.call('sharing.smb.setacl', [{ share_name: this.shareAclName, share_acl: acl }])))
       .pipe(untilDestroyed(this))
       .subscribe({
         next: () => {
@@ -152,6 +153,7 @@ export class SmbAclComponent implements OnInit {
             this.addAce();
 
             let aeWho: FormAclEntry['ae_who'];
+
             if (ace.ae_who_id?.id_type === NfsAclTag.Both) {
               aeWho = userIds.includes(ace.ae_who_id.id) ? NfsAclTag.User : NfsAclTag.UserGroup;
             } else {
@@ -176,22 +178,32 @@ export class SmbAclComponent implements OnInit {
       });
   }
 
-  private getAclEntriesFromForm(): SmbSharesecAce[] {
-    return this.form.value.entries.map((ace) => {
-      const whoId = ace.ae_who === NfsAclTag.UserGroup ? ace.group : ace.user;
+  private async getAclEntriesFromForm(): Promise<SmbSharesecAce[]> {
+    const results = [] as SmbSharesecAce[];
+    for (const ace of this.form.value.entries) {
+      const whoIdOrName = ace.ae_who === NfsAclTag.UserGroup ? ace.group : ace.user;
 
       const result = { ae_perm: ace.ae_perm, ae_type: ace.ae_type } as SmbSharesecAce;
 
-      if (ace.ae_who !== this.nfsAclTag.Everyone) {
-        result.ae_who_id = { id_type: ace.ae_who, id: whoId };
-      }
-
       if (ace.ae_who === NfsAclTag.Everyone) {
         result.ae_who_sid = 'S-1-1-0';
-      }
+      } else {
+        let id: number;
+        if (_.isNumber(whoIdOrName)) {
+          id = Number(whoIdOrName);
+        } else if (ace.ae_who === NfsAclTag.UserGroup) {
+          id = (await firstValueFrom(this.userService.getGroupByName(whoIdOrName.toString())))
+            .gr_gid;
+        } else {
+          id = (await firstValueFrom(this.userService.getUserByName(whoIdOrName.toString())))
+            .pw_uid;
+        }
 
-      return result;
-    });
+        result.ae_who_id = { id_type: ace.ae_who, id };
+      }
+      results.push(result);
+    }
+    return results;
   }
 
   private initialValueDataFromAce(


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 594ce987a9f58c7fd0927bbe79a47c39048961fd
    git cherry-pick -x df35b0190c725640c742c5fd4bbd6f3029e4cdce
    git cherry-pick -x b8609ae68bc07c83acd1468f3b80c8e7d8d644f9

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~3
    git cherry-pick -x 324fa0f9a287f5d9d742e132d275ec5061a58177

**Summary**

1. when AD cache is empty (see ticket), when **Group** combobox does not contain any suitable values to choose from,
I've changed to code to add the ability to type in a custom value from keyboard . When user presses **Save**, every value is validated for being a valid existing entry in the Active Directory 

2. Middleware returns special type of AD entry `BOTH` , and when AD cache is empty (see ticket) it's not possible to distinguish a user from a group. 
   It was agreed that, it would be unreasonable to try to squeeze in last-second middleware update for 24.04.2.
   So, in such cases, the WebUI code was updated to make an attempt of detecting the type, otherwise it treats an AD entry as `GROUP`.

**Testing**

1. Log into WebUI
2. Setup the Active directory
4. Disable AD User / Group Cache and rebuild cache
5. Save the configuration
6. Create an SMB share
7. Edit the SMB ACL
8. Add a known to exist AD Group using keyboard entry, not picking any of options of the dropdown menu (for example `AD02\domain users`)
  and/or add a User entry by typing on the keyboard (for example type in `AD02\administrator`)
9. Save the ACL
10. Edit the SMB ACL
11. Observe the AD Group and/or User entry

Original PR: https://github.com/truenas/webui/pull/10271
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129686