### PR TITLE
NAS-130645 / 24.10-RC.1 / Exclude used disks from automated disk selection (by bvasilenko)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/create-pool.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/create-pool.spec.ts
@@ -236,24 +236,24 @@ describe('PoolManagerComponent – create pool', () => {
         name: 'pool1',
         topology: {
           cache: [{
-            disks: ['sda3'],
-            type: 'STRIPE',
-          }],
-          data: [{
-            disks: ['sda0'],
-            type: 'STRIPE',
-          }],
-          dedup: [{
-            disks: ['sda1'],
-            type: 'STRIPE',
-          }],
-          log: [{
             disks: ['sda2'],
             type: 'STRIPE',
           }],
-          spares: ['sda5'],
-          special: [{
+          data: [{
+            disks: ['sda3'],
+            type: 'STRIPE',
+          }],
+          dedup: [{
             disks: ['sda6'],
+            type: 'STRIPE',
+          }],
+          log: [{
+            disks: ['sda0'],
+            type: 'STRIPE',
+          }],
+          spares: ['sda1'],
+          special: [{
+            disks: ['sda5'],
             type: 'STRIPE',
           }],
         },

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
@@ -210,6 +210,14 @@ describe('PoolManagerStore', () => {
             vdevs: manuallyConfiguredVdevs,
           },
         },
+        categorySequence: [
+          VdevType.Log,
+          VdevType.Spare,
+          VdevType.Cache,
+          VdevType.Special,
+          VdevType.Dedup,
+          VdevType.Data,
+        ],
       });
     });
 
@@ -246,7 +254,7 @@ describe('PoolManagerStore', () => {
       spectator.service.setManualTopologyCategory(VdevType.Data, [{}] as DetailsDisk[][]);
       spectator.service.resetTopologyCategory(VdevType.Data);
 
-      expect(await firstValueFrom(spectator.service.state$)).toMatchObject(initialState);
+      expect(await firstValueFrom(spectator.service.state$)).toMatchObject({ topology: initialState.topology });
     });
 
     it('resetTopology – completely resets pool topology', async () => {
@@ -254,7 +262,7 @@ describe('PoolManagerStore', () => {
       spectator.service.setManualTopologyCategory(VdevType.Log, [{}] as DetailsDisk[][]);
       spectator.service.resetTopology();
 
-      expect(await firstValueFrom(spectator.service.state$)).toMatchObject(initialState);
+      expect(await firstValueFrom(spectator.service.state$)).toMatchObject({ topology: initialState.topology });
     });
   });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs-maximize-dispersal.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs-maximize-dispersal.spec.ts
@@ -6,7 +6,7 @@ import { PoolManagerTopology } from 'app/pages/storage/modules/pool-manager/stor
 import {
   GenerateVdevsService,
 } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs.service';
