### PR TITLE
NAS-130073 / 24.10 / Fix `"IPv4 Address"` widget upon migration

### DIFF
--- a/src/app/pages/dashboard/services/dashboard.store.ts
+++ b/src/app/pages/dashboard/services/dashboard.store.ts
@@ -104,7 +104,7 @@ export class DashboardStore extends ComponentStore<DashboardState> {
   private getDashboardGroups(dashState: WidgetGroup[] | OldDashboardConfigItem[]): WidgetGroup[] {
     return dashState.map((widget) => {
       if (!widget.hasOwnProperty('layout')) {
-        const oldDashboardWidget = widget as unknown as OldDashboardConfigItem;
+        const oldDashboardWidget = widget as OldDashboardConfigItem;
         return {
           layout: WidgetGroupLayout.Full,
           slots: [{


### PR DESCRIPTION
**Changes:**

Minor type fix.

**Testing:**

Code review only.

To test that it actually works:
go to `src/app/pages/dashboard/services/dashboard.store.ts`

line 76: `groups: this.getDashboardGroups(dashState || demoWidgets),`

replace it with a config from dragonfish

```          
groups: this.getDashboardGroups([
  {
    name: 'System Information',
    rendered: true,
    id: '0',
  },
  {
    id: '1',
    name: 'System Information(Standby)',
    identifier: 'passive,true',
    rendered: true,
  },
  {
    id: '8',
    name: 'Pool',
    identifier: 'name,Pool:dozer',
    rendered: false,
  },
  {
    id: '9',
    name: 'Interface',
    identifier: 'name,ens1',
    rendered: true,
  },
] as any)
```
Go ahead and see that it actually renders the widget.
