### PR TITLE
NAS-130050 / 24.10 / Adds higlight styles for vdev disks

### DIFF
--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
@@ -51,7 +51,7 @@
 
       &.not-selected-vdev-disk {
         fill: black;
-        opacity: 0.2;
+        opacity: 0.5;
       }
     }
   }

--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
@@ -37,6 +37,17 @@
           fill: var(--primary) !important;
         }
       }
+
+      &.selected-vdev-disk {
+        filter: brightness(1.5);
+        stroke: white;
+        stroke-dasharray: none;
+        stroke-width: 4px;
+
+        &.tinted {
+          fill: var(--primary) !important;
+        }
+      }
     }
   }
 }

--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
@@ -10,8 +10,6 @@
 }
 
 .svg-container {
-  fill-opacity: 0.3;
-
   &.static {
     pointer-events: none;
   }
@@ -20,6 +18,7 @@
     .overlay-rect {
       cursor: pointer;
       fill: var(--black);
+      fill-opacity: 0.3;
       transition: fill-opacity 0.2s ease-in-out, filter 0.2s ease-in-out;
 
       &:hover {

--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
@@ -48,6 +48,11 @@
           fill: var(--primary) !important;
         }
       }
+
+      &.not-selected-vdev-disk {
+        fill: black;
+        opacity: 0.2;
+      }
     }
   }
 }

--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
@@ -203,7 +203,7 @@ export class EnclosureSvgComponent implements OnDestroy {
   private handleOverlayKeyNavigation(event: KeyboardEvent, slot: DashboardEnclosureSlot): void {
     switch (event.key) {
       case 'Enter':
-        this.selectedSlot.set(slot);
+        this.slotSelected(slot);
         break;
       case 'ArrowUp':
       case 'ArrowLeft':
@@ -233,18 +233,7 @@ export class EnclosureSvgComponent implements OnDestroy {
   private addInteractionListeners(slot: DashboardEnclosureSlot): void {
     const overlay = this.overlayRects[slot.drive_bay_number];
 
-    this.clickListener = this.renderer.listen(overlay, 'click', () => {
-      const selectedSlot = this.selectedSlot();
-      const newSlotExists = !!slot;
-      const prevSlotExists = !!selectedSlot;
-
-      if (newSlotExists && prevSlotExists && slot.dev === selectedSlot.dev) {
-        this.selectedSlot.set(undefined);
-        return;
-      }
-
-      this.selectedSlot.set(slot);
-    });
+    this.clickListener = this.renderer.listen(overlay, 'click', this.slotSelected.bind(this, slot));
 
     this.keyDownListener = this.renderer.listen(
       overlay,
@@ -263,6 +252,19 @@ export class EnclosureSvgComponent implements OnDestroy {
       }),
     );
   }
+
+  slotSelected = (slot: DashboardEnclosureSlot): void => {
+    const selectedSlot = this.selectedSlot();
+    const newSlotExists = !!slot;
+    const prevSlotExists = !!selectedSlot;
+
+    if (newSlotExists && prevSlotExists && slot.dev === selectedSlot.dev) {
+      this.selectedSlot.set(undefined);
+      return;
+    }
+
+    this.selectedSlot.set(slot);
+  };
 
   private addTint(slot: DashboardEnclosureSlot): void {
     const overlay = this.overlayRects[slot.drive_bay_number];

--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
@@ -161,23 +161,13 @@ export class EnclosureSvgComponent implements OnDestroy {
     if (!selectedVdevDisks?.length) {
       return;
     }
-    const selectedVdevDisksDriveBayNumbers = [];
-    const notSelectedVdevDisksDriveBayNumbers = [];
+
     for (const slot of allSlots) {
       if (selectedVdevDisks.includes(slot.dev)) {
-        selectedVdevDisksDriveBayNumbers.push(slot.drive_bay_number);
+        this.renderer.addClass(this.overlayRects[slot.drive_bay_number], 'selected-vdev-disk');
       } else if (slot.drive_bay_number !== selectedSlot.drive_bay_number) {
-        notSelectedVdevDisksDriveBayNumbers.push(slot.drive_bay_number);
+        this.renderer.addClass(this.overlayRects[slot.drive_bay_number], 'not-selected-vdev-disk');
       }
-    }
-
-    for (const vdevDiskDriveBayNumber of selectedVdevDisksDriveBayNumbers) {
-      const vdevDiskSlotOverlay = this.overlayRects[vdevDiskDriveBayNumber];
-      this.renderer.addClass(vdevDiskSlotOverlay, 'selected-vdev-disk');
-    }
-    for (const notVdevDiskDriveBayNumber of notSelectedVdevDisksDriveBayNumbers) {
-      const vdevDiskSlotOverlay = this.overlayRects[notVdevDiskDriveBayNumber];
-      this.renderer.addClass(vdevDiskSlotOverlay, 'not-selected-vdev-disk');
     }
   }
 

--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
@@ -237,23 +237,13 @@ export class EnclosureSvgComponent implements OnDestroy {
       const selectedSlot = this.selectedSlot();
       const newSlotExists = !!slot;
       const prevSlotExists = !!selectedSlot;
-      const prevSlotVdevDisks = prevSlotExists ? selectedSlot.pool_info?.vdev_disks.map((disk) => disk.dev) : [];
 
-      if (!newSlotExists) {
+      if (newSlotExists && prevSlotExists && slot.dev === selectedSlot.dev) {
         this.selectedSlot.set(undefined);
         return;
       }
 
-      if (!prevSlotExists) {
-        this.selectedSlot.set(slot);
-        return;
-      }
-
-      if (prevSlotVdevDisks.includes(slot.dev)) {
-        this.selectedSlot.set(slot);
-      } else {
-        this.selectedSlot.set(undefined);
-      }
+      this.selectedSlot.set(slot);
     });
 
     this.keyDownListener = this.renderer.listen(


### PR DESCRIPTION
**Changes:**

Added a new class to the `overlay-rect` that adds the same highlight styles as the selected slot but with a white border color to all other disks in the same vdev as the currently selected slot.

**Testing:**

Mock some enclosures and test by selecting different slots. Other slots that are also part of the same vdev should also get the highlight styles but with a white border.
