### PR TITLE
NAS-127581 / 24.10 / Add indicator in SMB that auditing is enabled

### DIFF
--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.spec.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.spec.ts
@@ -123,8 +123,8 @@ describe('SmbCardComponent', () => {
 
   it('should show table rows', async () => {
     const expectedRows = [
-      ['Name', 'Path', 'Description', 'Enabled', ''],
-      ['smb123', '/mnt/APPS/smb1', 'pool', '', ''],
+      ['Name', 'Path', 'Description', 'Enabled', 'Audit Logging', ''],
+      ['smb123', '/mnt/APPS/smb1', 'pool', '', 'No', ''],
     ];
 
     const cells = await table.getCellTexts();
@@ -132,7 +132,7 @@ describe('SmbCardComponent', () => {
   });
 
   it('shows form to edit an existing SMB Share when Edit button is pressed', async () => {
-    const editButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'edit' }), 1, 4);
+    const editButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'edit' }), 1, 5);
     await editButton.click();
 
     expect(spectator.inject(IxSlideInService).open).toHaveBeenCalledWith(SmbFormComponent, {
@@ -141,7 +141,7 @@ describe('SmbCardComponent', () => {
   });
 
   it('shows confirmation to delete SMB Share when Delete button is pressed', async () => {
-    const deleteIcon = await table.getHarnessInCell(IxIconHarness.with({ name: 'delete' }), 1, 4);
+    const deleteIcon = await table.getHarnessInCell(IxIconHarness.with({ name: 'delete' }), 1, 5);
     await deleteIcon.click();
 
     expect(spectator.inject(DialogService).confirm).toHaveBeenCalled();
@@ -161,7 +161,7 @@ describe('SmbCardComponent', () => {
   });
 
   it('handles edit Share ACL', async () => {
-    const editIcon = await table.getHarnessInCell(IxIconHarness.with({ name: 'share' }), 1, 4);
+    const editIcon = await table.getHarnessInCell(IxIconHarness.with({ name: 'share' }), 1, 5);
     await editIcon.click();
 
     expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith(
@@ -176,7 +176,7 @@ describe('SmbCardComponent', () => {
     const router = spectator.inject(Router);
     jest.spyOn(router, 'navigate').mockImplementation();
 
-    const editIcon = await table.getHarnessInCell(IxIconHarness.with({ name: 'security' }), 1, 4);
+    const editIcon = await table.getHarnessInCell(IxIconHarness.with({ name: 'security' }), 1, 5);
     await editIcon.click();
 
     expect(router.navigate).toHaveBeenCalledWith(

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
@@ -19,6 +19,9 @@ import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provi
 import { actionsColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { toggleColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-toggle/ix-cell-toggle.component';
+import {
+  yesNoColumn,
+} from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-yes-no/ix-cell-yes-no.component';
 import { createTable } from 'app/modules/ix-table/utils';
 import { SmbAclComponent } from 'app/pages/sharing/smb/smb-acl/smb-acl.component';
 import { SmbFormComponent } from 'app/pages/sharing/smb/smb-form/smb-form.component';
@@ -62,6 +65,10 @@ export class SmbCardComponent implements OnInit {
       propertyName: 'enabled',
       onRowToggle: (row: SmbShare) => this.onChangeEnabledState(row),
       requiredRoles: this.requiredRoles,
+    }),
+    yesNoColumn({
+      title: this.translate.instant('Audit Logging'),
+      propertyName: 'audit',
     }),
     actionsColumn({
       cssClass: 'wide-actions',

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
@@ -6,7 +6,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  tap, map, filter, switchMap, BehaviorSubject,
+  tap, map, filter, switchMap, BehaviorSubject, of,
 } from 'rxjs';
 import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
@@ -25,6 +25,7 @@ import {
 import { createTable } from 'app/modules/ix-table/utils';
 import { SmbAclComponent } from 'app/pages/sharing/smb/smb-acl/smb-acl.component';
 import { SmbFormComponent } from 'app/pages/sharing/smb/smb-form/smb-form.component';
+import { isRootShare } from 'app/pages/sharing/utils/smb.utils';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
 import { WebSocketService } from 'app/services/ws.service';
@@ -82,6 +83,7 @@ export class SmbCardComponent implements OnInit {
         {
           iconName: 'security',
           tooltip: this.translate.instant('Edit Filesystem ACL'),
+          disabled: (row) => of(isRootShare(row.path)),
           onClick: (row) => this.doFilesystemAclEdit(row),
           requiredRoles: this.requiredRoles,
         },

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.spec.ts
@@ -106,7 +106,7 @@ describe('SmbListComponent', () => {
   });
 
   it('opens smb edit form when "Edit" button is pressed', async () => {
-    const editButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'edit' }), 1, 4);
+    const editButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'edit' }), 1, 5);
     await editButton.click();
 
     expect(spectator.inject(IxSlideInService).open).toHaveBeenCalledWith(SmbFormComponent, {
@@ -115,7 +115,7 @@ describe('SmbListComponent', () => {
   });
 
   it('opens smb edit share ACL form when "Edit Share ACL" button is pressed', async () => {
-    const editShareAclButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'share' }), 1, 4);
+    const editShareAclButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'share' }), 1, 5);
     await editShareAclButton.click();
 
     expect(spectator.inject(IxSlideInService).open).toHaveBeenCalledWith(SmbAclComponent, {
@@ -124,7 +124,7 @@ describe('SmbListComponent', () => {
   });
 
   it('redirects to edit ACL page when "Edit Filesystem ACL" button is pressed', async () => {
-    const editFilesystemAclButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'security' }), 1, 4);
+    const editFilesystemAclButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'security' }), 1, 5);
     await editFilesystemAclButton.click();
 
     expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(
@@ -134,7 +134,7 @@ describe('SmbListComponent', () => {
   });
 
   it('opens delete dialog when "Delete" button is pressed', async () => {
-    const deleteButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'delete' }), 1, 4);
+    const deleteButton = await table.getHarnessInCell(IxIconHarness.with({ name: 'delete' }), 1, 5);
     await deleteButton.click();
 
     expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith('sharing.smb.delete', [1]);
@@ -142,8 +142,8 @@ describe('SmbListComponent', () => {
 
   it('should show table rows', async () => {
     const expectedRows = [
-      ['Name', 'Path', 'Description', 'Enabled', ''],
-      ['some-name', 'some-local-path', 'comment', '', ''],
+      ['Name', 'Path', 'Description', 'Enabled', 'Audit Logging', ''],
+      ['some-name', 'some-local-path', 'comment', '', 'No', ''],
     ];
 
     const cells = await table.getCellTexts();

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -18,6 +18,9 @@ import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provi
 import { actionsColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { toggleColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-toggle/ix-cell-toggle.component';
+import {
+  yesNoColumn,
+} from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-yes-no/ix-cell-yes-no.component';
 import { SortDirection } from 'app/modules/ix-table/enums/sort-direction.enum';
 import { createTable } from 'app/modules/ix-table/utils';
 import { AppLoaderService } from 'app/modules/loader/app-loader.service';
@@ -77,6 +80,10 @@ export class SmbListComponent implements OnInit {
           },
         });
       },
+    }),
+    yesNoColumn({
+      title: this.translate.instant('Audit Logging'),
+      propertyName: 'audit',
     }),
     actionsColumn({
       actions: [

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -27,6 +27,7 @@ import { AppLoaderService } from 'app/modules/loader/app-loader.service';
 import { SmbAclComponent } from 'app/pages/sharing/smb/smb-acl/smb-acl.component';
 import { SmbFormComponent } from 'app/pages/sharing/smb/smb-form/smb-form.component';
 import { smbListElements } from 'app/pages/sharing/smb/smb-list/smb-list.elements';
+import { isRootShare } from 'app/pages/sharing/utils/smb.utils';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
 import { WebSocketService } from 'app/services/ws.service';
@@ -124,7 +125,7 @@ export class SmbListComponent implements OnInit {
           iconName: 'security',
           tooltip: helptextSharingSmb.action_edit_acl,
           requiredRoles: this.requiredRoles,
-          disabled: (row) => of(!row.path.replace('/mnt/', '').includes('/')),
+          disabled: (row) => of(isRootShare(row.path)),
           onClick: (row) => {
             if (row.locked) {
               this.lockedPathDialog(row.path);

--- a/src/app/pages/sharing/utils/smb.utils.spec.ts
+++ b/src/app/pages/sharing/utils/smb.utils.spec.ts
@@ -1,0 +1,13 @@
+import { isRootShare } from 'app/pages/sharing/utils/smb.utils';
+
+describe('isRootShare', () => {
+  it('returns true when path is root share', () => {
+    const path = '/mnt/test';
+    expect(isRootShare(path)).toBe(true);
+  });
+
+  it('returns false when path is not root share', () => {
+    const path = '/mnt/test/test';
+    expect(isRootShare(path)).toBe(false);
+  });
+});

--- a/src/app/pages/sharing/utils/smb.utils.ts
+++ b/src/app/pages/sharing/utils/smb.utils.ts
@@ -1,0 +1,3 @@
+export function isRootShare(path: string): boolean {
+  return !path.replace('/mnt/', '').includes('/');
+}

--- a/src/app/services/dataset-service/dataset.service.ts
+++ b/src/app/services/dataset-service/dataset.service.ts
@@ -4,11 +4,10 @@ import * as _ from 'lodash';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ExplorerNodeType } from 'app/enums/explorer-type.enum';
-import { mntPath } from 'app/enums/mnt-path.enum';
 import { ExplorerNodeData } from 'app/interfaces/tree-node.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { TreeNodeProvider } from 'app/modules/forms/ix-forms/components/ix-explorer/tree-node-provider.interface';
-import { isRootDataset } from 'app/pages/datasets/utils/dataset.utils';
+import { isRootShare } from 'app/pages/sharing/utils/smb.utils';
 import { WebSocketService } from 'app/services/ws.service';
 
 @Injectable({ providedIn: 'root' })
@@ -60,7 +59,7 @@ export class DatasetService {
   }
 
   rootLevelDatasetWarning(path: string, message: string, skip = false): Observable<boolean> {
-    return isRootDataset({ name: path.replace(`${mntPath}/`, '') }) && !skip ? this.dialog.confirm({
+    return isRootShare(path) && !skip ? this.dialog.confirm({
       title: this.translate.instant('Warning'),
       message,
     }) : of(true);


### PR DESCRIPTION
**Changes:**

Add Audit Logging column to SMB tables.

**Testing:**

See new column.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | New column added to SMB tables.
