### PR TITLE
NAS-130259 / 24.10 / Ensure alphabetical order of shares on Shares dashboard

### DIFF
--- a/src/app/helptext/sharing/nfs/nfs.ts
+++ b/src/app/helptext/sharing/nfs/nfs.ts
@@ -7,11 +7,6 @@ export const helptextSharingNfs = {
  Consider creating a dataset instead.',
   ),
 
-  // NFSListComponent
-  column_path: T('Path'),
-  column_comment: T('Description'),
-  column_enabled: T('Enabled'),
-
   // NFSFormComponent
   tooltip_path: T('Full path to the pool, dataset or directory to share. \
   The path must reside within a pool. Mandatory.'),

--- a/src/app/helptext/sharing/smb/smb.ts
+++ b/src/app/helptext/sharing/smb/smb.ts
@@ -8,10 +8,6 @@ export const helptextSharingSmb = {
   ),
 
   shareAclDescription: T('The SMB share ACL defines access rights for users of this SMB share up to, but not beyond, the access granted by filesystem ACLs.'),
-  column_name: T('Name'),
-  column_path: T('Path'),
-  column_comment: T('Description'),
-  column_enabled: T('Enabled'),
 
   placeholder_path: T('Path'),
   tooltip_path: T('Select pool, dataset, or directory to share.'),

