### PR TITLE
NAS-130076 / 24.10 / EE - Replication advanced option button returns to Data Protection page

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-slide-in/components/ix-chained-slide-in/ix-chained-slide-in.component.html
+++ b/src/app/modules/forms/ix-forms/components/ix-slide-in/components/ix-chained-slide-in/ix-chained-slide-in.component.html
@@ -4,17 +4,15 @@
   [class.open]="components.length"
   [class.wide]="ixChainedSlideInService.isTopComponentWide$ | async"
 >
-  @for (component of components; track component; let i = $index; let last = $last) {
-    <div>
-      <ix-slide-in2
-        class="slide-in2-form"
-        [lastIndex]="components.length -1"
-        [id]="component.id"
-        [index]="i"
-        [componentInfo]="component"
-      ></ix-slide-in2>
-    </div>
-  }
+  <div *ngFor="let component of components; trackBy trackByComponentId; index as i;">
+    <ix-slide-in2
+      class="slide-in2-form"
+      [lastIndex]="components.length - 1"
+      [id]="component.id"
+      [index]="i"
+      [componentInfo]="component"
+    ></ix-slide-in2>
+  </div>
 </div>
 
 <div


### PR DESCRIPTION
**Changes:**
Using old `*ngFor` instead of `@for` - maybe we need to wait a bit for Angular Team updates and try it later again, pretty weird issue though.

**Testing:**

See ticket