### PR TITLE
NAS-130767 / 24.10-RC.1 / Optimize app.query calls (by denysbutenko)

### DIFF
--- a/src/app/interfaces/api/api-call-and-subscribe-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-and-subscribe-directory.interface.ts
@@ -1,3 +1,4 @@
+import { App } from 'app/interfaces/app.interface';
 import { ContainerImage } from 'app/interfaces/container-image.interface';
 import { Group } from 'app/interfaces/group.interface';
 import { Pool } from 'app/interfaces/pool.interface';
@@ -13,6 +14,7 @@ export interface ApiCallAndSubscribeEventDirectory {
   'pool.query': { response: Pool };
   'group.query': { response: Group };
   'app.image.query': { response: ContainerImage };
+  'app.query': { response: App };
 }
 
 export type ApiCallAndSubscribeMethod = keyof ApiCallAndSubscribeEventDirectory;

--- a/src/app/pages/apps/components/app-detail-view/app-resources-card/app-resources-card.component.spec.ts
+++ b/src/app/pages/apps/components/app-detail-view/app-resources-card/app-resources-card.component.spec.ts
@@ -2,7 +2,7 @@ import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { BehaviorSubject, of } from 'rxjs';
 import { mockCall, mockWebSocket } from 'app/core/testing/utils/mock-websocket.utils';
-import { DatasetDetails } from 'app/interfaces/dataset.interface';
+import { Statfs } from 'app/interfaces/filesystem-stat.interface';
 import { FileSizePipe } from 'app/modules/pipes/file-size/file-size.pipe';
 import { AppResourcesCardComponent } from 'app/pages/apps/components/app-detail-view/app-resources-card/app-resources-card.component';
 import { DockerStore } from 'app/pages/apps/store/docker.store';
