### PR TITLE
NAS-130859 / 25.04 / UI provides incorrect information about dataset ACL mode and does not provide a mechanism to fix it when incorrect

### DIFF
--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
@@ -23,6 +23,7 @@ import { ZfsPropertySource } from 'app/enums/zfs-property-source.enum';
 import { helptextDatasetForm } from 'app/helptext/storage/volumes/datasets/dataset-form';
 import { Dataset } from 'app/interfaces/dataset.interface';
 import { SystemInfo } from 'app/interfaces/system-info.interface';
+import { ZfsProperty } from 'app/interfaces/zfs-property.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxFieldsetHarness } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.harness';
 import { IxSelectHarness } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.harness';
@@ -360,6 +361,30 @@ describe('OtherOptionsSectionComponent', () => {
       await aclType.setValue('Inherit');
       expect(await aclMode.getValue()).toBe('Inherit');
       expect(await aclMode.isDisabled()).toBe(true);
+    });
+
+    it('should not disable incorrect ACL type & ACL mode setup to allow user to fix the issue in edit mode', async () => {
+      spectator.setInput({
+        parent: parentDataset,
+        existing: {
+          ...existingDataset,
+          acltype: {
+            value: DatasetAclType.Posix,
+          } as ZfsProperty<DatasetAclType, string>,
+          aclmode: {
+            value: AclMode.Passthrough,
+          } as ZfsProperty<AclMode, string>,
+        },
+      });
+
+      const aclType = await form.getControl('ACL Type') as IxSelectHarness;
+      const aclMode = await form.getControl('ACL Mode') as IxSelectHarness;
+
+      expect(await aclMode.getValue()).toBe('Passthrough');
+      expect(await aclMode.isDisabled()).toBe(false);
+
+      expect(await aclType.getValue()).toBe('POSIX');
+      expect(await aclType.isDisabled()).toBe(false);
     });
   });
 

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
@@ -257,6 +257,16 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
     const aclModeControl = this.form.controls.aclmode;
     const aclTypeControl = this.form.controls.acltype;
 
+    const invalidPosixOrOffAclType = (aclTypeControl.value === DatasetAclType.Posix
+      || aclTypeControl.value === DatasetAclType.Off) && aclModeControl.value !== AclMode.Discard;
+
+    const invalidInheritAclType = aclTypeControl.value === DatasetAclType.Inherit
+      && aclModeControl.value !== AclMode.Inherit;
+
+    if (!!this.existing && (invalidPosixOrOffAclType || invalidInheritAclType) && !aclTypeControl.touched) {
+      return;
+    }
+
     if (!this.parent) {
       aclModeControl.disable({ emitEvent: false });
       aclTypeControl.disable({ emitEvent: false });

--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -106,7 +106,7 @@
       color: var(--primary);
       cursor: pointer;
       margin-left: auto;
-      max-width: 50%;
+      max-width: 100%;
       overflow: hidden;
       text-decoration: underline;
       text-overflow: ellipsis;


### PR DESCRIPTION
Testing: 

If ACL Mode is somehow incorrectly set, in edit mode - user should be able to see it and be able change it, or update ACL Type and then we should see revalidation. 

Shortly, validation is turned off in edit mode if user has incorrect ACL Mode related to ACL Type.

Example:
`Posix -> passthrough`  is incorrect 
`Posix -> Discard` is correct

So if we entered edit mode and user has incorrect setup - he should be able to change it.
If user opened form with correct setup, like `Posix -> Discard` - Discard option shall remain disabled.

Result:

https://github.com/user-attachments/assets/3f3ee674-9f27-4a0a-a7e1-7b148ead9405

