### PR TITLE
NAS-129013 / 24.10-RC.1 / Skip disabled buttons for changes by directive (by denysbutenko)

### DIFF
--- a/src/app/directives/disable-focusable-elements/disable-focusable-elements.directive.ts
+++ b/src/app/directives/disable-focusable-elements/disable-focusable-elements.directive.ts
@@ -40,7 +40,7 @@ export class DisableFocusableElementsDirective implements OnChanges {
 
   private getFocusableElements(): NodeListOf<HTMLElement> {
     return this.elementRef.nativeElement.querySelectorAll(
-      'a, button, input, textarea, select, [tabindex]',
+      'a, button:not([disabled]), input, textarea, select, [tabindex]',
     );
   }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 546ad08f16bd266d4d038e605398fc6535fc01ff

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x a5e774f51df90ab8470516d508664f3c5388510e

**Changes:**

Fix `Initiate Failover` button on main dashboard (and other buttons too).

**Testing:**

On HA system. Disable Failover. Open main dashboard-ensure the `Initiate Failover` button is disabled. Click `Configure` button to edit mode. Save changes. Ensure `Initiate Failover` button still disabled.

Original PR: https://github.com/truenas/webui/pull/10523
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129013