### PR TITLE
NAS-130168 / 24.10 / NAS-130168

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -151,6 +151,7 @@ export class CloudSyncFormComponent implements OnInit {
     { label: 'One Zone-IA', value: 'ONEZONE_IA' },
     { label: 'Intelligent-Tiering', value: 'INTELLIGENT_TIERING' },
     { label: 'Glacier', value: 'GLACIER' },
+    { label: 'Glacier Instant Retrieval', value: 'GLACIER_IR' },
     { label: 'Glacier Deep Archive', value: 'DEEP_ARCHIVE' },
   ]);
 


### PR DESCRIPTION
Add Glacier Instant Retrieval storage class for AWS S3 Cloud Sync

**Changes:**

Adds `Glacier Instant Retrieval` to the storage class option for AWS S3 Cloud Sync task.  `GLACIER_IR` was added to Rclone in v1.58.0: https://rclone.org/changelog/#v1-58-0-2022-03-18

**Testing:**

https://ixsystems.atlassian.net/browse/NAS-130168

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | None found
|midddleware | Added to middleware in truenas/middleware#14094
