### PR TITLE
NAS-130692 / 24.10-RC.1 / Some text is not translated in Pool creation

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.html
+++ b/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.html
@@ -62,8 +62,8 @@
             [value]="option.value"
             [disabled]="option.disabled"
             [ixTest]="[controlDirective.name, option.label]"
-            [matTooltip]="option.hoverTooltip"
-            [attr.aria-label]="option.label"
+            [matTooltip]="option.hoverTooltip | translate"
+            [attr.aria-label]="option.label | translate"
           >
             @if (multiple) {
               <ix-icon


### PR DESCRIPTION
**Changes:**

Fixes translation issue.

**Testing:**

Check translation issue as described in the ticket.