### PR TITLE
NAS-130305 / 24.10 / Check global search with voice over

### DIFF
--- a/src/app/modules/global-search/components/global-search/global-search.component.html
+++ b/src/app/modules/global-search/components/global-search/global-search.component.html
@@ -1,4 +1,5 @@
 <div
+  #searchBoxWrapper
   cdkTrapFocus
   class="search-box-wrapper"
   [class.sidenav-collapsed]="sidenavService.isMenuCollapsed"

--- a/src/app/services/focus.service.ts
+++ b/src/app/services/focus.service.ts
@@ -11,6 +11,13 @@ export class FocusService {
 
     private lastFocusedElement: HTMLElement | null = null;
 
+    private focusableSelectors = [
+      'a[href]', 'area[href]', 'input:not([disabled]):not([type="hidden"])',
+      'select:not([disabled])', 'textarea:not([disabled])',
+      'button:not([disabled])', 'iframe', 'object', 'embed',
+      '[contenteditable]', '[tabindex]:not([tabindex="-1"])',
+    ];
+
     captureCurrentFocus(): void {
       this.lastFocusedElement = this.document.activeElement as HTMLElement;
     }
@@ -40,16 +47,15 @@ export class FocusService {
     focusFirstFocusableElement(element: HTMLElement): void {
       if (!element) return;
 
-      const focusableSelectors = [
-        'a[href]', 'area[href]', 'input:not([disabled]):not([type="hidden"])',
-        'select:not([disabled])', 'textarea:not([disabled])',
-        'button:not([disabled])', 'iframe', 'object', 'embed',
-        '[contenteditable]', '[tabindex]:not([tabindex="-1"])',
-      ];
-      const focusableElements = element.querySelectorAll(focusableSelectors.join(', '));
-      if (focusableElements.length > 0) {
-        const firstFocusable = focusableElements[0] as HTMLElement;
+      const focusableElements = this.getFocusableElements(element);
+      if (this.getFocusableElements(element).length > 0) {
+        const firstFocusable = focusableElements[0];
         firstFocusable.focus();
       }
+    }
+
+    getFocusableElements(wrapper: HTMLElement): HTMLElement[] {
+      const elements = wrapper.querySelectorAll(this.focusableSelectors.join(', '));
+      return Array.from(elements) as HTMLElement[];
     }
 }


### PR DESCRIPTION
**Changes:** 
Now when voice over is **ON** and we focus out from the search results to some other focusable element - `Global Search Results` panel is closed.
As well `Global Search Section` is no longer trapped and we can focus out from the search results once we tabbed fully.

**Testing:** 
See ticket & result 👇 :

https://github.com/user-attachments/assets/5dc81267-3036-41be-b524-e290a28135a4

