### PR TITLE
NAS-129783 / 24.10-RC.1 / After Failover, the secondary controller is not visible on the Dashboard (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -37,7 +37,7 @@
               ixTest="initiate-failover"
               [matTooltip]="'HA is Disabled' | translate"
               [matTooltipDisabled]="isHaEnabled()"
-              [disabled]="isDisabled$ | async"
+              [disabled]="!canFailover()"
               (click)="openDialog()"
             >
               @if (!isHaEnabled()) {
@@ -177,6 +177,13 @@
           <div>{{ 'This system is not licensed for HA.' | translate }}</div>
           <small>{{ 'Configure dashboard to edit this widget.' | translate }}</small>
         </h3>
+      </div>
+    }
+
+    @if (isWaitingForEnabledHa()) {
+      <div [class]="['empty', 'container', size()]">
+        <ix-icon class="icon" name="mdi-timer-cog-outline"></ix-icon>
+        <h3>{{ 'Waiting for standby controller' | translate }}</h3>
       </div>
     }
   </mat-card-content>

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
@@ -1,11 +1,13 @@
 import {
-  ChangeDetectionStrategy, Component, computed, input,
+  ChangeDetectionStrategy, Component, computed, effect, input,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
-import { filter, map } from 'rxjs';
+import {
+  filter, map,
+} from 'rxjs';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemFailover } from 'app/helptext/system/failover';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -30,9 +32,9 @@ import {
 export class WidgetSysInfoPassiveComponent {
   size = input.required<SlotSize>();
 
-  protected readonly isDisabled$ = this.store$.select(selectCanFailover).pipe(map((canFailover) => !canFailover));
   protected readonly requiredRoles = [Role.FailoverWrite];
 
+  canFailover = toSignal(this.store$.select(selectCanFailover));
   isIxHardware = toSignal(this.store$.select(selectIsIxHardware));
   isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
   isHaLicensed = toSignal(this.store$.select(selectIsHaLicensed));
@@ -54,6 +56,7 @@ export class WidgetSysInfoPassiveComponent {
     }),
   ));
 
+  isWaitingForEnabledHa = computed(() => !this.systemInfo() && !this.canFailover() && !this.isHaEnabled());
   version = computed(() => getSystemVersion(this.systemInfo().version, this.systemInfo().codename));
   uptime = computed(() => this.systemInfo().uptime_seconds + this.realElapsedSeconds());
   datetime = computed(() => {
@@ -71,7 +74,11 @@ export class WidgetSysInfoPassiveComponent {
     private router: Router,
     private localeService: LocaleService,
   ) {
-    this.resources.refreshSystemInfo();
+    effect(() => {
+      if (!this.systemInfo() && this.canFailover()) {
+        this.resources.refreshSystemInfo();
+      }
+    });
   }
 
   openDialog(): void {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -4224,6 +4224,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",
   "Warning: iSCSI Target is already in use.</font><br>": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3443,6 +3443,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",
   "Warning: iSCSI Target is already in use.</font><br>": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -2645,6 +2645,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",
   "Warning: {n} of {total} boot environments could not be deleted.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -4553,6 +4553,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",
   "Warning: iSCSI Target is already in use.</font><br>": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -944,6 +944,7 @@
   "Verbose Logging": "",
   "Virtual Machine": "",
   "Voltage": "",
+  "Waiting for standby controller": "",
   "Warnings": "",
   "Watch List": "",
   "Weak Ciphers": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -43,6 +43,7 @@
   "Validate effective ACL": "",
   "View Logs": "",
   "Volume Mounts": "",
+  "Waiting for standby controller": "",
   "We encountered an issue while applying the new network changes.  Unfortunately, we were unable to reconnect to the system after the changes were implemented.  As a result, we have restored the previous network configuration to ensure continued connectivity.": "",
   "{ n, plural, one {# snapshot} other {# snapshots} }": "",
   "{coreCount, plural, one {# core} other {# cores} }": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -4584,6 +4584,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -4281,6 +4281,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",
   "Warning: iSCSI Target is already in use.</font><br>": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -4350,6 +4350,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -4767,6 +4767,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1137,6 +1137,7 @@
   "WARNING: These unknown processes will be terminated while exporting the pool.": "",
   "Wait to start VM until SPICE client connects.": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning: {n} of {total} boot environments could not be deleted.": "",
   "Warning: {n} of {total} docker images could not be deleted.": "",
   "Warning: {n} of {total} snapshots could not be deleted.": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -4698,6 +4698,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -4716,6 +4716,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2959,6 +2959,7 @@
   "WARNING: These unknown processes will be terminated while exporting the pool.": "",
   "Wait to start VM until SPICE client connects.": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",
   "Warning: iSCSI Target is already in use.</font><br>": "",
   "Warning: {n} of {total} boot environments could not be deleted.": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -3057,6 +3057,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",
   "Warning: {n} of {total} boot environments could not be deleted.": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1744,6 +1744,7 @@
   "WARNING: These unknown processes will be terminated while exporting the pool.": "",
   "Wait to start VM until SPICE client connects.": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",
   "Warning: {n} of {total} boot environments could not be deleted.": "",
   "Warning: {n} of {total} docker images could not be deleted.": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -4776,6 +4776,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -1193,6 +1193,7 @@
   "WARNING: These unknown processes will be terminated while exporting the pool.": "",
   "Wait to start VM until SPICE client connects.": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning: {n} of {total} boot environments could not be deleted.": "",
   "Warning: {n} of {total} docker images could not be deleted.": "",
   "Warning: {n} of {total} snapshots could not be deleted.": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -4017,6 +4017,7 @@
   "Wait to start VM until SPICE client connects.": "",
   "Waiting": "",
   "Waiting for Active TrueNAS controller to come up...": "",
+  "Waiting for standby controller": "",
   "Warning!": "",
   "Warning: Debugs may contain log files with personal information such as usernames or other identifying information about your system. Please review debugs and redact any sensitive information before sharing with external entities.": "",
   "Warning: iSCSI Target is already in use.</font><br>": "",


### PR DESCRIPTION
Testing: see ticket

Result 👇 

https://github.com/user-attachments/assets/75664467-933f-4c71-8e16-e567a3815c9b



Original PR: https://github.com/truenas/webui/pull/10580
Jira URL: https://ixsystems.atlassian.net/browse/NAS-129783