### PR TITLE
NAS-130980 / 24.10-RC.1 / ElectricEel HA Dashboard is missing the Standby System Information card. (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.spec.ts
@@ -18,7 +18,7 @@ import {
 import { WidgetGroupComponent } from 'app/pages/dashboard/components/widget-group/widget-group.component';
 import { WidgetGroupFormComponent } from 'app/pages/dashboard/components/widget-group-form/widget-group-form.component';
 import { DashboardStore } from 'app/pages/dashboard/services/dashboard.store';
-import { defaultWidgets } from 'app/pages/dashboard/services/default-widgets.constant';
+import { getDefaultWidgets } from 'app/pages/dashboard/services/get-default-widgets';
 import { WidgetGroup, WidgetGroupLayout } from 'app/pages/dashboard/types/widget-group.interface';
 import { ChainedComponentResponse, IxChainedSlideInService } from 'app/services/ix-chained-slide-in.service';
 
@@ -160,7 +160,7 @@ describe('DashboardComponent', () => {
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await saveButton.click();
 
-      expect(spectator.inject(DashboardStore).save).toHaveBeenCalledWith(defaultWidgets);
+      expect(spectator.inject(DashboardStore).save).toHaveBeenCalledWith(getDefaultWidgets());
       expect(spectator.inject(SnackbarService).success).toHaveBeenCalledWith('Dashboard settings saved');
     });
 

--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
@@ -7,19 +7,21 @@ import {
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { isEqual } from 'lodash';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { EmptyConfig } from 'app/interfaces/empty-config.interface';
-import { DialogService } from 'app/modules/dialog/dialog.service';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { dashboardElements } from 'app/pages/dashboard/components/dashboard/dashboard.elements';
 import { WidgetGroupFormComponent } from 'app/pages/dashboard/components/widget-group-form/widget-group-form.component';
 import { DashboardStore } from 'app/pages/dashboard/services/dashboard.store';
-import { defaultWidgets } from 'app/pages/dashboard/services/default-widgets.constant';
+import { getDefaultWidgets } from 'app/pages/dashboard/services/get-default-widgets';
 import { WidgetGroup } from 'app/pages/dashboard/types/widget-group.interface';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { ChainedComponentResponse, IxChainedSlideInService } from 'app/services/ix-chained-slide-in.service';
+import { AppsState } from 'app/store';
+import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 
 @UntilDestroy()
 @Component({
@@ -44,13 +46,14 @@ export class DashboardComponent implements OnInit {
   readonly renderedGroups = signal<WidgetGroup[]>([]);
   readonly savedGroups = toSignal(this.dashboardStore.groups$);
   readonly isLoading = toSignal(this.dashboardStore.isLoading$);
+  readonly isHaLicensed = toSignal(this.store$.select(selectIsHaLicensed));
   readonly isLoadingFirstTime = computed(() => this.isLoading() && this.savedGroups() === null);
   readonly newFeatureConfig = {
     key: 'dashboardConfigure',
     message: this.translate.instant('New widgets and layouts.'),
   };
   readonly customLayout = computed(() => {
-    return !isEqual(this.renderedGroups(), defaultWidgets);
+    return !isEqual(this.renderedGroups(), getDefaultWidgets(this.isHaLicensed()));
   });
 
   emptyDashboardConf: EmptyConfig = {
@@ -67,7 +70,7 @@ export class DashboardComponent implements OnInit {
     private errorHandler: ErrorHandlerService,
     private translate: TranslateService,
     private snackbar: SnackbarService,
-    private dialog: DialogService,
+    private store$: Store<AppsState>,
   ) {}
 
   ngOnInit(): void {
@@ -146,7 +149,7 @@ export class DashboardComponent implements OnInit {
   }
 
   protected onReset(): void {
-    this.renderedGroups.set(defaultWidgets);
+    this.renderedGroups.set(getDefaultWidgets(this.isHaLicensed()));
     this.snackbar.success(this.translate.instant('Default widgets restored'));
   }
 

--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.ts
@@ -20,7 +20,7 @@ import { getDefaultWidgets } from 'app/pages/dashboard/services/get-default-widg
 import { WidgetGroup } from 'app/pages/dashboard/types/widget-group.interface';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { ChainedComponentResponse, IxChainedSlideInService } from 'app/services/ix-chained-slide-in.service';
-import { AppsState } from 'app/store';
+import { AppState } from 'app/store';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 
 @UntilDestroy()
@@ -70,7 +70,7 @@ export class DashboardComponent implements OnInit {
     private errorHandler: ErrorHandlerService,
     private translate: TranslateService,
     private snackbar: SnackbarService,
-    private store$: Store<AppsState>,
+    private store$: Store<AppState>,
   ) {}
 
   ngOnInit(): void {

--- a/src/app/pages/dashboard/services/dashboard.store.spec.ts
+++ b/src/app/pages/dashboard/services/dashboard.store.spec.ts
@@ -1,11 +1,13 @@
 import { createServiceFactory, SpectatorService, mockProvider } from '@ngneat/spectator/jest';
+import { provideMockStore } from '@ngrx/store/testing';
 import { firstValueFrom, of } from 'rxjs';
 import { mockCall, mockWebSocket } from 'app/core/testing/utils/mock-websocket.utils';
-import { defaultWidgets } from 'app/pages/dashboard/services/demo-widgets.constant';
+import { getDefaultWidgets } from 'app/pages/dashboard/services/get-default-widgets';
 import { WidgetGroupLayout } from 'app/pages/dashboard/types/widget-group.interface';
 import { WidgetType } from 'app/pages/dashboard/types/widget.interface';
 import { AuthService } from 'app/services/auth/auth.service';
 import { WebSocketService } from 'app/services/ws.service';
+import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import { DashboardStore, initialState } from './dashboard.store';
 
 const initialGroups = [
@@ -34,6 +36,14 @@ describe('DashboardStore', () => {
             dashState: initialGroups,
           },
         }),
+      }),
+      provideMockStore({
+        selectors: [
+          {
+            selector: selectIsHaLicensed,
+            value: true,
+          },
+        ],
       }),
       mockWebSocket([
         mockCall('auth.set_attribute'),
@@ -105,7 +115,7 @@ describe('DashboardStore', () => {
 
     expect(await firstValueFrom(spectator.service.state$)).toMatchObject({
       ...initialState,
-      groups: defaultWidgets,
+      groups: getDefaultWidgets(true),
     });
   });
 

--- a/src/app/pages/dashboard/services/dashboard.store.ts
+++ b/src/app/pages/dashboard/services/dashboard.store.ts
@@ -1,17 +1,20 @@
 import { Injectable } from '@angular/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { ComponentStore } from '@ngrx/component-store';
+import { Store } from '@ngrx/store';
 import {
   EMPTY,
-  Observable, catchError, filter, finalize, map, of, switchMap, tap,
+  Observable, catchError, combineLatest, filter, finalize, map, of, switchMap, tap,
 } from 'rxjs';
 import { WidgetName } from 'app/enums/widget-name.enum';
-import { defaultWidgets } from 'app/pages/dashboard/services/demo-widgets.constant';
+import { getDefaultWidgets } from 'app/pages/dashboard/services/get-default-widgets';
 import { WidgetGroup, WidgetGroupLayout } from 'app/pages/dashboard/types/widget-group.interface';
 import { SomeWidgetSettings, WidgetType } from 'app/pages/dashboard/types/widget.interface';
 import { AuthService } from 'app/services/auth/auth.service';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { WebSocketService } from 'app/services/ws.service';
+import { AppsState } from 'app/store';
+import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 
 // we have external `DashConfigItem` in old dashboard, but it will be removed once we go ahead with new dashboard
 export interface OldDashboardConfigItem {
@@ -50,6 +53,7 @@ export class DashboardStore extends ComponentStore<DashboardState> {
     private authService: AuthService,
     private ws: WebSocketService,
     private errorHandler: ErrorHandlerService,
+    private store$: Store<AppsState>,
   ) {
     super(initialState);
   }
@@ -64,15 +68,18 @@ export class DashboardStore extends ComponentStore<DashboardState> {
         }
         return this.authService.refreshUser();
       }),
-      switchMap(() => this.authService.user$.pipe(
-        filter(Boolean),
-        map((user) => user.attributes.dashState),
-      )),
-      tap((dashState) => {
+      switchMap(() => combineLatest([
+        this.authService.user$.pipe(
+          filter(Boolean),
+          map((user) => user.attributes.dashState),
+        ),
+        this.store$.select(selectIsHaLicensed),
+      ])),
+      tap(([dashState, isHaLicensed]) => {
         this.setState({
           isLoading: false,
           globalError: '',
-          groups: this.getDashboardGroups(dashState || defaultWidgets),
+          groups: this.getDashboardGroups(dashState || getDefaultWidgets(isHaLicensed)),
         });
       }),
       catchError((error) => {

--- a/src/app/pages/dashboard/services/dashboard.store.ts
+++ b/src/app/pages/dashboard/services/dashboard.store.ts
@@ -13,7 +13,7 @@ import { SomeWidgetSettings, WidgetType } from 'app/pages/dashboard/types/widget
 import { AuthService } from 'app/services/auth/auth.service';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { WebSocketService } from 'app/services/ws.service';
-import { AppsState } from 'app/store';
+import { AppState } from 'app/store';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 
 // we have external `DashConfigItem` in old dashboard, but it will be removed once we go ahead with new dashboard
@@ -53,7 +53,7 @@ export class DashboardStore extends ComponentStore<DashboardState> {
     private authService: AuthService,
     private ws: WebSocketService,
     private errorHandler: ErrorHandlerService,
-    private store$: Store<AppsState>,
+    private store$: Store<AppState>,
   ) {
     super(initialState);
   }

--- a/src/app/pages/dashboard/services/get-default-widgets.spec.ts
+++ b/src/app/pages/dashboard/services/get-default-widgets.spec.ts
@@ -1,0 +1,21 @@
+import { getDefaultWidgets } from 'app/pages/dashboard/services/get-default-widgets';
+import { WidgetGroup } from 'app/pages/dashboard/types/widget-group.interface';
+import { WidgetType } from 'app/pages/dashboard/types/widget.interface';
+
+describe('getDefaultWidgets', () => {
+  it('should return all default widgets when isHaLicensed is true', () => {
+    const result: WidgetGroup[] = getDefaultWidgets(true);
+
+    expect(result).toHaveLength(9);
+    expect(result[0].slots[0].type).toBe(WidgetType.SystemInfoActive);
+    expect(result[1].slots[0].type).toBe(WidgetType.SystemInfoPassive);
+  });
+
+  it('should return default widgets without the second widget when isHaLicensed is false', () => {
+    const result: WidgetGroup[] = getDefaultWidgets(false);
+
+    expect(result).toHaveLength(8);
+    expect(result[0].slots[0].type).toBe(WidgetType.SystemInfoActive);
+    expect(result[1].slots[0].type).toBe(WidgetType.CpuModelWidget);
+  });
+});

--- a/src/app/pages/dashboard/services/get-default-widgets.ts
+++ b/src/app/pages/dashboard/services/get-default-widgets.ts
@@ -1,11 +1,17 @@
 import { WidgetGroup, WidgetGroupLayout } from 'app/pages/dashboard/types/widget-group.interface';
 import { WidgetType } from 'app/pages/dashboard/types/widget.interface';
 
-export const defaultWidgets: WidgetGroup[] = [
+const defaultWidgets: WidgetGroup[] = [
   {
     layout: WidgetGroupLayout.Full,
     slots: [
       { type: WidgetType.SystemInfoActive },
+    ],
+  },
+  {
+    layout: WidgetGroupLayout.Full,
+    slots: [
+      { type: WidgetType.SystemInfoPassive },
     ],
   },
   {
@@ -54,3 +60,13 @@ export const defaultWidgets: WidgetGroup[] = [
     ],
   },
 ];
+
+export const getDefaultWidgets = (isHaLicensed?: boolean): WidgetGroup[] => {
+  if (!isHaLicensed) {
+    return defaultWidgets.filter(
+      (widgetGroup) => !widgetGroup.slots.some((slot) => slot.type === WidgetType.SystemInfoPassive),
+    );
+  }
+
+  return defaultWidgets;
+};


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 7d6616a8d9afaf3e86a8330a75978ba9819364f6
    git cherry-pick -x 827e60c86bac207acfaf4f7e803c9523196035db

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4efc5ea9d1d72a1beffffee2196a36d0088d9120

**Changes:**
Updated logic of default widgets generation.

**Testing:**
See ticket, try with HA system & on non HA system as well.



Original PR: https://github.com/truenas/webui/pull/10640
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130980