### PR TITLE
NAS-130607 / 24.10-RC.1 / Mobile adjustments for dashboard widgets (by AlexKarpov98)

### DIFF
--- a/src/app/modules/global-search/components/global-search-results/global-search-results.component.scss
+++ b/src/app/modules/global-search/components/global-search-results/global-search-results.component.scss
@@ -115,6 +115,7 @@
       display: inline-box;
       font-size: 16px;
       -webkit-line-clamp: 2;
+      line-clamp: 2;
       overflow: hidden;
       white-space: normal;
       word-break: break-word;

--- a/src/app/modules/ix-table/components/ix-table/ix-table.component.scss
+++ b/src/app/modules/ix-table/components/ix-table/ix-table.component.scss
@@ -20,6 +20,7 @@ table {
     -webkit-box-orient: vertical;
     display: -webkit-inline-box;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
     margin: 0 0 -5px;
     overflow: hidden;
     white-space: normal;

--- a/src/app/modules/layout/components/topbar/user-menu/user-menu.component.scss
+++ b/src/app/modules/layout/components/topbar/user-menu/user-menu.component.scss
@@ -15,6 +15,7 @@
     cursor: pointer;
     font-size: 14px;
     -webkit-line-clamp: 1;
+    line-clamp: 1;
     margin-right: 0.5rem;
     max-width: 200px;
     overflow: hidden;

--- a/src/app/pages/apps/components/available-apps/app-card/app-card.component.scss
+++ b/src/app/pages/apps/components/available-apps/app-card/app-card.component.scss
@@ -75,6 +75,7 @@
     display: inline-box;
     font-size: 1.2em;
     -webkit-line-clamp: 4;
+    line-clamp: 4;
     line-height: 1.2em;
     margin-bottom: 0;
     overflow: hidden;

--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.scss
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.scss
@@ -92,7 +92,14 @@
   mat-card-content .header h3,
   .slot .wrapper h3 {
     @media(max-width: 767px) {
+      -webkit-box-orient: vertical;
+      display: inline-box;
       font-size: 20px;
+      -webkit-line-clamp: 1;
+      line-clamp: 1;
+      overflow: hidden;
+      white-space: normal;
+      word-break: break-word;
     }
   }
 

--- a/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.scss
+++ b/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.scss
@@ -1,3 +1,4 @@
+@import 'scss-imports/cssvars';
 
 .category-type-wrapper {
   display: flex;
@@ -7,4 +8,8 @@
 
 .half-width {
   width: 50%;
+
+  @media (max-width: $breakpoint-xs) {
+    width: 100%;
+  }
 }

--- a/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.ts
+++ b/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.ts
@@ -106,7 +106,7 @@ export class WidgetGroupSlotFormComponent implements OnInit, AfterViewInit, OnCh
       return a.label.localeCompare(b.label);
     });
     if (!this.form.controls.type.value || !Array.from(uniqTypes).includes(this.form.controls.type.value)) {
-      const firstSupported = typeOptions.find((option) => !option.disabled).value;
+      const firstSupported = typeOptions.find((option) => !option.disabled)?.value;
       this.form.controls.type.setValue(firstSupported);
     }
     return of(typeOptions);