--- a/src/app/modules/ix-table/components/ix-table-pager-show-more/ix-table-pager-show-more.component.html
+++ b/src/app/modules/ix-table/components/ix-table-pager-show-more/ix-table-pager-show-more.component.html
@@ -1,11 +1,11 @@
-@if (collapsible && !expanded) {
+@if (collapsible && !expanded()) {
   <button
     mat-stroked-button
     ixTest="show-more"
     (click)="showMore()"
   >{{ 'View All' | translate }}</button>
 }
-@if (collapsible && expanded) {
+@if (collapsible && expanded()) {
   <button
     mat-stroked-button
     ixTest="show-less"

--- a/src/app/modules/ix-table/components/ix-table-pager-show-more/ix-table-pager-show-more.component.scss
+++ b/src/app/modules/ix-table/components/ix-table-pager-show-more/ix-table-pager-show-more.component.scss
@@ -12,3 +12,7 @@ button {
   justify-content: center;
   padding: 8px;
 }
+
+:host.clickable {
+  cursor: pointer;
+}

--- a/src/app/modules/ix-table/components/ix-table-pager-show-more/ix-table-pager-show-more.component.spec.ts
+++ b/src/app/modules/ix-table/components/ix-table-pager-show-more/ix-table-pager-show-more.component.spec.ts
@@ -32,7 +32,7 @@ describe('IxTablePagerShowMoreComponent', () => {
     spectator = createComponent({
       props: { dataProvider, pageSize: 2 },
     });
-    spectator.component.dataProvider.setRows(testTableData);
+    spectator.component.dataProvider().setRows(testTableData);
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     spectator.fixture.detectChanges();
   });

--- a/src/app/modules/ix-table/interfaces/table-sort.interface.ts
+++ b/src/app/modules/ix-table/interfaces/table-sort.interface.ts
@@ -1,7 +1,7 @@
 import { SortDirection } from 'app/modules/ix-table/enums/sort-direction.enum';
 
 export interface TableSort<T> {
-  propertyName?: keyof T;
+  propertyName: keyof T;
   direction: SortDirection;
   active: number;
   sortBy?: (row: T) => string | number;

--- a/src/app/modules/ix-table/interfaces/table-sort.interface.ts
+++ b/src/app/modules/ix-table/interfaces/table-sort.interface.ts
@@ -1,7 +1,7 @@
 import { SortDirection } from 'app/modules/ix-table/enums/sort-direction.enum';
 
 export interface TableSort<T> {
-  propertyName: keyof T;
+  propertyName?: keyof T;
   direction: SortDirection;
   active: number;
   sortBy?: (row: T) => string | number;

--- a/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.html
@@ -60,15 +60,9 @@
     ></tbody>
   </ix-table>
 
-  @if (iscsiShares.length > 4) {
-    <a
-      class="view-all"
-      [ixTest]="['iscsi-share', 'view-all']"
-      [routerLink]="['/sharing', 'iscsi', 'target']"
-    >
-      <span>
-        {{ 'View All' | translate }}
-      </span>
-    </a>
-  }
+  <ix-table-pager-show-more
+    [pageSize]="4"
+    [dataProvider]="dataProvider"
+    [routerLink]="['/sharing', 'iscsi', 'target']"
+  ></ix-table-pager-show-more>
 </mat-card>

--- a/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.scss
@@ -10,10 +10,3 @@ mat-card {
     margin-left: 5px;
   }
 }
-
-.view-all {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  padding: 5px;
-}

--- a/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.ts
@@ -123,8 +123,9 @@ export class IscsiCardComponent implements OnInit {
 
   setDefaultSort(): void {
     this.dataProvider.setSorting({
-      active: 0, // index column
+      active: 0,
       direction: SortDirection.Asc,
+      propertyName: 'name',
     });
   }
 }

--- a/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.html
@@ -50,15 +50,9 @@
     ></tbody>
   </ix-table>
 
-  @if (nfsShares.length > 4) {
-    <a
-      class="view-all"
-      [ixTest]="['nfs-share', 'view-all']"
-      [routerLink]="['/sharing', 'nfs']"
-    >
-      <span>
-        {{ 'View All' | translate }}
-      </span>
-    </a>
-  }
+  <ix-table-pager-show-more
+    [pageSize]="4"
+    [dataProvider]="dataProvider"
+    [routerLink]="['/sharing', 'nfs']"
+  ></ix-table-pager-show-more>
 </mat-card>

--- a/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.scss
@@ -11,13 +11,6 @@ mat-card {
   }
 }
 
-.view-all {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  padding: 5px;
-}
-
 :host ::ng-deep {
   .tight-actions {
     width: 80px;

--- a/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.ts
@@ -133,8 +133,9 @@ export class NfsCardComponent implements OnInit {
 
   setDefaultSort(): void {
     this.dataProvider.setSorting({
-      active: 0, // index column
+      active: 0,
       direction: SortDirection.Asc,
+      propertyName: 'path',
     });
   }
 }

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.html
@@ -50,15 +50,9 @@
     ></tbody>
   </ix-table>
 
-  @if (smbShares.length > 4) {
-    <a
-      class="view-all"
-      [ixTest]="['smb-share', 'view-all']"
-      [routerLink]="['/sharing', 'smb']"
-    >
-      <span>
-        {{ 'View All' | translate }}
-      </span>
-    </a>
-  }
+  <ix-table-pager-show-more
+    [pageSize]="4"
+    [dataProvider]="dataProvider"
+    [routerLink]="['/sharing', 'smb']"
+  ></ix-table-pager-show-more>
 </mat-card>

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.scss
@@ -11,13 +11,6 @@ mat-card {
   }
 }
 
-.view-all {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-  padding: 5px;
-}
-
 :host ::ng-deep {
   .wide-actions {
     width: 150px;

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
@@ -209,8 +209,9 @@ export class SmbCardComponent implements OnInit {
 
   setDefaultSort(): void {
     this.dataProvider.setSorting({
-      active: 0, // index column
+      active: 0,
       direction: SortDirection.Asc,
+      propertyName: 'name',
     });
   }
 }

--- a/src/app/pages/sharing/iscsi/target/target-list/target-list.component.ts
+++ b/src/app/pages/sharing/iscsi/target/target-list/target-list.component.ts
@@ -11,6 +11,7 @@ import { EmptyService } from 'app/modules/empty/empty.service';
 import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provider/async-data-provider';
 import { actionsColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-actions/ix-cell-actions.component';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
+import { SortDirection } from 'app/modules/ix-table/enums/sort-direction.enum';
 import { createTable } from 'app/modules/ix-table/utils';
 import { AppLoaderService } from 'app/modules/loader/app-loader.service';
 import { TargetFormComponent } from 'app/pages/sharing/iscsi/target/target-form/target-form.component';
@@ -114,6 +115,7 @@ export class TargetListComponent implements OnInit {
       tap((targets) => this.targets = targets),
     );
     this.dataProvider = new AsyncDataProvider(targets$);
+    this.setDefaultSort();
     this.refresh();
     this.dataProvider.emptyType$.pipe(untilDestroyed(this)).subscribe(() => {
       this.onListFiltered(this.filterString);
@@ -125,6 +127,14 @@ export class TargetListComponent implements OnInit {
     slideInRef.slideInClosed$
       .pipe(filter(Boolean), untilDestroyed(this))
       .subscribe(() => this.refresh());
+  }
+
+  setDefaultSort(): void {
+    this.dataProvider.setSorting({
+      active: 0,
+      direction: SortDirection.Asc,
+      propertyName: 'name',
+    });
   }
 
   onListFiltered(query: string): void {

--- a/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
@@ -143,6 +143,7 @@ export class NfsListComponent implements OnInit {
       untilDestroyed(this),
     );
     this.dataProvider = new AsyncDataProvider<NfsShare>(shares$);
+    this.setDefaultSort();
     this.refresh();
     this.dataProvider.emptyType$.pipe(untilDestroyed(this)).subscribe(() => {
       this.onListFiltered(this.filterString);
@@ -151,7 +152,7 @@ export class NfsListComponent implements OnInit {
 
   setDefaultSort(): void {
     this.dataProvider.setSorting({
-      active: 1,
+      active: 0,
       direction: SortDirection.Asc,
       propertyName: 'path',
     });

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -189,6 +189,7 @@ export class SmbListComponent implements OnInit {
     );
     this.dataProvider = new AsyncDataProvider<SmbShare>(shares$);
     this.dataProvider.load();
+    this.setDefaultSort();
     this.dataProvider.emptyType$.pipe(untilDestroyed(this)).subscribe(() => {
       this.onListFiltered(this.filterString);
     });
@@ -196,7 +197,7 @@ export class SmbListComponent implements OnInit {
 
   setDefaultSort(): void {
     this.dataProvider.setSorting({
-      active: 1,
+      active: 0,
       direction: SortDirection.Asc,
       propertyName: 'name',
     });

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -76,7 +76,7 @@ export class SmbListComponent implements OnInit {
             row.enabled = share.enabled;
           },
           error: (error: unknown) => {
-            this.refresh();
+            this.dataProvider.load();
             this.dialog.error(this.errorHandler.parseError(error));
           },
         });
@@ -95,7 +95,7 @@ export class SmbListComponent implements OnInit {
             const slideInRef = this.slideInService.open(SmbFormComponent, { data: { existingSmbShare: smbShare } });
             slideInRef.slideInClosed$
               .pipe(take(1), filter(Boolean), untilDestroyed(this))
-              .subscribe(() => this.refresh());
+              .subscribe(() => this.dataProvider.load());
           },
         },
         {
@@ -115,7 +115,7 @@ export class SmbListComponent implements OnInit {
                   this.appLoader.close();
                   const slideInRef = this.slideInService.open(SmbAclComponent, { data: shareAcl.share_name });
                   slideInRef.slideInClosed$.pipe(take(1), untilDestroyed(this)).subscribe(() => {
-                    this.refresh();
+                    this.dataProvider.load();
                   });
                 });
             }
@@ -155,8 +155,8 @@ export class SmbListComponent implements OnInit {
                 this.ws.call('sharing.smb.delete', [row.id]).pipe(
                   this.appLoader.withLoader(),
                   untilDestroyed(this),
-                ).subscribe({
-                  next: () => this.refresh(),
+                ).subscribe(() => {
+                  this.dataProvider.load();
                 });
               },
             });
@@ -188,7 +188,7 @@ export class SmbListComponent implements OnInit {
       untilDestroyed(this),
     );
     this.dataProvider = new AsyncDataProvider<SmbShare>(shares$);
-    this.refresh();
+    this.dataProvider.load();
     this.dataProvider.emptyType$.pipe(untilDestroyed(this)).subscribe(() => {
       this.onListFiltered(this.filterString);
     });
@@ -206,7 +206,7 @@ export class SmbListComponent implements OnInit {
     const slideInRef = this.slideInService.open(SmbFormComponent);
     slideInRef.slideInClosed$.pipe(take(1), filter(Boolean), untilDestroyed(this)).subscribe({
       next: () => {
-        this.refresh();
+        this.dataProvider.load();
       },
     });
   }
@@ -228,12 +228,8 @@ export class SmbListComponent implements OnInit {
 
   private lockedPathDialog(path: string): void {
     this.dialog.error({
-      title: helptextSharingSmb.action_edit_acl_dialog.title,
+      title: this.translate.instant('Error'),
       message: this.translate.instant('The path <i>{path}</i> is in a locked dataset.', { path }),
     });
-  }
-
-  private refresh(): void {
-    this.dataProvider.load();
   }
 }


### PR DESCRIPTION
**Changes:**

1. Fix sort on `SMB`, `NFS` and `iSCSI` cards
2. Sync behavior between mentioned cards
3. Use `ix-table-pager-show-more` component for `View All` button
4. Update `ix-table-pager-show-more` to use signals
5. Add router support in `ix-table-pager-show-more`
6. Minor cleanup

**Testing:**

Go to the Sharing dashboard. Create 5 or more shares for each card.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Minor UI changes for `View All` button
