### PR TITLE
NAS-130503 / 24.10 / Fix rollback and upgrade, as well updates for relevant buttons

### DIFF
--- a/src/app/interfaces/api/api-job-directory.interface.ts
+++ b/src/app/interfaces/api/api-job-directory.interface.ts
@@ -4,9 +4,9 @@ import { ActiveDirectoryConfig, LeaveActiveDirectory } from 'app/interfaces/acti
 import { ActiveDirectoryUpdate } from 'app/interfaces/active-directory.interface';
 import {
   App,
-  AppCreate, AppDeleteParams, AppStartQueryParams,
+  AppCreate, AppDeleteParams, AppRollbackParams, AppStartQueryParams,
   AppUpdate,
-  AppUpgradeParams, ChartRollbackParams,
+  AppUpgradeParams,
 } from 'app/interfaces/app.interface';
 import { AuditEntry } from 'app/interfaces/audit/audit.interface';
 import { Certificate, CertificateCreate, CertificateUpdate } from 'app/interfaces/certificate.interface';
@@ -80,7 +80,7 @@ export interface ApiJobDirectory {
   'app.stop': { params: AppStartQueryParams; response: void };
   'app.delete': { params: AppDeleteParams; response: boolean };
   'app.upgrade': { params: AppUpgradeParams; response: App };
-  'app.rollback': { params: [name: string, params: ChartRollbackParams]; response: App };
+  'app.rollback': { params: AppRollbackParams; response: App };
 
   // CloudBackup
   'cloud_backup.sync': { params: [id: number, params?: { dry_run: boolean }]; response: void };

--- a/src/app/interfaces/app.interface.ts
+++ b/src/app/interfaces/app.interface.ts
@@ -258,7 +258,4 @@ export type AppDeleteParams = [
   },
 ];
 
-export interface ChartRollbackParams {
-  rollback_snapshot?: boolean;
-  app_version: string;
-}
+export type AppRollbackParams = [app_name: string, { app_version: string; rollback_snapshot: boolean }];

