### PR TITLE
NAS-128558 / 24.10 / Context menu for user/power options are showing in the wrong place

### DIFF
--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -846,8 +846,8 @@ body .mat-calendar-next-button::after {
   }
 }
 
-.cdk-overlay-pane {
-  @media(max-width: $breakpoint-sm) {
+.cdk-overlay-pane.mat-mdc-dialog-panel {
+  @media(max-width: $breakpoint-xs) {
     max-width: 95% !important;
     width: inherit;
   }


### PR DESCRIPTION
**Changes:**

Styling changes

**Testing:**

See ticket, see result:

https://github.com/user-attachments/assets/ba8f44bf-e0a8-40e6-90d6-9805af365866