### PR TITLE
NAS-128526 / 24.10 / Fix network axis labels

### DIFF
--- a/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.ts
+++ b/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.ts
@@ -14,7 +14,7 @@ import { TinyColor } from '@ctrl/tinycolor';
 import { UUID } from 'angular2-uuid';
 import { utcToZonedTime } from 'date-fns-tz';
 import Dygraph, { dygraphs } from 'dygraphs';
-import { kb, Mb } from 'app/constants/bits.constant';
+import { Gb, kb, Mb } from 'app/constants/bits.constant';
 import {
   GiB, KiB, MiB, TiB,
 } from 'app/constants/bytes.constant';
@@ -269,7 +269,10 @@ export class LineChartComponent implements AfterViewInit, OnDestroy, OnChanges {
 
   axisLabelFormatter = (numero: number): string => {
     if (this.report?.name === ReportingGraphName.NetworkInterface) {
-      if (numero < kb) {
+      if (numero < Mb) {
+        if (this.yLabelPrefix === 'Gb') {
+          numero /= Gb;
+        }
         if (this.yLabelPrefix === 'Mb') {
           numero /= Mb;
         }


### PR DESCRIPTION
**Testing:**

1. Run a network transfer with rate ~1Gb/s
   _Alternatively, make a temporary adjustment of the reporting dashboard code, so that all the metrics are multiplied by 100*1024_
2. Go to **Reports** page,
3. Choose **Network** from the dropdown at the right top corner,

**Expected result:** vertical axis of network bandwidth charts display the following values in Gb/s

```
1
0.5
0
```
