### PR TITLE
NAS-130525 / 25.04 / Add back app-notes-card

### DIFF
--- a/src/app/pages/apps/apps.module.ts
+++ b/src/app/pages/apps/apps.module.ts
@@ -56,6 +56,7 @@ import { PullImageFormComponent } from 'app/pages/apps/components/docker-images/
 import { DockerHubRateInfoDialogComponent } from 'app/pages/apps/components/dockerhub-rate-limit-info-dialog/dockerhub-rate-limit-info-dialog.component';
 import { AppBulkUpgradeComponent } from 'app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component';
 import { AppInfoCardComponent } from 'app/pages/apps/components/installed-apps/app-info-card/app-info-card.component';
+import { AppNotesCardComponent } from 'app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component';
 import { AppRollbackModalComponent } from 'app/pages/apps/components/installed-apps/app-rollback-modal/app-rollback-modal.component';
 import { AppRowComponent } from 'app/pages/apps/components/installed-apps/app-row/app-row.component';
 import { AppSettingsButtonComponent } from 'app/pages/apps/components/installed-apps/app-settings-button/app-settings-button.component';
@@ -98,6 +99,7 @@ import { InstalledAppsComponent } from './components/installed-apps/installed-ap
     AppDetailsPanelComponent,
     AppWorkloadsCardComponent,
     AppResourcesCardComponent,
+    AppNotesCardComponent,
     AppsScopeWrapperComponent,
     AppAvailableInfoCardComponent,
     // TODO: https://ixsystems.atlassian.net/browse/NAS-130392

--- a/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.html
@@ -28,6 +28,7 @@
         (stopApp)="stopApp.emit()"
       ></ix-app-info-card>
       <ix-app-containers-card [app]="app()"></ix-app-containers-card>
+      <ix-app-notes-card *ngIf="app()?.notes" [app]="app()"></ix-app-notes-card>
       <ix-app-metadata-card
         [appMetadata]="app().metadata"
         [maxHeight]="180"

--- a/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.html
@@ -1,0 +1,12 @@
+<mat-card class="card">
+  <mat-card-header>
+    <h3 mat-card-title>{{ 'Notes' | translate }}</h3>
+  </mat-card-header>
+  <mat-card-content>
+    <ix-app-section-expand-collapse class="notes">
+      <div class="notes-list">
+        <markdown [data]="app().notes"></markdown>
+      </div>
+    </ix-app-section-expand-collapse>
+  </mat-card-content>
+</mat-card>

--- a/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.scss
@@ -1,0 +1,39 @@
+@import 'mixins/cards';
+
+.card {
+  @include details-card();
+  margin: 0;
+}
+
+.notes {
+  h4 {
+    margin-bottom: 8px;
+  }
+}
+
+.notes-list {
+  background-color: rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  padding: 12px;
+  word-wrap: break-word;
+
+  markdown ::ng-deep {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: var(--fg2);
+      font-weight: 500;
+      margin: 0;
+    }
+
+    h1 { font-size: 19px; }
+    h2 { font-size: 17px; }
+    h3 { font-size: 15px; }
+    h4 { font-size: 14px; }
+    h5 { font-size: 13px; }
+    h6 { font-size: 12px; }
+  }
+}

