### PR TITLE
NAS-130838 / 25.04 / API Keys deletion is not working

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -306,7 +306,7 @@ export interface ApiCallDirectory {
 
   // API Key
   'api_key.create': { params: [CreateApiKeyRequest]; response: ApiKey };
-  'api_key.delete': { params: [id: string]; response: boolean };
+  'api_key.delete': { params: [id: number]; response: boolean };
   'api_key.query': { params: QueryParams<ApiKey>; response: ApiKey[] };
   'api_key.update': { params: UpdateApiKeyRequest; response: ApiKey };
 

--- a/src/app/pages/api-keys/components/api-key-list/api-key-list.component.spec.ts
+++ b/src/app/pages/api-keys/components/api-key-list/api-key-list.component.spec.ts
@@ -114,6 +114,6 @@ describe('ApiKeyListComponent', () => {
       message: 'Are you sure you want to delete the <b>first-api-key</b> API Key?',
     });
 
-    expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith('api_key.delete', ['1']);
+    expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith('api_key.delete', [1]);
   });
 });

--- a/src/app/pages/api-keys/components/api-key-list/api-key-list.component.ts
+++ b/src/app/pages/api-keys/components/api-key-list/api-key-list.component.ts
@@ -151,7 +151,7 @@ export class ApiKeyListComponent implements OnInit {
     }).pipe(
       filter(Boolean),
       tap(() => this.loader.open()),
-      switchMap(() => this.ws.call('api_key.delete', [String(apiKey.id)])),
+      switchMap(() => this.ws.call('api_key.delete', [apiKey.id])),
       untilDestroyed(this),
     ).subscribe({
       next: () => this.store.apiKeyDeleted(apiKey.id),


### PR DESCRIPTION
Testing: see ticket.

API Keys - can be removed now.