### PR TITLE
Add hybrid mode to UPS

### DIFF
--- a/src/app/enums/ups-mode.enum.ts
+++ b/src/app/enums/ups-mode.enum.ts
@@ -6,4 +6,5 @@ export enum UpsMode {
 export enum UpsShutdownMode {
   LowBattery = 'LOWBATT',
   Battery = 'BATT',
+  Hybrid = 'HYBRID',
 }

--- a/src/app/helptext/services/components/service-ups.ts
+++ b/src/app/helptext/services/components/service-ups.ts
@@ -58,6 +58,7 @@ export const helptextServiceUps = {
   ups_shutdown_options: [
     { label: 'UPS reaches low battery', value: UpsShutdownMode.LowBattery },
     { label: 'UPS goes on battery', value: UpsShutdownMode.Battery },
+    { label: 'Hybrid (Going on battery starts Shutdown Timer, Low battery executes shutdown immediately)', value: UpsShutdownMode.Hybrid },
   ],
 
   ups_shutdowntimer_placeholder: T('Shutdown Timer'),
@@ -65,7 +66,7 @@ export const helptextServiceUps = {
  before initiating shutdown. Shutdown will not occur\
  if power is restored while the timer is counting\
  down. This value only applies when <b>Shutdown\
- mode</b> is set to <i>UPS goes on battery</i>.'),
+ mode</b> is set to <i>UPS goes on battery</i> or <i>Hybrid</i>.'),
 
   ups_shutdowncmd_placeholder: T('Shutdown Command'),
   ups_shutdowncmd_tooltip: T('When battery power is low or the shutdown timer ends,\


### PR DESCRIPTION
Implements this feature request: https://forums.truenas.com/t/ups-server-additional-shutdown-mode/11257

Hybrid mode:
When UPS is on battery Shutdown Timer is started. If low battery is reached shutdown is executed immediately.

Middleware pull request: https://github.com/truenas/middleware/pull/14339