### PR TITLE
NAS-130027 / 24.10 / Update styles for mobile layout

### DIFF
--- a/src/app/modules/dialog/components/error-dialog/error-dialog.component.scss
+++ b/src/app/modules/dialog/components/error-dialog/error-dialog.component.scss
@@ -29,7 +29,7 @@ $opened-scroll-container-height: calc(80vh - 48px - 240px); // Viewport - topbar
     background: var(--contrast-darker);
     border: 1px solid var(--lines);
     color: var(--fg2);
-    font-family: 'Droid Sans Mono', 'Courier New', Courier, monospace;
+    font-family: var(--font-family-monospace);
     max-height: $opened-scroll-container-height;
     min-height: 100px;
     overflow: auto;

--- a/src/app/modules/dialog/components/info-dialog/info-dialog.component.scss
+++ b/src/app/modules/dialog/components/info-dialog/info-dialog.component.scss
@@ -8,7 +8,7 @@
 
   span {
     display: block;
-    font-family: monospace;
+    font-family: var(--font-family-monospace);
     unicode-bidi: embed;
     white-space: pre-line;
   }

--- a/src/app/modules/dialog/components/job-progress/job-progress-dialog.component.scss
+++ b/src/app/modules/dialog/components/job-progress/job-progress-dialog.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   display: block;

--- a/src/app/modules/dialog/components/multi-error-dialog/error-template/error-template.component.scss
+++ b/src/app/modules/dialog/components/multi-error-dialog/error-template/error-template.component.scss
@@ -23,7 +23,7 @@ $opened-scroll-container-height: calc(80vh - 48px - 240px); // Viewport - topbar
     background: var(--contrast-darker);
     border: 1px solid var(--lines);
     color: var(--fg2);
-    font-family: 'Droid Sans Mono', 'Courier New', Courier, monospace;
+    font-family: var(--font-family-monospace);
     max-height: $opened-scroll-container-height;
     min-height: 100px;
     overflow: auto;

--- a/src/app/modules/entity/entity-job/entity-job.component.scss
+++ b/src/app/modules/entity/entity-job/entity-job.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   display: block;

--- a/src/app/modules/forms/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.scss
+++ b/src/app/modules/forms/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   color: var(--fg1);

