### PR TITLE
NAS-130373 / 24.10 / Timestamp & Event Data differ on Audit Logs for sudo

### DIFF
--- a/src/app/pages/audit/components/audit/audit.component.spec.ts
+++ b/src/app/pages/audit/components/audit/audit.component.spec.ts
@@ -28,9 +28,8 @@ describe('AuditComponent', () => {
     {
       audit_id: '1',
       timestamp: {
-        $date: 1712932440770,
+        $date: 1723453417000,
       },
-      message_timestamp: 1712932440,
       address: '10.220.2.21',
       username: 'Administrator',
       service: AuditService.Smb,
@@ -44,7 +43,6 @@ describe('AuditComponent', () => {
       timestamp: {
         $date: 1712932952481,
       },
-      message_timestamp: 1712932952,
       address: '10.220.2.21',
       username: 'bob',
       service: AuditService.Smb,
@@ -121,7 +119,7 @@ describe('AuditComponent', () => {
     await spectator.fixture.whenRenderingDone();
     expect(await table.getCellTexts()).toEqual([
       ['Service', 'User', 'Timestamp', 'Event', 'Event Data'],
-      ['SMB', 'Administrator', '2024-04-12 07:34:00', 'Authentication', 'Account: Administrator'],
+      ['SMB', 'Administrator', '2024-08-12 02:03:37', 'Authentication', 'Account: Administrator'],
       ['SMB', 'bob', '2024-04-12 07:42:32', 'Create', 'File: test.txt'],
     ]);
   });

--- a/src/app/pages/audit/components/audit/audit.component.ts
+++ b/src/app/pages/audit/components/audit/audit.component.ts
@@ -81,8 +81,7 @@ export class AuditComponent implements OnInit, OnDestroy {
     }),
     dateColumn({
       title: this.translate.instant('Timestamp'),
-      propertyName: 'message_timestamp',
-      getValue: (row) => row.message_timestamp * 1000,
+      propertyName: 'timestamp',
     }),
     textColumn({
       title: this.translate.instant('Event'),


### PR DESCRIPTION
**Changes:**

Corrected field to be displayed.

**Testing:**

See ticket, Result ⬇️ 
<img width="1492" alt="Screenshot 2024-08-12 at 12 40 23" src="https://github.com/user-attachments/assets/884e0e4a-bfd2-4512-92b8-48b100e12e8b">

