### PR TITLE
NAS-130130 / 24.10 / Fix IPv4 card does not display IP

### DIFF
--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
@@ -29,6 +29,17 @@ describe('WidgetInterfaceIpComponent', () => {
                 { type: NetworkInterfaceAliasType.Inet6, address: 'fe80::1' },
               ],
             },
+            {
+              name: 'eth2',
+              aliases: [],
+              state: {
+                aliases: [
+                  { type: NetworkInterfaceAliasType.Inet, address: '192.168.1.10' },
+                  { type: NetworkInterfaceAliasType.Inet, address: '192.168.1.11' },
+                  { type: NetworkInterfaceAliasType.Inet6, address: 'fe80::1' },
+                ],
+              },
+            },
           ],
         }),
       }),
@@ -53,6 +64,25 @@ describe('WidgetInterfaceIpComponent', () => {
     const widget = spectator.query(MockComponent(WidgetDatapointComponent));
     expect(widget).toBeTruthy();
     expect(widget.text).toBe('192.168.1.1\n192.168.1.2');
+  });
+
+  it('renders IPv4 addresses for the selected network interface from state', () => {
+    spectator.setInput('settings', { interface: 'eth2' });
+
+    const widget = spectator.query(MockComponent(WidgetDatapointComponent));
+    expect(widget).toBeTruthy();
+    expect(widget.text).toBe('192.168.1.10\n192.168.1.11');
+  });
+
+  it('renders IPv6 addresses for the selected network interface', () => {
+    spectator.setInput('settings', {
+      interface: 'eth1',
+      widgetName: 'IPv6 Address',
+    });
+
+    const widget = spectator.query(MockComponent(WidgetDatapointComponent));
+    expect(widget).toBeTruthy();
+    expect(widget.text).toBe('fe80::1');
   });
 
   it('renders "interface not found" when selected interface is not available in interface data', () => {

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
@@ -52,13 +52,17 @@ export class WidgetInterfaceIpComponent implements WidgetComponent<WidgetInterfa
       // TODO: Show as widget error.
       return this.translate.instant('Network interface {interface} not found.', { interface: interfaceId });
     }
+    let networkInterfaceAlias = networkInterface.aliases;
+    if (!networkInterfaceAlias.length && networkInterface?.state?.aliases?.length) {
+      networkInterfaceAlias = networkInterface.state.aliases;
+    }
 
-    const ip4aliases = networkInterface.aliases.filter((alias) => alias.type === this.interfaceType());
+    const ipAliases = networkInterfaceAlias.filter((alias) => alias.type === this.interfaceType());
 
-    if (!ip4aliases.length) {
+    if (!ipAliases.length) {
       return this.translate.instant('N/A');
     }
 
-    return ip4aliases.map((alias) => alias.address).join('\n');
+    return ipAliases.map((alias) => alias.address).join('\n');
   }
 }


### PR DESCRIPTION
**Changes:**

Look at aliases in the network interface state. Updated tests. Added case for IPv6.

**Testing:**

Check the ticket

