### PR TITLE
NAS-130830 / 24.10-RC.1 / Audit Logging status on SMB share tables is always Yes (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.spec.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.spec.ts
@@ -39,29 +39,15 @@ describe('SmbCardComponent', () => {
       id: 3,
       purpose: SmbPresetType.MultiUserTimeMachine,
       path: '/mnt/APPS/smb1',
-      path_suffix: '',
       home: true,
       name: 'smb123',
       comment: 'pool',
-      ro: false,
-      browsable: true,
-      recyclebin: false,
-      guestok: false,
-      hostsallow: [],
-      hostsdeny: [],
-      aapl_name_mangling: false,
-      abe: false,
-      acl: true,
-      durablehandle: true,
-      streams: true,
-      timemachine: true,
       vuid: '04305a6f-7a37-43dc-8fc0-fe6662751437',
-      shadowcopy: true,
-      fsrvp: false,
       enabled: true,
-      cluster_volname: '',
       path_local: '/mnt/APPS/smb1',
-      locked: false,
+      audit: {
+        enable: true,
+      },
     },
   ] as SmbShare[];
 
@@ -124,7 +110,7 @@ describe('SmbCardComponent', () => {
   it('should show table rows', async () => {
     const expectedRows = [
       ['Name', 'Path', 'Description', 'Enabled', 'Audit Logging', ''],
-      ['smb123', '/mnt/APPS/smb1', 'pool', '', 'No', ''],
+      ['smb123', '/mnt/APPS/smb1', 'pool', '', 'Yes', ''],
     ];
 
     const cells = await table.getCellTexts();

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
@@ -68,7 +68,7 @@ export class SmbCardComponent implements OnInit {
     }),
     yesNoColumn({
       title: this.translate.instant('Audit Logging'),
-      propertyName: 'audit',
+      getValue: (row) => Boolean(row.audit?.enable),
     }),
     actionsColumn({
       cssClass: 'wide-actions',

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.spec.ts
@@ -35,6 +35,9 @@ const shares: Partial<SmbShare>[] = [
     comment: 'comment',
     path: 'some-path',
     path_local: 'some-local-path',
+    audit: {
+      enable: true,
+    },
   },
 ];
 
@@ -143,7 +146,7 @@ describe('SmbListComponent', () => {
   it('should show table rows', async () => {
     const expectedRows = [
       ['Name', 'Path', 'Description', 'Enabled', 'Audit Logging', ''],
-      ['some-name', 'some-local-path', 'comment', '', 'No', ''],
+      ['some-name', 'some-local-path', 'comment', '', 'Yes', ''],
     ];
 
     const cells = await table.getCellTexts();

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -84,7 +84,7 @@ export class SmbListComponent implements OnInit {
     }),
     yesNoColumn({
       title: this.translate.instant('Audit Logging'),
-      propertyName: 'audit',
+      getValue: (row) => Boolean(row.audit?.enable),
     }),
     actionsColumn({
       actions: [


### PR DESCRIPTION
Testing: see ticket

Result 👇 

<img width="745" alt="Screenshot 2024-08-29 at 11 58 45" src="https://github.com/user-attachments/assets/d34932c2-69c9-4f94-8839-3f07f5fef889">


Original PR: https://github.com/truenas/webui/pull/10582
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130830