### PR TITLE
NAS-130636 / 25.04 / Fix lazy image loading

### DIFF
--- a/src/app/pages/apps/components/app-card-logo/app-card-logo.component.html
+++ b/src/app/pages/apps/components/app-card-logo/app-card-logo.component.html
@@ -7,7 +7,7 @@
     [offset]="800"
     [lazyLoad]="url()"
     [defaultImage]="appImagePlaceholder"
-    [scrollTarget]="scrollTarget"
+    [customObservable]="scroll$"
     (onStateChange)="onLogoLoaded($event)"
   >
 </div>

--- a/src/app/pages/apps/components/app-card-logo/app-card-logo.component.spec.ts
+++ b/src/app/pages/apps/components/app-card-logo/app-card-logo.component.spec.ts
@@ -1,6 +1,7 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { LazyLoadImageDirective, LazyLoadImageModule } from 'ng-lazyload-image';
 import { AppCardLogoComponent } from 'app/pages/apps/components/app-card-logo/app-card-logo.component';
+import { LayoutService } from 'app/services/layout.service';
 
 describe('AppCardLogoComponent', () => {
   let spectator: Spectator<AppCardLogoComponent>;
@@ -8,6 +9,11 @@ describe('AppCardLogoComponent', () => {
   const createComponent = createComponentFactory({
     component: AppCardLogoComponent,
     imports: [LazyLoadImageModule],
+    providers: [
+      mockProvider(LayoutService, {
+        getContentContainer: jest.fn(() => document.createElement('div')),
+      }),
+    ],
   });
 
   beforeEach(() => {

--- a/src/app/pages/apps/components/app-card-logo/app-card-logo.component.ts
+++ b/src/app/pages/apps/components/app-card-logo/app-card-logo.component.ts
@@ -2,12 +2,18 @@ import {
   ChangeDetectionStrategy, Component, inject, input,
   signal,
 } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import {
   LAZYLOAD_IMAGE_HOOKS, LazyLoadImageModule, ScrollHooks, StateChange,
 } from 'ng-lazyload-image';
+import {
+  fromEvent, merge, Observable, Subject,
+} from 'rxjs';
 import { appImagePlaceholder } from 'app/constants/catalog.constants';
 import { LayoutService } from 'app/services/layout.service';
 
+@UntilDestroy()
 @Component({
   selector: 'ix-app-card-logo',
   templateUrl: './app-card-logo.component.html',
@@ -18,15 +24,32 @@ import { LayoutService } from 'app/services/layout.service';
   providers: [{ provide: LAZYLOAD_IMAGE_HOOKS, useClass: ScrollHooks }],
 })
 export class AppCardLogoComponent {
-  readonly url = input<string>();
+  url = input.required<string>();
   protected wasLogoLoaded = signal(false);
 
   private layoutService = inject(LayoutService);
 
-  readonly scrollTarget = this.layoutService.getContentContainer();
-  readonly appImagePlaceholder = appImagePlaceholder;
+  protected readonly scrollTarget = this.layoutService.getContentContainer();
+  protected readonly appImagePlaceholder = appImagePlaceholder;
 
-  onLogoLoaded(event: StateChange): void {
+  protected readonly initialEmitter$ = new Subject<void>();
+  protected readonly scroll$: Observable<Event | void>;
+
+  constructor() {
+    this.scroll$ = merge(
+      fromEvent(this.scrollTarget, 'scroll'),
+      this.initialEmitter$,
+    );
+    toObservable(this.url).pipe(
+      untilDestroyed(this),
+    ).subscribe({
+      next: () => {
+        this.initialEmitter$.next();
+      },
+    });
+  }
+
+  protected onLogoLoaded(event: StateChange): void {
     if (event.reason !== 'loading-succeeded') {
       return;
     }

--- a/src/app/pages/apps/components/available-apps/available-apps.component.spec.ts
+++ b/src/app/pages/apps/components/available-apps/available-apps.component.spec.ts
@@ -50,7 +50,7 @@ describe('Finding app', () => {
     declarations: [
       AvailableAppsHeaderComponent,
       AppCardComponent,
-      AppCardLogoComponent,
+      MockDeclaration(AppCardLogoComponent),
       MockDeclaration(CustomAppButtonComponent),
     ],
     providers: [


### PR DESCRIPTION
**Changes:**

Adds a custom observable to lazy-image-load process. Solves the problem where scrolling of the container element wasn't triggered so image wasn't loading.

**Testing:**

Go to apps page, discover apps and search for different apps. The image icon should load properly and should show without any scrolling or clicking on the page automatically.

