### PR TITLE
NAS-128620 / 25.04 / Rethink widget group containers when sorting widgets on main dashboard

### DIFF
--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.scss
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.scss
@@ -49,14 +49,25 @@
 }
 
 .group-container.editing {
-  outline: 1px dashed var(--alt-fg1);
+  background: radial-gradient(circle at center, #445e74, #222f3a);
+  border-radius: 10px;
+  box-shadow: 0 0 3px 0 var(--primary);
 
   .group {
+    opacity: 0.65;
     transform: scale(0.85) translate(0, 10px);
   }
 
   .controls {
     opacity: 1;
+  }
+}
+
+:host ::ng-deep {
+  .group-container.editing {
+    .slot {
+      border-radius: 10px;
+    }
   }
 }
 

--- a/src/app/pages/dashboard/components/dashboard/widget-group-controls/widget-group-controls.component.html
+++ b/src/app/pages/dashboard/components/dashboard/widget-group-controls/widget-group-controls.component.html
@@ -38,6 +38,6 @@
     [ixTest]="['delete-group', 'widget' + index()]"
     (click)="delete.emit()"
   >
-    <ix-icon name="delete"></ix-icon>
+    <ix-icon name="cancel"></ix-icon>
   </button>
 </div>

--- a/src/app/pages/dashboard/components/dashboard/widget-group-controls/widget-group-controls.component.scss
+++ b/src/app/pages/dashboard/components/dashboard/widget-group-controls/widget-group-controls.component.scss
@@ -13,6 +13,10 @@
   transition: opacity $animation-duration;
   width: 100%;
 
+  ix-icon {
+    color: var(--primary);
+  }
+
   .mobile-reorder-buttons {
     align-self: flex-start;
     display: flex;
@@ -34,6 +38,10 @@
     position: absolute;
     top: 0;
     width: 60px;
+
+    ix-icon {
+      font-size: 50px;
+    }
 
     @media #{$media-gt-xs} {
       display: block;


### PR DESCRIPTION
Evgeny: 
`I don’t know if we’ll keep it, but let’s make a PR and see how it looks.`

**Before:** 
<img width="1728" alt="Screenshot 2024-08-15 at 14 12 50" src="https://github.com/user-attachments/assets/0a4d268e-3e86-4af7-87c2-055e518e8de2">


**After:**
<img width="1728" alt="Screenshot 2024-08-15 at 14 07 45" src="https://github.com/user-attachments/assets/1c8d50a9-d1ce-4fe5-8c18-98cc1633e4e2">

@undsoft - you can check it out now.