### PR TITLE
NAS-129726 / 24.10 / Impossible to get to truecloud backup task snapshots from dashboard

### DIFF
--- a/src/app/directives/navigate-and-interact/navigate-and-interact.directive.ts
+++ b/src/app/directives/navigate-and-interact/navigate-and-interact.directive.ts
@@ -17,10 +17,13 @@ export class NavigateAndInteractDirective {
   @HostListener('click')
   onClick(): void {
     this.router.navigate(this.navigateRoute(), { fragment: this.navigateHash() }).then(() => {
-      const htmlElement = document.getElementById(this.navigateHash());
-      if (htmlElement) {
-        this.handleHashScrollIntoView(htmlElement);
-      }
+      setTimeout(() => {
+        const htmlElement = document.getElementById(this.navigateHash());
+
+        if (htmlElement) {
+          this.handleHashScrollIntoView(htmlElement);
+        }
+      }, 150);
     });
   }
 

--- a/src/app/directives/navigate-and-interact/navigate-and-interact.directive.ts
+++ b/src/app/directives/navigate-and-interact/navigate-and-interact.directive.ts
@@ -17,13 +17,10 @@ export class NavigateAndInteractDirective {
   @HostListener('click')
   onClick(): void {
     this.router.navigate(this.navigateRoute(), { fragment: this.navigateHash() }).then(() => {
-      setTimeout(() => {
-        const htmlElement = document.getElementById(this.navigateHash());
-
-        if (htmlElement) {
-          this.handleHashScrollIntoView(htmlElement);
-        }
-      }, 150);
+      const htmlElement = document.getElementById(this.navigateHash());
+      if (htmlElement) {
+        this.handleHashScrollIntoView(htmlElement);
+      }
     });
   }
 

--- a/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component.scss
+++ b/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component.scss
@@ -2,7 +2,7 @@
 
 .actions {
   display: flex;
-  gap: 1;
+  gap: 0;
   justify-content: flex-end;
 
   @media(max-width: $breakpoint-sm) {

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-card/cloud-backup-card.component.scss
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-card/cloud-backup-card.component.scss
@@ -6,3 +6,9 @@
     margin-left: 5px;
   }
 }
+
+:host ::ng-deep {
+  .wide-actions {
+    width: 100px;
+  }
+}

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-card/cloud-backup-card.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-card/cloud-backup-card.component.spec.ts
@@ -2,6 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { Router } from '@angular/router';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
@@ -144,5 +145,15 @@ describe('CloudBackupCardComponent', () => {
       'cloud_backup.update',
       [1, { enabled: true }],
     );
+  });
+
+  it('navigates to the details page when View Details button is pressed', async () => {
+    const router = spectator.inject(Router);
+    const navigateSpy = jest.spyOn(router, 'navigate').mockImplementation();
+
+    const viewDetailsIcon = await table.getHarnessInCell(IxIconHarness.with({ name: 'visibility' }), 1, 5);
+    await viewDetailsIcon.click();
+
+    expect(navigateSpy).toHaveBeenCalledWith(['/data-protection', 'cloud-backup'], { fragment: '1' });
   });
 });

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-card/cloud-backup-card.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-card/cloud-backup-card.component.ts
@@ -1,7 +1,7 @@
-import { BreakpointObserver } from '@angular/cdk/layout';
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit,
 } from '@angular/core';
