### PR TITLE
NAS-129950 / 24.10 / Preset in scheduler does not update with the rest of the form

### DIFF
--- a/src/app/modules/scheduler/components/scheduler-modal/scheduler-modal.component.spec.ts
+++ b/src/app/modules/scheduler/components/scheduler-modal/scheduler-modal.component.spec.ts
@@ -173,6 +173,20 @@ describe('SchedulerModalComponent', () => {
       expect(explanationSection).toExist();
       expect(explanationSection).toHaveText('or');
     });
+
+    it('updates Preset when other form fields are updated', async () => {
+      const presetSelect = await loader.getHarness(IxSelectHarness.with({ selector: '.preset-select' }));
+      await presetSelect.setValue('Daily');
+
+      const hours = await loader.getHarness(IxInputHarness.with({ label: 'Hours' }));
+      await hours.setValue('2');
+
+      expect(await presetSelect.getValue()).toBe('');
+
+      await hours.setValue('*');
+
+      expect(await presetSelect.getValue()).toBe('Hourly');
+    });
   });
 
   describe('hideMinutes', () => {

--- a/src/app/modules/scheduler/components/scheduler-modal/scheduler-modal.component.ts
+++ b/src/app/modules/scheduler/components/scheduler-modal/scheduler-modal.component.ts
@@ -31,7 +31,7 @@ import { selectTimezone } from 'app/store/system-config/system-config.selectors'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SchedulerModalComponent implements OnInit {
-  form = this.formBuilder.group({
+  protected form = this.formBuilder.group({
     preset: [''],
     minutes: ['', [Validators.required, this.validators.crontabPartValidator(CrontabPart.Minutes)]],
     hours: ['', [Validators.required, this.validators.crontabPartValidator(CrontabPart.Hours)]],
@@ -134,6 +134,10 @@ export class SchedulerModalComponent implements OnInit {
 
   private setupFormSubscriptions(): void {
     this.form.controls.preset.valueChanges.pipe(untilDestroyed(this)).subscribe((preset) => {
+      if (!preset) {
+        return;
+      }
+
       this.setValuesFromCrontab(preset);
     });
 
@@ -143,6 +147,7 @@ export class SchedulerModalComponent implements OnInit {
       }
 
       this.crontab = this.getCrontabFromForm();
+      this.updatePresetToMatchCrontab();
     });
   }
 
@@ -214,5 +219,13 @@ export class SchedulerModalComponent implements OnInit {
 
   private get areAllWeekdaysSelected(): boolean {
     return this.selectedWeekdays.length === 0 || this.selectedWeekdays.length === 7;
+  }
+
+  private updatePresetToMatchCrontab(): void {
+    const matchingPreset = this.presets.some((preset) => {
+      return preset.value === this.crontab;
+    });
+
+    this.form.patchValue({ preset: matchingPreset ? this.crontab : '' }, { emitEvent: false });
   }
 }

--- a/src/app/modules/scheduler/components/scheduler/scheduler.component.spec.ts
+++ b/src/app/modules/scheduler/components/scheduler/scheduler.component.spec.ts
@@ -78,7 +78,7 @@ describe('SchedulerComponent', () => {
     expect(optionLabels).toEqual([
       'Hourly (0 * * * *)  At the start of each hour',
       'Daily (0 0 * * *)  At 00:00 (12:00 AM)',
-      'Weekly (0 0 * * 0)  On Sundays at 00:00 (12:00 AM)',
+      'Weekly (0 0 * * sun)  On Sundays at 00:00 (12:00 AM)',
       'Monthly (0 0 1 * *)  On the first day of the month at 00:00 (12:00 AM)',
       'Create  Custom schedule',
     ]);

--- a/src/app/modules/scheduler/utils/get-default-crontab-presets.utils.ts
+++ b/src/app/modules/scheduler/utils/get-default-crontab-presets.utils.ts
@@ -4,7 +4,7 @@ import { CronPreset } from 'app/modules/scheduler/interfaces/cron-preset.interfa
 export enum CronPresetValue {
   Hourly = '0 * * * *',
   Daily = '0 0 * * *',
-  Weekly = '0 0 * * 0',
+  Weekly = '0 0 * * sun',
   Monthly = '0 0 1 * *',
 }
 

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
@@ -236,7 +236,7 @@ describe('CloudBackupFormComponent', () => {
         Password: '1234',
         'Post-script': '',
         'Pre-script': '',
-        Schedule: 'Weekly (0 0 * * 0)  On Sundays at 00:00 (12:00 AM)',
+        Schedule: 'Weekly (0 0 * * sun)  On Sundays at 00:00 (12:00 AM)',
         'Source Path': '/mnt/my pool',
         'Take Snapshot': false,
         Transfers: '5',

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
@@ -62,10 +62,10 @@ describe('CloudBackupFormComponent', () => {
       hour: '0',
       dom: '*',
       month: '*',
-      dow: '0',
+      dow: 'sun',
     },
     locked: false,
-  } as unknown as CloudBackup;
+  } as CloudBackup;
 
   let loader: HarnessLoader;
   let spectator: Spectator<CloudBackupFormComponent>;
@@ -256,7 +256,7 @@ describe('CloudBackupFormComponent', () => {
         path: '/mnt/my pool',
         post_script: '',
         pre_script: '',
-        schedule: '0 0 * * 0',
+        schedule: '0 0 * * sun',
         snapshot: false,
         transfers: 5,
       });
@@ -311,7 +311,7 @@ describe('CloudBackupFormComponent', () => {
         pre_script: '',
         schedule: {
           dom: '*',
-          dow: '0',
+          dow: 'sun',
           hour: '0',
           minute: '0',
           month: '*',


### PR DESCRIPTION
**Changes:**

In scheduler modal, when selecting Custom, Preset dropdown in the modal will now react to changes in other fields.

**Testing:**

Detailed instructions are in the ticket.
