### PR TITLE
NAS-130656 / 24.10-RC.1 / Portal group IDs on iSCSI target are shown as incorrect (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/iscsi/target/target-form/target-form.component.spec.ts
+++ b/src/app/pages/sharing/iscsi/target/target-form/target-form.component.spec.ts
@@ -233,8 +233,8 @@ describe('TargetFormComponent', () => {
       expect(websocket.call).toHaveBeenNthCalledWith(3, 'iscsi.auth.query', []);
 
       expect(portal).toEqual([
-        { label: '11 (comment_1)', value: 1 },
-        { label: '22 (comment_2)', value: 2 },
+        { label: '1 (comment_1)', value: 1 },
+        { label: '2 (comment_2)', value: 2 },
       ]);
 
       expect(initiator).toEqual([

--- a/src/app/pages/sharing/iscsi/target/target-form/target-form.component.ts
+++ b/src/app/pages/sharing/iscsi/target/target-form/target-form.component.ts
@@ -46,14 +46,11 @@ export class TargetFormComponent implements OnInit {
   readonly modes$ = of(this.helptext.target_form_enum_mode);
   readonly portals$ = this.iscsiService.listPortals().pipe(
     map((portals) => {
-      const opts: Option[] = [];
-      portals.forEach((portal) => {
-        let label = String(portal.tag);
-        if (portal.comment) {
-          label += ' (' + portal.comment + ')';
-        }
-        opts.push({ label, value: portal.id });
+      const opts: Option[] = portals.map((portal) => {
+        const label = portal.comment ? `${portal.id} (${portal.comment})` : String(portal.id);
+        return { label, value: portal.id };
       });
+
       return opts;
     }),
   );


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x a9c3d6b4fdbe99c9edd3f9337f95d6bf84f5c6e8

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 45c1c8e73f7a20f60e2018da4fa5b368ba8af6c1

Testing: see ticket. We used different identifiers - that's the issue.

Original PR: https://github.com/truenas/webui/pull/10512
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130656