### PR TITLE
NAS-130678 / 24.10-RC.1 / Fix dRAID logic for number of children when creating a pool (by bvasilenko)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.spec.ts
@@ -51,10 +51,11 @@ describe('DraidSelectionComponent', () => {
           { type: DiskType.Hdd, size: 10 * GiB, name: 'disk2' },
           { type: DiskType.Hdd, size: 10 * GiB, name: 'disk3' },
           { type: DiskType.Hdd, size: 10 * GiB, name: 'disk4' },
-          { type: DiskType.Hdd, size: 20 * GiB, name: 'disk5' },
-          { type: DiskType.Ssd, size: 20 * GiB, name: 'disk6' },
-          { type: DiskType.Ssd, size: 30 * GiB, name: 'disk7' },
+          { type: DiskType.Hdd, size: 10 * GiB, name: 'disk5' },
+          { type: DiskType.Hdd, size: 20 * GiB, name: 'disk6' },
+          { type: DiskType.Ssd, size: 20 * GiB, name: 'disk7' },
           { type: DiskType.Ssd, size: 30 * GiB, name: 'disk8' },
+          { type: DiskType.Ssd, size: 30 * GiB, name: 'disk9' },
         ] as DetailsDisk[],
         isStepActive: true,
       },
@@ -92,7 +93,7 @@ describe('DraidSelectionComponent', () => {
     });
 
     const dataDevices = await form.getControl('Data Devices') as IxSelectHarness;