+import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import {
@@ -93,6 +93,12 @@ export class CloudBackupCardComponent implements OnInit {
           requiredRoles: this.requiredRoles,
         },
         {
+          iconName: 'visibility',
+          tooltip: this.translate.instant('View Details'),
+          onClick: (row) => this.router.navigate(['/data-protection', 'cloud-backup'], { fragment: row.id.toString() }),
+          requiredRoles: this.requiredRoles,
+        },
+        {
           iconName: 'delete',
           tooltip: this.translate.instant('Delete'),
           onClick: (row) => this.doDelete(row),
@@ -114,7 +120,7 @@ export class CloudBackupCardComponent implements OnInit {
     private errorHandler: ErrorHandlerService,
     private snackbar: SnackbarService,
     private appLoader: AppLoaderService,
-    private breakpointObserver: BreakpointObserver,
+    private router: Router,
     protected emptyService: EmptyService,
     @Inject(WINDOW) private window: Window,
   ) {}

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.ts
@@ -125,7 +125,7 @@ export class CloudBackupListComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.fragment.pipe(
-      tap((fragment: string | null) => this.loadCloudBackups(fragment)),
+      tap((id) => this.loadCloudBackups(id)),
       untilDestroyed(this),
     ).subscribe();
 
@@ -229,13 +229,13 @@ export class CloudBackupListComponent implements OnInit {
     }
   }
 
-  private loadCloudBackups(fragment?: string): void {
+  private loadCloudBackups(id?: string): void {
     const cloudBackups$ = this.ws.call('cloud_backup.query').pipe(
       tap((cloudBackups) => {
         this.cloudBackups = cloudBackups;
 
-        const selectedBackup = fragment
-          ? cloudBackups.find((cloudBackup) => cloudBackup.id.toString() === fragment)
+        const selectedBackup = id
+          ? cloudBackups.find((cloudBackup) => cloudBackup.id.toString() === id)
           : cloudBackups.find((cloudBackup) => cloudBackup.id === this.dataProvider?.expandedRow?.id);
 
         this.dataProvider.expandedRow = this.isMobileView ? null : (selectedBackup || cloudBackups[0]);

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.ts
@@ -2,6 +2,7 @@ import { BreakpointObserver, BreakpointState, Breakpoints } from '@angular/cdk/l
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit,
 } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import {
@@ -117,23 +118,17 @@ export class CloudBackupListComponent implements OnInit {
     private snackbar: SnackbarService,
     private appLoader: AppLoaderService,
     private breakpointObserver: BreakpointObserver,
+    private route: ActivatedRoute,
     protected emptyService: EmptyService,
     @Inject(WINDOW) private window: Window,
   ) {}
 
   ngOnInit(): void {
-    const cloudBackups$ = this.ws.call('cloud_backup.query').pipe(
-      tap((cloudBackups) => {
-        this.cloudBackups = cloudBackups;
-        const selectedBackup = cloudBackups.find(
-          (cloudBackup) => cloudBackup.id === this.dataProvider?.expandedRow?.id,
-        );
-        this.dataProvider.expandedRow = this.isMobileView ? null : (selectedBackup || cloudBackups[0]);
-        this.expanded(this.dataProvider.expandedRow);
-      }),
-    );
-    this.dataProvider = new AsyncDataProvider<CloudBackup>(cloudBackups$);
-    this.getCloudBackups();
+    this.route.fragment.pipe(
+      tap((fragment: string | null) => this.loadCloudBackups(fragment)),
+      untilDestroyed(this),
+    ).subscribe();
+
     this.initMobileView();
   }
 
@@ -232,6 +227,24 @@ export class CloudBackupListComponent implements OnInit {
       // focus on details container
       setTimeout(() => (this.window.document.getElementsByClassName('mobile-back-button')[0] as HTMLElement).focus(), 0);
     }
+  }
+
+  private loadCloudBackups(fragment?: string): void {
+    const cloudBackups$ = this.ws.call('cloud_backup.query').pipe(
+      tap((cloudBackups) => {
+        this.cloudBackups = cloudBackups;
+
+        const selectedBackup = fragment
+          ? cloudBackups.find((cloudBackup) => cloudBackup.id.toString() === fragment)
+          : cloudBackups.find((cloudBackup) => cloudBackup.id === this.dataProvider?.expandedRow?.id);
+
+        this.dataProvider.expandedRow = this.isMobileView ? null : (selectedBackup || cloudBackups[0]);
+        this.expanded(this.dataProvider.expandedRow);
+      }),
+    );
+
+    this.dataProvider = new AsyncDataProvider<CloudBackup>(cloudBackups$);
+    this.getCloudBackups();
   }
 
   private onChangeEnabledState(cloudBackup: CloudBackup): void {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -4399,6 +4399,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3468,6 +3468,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -2656,6 +2656,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -4588,6 +4588,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1246,6 +1246,7 @@
   "View All": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Less": "",
   "View More": "",
   "View Netdata": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -4618,6 +4618,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -4311,6 +4311,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -4382,6 +4382,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -4802,6 +4802,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1118,6 +1118,7 @@
   "View All": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Less": "",
   "View More": "",
   "View Netdata": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -4733,6 +4733,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -4751,6 +4751,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2970,6 +2970,7 @@
   "View All": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Enclosure": "",
   "View Less": "",
   "View Logs": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -3088,6 +3088,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1732,6 +1732,7 @@
   "View All": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Less": "",
   "View More": "",
   "View Netdata": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -4811,6 +4811,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -1177,6 +1177,7 @@
   "View All": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Less": "",
   "View More": "",
   "View Netdata": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -4048,6 +4048,7 @@
   "View All Scrub Tasks": "",
   "View All Test Results": "",
   "View Changelog": "",
+  "View Details": "",
   "View Disk Space Reports": "",
   "View Enclosure": "",
   "View Less": "",


### PR DESCRIPTION
**Changes:**
Added new navigation button for the Backup Task Snapshots Card.

**Testing:**
See ticket, try the button with different cloud backup tasks.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | New button on UI side
