### PR TITLE
NAS-130665 / 24.10-RC.1 / Update Last Resilver Never as neutral (by denysbutenko)

### DIFF
--- a/src/app/pages/dashboard/widgets/storage/interfaces/pool-info.interface.ts
+++ b/src/app/pages/dashboard/widgets/storage/interfaces/pool-info.interface.ts
@@ -11,6 +11,7 @@ export enum StatusLevel {
   Safe = 'safe',
   Warn = 'warn',
   Error = 'error',
+  Neutral = 'neutral',
 }
 
 export enum StatusIcon {
@@ -19,6 +20,7 @@ export enum StatusIcon {
   MdiAlert = 'mdi-alert',
   MdiCloseCircle = 'mdi-close-circle',
   ArrowCircleRight = 'arrow_circle_right',
+  Neutral = 'mdi-minus-circle',
 }
 
 export interface PoolInfo {

--- a/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.ts
+++ b/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.ts
@@ -249,8 +249,8 @@ export class WidgetStorageComponent {
       level = isScanFinished ? StatusLevel.Safe : StatusLevel.Warn;
       value = this.formatDateTimePipe.transform(endTime);
     } else {
-      icon = StatusIcon.MdiCloseCircle;
-      level = StatusLevel.Error;
+      icon = StatusIcon.Neutral;
+      level = StatusLevel.Neutral;
       value = this.translate.instant('Never');
     }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 8f813fbfb7f21bf7f679ae2f56b075a81e2561d8

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4b31f8e63e29dbfcb71ab5e444b7e1de92f633e9

**Changes:**

Update icon and color when `Last Resilver` is `Never`

**Testing:**

Check the Storage widget

Original PR: https://github.com/truenas/webui/pull/10515
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130665