### PR TITLE
NAS-130419 / 25.04 / Fix dashboard crashing when update.check failed

### DIFF
--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { subHours, subMinutes } from 'date-fns';
 import {
-  Observable, Subject, combineLatestWith, debounceTime,
+  Observable, Subject, catchError, combineLatestWith, debounceTime,
   forkJoin, map, of, repeat, shareReplay, switchMap, take, timer,
 } from 'rxjs';
 import { SystemUpdateStatus } from 'app/enums/system-update.enum';
@@ -69,6 +69,7 @@ export class WidgetResourcesService {
 
   readonly updateAvailable$ = this.ws.call('update.check_available').pipe(
     map((update) => update.status === SystemUpdateStatus.Available),
+    catchError(() => of(false)),
     shareReplay({ refCount: false, bufferSize: 1 }),
   );
 


### PR DESCRIPTION
**Changes:**

The main dashboard still works when `update.check_available` has failed

**Testing:**

Create a fresh VM and try to open main dashboard, ensure it works
