### PR TITLE
NAS-130994 / 24.10-RC.1 / Fix interface name in the widget (by bvasilenko)

### DIFF
--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.ts
@@ -99,7 +99,7 @@ export class WidgetInterfaceComponent implements WidgetComponent<WidgetInterface
   protected chartData = computed<ChartData<'line'>>(() => {
     const currentTheme = this.theme.currentTheme();
     const response = this.networkStats();
-    const networkInterfaceName = this.interfaceId();
+    const networkInterfaceName = this.interface().value.name;
     const startDate = Date.now() - oneHourMillis - oneMinuteMillis;
     const labels = response.map((_, index) => (startDate + index * 1000));
 


### PR DESCRIPTION

**Testing:**

On the **Dashboard** page,

When User adds 2 stacked small widgets, one of them is **Network \> Interface**

**Expected result:** no empty `[]` at the chart's legend, see ticket

Original PR: https://github.com/truenas/webui/pull/10625
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130994