-    expect(await dataDevices.getOptionLabels()).toEqual(['2', '3']);
+    expect(await dataDevices.getOptionLabels()).toEqual(['2', '3', '4']);
   });
 
   it('updates Spares and Children options when Data Devices are selected', async () => {
@@ -104,11 +105,11 @@ describe('DraidSelectionComponent', () => {
     );
 
     const spares = await form.getControl('Distributed Hot Spares') as IxSelectHarness;
-    expect(await spares.getOptionLabels()).toEqual(['0', '1']);
+    expect(await spares.getOptionLabels()).toEqual(['0', '1', '2']);
     expect(await spares.getValue()).toBe('0');
 
     const children = await form.getControl('Children') as IxSelectHarness;
-    expect(await children.getOptionLabels()).toEqual(['3', '4']);
+    expect(await children.getOptionLabels()).toEqual(['4', '5']);
   });
 
   it('updates Children when Spares are selected', async () => {
@@ -121,7 +122,7 @@ describe('DraidSelectionComponent', () => {
     );
 
     const children = await form.getControl('Children') as IxSelectHarness;
-    expect(await children.getOptionLabels()).toEqual(['4']);
+    expect(await children.getOptionLabels()).toEqual(['5']);
   });
 
   it('defaults Children to optimal number, but only once', async () => {
@@ -133,12 +134,12 @@ describe('DraidSelectionComponent', () => {
     );
 
     const children = await form.getControl('Children') as IxSelectHarness;
-    expect(await children.getValue()).toBe('3');
+    expect(await children.getValue()).toBe('5');
 
     await form.fillForm({
       'Treat Disk Size as Minimum': true,
     });
-    expect(await children.getValue()).toBe('6');
+    expect(await children.getValue()).toBe('9');
   });
 
   it('updates number of vdevs when Children are selected', async () => {
@@ -154,7 +155,7 @@ describe('DraidSelectionComponent', () => {
     expect(await vdevs.getOptionLabels()).toEqual(['1']);
 
     await form.fillForm({
-      Children: '3',
+      Children: '4',
     });
 
     expect(await vdevs.getOptionLabels()).toEqual(['1', '2']);
@@ -167,8 +168,8 @@ describe('DraidSelectionComponent', () => {
         'Treat Disk Size as Minimum': true,
         'Data Devices': '2',
         'Distributed Hot Spares': '1',
-        Children: '4',
-        'Number of VDEVs': '2',
+        Children: '5',
+        'Number of VDEVs': '1',
       },
     );
 
@@ -178,8 +179,8 @@ describe('DraidSelectionComponent', () => {
       {
         draidDataDisks: 2,
         draidSpareDisks: 1,
-        vdevsNumber: 2,
-        width: 4,
+        vdevsNumber: 1,
+        width: 5,
       },
     );
   });
@@ -191,8 +192,8 @@ describe('DraidSelectionComponent', () => {
         'Treat Disk Size as Minimum': true,
         'Data Devices': '2',
         'Distributed Hot Spares': '1',
-        Children: '4',
-        'Number of VDEVs': '2',
+        Children: '5',
+        'Number of VDEVs': '1',
       },
     );
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.ts
@@ -190,44 +190,25 @@ export class DraidSelectionComponent implements OnInit, OnChanges {
     const dataDevices = this.form.controls.dataDevicesPerGroup.value;
     const hotSpares = this.form.controls.spares.value;
     const groupSize = Math.min(dataDevices + this.parityDevices, maxDisksInDraidGroup);
-    const maxGroups = Math.floor((maxPossibleWidth - hotSpares) / groupSize);
-    const optimalMaximum = maxGroups * groupSize + hotSpares;
 
     let nextOptions: Option[] = [];
     if ((groupSize + hotSpares) <= maxPossibleWidth && dataDevices) {
-      nextOptions = _.range(1, maxGroups + 1).map((i) => {
-        const disks = i * groupSize + hotSpares;
+      nextOptions = _.range(groupSize + hotSpares, maxPossibleWidth).map((item) => {
+        const disks = item + 1;
         return {
           label: String(disks),
           value: disks,
         };
       });
-
-      if (maxPossibleWidth > optimalMaximum) {
-        nextOptions.push({
-          label: String(maxPossibleWidth),
-          value: maxPossibleWidth,
-        });
-      }
     }
 
     unsetControlIfNoMatchingOption(this.form.controls.children, nextOptions);
 
     if (this.isStepActive) {
-      const hasOptimalOption = nextOptions.some((option) => option.value === optimalMaximum);
-      if (nextOptions.length === 1) {
-        // If there is one option, pick it.
-        setValueIfNotSame(
-          this.form.controls.children,
-          Number(nextOptions[0].value),
-        );
-      } else if (hasOptimalOption) {
-        // Or try to default to normal maximum number of groups and spares.
-        setValueIfNotSame(
-          this.form.controls.children,
-          optimalMaximum,
-        );
-      }
+      setValueIfNotSame(
+        this.form.controls.children,
+        maxPossibleWidth,
+      );
     }
 
     this.widthOptions$ = of(nextOptions);

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/draid-pool-creation.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/draid-pool-creation.spec.ts
@@ -122,6 +122,11 @@ describe('PoolManagerComponent – creating dRAID pool', () => {
               size: 20 * GiB,
               type: DiskType.Hdd,
             },
+            {
+              devname: 'sda5',
+              size: 20 * GiB,
+              type: DiskType.Hdd,
+            },
           ] as DetailsDisk[],
         }),
         mockCall('enclosure2.query', [] as Enclosure[]),
@@ -160,12 +165,12 @@ describe('PoolManagerComponent – creating dRAID pool', () => {
       'Disk Size': '20 GiB (HDD)',
       'Data Devices': '2',
       'Distributed Hot Spares': '1',
-      Children: '4',
+      Children: '5',
       'Number of VDEVs': '1',
     });
 
     expect(await wizard.getConfigurationPreviewSummary()).toMatchObject({
-      'Data:': '1 × DRAID1 | 4 × 20 GiB (HDD)',
+      'Data:': '1 × DRAID1 | 5 × 20 GiB (HDD)',
     });
 
     const stepper = await wizard.getStepper();
@@ -183,7 +188,7 @@ describe('PoolManagerComponent – creating dRAID pool', () => {
       topology: {
         data: [
           {
-            disks: ['sda3', 'sda0', 'sda1', 'sda2'],
+            disks: ['sda3', 'sda0', 'sda1', 'sda2', 'sda5'],
             type: CreateVdevLayout.Draid1,
             draid_data_disks: 2,
             draid_spare_disks: 1,


### PR DESCRIPTION
**Changes:**

Previously in the code the comparison operator was not strict and was including the value `p+d+s`. But as per the ticket requirements, the comparison operator is now strict

**Testing:**

Please see ticket for replication steps and expected results

Original PR: https://github.com/truenas/webui/pull/10510
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130678