### PR TITLE
NAS-130123 / 24.10 / Proactive Support Fixes

### DIFF
--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.spec.ts
@@ -79,6 +79,9 @@ describe('ProactiveComponent', () => {
       'Secondary Phone Number': '+999999999',
       'Secondary Title': 'Cannot connect',
     });
+
+    const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+    expect(await saveButton.isDisabled()).toBeFalsy();
   });
 
   it('saves support config when form is submitted', async () => {

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -4,14 +4,14 @@ import {
   Component,
   OnInit,
 } from '@angular/core';
-import { FormBuilder, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import { forkJoin } from 'rxjs';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemSupport as helptext } from 'app/helptext/system/support';
 import { DialogService } from 'app/modules/dialog/dialog.service';
-import { SupportConfigUpdate } from 'app/modules/feedback/interfaces/file-ticket.interface';
+import { SupportConfig, SupportConfigUpdate } from 'app/modules/feedback/interfaces/file-ticket.interface';
 import { IxSlideInRef } from 'app/modules/forms/ix-forms/components/ix-slide-in/ix-slide-in-ref';
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
 import { emailValidator } from 'app/modules/forms/ix-forms/validators/email-validation/email-validation';
@@ -104,10 +104,8 @@ export class ProactiveComponent implements OnInit {
             this.supportUnavailable();
             return;
           }
-          this.form.patchValue({
-            ...config,
-            enabled: isEnabled,
-          });
+
+          this.patchFormValues(config, isEnabled);
         },
         error: (error: unknown) => {
           this.isFormDisabled = true;
@@ -125,5 +123,20 @@ export class ProactiveComponent implements OnInit {
       helptext.proactive.dialog_unavailable_title,
       helptext.proactive.dialog_unavailable_warning,
     );
+  }
+
+  patchFormValues(config: Partial<SupportConfig>, isEnabled: boolean): void {
+    const updateValues: Partial<SupportConfig> = {};
+
+    Object.keys(config).forEach((key: keyof SupportConfig) => {
+      const control = (this.form.controls[key as never] || {}) as FormControl;
+      if (config[key] !== control.value) {
+        updateValues[key] = config[key] as never;
+      }
+    });
+
+    updateValues.enabled = isEnabled;
+
+    this.form.patchValue(updateValues);
   }
 }


### PR DESCRIPTION
Testing: see ticket. Now once you open the form - you should not see errors if you didn't touch anything.
<img width="798" alt="Screenshot 2024-07-19 at 15 02 21" src="https://github.com/user-attachments/assets/c316383c-5eed-4955-9866-d4f7a3b29aec">
