### PR TITLE
NAS-130049 / 24.10-RC.1 / Consider removing blue plus overlay from feedback icon. (by AlexKarpov98)

### DIFF
--- a/src/app/modules/layout/components/topbar/topbar.component.html
+++ b/src/app/modules/layout/components/topbar/topbar.component.html
@@ -28,8 +28,6 @@
 
         <button
           mat-icon-button
-          matBadge="+"
-          matBadgeSize="small"
           class="topbar-button-right"
           ixTest="leave-feedback"
           [matTooltip]="'Send Feedback' | translate"


### PR DESCRIPTION
**Changes:**

Icon visual change.

**Testing:**
<img width="404" alt="Screenshot 2024-08-14 at 12 23 16" src="https://github.com/user-attachments/assets/9428305c-015d-471c-abaa-18275700acf2">


### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Icon visual change.


Original PR: https://github.com/truenas/webui/pull/10459
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130049