--- a/src/app/pages/apps/components/app-wizard/app-wizard.component.ts
+++ b/src/app/pages/apps/components/app-wizard/app-wizard.component.ts
@@ -238,8 +238,8 @@ export class AppWizardComponent implements OnInit, OnDestroy {
       job$ = this.ws.job('app.create', [
         {
           values: data,
-          catalog_app: data.release_name,
-          app_name: this.catalogApp.name,
+          catalog_app: this.catalogApp.name,
+          app_name: data.release_name,
           train: this.train,
           version,
         } as AppCreate,

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -7,18 +7,18 @@
       <button
         id="edit-app"
         mat-button
-        [ixTest]="[app?.name, 'edit']"
+        [ixTest]="[app()?.name, 'edit']"
         (click)="editButtonPressed()"
       >
         {{ 'Edit' | translate }}
       </button>
 
-      @if (hasUpdates) {
+      @if (hasUpdates()) {
         <button
           *ixRequiresRoles="requiredRoles"
           id="update-app"
           mat-button
-          [ixTest]="[app?.name, 'update']"
+          [ixTest]="[app()?.name, 'update']"
           (click)="updateButtonPressed()"
         >
           {{ 'Update' | translate }}
@@ -29,23 +29,23 @@
   <mat-card-content>
     <div fxLayout="row" fxLayoutGap="8px">
       <div class="app-logo">
-        <img [src]="app?.metadata?.icon" [src-fallback]="imagePlaceholder" />
+        <img [src]="app()?.metadata?.icon" [src-fallback]="imagePlaceholder" />
       </div>
       <div class="details-list">
         <div class="details-item">
           <div class="label">{{ 'Name' | translate }}:</div>
           <div class="value">
-            {{ app?.name | orNotAvailable }}
+            {{ app()?.name | orNotAvailable }}
           </div>
         </div>
         <div class="details-item">
           <div class="label">{{ 'App Version' | translate }}:</div>
           <div class="value">
-            @if (!isCustomApp) {
-              {{ app?.metadata?.app_version | orNotAvailable }}
-            } @else if (app.human_version) {
+            @if (!isCustomApp()) {
+              {{ app()?.metadata?.app_version | orNotAvailable }}
+            } @else if (app().human_version) {
               <!-- Show docker image tag as version for custom apps -->
-              {{ app.human_version?.split(':')?.[1]?.split('_')?.[0] }}
+              {{ app().human_version?.split(':')?.[1]?.split('_')?.[0] }}
             }
           </div>
         </div>
@@ -53,13 +53,13 @@
           <div class="label">{{ 'Source' | translate }}:</div>
           <div class="value">
             <div>
-              @for (source of app?.metadata?.sources; track source; let last = $last) {
+              @for (source of app()?.metadata?.sources; track source; let last = $last) {
                 <a
                   class="source-link"
                   target="_blank"
                   [href]="source"
                   [title]="source"
-                  [ixTest]="[app.name, 'source']"
+                  [ixTest]="[app().name, 'source']"
                 >{{ source | cleanLink }}</a>
                 @if (!last) {
                   <span>, </span>
@@ -74,17 +74,17 @@
         <div class="details-item">
           <div class="label">{{ 'Train' | translate }}:</div>
           <div class="value">
-            {{ app?.metadata?.train | orNotAvailable }}
+            {{ app()?.metadata?.train | orNotAvailable }}
           </div>
         </div>
-        @if (app?.portals) {
+        @if (app()?.portals) {
           <div class="portals">
-            @for (portal of app.portals | keyvalue; track portal.key) {
+            @for (portal of app().portals | keyvalue; track portal.key) {
               <button
                 mat-button
                 class="portal-button"
-                [ixTest]="['portal', app.name, portal.key]"
-                (click)="portalLink(app, portal.key)"
+                [ixTest]="['portal', app().name, portal.key]"
+                (click)="portalLink(app(), portal.key)"
               >
                 {{ portal.key }}
               </button>
@@ -95,7 +95,7 @@
     </div>
   </mat-card-content>
 
-  @if (app) {
+  @if (app()) {
     <mat-card-actions>
       <div class="cell cell-action cell-status-actions">
         <ng-container *ixRequiresRoles="requiredRoles">
@@ -103,7 +103,7 @@
             <button
               mat-button
               matTooltipPosition="above"
-              [ixTest]="[app.name, 'start']"
+              [ixTest]="[app().name, 'start']"
               [matTooltip]="'Start' | translate"
               [disabled]="inProgress"
               (click)="startApp.emit(); $event.stopPropagation()"
@@ -117,7 +117,7 @@
             <button
               mat-button
               matTooltipPosition="above"
-              [ixTest]="[app.name, 'stop']"
+              [ixTest]="[app().name, 'stop']"
               [matTooltip]="'Stop' | translate"
               [disabled]="isStartingOrStopping"
               (click)="stopApp.emit(); $event.stopPropagation()"
@@ -129,11 +129,10 @@
       </div>
 
       <ng-container *ixRequiresRoles="requiredRoles">
-        <!-- TODO: Fix App Rollback condition -->
-        @if (false) {
+        @if (isRollbackPossible()) {
           <button
             mat-button
-            [ixTest]="[app.name, 'rollback']"
+            [ixTest]="[app().name, 'rollback']"
             (click)="rollbackApp()"
           >
             {{ 'Roll Back' | translate }}
@@ -145,7 +144,7 @@
         <button
           *ixRequiresRoles="requiredRoles"
           mat-button
-          [ixTest]="[app.name, 'delete']"
+          [ixTest]="[app().name, 'delete']"
           (click)="deleteButtonPressed()"
         >
           {{ 'Delete' | translate }}

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -11,7 +11,7 @@ import { ImgFallbackDirective } from 'ngx-img-fallback';
 import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 import { of } from 'rxjs';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { mockWebSocket, mockJob } from 'app/core/testing/utils/mock-websocket.utils';
+import { mockWebSocket, mockJob, mockCall } from 'app/core/testing/utils/mock-websocket.utils';
 import { App } from 'app/interfaces/app.interface';
 import { AppUpgradeSummary } from 'app/interfaces/application.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -99,6 +99,7 @@ describe('AppInfoCardComponent', () => {
       mockWebSocket([
         mockJob('app.upgrade'),
         mockJob('app.delete'),
+        mockCall('app.rollback_versions', ['1.2.1']),
       ]),
     ],
   });
@@ -113,6 +114,7 @@ describe('AppInfoCardComponent', () => {
   });
 
   it('shows header', () => {
+    spectator.detectChanges();
     expect(spectator.query('mat-card-header h3')).toHaveText('Application Info');
     expect(spectator.query('mat-card-header button#edit-app')).toHaveText('Edit');
     expect(spectator.query('mat-card-header button#update-app')).toHaveText('Update');

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -190,7 +190,7 @@ export class AppInfoCardComponent {
       tap((summary) => this.hasUpdates.set(summary.available_versions_for_upgrade.length > 0)),
       catchError((error: WebSocketError) => {
         this.hasUpdates.set(false);
-        return error.reason.includes('No upgrade available') ? EMPTY : of(error);
+        return error?.reason?.includes('No upgrade available') ? EMPTY : of(error);
       }),
       untilDestroyed(this),
     ).subscribe();


### PR DESCRIPTION
**Changes:**

Fixes proper button hidden/unhidden status for update and rollback buttons. Fixes rollback operation.

**Testing:**
Test by adding `test` train to catalog and install `nginx` version `1.0.5`. Then update to latest version and rollback to version `1.0.5`. You should be able to do this without refreshing the page or navigating away.
