### PR TITLE
NAS-130719 / 24.10-RC.1 / UI Global Search passes "undefined" url path to Docs Hub (by AlexKarpov98)

### DIFF
--- a/src/app/modules/global-search/components/global-search/global-search.component.ts
+++ b/src/app/modules/global-search/components/global-search/global-search.component.ts
@@ -16,6 +16,7 @@ import {
 } from 'rxjs';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { searchDelayConst } from 'app/modules/global-search/constants/delay.const';
+import { extractVersion } from 'app/modules/global-search/helpers/extract-version';
 import { moveToNextFocusableElement, moveToPreviousFocusableElement } from 'app/modules/global-search/helpers/focus-helper';
 import { UiSearchableElement } from 'app/modules/global-search/interfaces/ui-searchable-element.interface';
 import { GlobalSearchSectionsProvider } from 'app/modules/global-search/services/global-search-sections.service';
@@ -151,7 +152,7 @@ export class GlobalSearchComponent implements OnInit, AfterViewInit, OnDestroy {
         ...searchResults,
         ...this.globalSearchSectionsProvider.getHelpSectionResults(
           this.searchControl.value,
-          this.extractVersion(this.systemVersion),
+          extractVersion(this.systemVersion),
         ),
       ];
       this.isLoading = false;
@@ -171,10 +172,6 @@ export class GlobalSearchComponent implements OnInit, AfterViewInit, OnDestroy {
       .subscribe((systemInfo) => {
         this.systemVersion = systemInfo.version;
       });
-  }
-
-  private extractVersion(version: string): string {
-    return version.match(/(\d+\.\d+)\.\d+-/)?.[1];
   }
 
   private listenForSelectionChanges(): void {

--- a/src/app/modules/global-search/helpers/extract-version.spec.ts
+++ b/src/app/modules/global-search/helpers/extract-version.spec.ts
@@ -1,0 +1,43 @@
+import { extractVersion } from './extract-version';
+
+describe('extractVersion', () => {
+  it('should extract the version "24.10" from "TrueNAS-SCALE-24.10.0-MASTER-20240324-065034"', () => {
+    const result = extractVersion('TrueNAS-SCALE-24.10.0-MASTER-20240324-065034');
+    expect(result).toBe('24.10');
+  });
+
+  it('should extract the version "24.10" from "24.10-BETA.1-INTERNAL.7"', () => {
+    const result = extractVersion('24.10-BETA.1-INTERNAL.7');
+    expect(result).toBe('24.10');
+  });
+
+  it('should return undefined for a string with no matching version pattern', () => {
+    const result = extractVersion('NoVersionHere');
+    expect(result).toBeUndefined();
+  });
+
+  it('should extract the version "1.2" from "1.2.3-alpha"', () => {
+    const result = extractVersion('1.2.3-alpha');
+    expect(result).toBe('1.2');
+  });
+
+  it('should extract the version "10.20" from "v10.20.30-beta-release"', () => {
+    const result = extractVersion('v10.20.30-beta-release');
+    expect(result).toBe('10.20');
+  });
+
+  it('should extract the version "0.1" from "v0.1.0-RC1"', () => {
+    const result = extractVersion('v0.1.0-RC1');
+    expect(result).toBe('0.1');
+  });
+
+  it('should return undefined for a string "Version-1-2-3"', () => {
+    const result = extractVersion('Version-1-2-3');
+    expect(result).toBeUndefined();
+  });
+
+  it('should extract the version "2.5" from "2.5-rc.1-build.2023"', () => {
+    const result = extractVersion('2.5-rc.1-build.2023');
+    expect(result).toBe('2.5');
+  });
+});

--- a/src/app/modules/global-search/helpers/extract-version.ts
+++ b/src/app/modules/global-search/helpers/extract-version.ts
@@ -1,0 +1,3 @@
+export function extractVersion(version: string): string | undefined {
+  return version.match(/(\d+\.\d+)(?:\.\d+)?/)?.[1];
+}

--- a/src/app/modules/global-search/services/global-search-sections.service.spec.ts
+++ b/src/app/modules/global-search/services/global-search-sections.service.spec.ts
@@ -79,14 +79,24 @@ describe('GlobalSearchSectionsProvider', () => {
     }]);
   });
 
+  it('should generate help section results based on search term and missing app version', () => {
+    const searchTerm = 'test';
+    const results = spectator.service.getHelpSectionResults(searchTerm, undefined);
+
+    expect(results).toEqual([{
+      hierarchy: ['Search Documentation for «{value}»'],
+      targetHref: 'https://www.truenas.com/docs/search/?query=test',
+      section: GlobalSearchSection.Help,
+    }]);
+  });
+
   it('should generate help section results based on special case search term', () => {
     const searchTerm = 'help';
-    const appVersion = '24.10';
-    const results = spectator.service.getHelpSectionResults(searchTerm, appVersion);
+    const results = spectator.service.getHelpSectionResults(searchTerm);
 
     expect(results).toEqual([{
       hierarchy: ['Go to Documentation'],
-      targetHref: 'https://www.truenas.com/docs/search/',
+      targetHref: 'https://www.truenas.com/docs/search',
       section: GlobalSearchSection.Help,
     }]);
   });

--- a/src/app/modules/global-search/services/global-search-sections.service.ts
+++ b/src/app/modules/global-search/services/global-search-sections.service.ts
@@ -31,16 +31,19 @@ export class GlobalSearchSectionsProvider {
     return this.searchProvider.search(searchTerm, this.globalSearchMaximumLimit);
   }
 
-  getHelpSectionResults(searchTerm: string, appVersion: string): UiSearchableElement[] {
+  getHelpSectionResults(searchTerm: string, appVersion?: string): UiSearchableElement[] {
     const documentationKeywords = new Set(['help', 'documentation', 'docs', 'guide', 'support']);
     const normalizedSearchTerm = searchTerm.toLowerCase();
     const isDocumentationKeyword = documentationKeywords.has(normalizedSearchTerm);
+    const targetHref = appVersion
+      ? `https://www.truenas.com/docs/scale/${appVersion}/search`
+      : 'https://www.truenas.com/docs/search';
 
     if (isDocumentationKeyword) {
       return [
         {
           hierarchy: [this.translate.instant('Go to Documentation')],
-          targetHref: 'https://www.truenas.com/docs/search/',
+          targetHref,
           section: GlobalSearchSection.Help,
         },
       ];
@@ -49,7 +52,7 @@ export class GlobalSearchSectionsProvider {
     return [
       {
         hierarchy: [this.translate.instant('Search Documentation for «{value}»', { value: searchTerm })],
-        targetHref: `https://www.truenas.com/docs/scale/${appVersion}/search/?query=${searchTerm}`,
+        targetHref: `${targetHref}/?query=${searchTerm}`,
         section: GlobalSearchSection.Help,
       },
     ];


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x dc595392f0c139178d6f177b78225f7f845c3883
    git cherry-pick -x 27bd75f2ba4f8d7a1a5ef1333d36f4eebf03949d
    git cherry-pick -x 2bd2ed0ed0dcc25da9e7ee48bb7ae45fbe24f0c2
    git cherry-pick -x f6a5d1978948cc7808239b1c8b4fb695f7256e51
    git cherry-pick -x 27b50c0dd793c550ae61b1d4bc47b9130b72caf2

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 974607f856a7a4af249f38b68f7265549c955728

**Testing:** see ticket.
If no version found - we redirect user to global docs, not version specific.

Original PR: https://github.com/truenas/webui/pull/10533
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130719