### PR TITLE
NAS-130572 / 24.04-RC.1 / Fix EULA condition to display (by denysbutenko)

### DIFF
--- a/src/app/store/eula/eula.effects.spec.ts
+++ b/src/app/store/eula/eula.effects.spec.ts
@@ -27,7 +27,7 @@ describe('EulaEffects', () => {
         confirm: jest.fn(() => of(true)),
       }),
       mockProvider(SystemGeneralService, {
-        isEnterprise: true,
+        isEnterprise$: of(true),
       }),
       mockAuth(),
     ],

--- a/src/app/store/eula/eula.effects.ts
+++ b/src/app/store/eula/eula.effects.ts
@@ -18,7 +18,7 @@ import { adminUiInitialized } from 'app/store/admin-panel/admin.actions';
 export class EulaEffects {
   checkEula$ = createEffect(() => this.actions$.pipe(
     ofType(adminUiInitialized),
-    filter(() => this.systemGeneralService.isEnterprise),
+    filterAsync(() => this.sysGenService.isEnterprise$.pipe(filter(Boolean))),
     filterAsync(() => this.authService.hasRole([Role.FullAdmin])),
     mergeMap(() => {
       return this.ws.call('truenas.is_eula_accepted').pipe(
@@ -51,7 +51,7 @@ export class EulaEffects {
     private dialogService: DialogService,
     private translate: TranslateService,
     private errorHandler: ErrorHandlerService,
-    private systemGeneralService: SystemGeneralService,
+    private sysGenService: SystemGeneralService,
     private authService: AuthService,
   ) { }
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 92140fc57e2b1b52483ff2fe9aef2e47a671bedf

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 80bf434135c301ac0e30ff5ef9b5666f10bd8cd0

**Changes:**

Fix condition to show EULA dialog for enterprise users on first loading.

**Testing:**

Ensure you can see EULA dialog on fresh system when first time log-in

Original PR: https://github.com/truenas/webui/pull/10440
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130572