--- a/src/app/pages/dashboard/widgets/apps/widget-app-settings/widget-app-settings.component.scss
+++ b/src/app/pages/dashboard/widgets/apps/widget-app-settings/widget-app-settings.component.scss
@@ -1,3 +1,10 @@
+
+@import 'scss-imports/cssvars';
+
 .half-width {
   width: 50%;
+
+  @media (max-width: $breakpoint-xs) {
+    width: 100%;
+  }
 }

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-empty/backup-task-empty.component.scss
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-empty/backup-task-empty.component.scss
@@ -23,7 +23,7 @@
 
   .backup-actions {
     font-size: 15px;
-    margin-bottom: 60px;
+    margin-bottom: 55px;
     position: relative;
     text-align: center;
     z-index: 1;

--- a/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.scss
+++ b/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.scss
@@ -1,3 +1,4 @@
+@import 'scss-imports/cssvars';
 @import '../../../dashboard-variables';
 
 :host {
@@ -32,6 +33,10 @@ mat-card {
       padding: 0 12px;
       text-align: center;
       width: 100%;
+
+      @media (max-width: $breakpoint-xs) {
+        padding: 0 5px;
+      }
 
       > div {
         word-break: break-word;

--- a/src/app/pages/dashboard/widgets/custom/arbitrary-text/widget-arbitrary-text-settings/widget-arbitrary-text-settings.component.scss
+++ b/src/app/pages/dashboard/widgets/custom/arbitrary-text/widget-arbitrary-text-settings/widget-arbitrary-text-settings.component.scss
@@ -1,3 +1,9 @@
+@import 'scss-imports/cssvars';
+
 .half-width {
   width: 50%;
+
+  @media (max-width: $breakpoint-xs) {
+    width: 100%;
+  }
 }

--- a/src/app/pages/dashboard/widgets/help/widget-help/widget-help.component.scss
+++ b/src/app/pages/dashboard/widgets/help/widget-help/widget-help.component.scss
@@ -123,12 +123,21 @@
     margin-right: 15px;
     max-width: 90%;
     text-align: left;
+
+    @media (max-width: $breakpoint-xs) {
+      font-size: 12px;
+      margin-left: 15px;
+    }
   }
 }
 
 .open-source {
   font-size: 0.75rem;
   text-align: center;
+
+  @media (max-width: $breakpoint-xs) {
+    display: none;
+  }
 }
 
 %half-and-quarter-size {

--- a/src/app/pages/dashboard/widgets/memory/widget-memory/widget-memory.component.scss
+++ b/src/app/pages/dashboard/widgets/memory/widget-memory/widget-memory.component.scss
@@ -48,12 +48,29 @@
     @extend %quarter-size;
   }
 
+  &.full,
+  &.half {
+    @media(max-width: $breakpoint-xs) {
+      .stats {
+        flex: 0 0 60%;
+      }
+
+      .chart {
+        flex: 0 0 40%;
+      }
+    }
+  }
+
   .stats {
     align-items: center;
     display: flex;
     flex: 0 0 45%;
     flex-direction: column;
     justify-content: center;
+
+    @media(max-width: $breakpoint-xs) {
+      flex: 1;
+    }
 
     .total-memory {
       color: var(--fg1);
@@ -107,6 +124,11 @@
     padding-right: 35px;
     position: relative;
 
+    @media(max-width: $breakpoint-xs) {
+      flex: 0 0 50%;
+      padding: 0 16px 0 0;
+    }
+
     .skeleton {
       display: block;
       flex-grow: 1;
@@ -143,6 +165,12 @@
   .stats {
     flex: 0 0 60%;
 
+    @media(max-width: $breakpoint-xs) {
+      .stats-item {
+        justify-content: center;
+      }
+    }
+
     .legend {
       margin-bottom: 0;
       row-gap: 0;
@@ -176,17 +204,17 @@
     flex: 0 0 58%;
 
     @media(max-width: $breakpoint-xs) {
-      flex: 0 0 68%;
+      flex: 1;
+
+      .stats-item {
+        justify-content: center;
+      }
     }
 
     .label,
     .stats-item {
       font-size: 12px;
       margin-right: 4px;
-
-      @media(max-width: $breakpoint-xs) {
-        font-size: 10px;
-      }
     }
 
     .legend {
@@ -198,9 +226,12 @@
       }
     }
 
-    .total-memory,
+    .total-memory {
+      font-size: 30px;
+    }
+
     .memory-used-caption {
-      display: none;
+      margin-bottom: 12px;
     }
   }
 
@@ -210,6 +241,13 @@
 
     @media(max-width: $breakpoint-xs) {
       flex: 0 0 25%;
+    }
+  }
+
+  .chart,
+  .legend-swatch {
+    @media (max-width: $breakpoint-xs) {
+      display: none;
     }
   }
 }

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.scss
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.scss
@@ -1,3 +1,9 @@
+@import 'scss-imports/cssvars';
+
 .half-width {
   width: 50%;
+
+  @media (max-width: $breakpoint-xs) {
+    width: 100%;
+  }
 }

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.html
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.html
@@ -85,7 +85,7 @@
               }
               @if (!isLoading()) {
                 <div class="info-list-item">
-                  <span>{{ 'IP Address' | translate }}:</span>
+                  <span>{{ 'IP' | translate }}:</span>
                   <span>{{ getIpAddress(interface().value) }}</span>
                 </div>
               } @else {

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.scss
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.scss
@@ -1,3 +1,5 @@
+@import 'scss-imports/variables';
+
 .card {
   box-sizing: border-box;
   display: flex;
@@ -55,20 +57,6 @@
     }
   }
 
-  &.half {
-    flex-direction: row;
-
-    .nic-info {
-      flex: 1 1 30%;
-      max-width: 30%;
-    }
-
-    .nic-chart {
-      flex: 1 1 70%;
-      max-width: 70%;
-    }
-  }
-
   &.half,
   &.quarter {
     padding: 0;
@@ -82,6 +70,10 @@
       display: flex;
       flex-direction: column-reverse;
       padding: 0 16px 24px;
+
+      @media (max-width: $breakpoint-xs) {
+        padding: 0;
+      }
     }
 
     .in-out {
@@ -110,6 +102,51 @@
       margin-top: 12px;
       opacity: 0.75;
       place-content: center center;
+    }
+  }
+
+  &.half {
+    flex-direction: row;
+
+    @media (max-width: $breakpoint-xs) {
+      display: block;
+
+      .info-header-title {
+        max-width: 55%;
+      }
+
+      .info-list-item.state {
+        display: none;
+      }
+
+      .info-column {
+        position: absolute;
+        right: 0;
+        top: 10px;
+      }
+    }
+
+    .nic-info {
+      flex: 1 1 30%;
+      max-width: 30%;
+
+      @media (max-width: $breakpoint-xs) {
+        flex: 1;
+        max-width: 100%;
+      }
+    }
+
+    .nic-chart {
+      align-items: center;
+      display: flex;
+      flex: 1 1 70%;
+      justify-content: center;
+      max-width: 70%;
+
+      @media (max-width: $breakpoint-xs) {
+        flex: 1;
+        max-width: 100%;
+      }
     }
   }
 
@@ -144,6 +181,10 @@
   padding: 0 8px;
   place-content: stretch flex-start;
 
+  @media (max-width: $breakpoint-xs) {
+    padding: 0;
+  }
+
   .divider {
     background-color: var(--lines);
     margin: 5px 0;
@@ -169,12 +210,20 @@
   min-width: 0;
   place-content: center flex-start;
   width: 100%;
+
+  @media (max-width: $breakpoint-xs) {
+    gap: 4px;
+  }
 }
 
 .info-column {
   &.primary {
     flex: 1;
     padding-right: 16px;
+
+    @media (max-width: $breakpoint-xs) {
+      padding-right: 6px;
+    }
   }
 
   &.secondary {
@@ -218,6 +267,10 @@
   user-select: none;
   user-select: none;
   width: 20px;
+
+  @media (max-width: $breakpoint-xs) {
+    display: none;
+  }
 
   .ix-icon {
     font-size: 16px;

--- a/src/app/pages/dashboard/widgets/storage/widget-pool-disks-with-zfs-errors/widget-pool-disks-with-zfs-errors.component.scss
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool-disks-with-zfs-errors/widget-pool-disks-with-zfs-errors.component.scss
@@ -1,17 +1,8 @@
 :host ::ng-deep {
   .container {
     &.quarter {
+      padding-bottom: 0;
       padding-top: 0;
-
-      .item .value {
-        margin: 26px 0;
-      }
-    }
-  }
-
-  ngx-skeleton-loader {
-    span {
-      margin-bottom: 0 !important;
     }
   }
 }

--- a/src/app/pages/dashboard/widgets/storage/widget-pool-last-scan-errors/widget-pool-last-scan-errors.component.scss
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool-last-scan-errors/widget-pool-last-scan-errors.component.scss
@@ -1,17 +1,8 @@
 :host ::ng-deep {
   .container {
     &.quarter {
+      padding-bottom: 0;
       padding-top: 0;
-
-      .item .value {
-        margin: 26px 0;
-      }
-    }
-  }
-
-  ngx-skeleton-loader {
-    span {
-      margin-bottom: 0 !important;
     }
   }
 }

--- a/src/app/pages/dashboard/widgets/storage/widget-pool-status/widget-pool-status.component.scss
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool-status/widget-pool-status.component.scss
@@ -1,17 +1,8 @@
 :host ::ng-deep {
   .container {
     &.quarter {
+      padding-bottom: 0;
       padding-top: 0;
-
-      .item .value {
-        margin: 26px 0;
-      }
-    }
-  }
-
-  ngx-skeleton-loader {
-    span {
-      margin-bottom: 0 !important;
     }
   }
 }

--- a/src/app/pages/dashboard/widgets/storage/widget-pool-usage-gauge/widget-pool-usage-gauge.component.scss
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool-usage-gauge/widget-pool-usage-gauge.component.scss
@@ -1,10 +1,4 @@
-:host ::ng-deep {
-  ngx-skeleton-loader {
-    span {
-      margin-bottom: 0 !important;
-    }
-  }
-}
+@import 'scss-imports/cssvars';
 
 :host ::ng-deep .container {
   &.full {
@@ -15,12 +9,24 @@
       justify-content: center;
       text-align: center;
 
+      .left .pool-name .stats {
+        display: none;
+      }
+
       .left .lines {
         gap: 3px !important;
+      }
 
-        .line {
-          justify-content: center;
-        }
+      .left .lines .line {
+        justify-content: center;
+      }
+    }
+  }
+
+  &.half {
+    .right {
+      @media (max-width: $breakpoint-xs) {
+        display: none;
       }
     }
   }
@@ -30,7 +36,8 @@
     padding-top: 0;
 
     .pool-info-top {
-      height: 118px;
+      height: 115px;
+      opacity: 0.7;
 
       .left {
         .pool-name,
@@ -42,6 +49,12 @@
           gap: 2px !important;
           height: 100%;
           justify-content: center;
+        }
+      }
+
+      .left .lines .line.pool-usage {
+        @media (max-width: $breakpoint-xs) {
+          display: block !important;
         }
       }
 

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-stats.scss
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-stats.scss
@@ -12,7 +12,7 @@
   }
 
   .value {
-    margin: 18px 0;
+    margin: 26px 0;
   }
 
   .divider {

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.html
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.html
@@ -2,13 +2,34 @@
   <div class="left">
     <h3 class="pool-name">
       @if (!isPoolLoading()) {
-        {{ pool().name }}
+        <span class="name">
+          {{ pool().name }}
+        </span>
+
+        @if (!isDatasetLoading()) {
+          <span class="stats">
+            {{ usedPercentage() / 100 | percent: '1.0-1' }}
+            {{ 'Used' | translate }}
+          </span>
+        }
       } @else {
         <ngx-skeleton-loader class="skeleton"></ngx-skeleton-loader>
       }
     </h3>
     <div class="divider"></div>
     <div class="lines">
+      @if (!isDatasetLoading()) {
+        <div class="line pool-usage">
+          <span class="label">{{ 'Pool Usage' | translate }}:</span>
+          @if (!isDisksLoading()) {
+            <span class="value">
+              {{ usedPercentage() / 100 | percent: '1.0-1' }}
+            </span>
+          } @else {
+            <ngx-skeleton-loader class="skeleton"></ngx-skeleton-loader>
+          }
+        </div>
+      }
       <div class="line">
         <span class="label">{{ 'Data Topology' | translate }}:</span>
         @if (!isDisksLoading()) {

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.scss
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.scss
@@ -1,9 +1,29 @@
+@import 'scss-imports/cssvars';
+
 .pool-info-top {
   background: var(--bg1);
   border-radius: 2px;
   display: flex;
   height: 190px;
   padding: 12px;
+}
+
+.pool-name {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+
+  span {
+    &.stats {
+      display: none;
+
+      @media (max-width: $breakpoint-xs) {
+        display: block;
+        font-size: 20px;
+        font-weight: normal;
+      }
+    }
+  }
 }
 
 .pool-info-top .left {
@@ -23,12 +43,16 @@
   .lines {
     display: flex;
     flex-direction: column;
-    font-size: 13px;
+    font-size: 12px;
     gap: 10px;
 
     .line {
       display: flex;
       height: initial;
+
+      &.pool-usage {
+        display: none;
+      }
     }
 
     .label {

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.spec.ts
@@ -115,6 +115,7 @@ describe('PoolUsageGaugeComponent', () => {
       });
     });
     expect(lines).toEqual([
+      { label: 'Pool Usage:', value: '80.2%' },
       { label: 'Data Topology:', value: '2 x DISK | 1 wide | 5 GiB' },
       { label: 'Usable Capacity:', value: '2.63 GiB' },
       { label: 'Last Scrub Date:', value: '2024-06-09 10:00:20' },

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/widget-pool-settings/widget-pool-settings.component.scss
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/widget-pool-settings/widget-pool-settings.component.scss
@@ -1,3 +1,9 @@
+@import 'scss-imports/cssvars';
+
 .half-width {
   width: 50%;
+
+  @media (max-width: $breakpoint-xs) {
+    width: 100%;
+  }
 }

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/widget-pool.component.scss
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/widget-pool.component.scss
@@ -22,19 +22,57 @@
   }
 }
 
+.mat-mdc-card .mat-mdc-card-content > div.container {
+  padding-top: 0;
+}
+
 .container {
+  &.full,
+  &.half {
+    &::ng-deep {
+      @media (max-width: $breakpoint-xs) {
+        .pool-info-top .right {
+          display: none;
+        }
+
+        .pool-info-bottom .item {
+          min-height: 100%;
+          text-align: center;
+        }
+
+        .pool-info-bottom .item .value {
+          font-size: 20px;
+        }
+      }
+    }
+  }
+
   .pool-info-wrapper {
     display: flex;
     flex-direction: column;
     gap: 12px;
 
+    @media (max-width: $breakpoint-xs) {
+      gap: 10px;
+    }
+
     .pool-info-bottom {
       display: flex;
       gap: 12px;
 
+      @media (max-width: $breakpoint-xs) {
+        gap: 10px;
+      }
+
       > * {
         display: block;
         width: 100%;
+      }
+
+      @media (max-width: $breakpoint-xs) {
+        .value {
+          font-size: 20px;
+        }
       }
     }
   }

--- a/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.html
+++ b/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.html
@@ -18,8 +18,8 @@
       @if (!isLoading()) {
         <mat-grid-list
           [cols]="isTwoTilesInRow ? 2 : 1"
-          [gutterSize]="isThreeTilesInColumn ? '7px' : '16px'"
-          [rowHeight]="poolsInfo().length ? (isThreeTilesInColumn ? '100px' : '150px') : '300px'"
+          [gutterSize]="isThreeTilesInColumn ? '7px' : '12px'"
+          [rowHeight]="poolsInfo().length ? (isThreeTilesInColumn ? '100px' : '153px') : '300px'"
         >
           @for (poolInfo of poolsInfo().slice(0, 6); track poolInfo) {
             <mat-grid-tile class="grid-tile">

--- a/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.scss
+++ b/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.scss
@@ -18,7 +18,7 @@
   }
 
   .container {
-    padding: 12px;
+    padding: 4px 16px 16px;
   }
 }
 
@@ -28,6 +28,20 @@
 
   h3 {
     font-size: 24px;
+  }
+}
+
+mat-grid-list[cols='2'] {
+  ul li:nth-child(2) {
+    .value {
+      font-size: 11px;
+    }
+
+    @media (max-width: $breakpoint-xs) {
+      .label {
+        display: none;
+      }
+    }
   }
 }
 
@@ -50,9 +64,13 @@
     max-width: 100%;
     min-height: 100%;
     min-width: 100%;
-    padding-left: 16px;
+    padding: 0 0 0 12px;
     place-content: stretch flex-start;
     width: 100%;
+
+    @media (max-width: $breakpoint-xs) {
+      padding: 0 8px;
+    }
 
     .tile-header {
       align-items: center;
@@ -88,6 +106,10 @@
         height: 75%;
         margin-right: 12px;
         width: 1px;
+
+        @media (max-width: $breakpoint-xs) {
+          margin: 0 2px;
+        }
       }
 
       ul {
@@ -95,7 +117,10 @@
         display: flex;
         flex: 1 1 100%;
         flex-direction: column;
-        max-width: 100%;
+
+        @media (max-width: $breakpoint-xs) {
+          max-width: 100% !important;
+        }
       }
 
       li {
@@ -107,9 +132,14 @@
         white-space: nowrap;
 
         .label {
-          margin-right: 6px;
+          margin-right: 2px;
+        }
+
+        .label,
+        .value {
           overflow: hidden;
           text-overflow: ellipsis;
+          white-space: nowrap;
         }
       }
     }

--- a/src/app/pages/dashboard/widgets/system/common/widget-sys-info.scss
+++ b/src/app/pages/dashboard/widgets/system/common/widget-sys-info.scss
@@ -21,12 +21,26 @@
 
       .card-action-container {
         padding: 0 0 10px;
+
+        @media (max-width: $breakpoint-xs) {
+          padding: 10px 0 0;
+        }
       }
 
       .product-image {
         gap: 0;
         margin-bottom: 10px;
         padding-top: 10px;
+
+        @media (max-width: $breakpoint-xs) {
+          margin: 0;
+        }
+      }
+
+      .product-image img {
+        @media (max-width: $breakpoint-xs) {
+          width: 120px;
+        }
       }
 
       .product-image-placeholder {
@@ -45,6 +59,42 @@
         &:nth-child(2),
         &:nth-child(5) {
           display: flex;
+        }
+      }
+
+      .content-left {
+        @media (max-width: $breakpoint-xs) {
+          display: none;
+        }
+      }
+    }
+
+    &.full,
+    &.half {
+      @media (max-width: $breakpoint-xs) {
+        .container {
+          display: grid;
+        }
+
+        .content-left {
+          background-color: transparent;
+          max-width: 100%;
+          order: 2;
+        }
+
+        .content-right {
+          max-width: 100%;
+          order: 1;
+        }
+
+        .content-right mat-list mat-list-item:nth-child(3),
+        .product-image,
+        .product-logo-container {
+          display: none;
+        }
+
+        .card-action-container {
+          padding: 0 0 8px;
         }
       }
     }

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -398,6 +398,7 @@ body .mdc-card__actions,
       -webkit-box-orient: vertical;
       display: inline-box;
       -webkit-line-clamp: 2;
+      line-clamp: 2;
       max-width: 75%;
       overflow: hidden;
       text-overflow: ellipsis;


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 238af6c20307ac8079939a6c43a26110fd4864a2
    git cherry-pick -x 550f74cd18a7f3e78bae812a20de7cfca0009d9e
    git cherry-pick -x 7060a2d2a0781110c8b5daa5d1473f0d30d1f59b
    git cherry-pick -x 63041fdcef046d4ca1ee755e19abe176388ddde7
    git cherry-pick -x 7c8ce1b9001f80222025349ecdcce52479bea119
    git cherry-pick -x ede88ac073dac1408193ed757b3156e79e767a6a
    git cherry-pick -x 16098573d7aee3a41f8290bac9678d1783da359c
    git cherry-pick -x bc17d740a3676a71c0ec9d9d4d8f85c6c3a262dd

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x b0d75a1e208fe99a2728ebe97eb984dd181305db

**Changes:**

Adjustments for widgets (mobile view)

**Testing:**

See ticket, check all of the widget with all sizes. 
Try to find any regression.

UI should be more user friendly & consistent now.

**Before:**

https://github.com/user-attachments/assets/66101553-0bd0-4f3d-8e83-1069faa82504


**Result:**

https://github.com/user-attachments/assets/88a00a8b-8d8b-428f-89ed-f6152e8bc4e6



### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Adjustments for widgets (mobile view), maybe there are some screenshots


Original PR: https://github.com/truenas/webui/pull/10507
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130607