@@ -21,11 +21,9 @@ describe('AppResourcesCardComponent', () => {
     ],
     providers: [
       mockWebSocket([
-        mockCall('pool.dataset.get_instance', {
-          available: {
-            rawvalue: '2500',
-          },
-        } as DatasetDetails),
+        mockCall('filesystem.statfs', {
+          avail_bytes: 2500,
+        } as Statfs),
       ]),
       mockProvider(DockerStore, {
         selectedPool$: of('pool'),
@@ -55,7 +53,7 @@ describe('AppResourcesCardComponent', () => {
   });
 
   it('loads and reports available space on apps dataset', () => {
-    expect(websocket.call).toHaveBeenCalledWith('pool.dataset.get_instance', ['pool/ix-apps']);
+    expect(websocket.call).toHaveBeenCalledWith('filesystem.statfs', ['/mnt/.ix-apps']);
     expect(spectator.queryAll('.app-list-item')[3]).toHaveText('Available Space: 2.44 KiB');
   });
 });

--- a/src/app/pages/apps/components/app-detail-view/app-resources-card/app-resources-card.component.ts
+++ b/src/app/pages/apps/components/app-detail-view/app-resources-card/app-resources-card.component.ts
@@ -5,6 +5,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import {
   Observable, filter, map, switchMap, throttleTime,
 } from 'rxjs';
+import { mntPath } from 'app/enums/mnt-path.enum';
 import { toLoadingState } from 'app/helpers/operators/to-loading-state.helper';
 import { MemoryStatsEventData } from 'app/interfaces/events/memory-stats-event.interface';
 import { DockerStore } from 'app/pages/apps/store/docker.store';
@@ -27,11 +28,9 @@ export class AppResourcesCardComponent implements OnInit {
 
   availableSpace$ = this.dockerStore.selectedPool$.pipe(
     filter((pool) => !!pool),
-    switchMap((pool) => this.ws.call('pool.dataset.get_instance', [`${pool}/${ixAppsDataset}`])),
-    map((dataset) => dataset.available.rawvalue),
-  ).pipe(
-    toLoadingState(),
-  );
+    switchMap(() => this.ws.call('filesystem.statfs', [`${mntPath}/.${ixAppsDataset}`])),
+    map((statfs) => statfs.avail_bytes),
+  ).pipe(toLoadingState());
 
   constructor(
     private ws: WebSocketService,

--- a/src/app/pages/apps/services/applications.service.ts
+++ b/src/app/pages/apps/services/applications.service.ts
@@ -71,7 +71,7 @@ export class ApplicationsService {
   }
 
   getAllApps(): Observable<App[]> {
-    return this.ws.call('app.query', [[], { extra: { retrieve_config: true } }]);
+    return this.ws.callAndSubscribe('app.query', [[], { extra: { retrieve_config: true } }]);
   }
 
   getApp(name: string): Observable<App[]> {

--- a/src/app/pages/apps/store/installed-apps-store.service.spec.ts
+++ b/src/app/pages/apps/store/installed-apps-store.service.spec.ts
@@ -6,7 +6,6 @@ import { ApiEvent } from 'app/interfaces/api-message.interface';
 import { App, AppStartQueryParams } from 'app/interfaces/app.interface';
 import { Job } from 'app/interfaces/job.interface';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
-import { AppsStore } from 'app/pages/apps/store/apps-store.service';
 import { DockerStore } from 'app/pages/apps/store/docker.store';
 import { InstalledAppsStore } from 'app/pages/apps/store/installed-apps-store.service';
 
@@ -33,9 +32,6 @@ describe('InstalledAppsStore', () => {
             ...installedChartReleases,
           ] as App[]);
         }) as () => Observable<App[]>,
-      }),
-      mockProvider(AppsStore, {
-        patchState: jest.fn(),
       }),
       mockProvider(DockerStore, {
         isLoading$: of(false),

--- a/src/app/pages/apps/store/installed-apps-store.service.ts
+++ b/src/app/pages/apps/store/installed-apps-store.service.ts
@@ -1,16 +1,12 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { UntilDestroy } from '@ngneat/until-destroy';
 import { ComponentStore } from '@ngrx/component-store';
 import {
   EMPTY,
-  Observable, Subscription, catchError, combineLatest, filter, of, switchMap, tap,
+  Observable, catchError, combineLatest, debounceTime, filter, of, switchMap, tap,
 } from 'rxjs';
-import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
-import { ApiEvent } from 'app/interfaces/api-message.interface';
 import { App } from 'app/interfaces/app.interface';
-import { AvailableApp } from 'app/interfaces/available-app.interface';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
-import { AppsStore } from 'app/pages/apps/store/apps-store.service';
 import { DockerStore } from 'app/pages/apps/store/docker.store';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 
@@ -29,11 +25,9 @@ const initialState: InstalledAppsState = {
 export class InstalledAppsStore extends ComponentStore<InstalledAppsState> implements OnDestroy {
   readonly installedApps$ = this.select((state) => state.installedApps);
   readonly isLoading$ = this.select((state) => state.isLoading);
-  private installedAppsSubscription: Subscription;
 
   constructor(
     private appsService: ApplicationsService,
-    private appsStore: AppsStore,
     private dockerStore: DockerStore,
     private errorHandler: ErrorHandlerService,
   ) {
@@ -69,105 +63,14 @@ export class InstalledAppsStore extends ComponentStore<InstalledAppsState> imple
     });
   }
 
-  private handleRemovedApps(updatedAppName: string, allApps: AvailableApp[]): AvailableApp[] {
-    return allApps.map((app) => {
-      if (app.name === updatedAppName) {
-        return { ...app, installed: false } as AvailableApp;
-      }
-      return app;
-    });
-  }
-
-  private subscribeToInstalledAppsUpdates(): void {
-    if (this.installedAppsSubscription) {
-      return;
-    }
-
-    // TODO: Messy. Refactor.
-    this.installedAppsSubscription = this.appsService.getInstalledAppsUpdates().pipe(
-      tap(() => this.patchState({ isLoading: true })),
-      tap((apiEvent: ApiEvent) => {
-        if (apiEvent.msg === IncomingApiMessageType.Removed) {
-          this.patchState((state: InstalledAppsState): InstalledAppsState => {
-            return {
-              ...state,
-              installedApps: state.installedApps.filter((app) => app.name !== apiEvent.id.toString()),
-            };
-          });
-          this.appsStore.patchState((state) => {
-            return {
-              ...state,
-              availableApps: this.handleRemovedApps(apiEvent.id as string, state.availableApps),
-              recommendedApps: this.handleRemovedApps(apiEvent.id as string, state.recommendedApps),
-              latestApps: this.handleRemovedApps(apiEvent.id as string, state.latestApps),
-            };
-          });
-        }
-      }),
-      filter((apiEvent) => {
-        if (apiEvent.msg === IncomingApiMessageType.Removed) {
-          this.patchState({ isLoading: false });
-        }
-        return apiEvent.msg !== IncomingApiMessageType.Removed;
-      }),
-      switchMap((apiEvent: ApiEvent) => combineLatest([
-        of(apiEvent),
-        this.appsService.getApp(apiEvent.id as string),
-      ])),
-      tap(([apiEvent, apps]) => {
-        if (!apps?.length) {
-          return;
-        }
-        this.patchState((state: InstalledAppsState): InstalledAppsState => {
-          if (apiEvent.msg === IncomingApiMessageType.Added) {
-            return {
-              ...state,
-              installedApps: [...state.installedApps, { ...apps[0] }],
-            };
-          }
-          return {
-            ...state,
-            installedApps: state.installedApps.map((installedApp) => {
-              if (installedApp.name === apiEvent.id) {
-                return { ...installedApp, ...apps[0] };
-              }
-              return installedApp;
-            }),
-          };
-        });
-
-        const updateApps = (appsToUpdate: AvailableApp[]): AvailableApp[] => appsToUpdate.map((app) => {
-          return app.name === apps[0].id ? { ...app, installed: true } : app;
-        });
-
-        this.appsStore.patchState((state) => {
-          return {
-            ...state,
-            availableApps: updateApps(state.availableApps),
-            recommendedApps: updateApps(state.recommendedApps),
-            latestApps: updateApps(state.latestApps),
-          };
-        });
-      }),
-      tap(() => this.patchState({ isLoading: false })),
-      untilDestroyed(this),
-    ).subscribe();
-  }
-
   private loadInstalledApps(): Observable<unknown> {
     return combineLatest([
       this.dockerStore.isLoading$,
       this.dockerStore.isDockerStarted$,
     ]).pipe(
-      filter(
-        ([loading, isDockerStarted]) => {
-          return !loading && isDockerStarted !== null;
-        },
-      ),
-      tap((isDockerStarted) => {
-        if (isDockerStarted) {
-          this.subscribeToInstalledAppsUpdates();
-        }
+      debounceTime(300),
+      filter(([loading, isDockerStarted]) => {
+        return !loading && isDockerStarted !== null;
       }),
       switchMap((isDockerStarted) => {
         if (!isDockerStarted) {
@@ -175,7 +78,7 @@ export class InstalledAppsStore extends ComponentStore<InstalledAppsState> imple
         }
 
         return this.appsService.getAllApps().pipe(
-          tap((installedApps: App[]) => {
+          tap((installedApps) => {
             this.patchState({
               installedApps: [...installedApps],
             });

--- a/src/app/pages/apps/store/installed-apps-store.service.ts
+++ b/src/app/pages/apps/store/installed-apps-store.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { UntilDestroy } from '@ngneat/until-destroy';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { ComponentStore } from '@ngrx/component-store';
 import {
   EMPTY,
@@ -53,6 +53,7 @@ export class InstalledAppsStore extends ComponentStore<InstalledAppsState> imple
         this.handleError(error);
         return EMPTY;
       }),
+      untilDestroyed(this),
     );
   });
 
@@ -85,6 +86,7 @@ export class InstalledAppsStore extends ComponentStore<InstalledAppsState> imple
           }),
         );
       }),
+      untilDestroyed(this),
     );
   }
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 6baf69935d7e569dbf892d08fb1a517214e9baf2
    git cherry-pick -x 7145acbbbefc03723e093066570849702054fd6c
    git cherry-pick -x 9baf8724b722800ec335972cdf38485f0ef2fb51
    git cherry-pick -x 2a9b772f16dfe6ceac393e0c7efe5234e08bab78
    git cherry-pick -x 4c128b3338cd8cc06ce264de3230da396f520a08

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~2
    git cherry-pick -x 4598a0c26ee95531e5cf055e2afaae6e9b8bc99c

**Changes:**

- Reduce usage `app.query` endpoint
- Use `app.available_space` for retrieving available space in ix-apps dataset 

**Testing:**

See ticket for details

Original PR: https://github.com/truenas/webui/pull/10569
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130767