-import { generateVdevDisks, expectDisks } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/test-utils';
+import { generateVdevDisks, expectDisks, categorySequence } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/test-utils';
 
 describe('GenerateVdevsService - maximize dispersal', () => {
   let spectator: SpectatorService<GenerateVdevsService>;
@@ -27,6 +27,7 @@ describe('GenerateVdevsService - maximize dispersal', () => {
         },
       } as PoolManagerTopology,
       maximizeDispersal: true,
+      categorySequence,
     });
 
     expect(vdevs).toEqual({
@@ -49,6 +50,7 @@ describe('GenerateVdevsService - maximize dispersal', () => {
         },
       } as PoolManagerTopology,
       maximizeDispersal: true,
+      categorySequence,
     });
 
     expect(vdevs).toEqual({
@@ -82,6 +84,7 @@ describe('GenerateVdevsService - maximize dispersal', () => {
         },
       } as PoolManagerTopology,
       maximizeDispersal: true,
+      categorySequence,
     });
 
     expect(vdevs).toEqual({
@@ -122,6 +125,7 @@ describe('GenerateVdevsService - maximize dispersal', () => {
         },
       } as PoolManagerTopology,
       maximizeDispersal: true,
+      categorySequence,
     });
 
     expect(vdevs).toEqual({

--- a/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs-normal.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs-normal.spec.ts
@@ -6,7 +6,7 @@ import { PoolManagerTopology } from 'app/pages/storage/modules/pool-manager/stor
 import {
   GenerateVdevsService,
 } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs.service';
-import { generateVdevDisks, expectDisks } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/test-utils';
+import { generateVdevDisks, expectDisks, categorySequence } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/test-utils';
 
 describe('GenerateVdevsService - normal cases', () => {
   let spectator: SpectatorService<GenerateVdevsService>;
@@ -27,6 +27,7 @@ describe('GenerateVdevsService - normal cases', () => {
         },
       } as PoolManagerTopology,
       maximizeDispersal: false,
+      categorySequence,
     });
 
     expect(vdevs).toEqual({
@@ -65,6 +66,7 @@ describe('GenerateVdevsService - normal cases', () => {
         },
       } as PoolManagerTopology,
       maximizeDispersal: false,
+      categorySequence,
     });
 
     expect(vdevs).toEqual({
@@ -110,6 +112,7 @@ describe('GenerateVdevsService - normal cases', () => {
         },
       } as PoolManagerTopology,
       maximizeDispersal: false,
+      categorySequence,
     });
 
     expect(vdevs).toEqual({

--- a/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs-treat-as-minimum.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs-treat-as-minimum.spec.ts
@@ -6,7 +6,7 @@ import { PoolManagerTopology } from 'app/pages/storage/modules/pool-manager/stor
 import {
   GenerateVdevsService,
 } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs.service';
-import { generateVdevDisks, expectDisks } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/test-utils';
+import { generateVdevDisks, expectDisks, categorySequence } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/test-utils';
 
 describe('GenerateVdevsService - treat disk size as minimum', () => {
   let spectator: SpectatorService<GenerateVdevsService>;
@@ -45,6 +45,7 @@ describe('GenerateVdevsService - treat disk size as minimum', () => {
           },
         } as PoolManagerTopology,
         maximizeDispersal: false,
+        categorySequence,
       });
 
       expect(vdevs).toEqual({
@@ -91,6 +92,7 @@ describe('GenerateVdevsService - treat disk size as minimum', () => {
           },
         } as PoolManagerTopology,
         maximizeDispersal: false,
+        categorySequence,
       });
 
       expect(vdevs).toEqual({
@@ -132,6 +134,7 @@ describe('GenerateVdevsService - treat disk size as minimum', () => {
           },
         } as PoolManagerTopology,
         maximizeDispersal: true,
+        categorySequence,
       });
 
       expect(vdevs).toEqual({

--- a/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs.service.ts
@@ -27,17 +27,19 @@ export class GenerateVdevsService {
     allowedDisks,
     topology,
     maximizeDispersal,
+    categorySequence,
   }: {
     allowedDisks: DetailsDisk[];
     topology: PoolManagerTopology;
     maximizeDispersal: boolean;
+    categorySequence: VdevType[];
   }): GeneratedVdevs {
     let disks = this.excludeManualSelectionDisks([...allowedDisks], topology);
     disks = this.sortDisksByEnclosure(disks);
     this.groupedDisks = new GroupedDisks(disks);
     this.enclosureList = new EnclosureList(disks);
 
-    const categories = this.excludeManualCategories(topology);
+    const categories = this.generateCategories(topology, categorySequence);
 
     return this.placeDisksInCategories(categories, maximizeDispersal);
   }
@@ -95,10 +97,10 @@ export class GenerateVdevsService {
     });
   }
 
-  private excludeManualCategories(topology: PoolManagerTopology): TypeAndCategory[] {
-    return Object.entries(topology)
-      .filter(([, category]) => !category.hasCustomDiskSelection)
-      .map(([type, category]) => [type as VdevType, category]);
+  private generateCategories(topology: PoolManagerTopology, categorySequence: VdevType[]): TypeAndCategory[] {
+    return categorySequence
+      .filter((category) => topology[category] && !topology[category].hasCustomDiskSelection)
+      .map((category) => [category, topology[category]]);
   }
 
   private isCategorySet(category: PoolManagerTopologyCategory): boolean {

--- a/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/test-utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/generate-vdevs/test-utils.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { GiB } from 'app/constants/bytes.constant';
 import { DiskType } from 'app/enums/disk-type.enum';
+import { VdevType } from 'app/enums/v-dev-type.enum';
 import { DetailsDisk } from 'app/interfaces/disk.interface';
 
 function makeDisk(enclosure: string, slot: number): DetailsDisk {
@@ -68,6 +69,15 @@ export const generateVdevDisks = _.shuffle([
     size: 2 * GiB,
   },
 ] as DetailsDisk[]);
+
+export const categorySequence: VdevType[] = [
+  VdevType.Data,
+  VdevType.Log,
+  VdevType.Spare,
+  VdevType.Cache,
+  VdevType.Special,
+  VdevType.Dedup,
+];
 
 export function expectDisks(vdevs: string[][]): unknown[][] {
   return vdevs.map((vdev) => {


### PR DESCRIPTION
Summary:

The problem was that the `findSuitableDisks` method was returning more suitable disks for the checked `treatDiskSizeAsMinimum` than there actually were. This occurs because `removeUsedDisks` for **Metadata** was called later than `findSuitableDisks` for **Dedup**, and the disks occupied by **Metadata** were available for selection.

Testing:

For replication steps, please follow the video attached to the ticket


Original PR: https://github.com/truenas/webui/pull/10559
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130645