--- a/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.spec.ts
@@ -1,0 +1,89 @@
+import { Spectator } from '@ngneat/spectator';
+import { createComponentFactory } from '@ngneat/spectator/jest';
+import { MarkdownModule } from 'ngx-markdown';
+import { App, ChartFormValue } from 'app/interfaces/app.interface';
+import { AppSectionExpandCollapseComponent } from 'app/pages/apps/components/app-section-expand-collapse/app-section-expand-collapse.component';
+import { AppNotesCardComponent } from './app-notes-card.component';
+
+describe('AppNotesCardComponent', () => {
+  let spectator: Spectator<AppNotesCardComponent>;
+  const existingAppEdit = {
+    name: 'app-name',
+    id: 'app_name',
+    config: {
+      maizeEnabled: true,
+      release_name: 'app_name',
+      timezone: 'America/Los_Angeles',
+    } as Record<string, ChartFormValue>,
+    metadata: {},
+    notes: `
+      # Welcome to TrueNAS SCALE
+      Thank you for installing MinIO App.
+      # Documentation
+      Documentation for this app can be found at https://docs.ixsystems.com.
+      # Bug reports
+      If you find a bug in this app, please file an issue at https://jira.ixsystems.com
+    `,
+    version_details: {
+      schema: {
+        groups: [
+          { name: 'Machinaris Configuration' },
+        ],
+        questions: [
+          {
+            variable: 'timezone',
+            group: 'Machinaris Configuration',
+            schema: {
+              type: 'string',
+              enum: [{ value: 'America/Los_Angeles', description: "'America/Los_Angeles' timezone" }],
+              default: 'America/Los_Angeles',
+            },
+          },
+        ],
+      },
+    },
+  } as App;
+
+  const createComponent = createComponentFactory({
+    component: AppNotesCardComponent,
+    declarations: [
+      AppSectionExpandCollapseComponent,
+    ],
+    imports: [
+      MarkdownModule.forRoot(),
+    ],
+  });
+
+  beforeEach(() => {
+    // Expected sanitizer warnings (because of newlines).
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    spectator = createComponent({
+      props: {
+        app: existingAppEdit,
+      },
+    });
+  });
+
+  it('shows header', () => {
+    expect(spectator.query('mat-card-header h3')).toHaveText('Notes');
+  });
+
+  it('shows titles', () => {
+    const titles = spectator.queryAll('.notes-list h1');
+    expect(titles).toHaveLength(3);
+
+    expect(titles[0]).toHaveText('Welcome to TrueNAS SCALE');
+    expect(titles[1]).toHaveText('Documentation');
+    expect(titles[2]).toHaveText('Bug reports');
+  });
+
+  it('shows paragraphs', () => {
+    const paragraphs = spectator.queryAll('.notes-list p');
+    expect(paragraphs).toHaveLength(3);
+
+    expect(paragraphs[0]).toHaveText('Thank you for installing MinIO App.');
+    expect(paragraphs[1]).toHaveText('Documentation for this app can be found at https://docs.ixsystems.com.');
+    expect(paragraphs[2]).toHaveText('If you find a bug in this app, please file an issue at https://jira.ixsystems.com');
+  });
+});

--- a/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-notes-card/app-notes-card.component.ts
@@ -1,0 +1,14 @@
+import {
+  ChangeDetectionStrategy, Component, input,
+} from '@angular/core';
+import { App } from 'app/interfaces/app.interface';
+
+@Component({
+  selector: 'ix-app-notes-card',
+  templateUrl: './app-notes-card.component.html',
+  styleUrls: ['./app-notes-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppNotesCardComponent {
+  readonly app = input.required<App>();
+}

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2612,6 +2612,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2034,6 +2034,7 @@
   "Normal VDEV type, used for primary storage operations. ZFS pools always have at least one DATA VDEV.": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notifications": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1558,6 +1558,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notifications": "",
   "Notransfer Timeout": "",
   "Now": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2724,6 +2724,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -723,6 +723,7 @@
   "No volume mounts": "",
   "None requested": "",
   "Not Shared": "",
+  "Notes": "",
   "Notifications": "",
   "Num Pending Deletes": "",
   "Offline VDEVs": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -20,6 +20,7 @@
   "Network Reconnection Issue": "",
   "No containers are available.": "",
   "No volume mounts": "",
+  "Notes": "",
   "Ok": "",
   "Pod Logs": "",
   "Pool Usage": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2692,6 +2692,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2565,6 +2565,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2456,6 +2456,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2878,6 +2878,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -726,6 +726,7 @@
   "No volume mounts": "",
   "None requested": "",
   "Not Shared": "",
+  "Notes": "",
   "Ok": "",
   "One half widget and two quarter widgets below": "",
   "One large widget": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2828,6 +2828,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2824,6 +2824,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1635,6 +1635,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notransfer Timeout": "",
   "Num Pending Deletes": "",
   "Number of bytes": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1780,6 +1780,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notifications": "",
   "Notransfer Timeout": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1082,6 +1082,7 @@
   "None requested": "",
   "Normal VDEV type, used for primary storage operations. ZFS pools always have at least one DATA VDEV.": "",
   "Not Shared": "",
+  "Notes": "",
   "Notifications": "",
   "Num Pending Deletes": "",
   "Number of days to retain local audit messages.": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2884,6 +2884,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notice": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -759,6 +759,7 @@
   "No volume mounts": "",
   "None requested": "",
   "Not Shared": "",
+  "Notes": "",
   "Ok": "",
   "Once an enclosure is selected, all other VDEV creation steps will limit disk selection options to disks in the selected enclosure. If the enclosure selection is changed, all disk selections will be reset.": "",
   "One half widget and two quarter widgets below": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2406,6 +2406,7 @@
   "Not Set": "",
   "Not Shared": "",
   "Not enough free space. Maximum available: {space}": "",
+  "Notes": "",
   "Notes about this disk.": "",
   "Notes about this extent.": "",
   "Notifications": "",


### PR DESCRIPTION
**Changes:**

Adds back notes app card to show notes in a separate card

**Testing:**

If there are notes available on an app, they should show up in a notes card in the details card panel.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Adds back notes card for app details