--- a/src/app/modules/forms/search-input/components/advanced-search/advanced-search.component.scss
+++ b/src/app/modules/forms/search-input/components/advanced-search/advanced-search.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 @import 'mixins/layout';
 
 :host {

--- a/src/app/modules/forms/search-input/components/basic-search/basic-search.component.scss
+++ b/src/app/modules/forms/search-input/components/basic-search/basic-search.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 @import 'mixins/layout';
 
 :host {

--- a/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component.scss
+++ b/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .actions {
   display: flex;

--- a/src/app/modules/ix-table/components/ix-table-body/ix-table-body.component.scss
+++ b/src/app/modules/ix-table/components/ix-table-body/ix-table-body.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   background: var(--bg2);

--- a/src/app/modules/ix-table/components/ix-table-head/ix-table-head.component.scss
+++ b/src/app/modules/ix-table/components/ix-table-head/ix-table-head.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 tr {
   th {

--- a/src/app/modules/ix-table/components/ix-table-pager/ix-table-pager.component.scss
+++ b/src/app/modules/ix-table/components/ix-table-pager/ix-table-pager.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host ::ng-deep {
   .mat-mdc-form-field-infix {

--- a/src/app/modules/layout/components/admin-layout/admin-layout.component.scss
+++ b/src/app/modules/layout/components/admin-layout/admin-layout.component.scss
@@ -1,5 +1,5 @@
 @import 'scss-imports/cssvars';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .mat-sidenav-container {
   height: 100vh;
@@ -88,11 +88,6 @@
   width: 108px !important;
 }
 
-/* To get rid of VScroll on entity tables */
-.rightside-content-hold {
-  padding-bottom: 5px;
-}
-
 .hostname-label {
   font-size: 12px;
   margin: auto;
@@ -154,18 +149,18 @@ ix-jw-modal {
   display: block;
   height: calc(100% - 48px);
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: auto !important;
   padding: 16px;
   position: absolute;
   top: 48px;
   width: 100%;
 
-  &.has-console-footer {
-    height: calc(100% - 95px);
+  @media (max-width: $breakpoint-tablet) {
+    padding-bottom: 96px !important;
+  }
 
-    @media (max-width: $breakpoint-tablet) {
-      height: calc(100% - 144px);
-    }
+  &.has-console-footer {
+    height: calc(100% - #{$console-footer-height + $topbar-mobile-height});
   }
 }
 

--- a/src/app/modules/layout/components/console-footer/console-footer.component.html
+++ b/src/app/modules/layout/components/console-footer/console-footer.component.html
@@ -1,5 +1,5 @@
-<div class="footer-console-bar">
-  <pre #messageContainer class="messages" (click)="onShowConsolePanel()">
-    {{ lastThreeLogLines$ | async }}
-  </pre>
-</div>
+<pre
+  #messageContainer
+  class="messages"
+  (click)="onShowConsolePanel()"
+>{{ lastThreeLogLines$ | async }}</pre>

--- a/src/app/modules/layout/components/console-footer/console-footer.component.scss
+++ b/src/app/modules/layout/components/console-footer/console-footer.component.scss
@@ -1,8 +1,10 @@
-.footer-console-bar {
+@import 'scss-imports/variables';
+
+:host {
   background-color: #000;
   bottom: 0;
   cursor: pointer;
-  height: 45px;
+  height: $console-footer-height;
   position: absolute;
   width: 100%;
   z-index: 10;
@@ -10,7 +12,7 @@
   .messages {
     background-color: #000;
     color: #0f0;
-    font-family: monospace, Courier New, Courier;
+    font-family: var(--font-family-monospace);
     font-size: 9pt;
     height: 39px;
     line-height: 1;
@@ -21,3 +23,5 @@
     white-space: pre-wrap;
   }
 }
+
+

--- a/src/app/modules/layout/components/console-footer/console-messages.store.ts
+++ b/src/app/modules/layout/components/console-footer/console-messages.store.ts
@@ -24,8 +24,7 @@ export class ConsoleMessagesStore extends ComponentStore<ConsoleMessagesState> i
   private readonly maxMessages = 500;
 
   private addMessage = this.updater((state, message: string) => {
-    const newLines = message.split('\n')
-      .filter((line) => line.trim().length > 0);
+    const newLines = message.split('\n').filter((line) => line.trim().length > 0);
 
     let lines = [...state.lines, ...newLines];
     lines = lines.slice(-this.maxMessages);

--- a/src/app/modules/layout/components/topbar/topbar.component.scss
+++ b/src/app/modules/layout/components/topbar/topbar.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   position: fixed;
@@ -21,7 +21,7 @@
     @media (max-width: $breakpoint-tablet) {
       background-color: var(--topbar);
       bottom: 0;
-      height: 48px;
+      height: $topbar-mobile-height;
       left: 0;
       padding: 0 16px;
       place-content: space-around;
@@ -29,7 +29,7 @@
       width: 100%;
 
       &.has-console-footer {
-        bottom: 47px;
+        bottom: $console-footer-height;
       }
     }
 

--- a/src/app/modules/page-header/page-title-header/page-header.component.scss
+++ b/src/app/modules/page-header/page-title-header/page-header.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   border-bottom: solid 1px var(--lines);

--- a/src/app/pages/account/groups/privilege/privilege-list/privilege-list.component.scss
+++ b/src/app/pages/account/groups/privilege/privilege-list/privilege-list.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 @import 'mixins/layout';
 
 .search-container {

--- a/src/app/pages/account/users/user-form/user-form.component.scss
+++ b/src/app/pages/account/users/user-form/user-form.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   ix-slide-toggle {

--- a/src/app/pages/api-keys/components/key-created-dialog/key-created-dialog.component.scss
+++ b/src/app/pages/api-keys/components/key-created-dialog/key-created-dialog.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   display: block;

--- a/src/app/pages/apps/components/app-detail-view/app-detail-view.component.scss
+++ b/src/app/pages/apps/components/app-detail-view/app-detail-view.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   color: var(--fg1);

--- a/src/app/pages/apps/components/available-apps/available-apps-header/available-apps-header.component.scss
+++ b/src/app/pages/apps/components/available-apps/available-apps-header/available-apps-header.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   border-bottom: 1px solid var(--lines);

--- a/src/app/pages/apps/components/available-apps/available-apps.component.scss
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   .apps {

--- a/src/app/pages/apps/components/available-apps/category-view/category-view.component.scss
+++ b/src/app/pages/apps/components/available-apps/category-view/category-view.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .apps {
   column-gap: 40px;

--- a/src/app/pages/apps/components/chart-wizard/chart-wizard.component.scss
+++ b/src/app/pages/apps/components/chart-wizard/chart-wizard.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .chart-wizard-wrapper {
   display: flex;

--- a/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.scss
@@ -1,5 +1,5 @@
 @import 'mixins/cards';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .header {
   @media (max-width: calc($breakpoint-hidden - 1px)) {

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.scss
@@ -1,5 +1,5 @@
 @import 'mixins/cards';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .app-logo {
   flex: 0 0 auto;

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   align-items: center;

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 @import 'mixins/layout';
 
 @include tree-node-with-details-container;

--- a/src/app/pages/audit/components/audit/audit.component.scss
+++ b/src/app/pages/audit/components/audit/audit.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 @import 'mixins/layout';
 
 @include tree-node-with-details-container;

--- a/src/app/pages/audit/components/event-data-details-card/event-data-details-card.component.scss
+++ b/src/app/pages/audit/components/event-data-details-card/event-data-details-card.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 @import 'mixins/layout';
 
 pre {

--- a/src/app/pages/audit/components/log-details-panel/log-details-panel.component.scss
+++ b/src/app/pages/audit/components/log-details-panel/log-details-panel.component.scss
@@ -1,5 +1,5 @@
 @import 'mixins/cards';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   width: 100%;

--- a/src/app/pages/credentials/backup-credentials/backup-credentials.component.scss
+++ b/src/app/pages/credentials/backup-credentials/backup-credentials.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   display: block;

--- a/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.scss
+++ b/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.scss
@@ -7,5 +7,5 @@
 }
 
 .remote-host-key-textarea ::ng-deep textarea {
-  font-family: monospace;
+  font-family: var(--font-family-monospace);
 }

--- a/src/app/pages/credentials/backup-credentials/ssh-keypair-form/ssh-keypair-form.component.scss
+++ b/src/app/pages/credentials/backup-credentials/ssh-keypair-form/ssh-keypair-form.component.scss
@@ -1,5 +1,5 @@
 .key-text-area ::ng-deep textarea {
-  font-family: monospace;
+  font-family: var(--font-family-monospace);
 }
 
 .help-text {

--- a/src/app/pages/credentials/certificates-dash/certificates-dash.component.scss
+++ b/src/app/pages/credentials/certificates-dash/certificates-dash.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   display: block;

--- a/src/app/pages/dashboard/widgets/help/widget-help/widget-help.component.scss
+++ b/src/app/pages/dashboard/widgets/help/widget-help/widget-help.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/cssvars';
+@import 'scss-imports/variables';
 
 .card {
   height: 100%;
@@ -25,6 +25,10 @@
       .lines {
         padding: 16px 0;
         row-gap: 24px;
+
+        @media (max-width: $breakpoint-tablet) {
+          row-gap: 12px;
+        }
       }
 
       .open-source {
@@ -43,6 +47,10 @@
 
     &.quarter {
       padding: 8px;
+
+      @media (max-width: $breakpoint-tablet) {
+        padding-bottom: 0;
+      }
 
       &.enterprise {
         padding: 16px 16px 0;

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-details.component.scss
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-details.component.scss
@@ -1,5 +1,5 @@
 @import 'mixins/cards';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   width: 100%;

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.scss
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .fieldsets {
   display: flex;

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.scss
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 @import 'mixins/layout';
 
 @include tree-node-with-details-container;

--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.scss
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .fieldsets {
   display: flex;

--- a/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-what-and-when/cloudsync-what-and-when.component.scss
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-what-and-when/cloudsync-what-and-when.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .cloudsync {
   display: flex;

--- a/src/app/pages/data-protection/replication/replication-form/replication-form.component.scss
+++ b/src/app/pages/data-protection/replication/replication-form/replication-form.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .form-actions {
   margin: 8px 10px;

--- a/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.scss
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .fieldsets {
   display: flex;

--- a/src/app/pages/data-protection/snapshot-task/snapshot-task-form/snapshot-task-form.component.scss
+++ b/src/app/pages/data-protection/snapshot-task/snapshot-task-form/snapshot-task-form.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .columns {
   display: flex;

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.scss
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.scss
@@ -1,5 +1,5 @@
 @import 'mixins/cards';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .card {
   @include details-card();

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-settings/dataset-capacity-settings.component.scss
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-settings/dataset-capacity-settings.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .columns {
   display: flex;

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.scss
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/space-management-chart/space-management-chart.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 $chart-size: 100px;
 
 :host {

--- a/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.scss
+++ b/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.scss
@@ -1,5 +1,5 @@
 @import 'mixins/cards';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host ::ng-deep {
   .add-buttons {

--- a/src/app/pages/datasets/components/dataset-form/sections/quotas-section/quotas-section.component.scss
+++ b/src/app/pages/datasets/components/dataset-form/sections/quotas-section/quotas-section.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .columns {
   column-gap: 15px;

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 @import 'mixins/layout';
 
 @include tree-node-with-details-container;

--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   align-items: center;

--- a/src/app/pages/datasets/modules/permissions/components/strip-acl-modal/strip-acl-modal.component.scss
+++ b/src/app/pages/datasets/modules/permissions/components/strip-acl-modal/strip-acl-modal.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .modal-body {
   max-width: 550px;

--- a/src/app/pages/directory-service/components/active-directory/active-directory.component.scss
+++ b/src/app/pages/directory-service/components/active-directory/active-directory.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .columns {
   display: flex;

--- a/src/app/pages/directory-service/components/ldap/ldap.component.scss
+++ b/src/app/pages/directory-service/components/ldap/ldap.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .columns {
   display: flex;

--- a/src/app/pages/network/components/configuration/configuration.component.scss
+++ b/src/app/pages/network/components/configuration/configuration.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .form-actions {
   border-top: 1px solid var(--lines);

--- a/src/app/pages/network/components/ipmi-card/ipmi-events-dialog/ipmi-events-dialog.component.scss
+++ b/src/app/pages/network/components/ipmi-card/ipmi-events-dialog/ipmi-events-dialog.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   display: flex;

--- a/src/app/pages/network/components/network-configuration-card/network-configuration-card.component.scss
+++ b/src/app/pages/network/components/network-configuration-card/network-configuration-card.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host ::ng-deep {
   mat-list-item {

--- a/src/app/pages/network/network.component.scss
+++ b/src/app/pages/network/network.component.scss
@@ -1,7 +1,3 @@
-div.dashboard {
-  height: calc(100vh - 175px);
-}
-
 div.content {
   flex: 1;
 }

--- a/src/app/pages/reports-dashboard/components/report/report.component.scss
+++ b/src/app/pages/reports-dashboard/components/report/report.component.scss
@@ -1,5 +1,5 @@
 @import 'mixins/loader';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .mat-mdc-card-content {
   height: 100%;

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.scss
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .card {
   margin-left: auto;

--- a/src/app/pages/services/components/service-nfs/service-nfs.component.scss
+++ b/src/app/pages/services/components/service-nfs/service-nfs.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .two-columns {
   border-bottom: 1px solid var(--lines);

--- a/src/app/pages/services/components/service-snmp/service-snmp.component.scss
+++ b/src/app/pages/services/components/service-snmp/service-snmp.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .card {
   margin-left: auto;

--- a/src/app/pages/services/components/service-ups/service-ups.component.scss
+++ b/src/app/pages/services/components/service-ups/service-ups.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .form-actions {
   padding: 0 11px;

--- a/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.scss
+++ b/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .two-columns {
   display: flex;

--- a/src/app/pages/sharing/smb/smb-status/components/smb-lock-list/smb-lock-list.component.scss
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-lock-list/smb-lock-list.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 ix-table::ng-deep .details td {
   padding-bottom: 16px !important;

--- a/src/app/pages/storage/components/dashboard-pool/export-disconnect-modal/export-disconnect-modal.component.scss
+++ b/src/app/pages/storage/components/dashboard-pool/export-disconnect-modal/export-disconnect-modal.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   display: block;

--- a/src/app/pages/storage/components/unused-resources/unused-resources.component.scss
+++ b/src/app/pages/storage/components/unused-resources/unused-resources.component.scss
@@ -1,5 +1,5 @@
 @import 'mixins/cards';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .header {
   align-items: center;

--- a/src/app/pages/storage/modules/devices/components/devices/devices.component.scss
+++ b/src/app/pages/storage/modules/devices/components/devices/devices.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 @import 'mixins/layout';
 
 @include tree-node-with-details-container;

--- a/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.scss
+++ b/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.scss
@@ -1,5 +1,5 @@
 @import 'mixins/cards';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .title {
   $title-gap: 8px;

--- a/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.scss
+++ b/src/app/pages/storage/modules/devices/components/topology-item-node/topology-item-node.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   align-items: center;

--- a/src/app/pages/storage/modules/disks/components/disk-form/disk-form.component.scss
+++ b/src/app/pages/storage/modules/disks/components/disk-form/disk-form.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .two-columns {
   display: flex;

--- a/src/app/pages/storage/modules/disks/components/manual-test-dialog/manual-test-dialog.component.scss
+++ b/src/app/pages/storage/modules/disks/components/manual-test-dialog/manual-test-dialog.component.scss
@@ -19,7 +19,7 @@
   }
 
   .error {
-    font-family: monospace;
+    font-family: var(--font-family-monospace);
     white-space: pre-line;
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/manual-disk-selection.component.scss
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/manual-disk-selection.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 ::ng-deep {
   .manual-disk-selection-ref {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.scss
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .layout-container {
   max-width: 50%;

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/normal-selection/normal-selection.component.scss
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/normal-selection/normal-selection.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .content-container {
   border: 1px solid var(--lines);

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/custom-layout-applied/custom-layout-applied.component.scss
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/custom-layout-applied/custom-layout-applied.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .content-container {
   border: 1px solid var(--lines);

--- a/src/app/pages/system/alert-config-form/alert-config-form.component.scss
+++ b/src/app/pages/system/alert-config-form/alert-config-form.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .form-card {
   margin: 24px 0.333333rem;

--- a/src/app/pages/system/alert-settings2/alert-settings2.component.scss
+++ b/src/app/pages/system/alert-settings2/alert-settings2.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 :host {
   display: flex;
@@ -81,7 +81,7 @@
   flex-direction: row;
   justify-content: space-between;
   width: 100%;
-  
+
 }
 
 .mdc-list-item {

--- a/src/app/pages/system/bootenv/bootenv-status/bootenv-node-item/bootenv-node-item.component.scss
+++ b/src/app/pages/system/bootenv/bootenv-status/bootenv-node-item/bootenv-node-item.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 $level-offset: 25px;
 $padding-left: 8px;

--- a/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.scss
+++ b/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 $singlecolumn-max-width: ($card-width-slim + $gap * 2);
 $dualcolumn-slim-max-width: ($card-width-slim * 2 + $gap * 2);

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.scss
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 .two-columns {
   display: flex;

--- a/src/app/pages/vm/devices/device-list/device-details/device-details.component.scss
+++ b/src/app/pages/vm/devices/device-list/device-details/device-details.component.scss
@@ -13,6 +13,6 @@ h1 {
 }
 
 .attributes {
-  font-family: monospace;
+  font-family: var(--font-family-monospace);
   white-space: pre-line;
 }

--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -1,6 +1,6 @@
 @import 'mixins/animations';
 @import 'mixins/buttons';
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 @mixin details-cards {
   height: 100%;

--- a/src/assets/styles/mixins/loader.scss
+++ b/src/assets/styles/mixins/loader.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 @mixin background-logo-loader($zoom: 1) {
   &::after {

--- a/src/assets/styles/other/_egret_overrides.scss
+++ b/src/assets/styles/other/_egret_overrides.scss
@@ -1,4 +1,4 @@
-@import 'scss-imports/splitview';
+@import 'scss-imports/variables';
 
 /* Universal Overrides for Egret */
 
@@ -18,14 +18,6 @@ div.mat-toolbar {
   min-height: 64px;
   padding: 0 16px;
   width: 100%;
-}
-
-.xs .rightside-content-hold {
-  padding: 0 !important;
-
-  @media (max-width: $breakpoint-tablet) {
-    padding-bottom: 96px !important;
-  }
 }
 
 /* Tabbed navigation is fixed too */

--- a/src/assets/styles/other/_fn-styles.scss
+++ b/src/assets/styles/other/_fn-styles.scss
@@ -130,13 +130,13 @@ h6 {
 
 code {
   background: rgba(0, 0, 0, 0.08);
-  font-family: 'Droid Sans Mono', 'Courier New', Courier, monospace !important;
+  font-family: var(--font-family-monospace) !important;
   padding: 8px;
 }
 
 samp {
   background: rgba(180, 180, 180, 0.5);
-  font-family: 'Droid Sans Mono', 'Courier New', Courier, monospace !important;
+  font-family: var(--font-family-monospace) !important;
   padding: 2px;
 }
 

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -45,7 +45,7 @@ small {font-size: 0.833em;}
 
 span.code {
   background: rgba(255, 255, 255, 0.1);
-  font-family: 'Inconsolata', monospace;
+  font-family: var(--font-family-monospace);
   opacity: 0.75;
 }
 

--- a/src/assets/styles/other/_root-variables.scss
+++ b/src/assets/styles/other/_root-variables.scss
@@ -17,6 +17,7 @@
   --primary-lighter: var(--primary);
   --font-family-header: 'Titillium Web', sans-serif;
   --font-family-body: 'IBM Plex Sans', 'Roboto' , 'Helvetica Neue' ,sans-serif;
+  --font-family-monospace: 'Droid Sans Mono', 'Courier New', Courier, monospace;
 
   // TODO: Standartize on one or rename to something more descriptive?
   --font-family-body2: 'Roboto' , 'Helvetica Neue' ,sans-serif;

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -878,10 +878,6 @@ $primary-dark: darken(map-get($md-primary, 500), 8%);
     white-space: nowrap;
   }
 
-  .rightside-content-hold {
-    overflow-y: auto;
-  }
-
   #acme_directory_uri mat-form-field {
     width: 50%;
   }

--- a/src/assets/styles/scss-imports/variables.scss
+++ b/src/assets/styles/scss-imports/variables.scss
@@ -15,3 +15,8 @@ $breakpoint-triplecolumn: 2500px;
 $breakpoint-flex: 3132px;
 $breakpoint-hidden: calc($breakpoint-singlecolumn - 1px);
 
+// Console Footer
+$console-footer-height: 45px;
+
+// Topbar
+$topbar-mobile-height: 48px;


### PR DESCRIPTION
**Changes:**

- Add padding to the layout container. 
- Rename `spltiview.scss` into `variables.scss`. 
- Update styles to use variables.

**Testing:**

Test the UI main pages on mobile and tablets when `Show Console Messages` is on and off. See the ticket for an issue demo.