### PR TITLE
NAS-130759 / 24.10-RC.1 / Use same instance on destroy and on init for `tree-vritual-scroll-view` (by RehanY147)

### DIFF
--- a/src/app/modules/ix-tree/components/tree-virtual-scroll-view/tree-virtual-scroll-view.component.ts
+++ b/src/app/modules/ix-tree/components/tree-virtual-scroll-view/tree-virtual-scroll-view.component.ts
@@ -83,13 +83,13 @@ export class TreeVirtualScrollViewComponent<T> extends Tree<T> implements OnChan
   override ngOnInit(): void {
     this.scrollableElement = document.querySelector('.rightside-content-hold');
     if (this.scrollableElement) {
-      this.scrollableElement.addEventListener('scroll', this.scrolled.bind(this));
+      this.scrollableElement.addEventListener('scroll', this.scrolled);
     }
   }
 
   override ngOnDestroy(): void {
     if (this.scrollableElement) {
-      this.scrollableElement.removeEventListener('scroll', this.scrolled.bind(this));
+      this.scrollableElement.removeEventListener('scroll', this.scrolled);
     }
   }
 
@@ -133,7 +133,7 @@ export class TreeVirtualScrollViewComponent<T> extends Tree<T> implements OnChan
     });
   }
 
-  private scrolled(): void {
+  private readonly scrolled = (): void => {
     this.viewportScrolled.emit(this.virtualScrollViewport.elementRef.nativeElement.scrollLeft);
-  }
+  };
 }


### PR DESCRIPTION
**Changes:**

Instead of recreating the instance to disconnect from event listener on component destroy event, use the same instance that is used to register the callback method.

**Testing:**

Have some datasets setup on a pool. Navigate quickly between different pages and come back to the datasets dashboard and try scrolling. If you do it quickly, you can see lots of instances of the same error on the console. This fix resolves that issue.

Original PR: https://github.com/truenas/webui/pull/10532
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130759