### PR TITLE
NAS-131016 / 24.10-RC.1 / Uptime on Dashboard runs too fast (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -157,7 +157,7 @@
             <strong>{{ 'Uptime' | translate }}:</strong>
             @if (isLoaded()) {
               <span>
-                {{ uptime() | uptime: (datetime() | formatDateTime:' ':'HH:mm') }}
+                {{ uptime() | uptime: datetime() }}
               </span>
             } @else {
               <ngx-skeleton-loader

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
@@ -142,7 +142,7 @@ describe('WidgetSysInfoActiveComponent', () => {
       'Support License: Best contract, expires 2025-01-01',
       'System Serial: AA-00001',
       'Hostname: test-hostname-a',
-      'Uptime: 23 hours 12 minutes as of 2024-03-15 10:34:11',
+      'Uptime: 23 hours 12 minutes as of 10:34',
     ]);
   });
 
@@ -161,7 +161,7 @@ describe('WidgetSysInfoActiveComponent', () => {
     const updatedDatetime = spectator.component.datetime();
 
     expect(updatedUptime).toBeGreaterThan(initialUptime);
-    expect(updatedDatetime).toBeGreaterThan(initialDatetime);
+    expect(updatedDatetime).toBe(initialDatetime);
 
     jest.useRealTimers();
   });

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
@@ -48,10 +48,9 @@ export class WidgetSysInfoActiveComponent {
   version = computed(() => getSystemVersion(this.systemInfo().version, this.systemInfo().codename));
   uptime = computed(() => this.systemInfo().uptime_seconds + this.realElapsedSeconds());
   datetime = computed(() => {
-    const [dateValue, timeValue] = this.localeService.getDateAndTime();
-    const extractedDate = this.localeService.getDateFromString(`${dateValue} ${timeValue}`, this.systemInfo().timezone);
-
-    return extractedDate.getTime() + (this.realElapsedSeconds() * 1000);
+    this.realElapsedSeconds();
+    const [, timeValue] = this.localeService.getDateAndTime();
+    return `${timeValue.split(':')[0]}:${timeValue.split(':')[1]}`;
   });
   isLoaded = computed(() => this.systemInfo());
 

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -152,7 +152,7 @@
             <strong>{{ 'Uptime' | translate }}:</strong>
             @if (isLoaded()) {
               <span>
-                {{ uptime() | uptime: (datetime() | formatDateTime:' ':'HH:mm') }}
+                {{ uptime() | uptime: datetime() }}
               </span>
             } @else {
               <ngx-skeleton-loader

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
@@ -153,7 +153,7 @@ describe('WidgetSysInfoPassiveComponent', () => {
         'Support License: Best contract, expires 2025-01-01',
         'System Serial: AA-00002',
         'Hostname: test-hostname-b',
-        'Uptime: 1 minute 17 seconds as of 2024-03-15 10:34:11',
+        'Uptime: 1 minute 17 seconds as of 10:34',
       ]);
     });
 
@@ -172,7 +172,7 @@ describe('WidgetSysInfoPassiveComponent', () => {
       const updatedDatetime = spectator.component.datetime();
 
       expect(updatedUptime).toBeGreaterThan(initialUptime);
-      expect(updatedDatetime).toBeGreaterThan(initialDatetime);
+      expect(updatedDatetime).toBe(initialDatetime);
 
       jest.useRealTimers();
     });

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
@@ -60,10 +60,9 @@ export class WidgetSysInfoPassiveComponent {
   version = computed(() => getSystemVersion(this.systemInfo().version, this.systemInfo().codename));
   uptime = computed(() => this.systemInfo().uptime_seconds + this.realElapsedSeconds());
   datetime = computed(() => {
-    const [dateValue, timeValue] = this.localeService.getDateAndTime();
-    const extractedDate = this.localeService.getDateFromString(`${dateValue} ${timeValue}`, this.systemInfo().timezone);
-
-    return extractedDate.getTime() + (this.realElapsedSeconds() * 1000);
+    this.realElapsedSeconds();
+    const [, timeValue] = this.localeService.getDateAndTime();
+    return `${timeValue.split(':')[0]}:${timeValue.split(':')[1]}`;
   });
   isLoaded = computed(() => this.systemInfo());
 

--- a/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.html
@@ -3,6 +3,6 @@
     *ixWithLoadingState="systemInfo$ as systemInfo"
     [size]="size()"
     [label]="name | translate"
-    [text]="uptime() | uptime: (datetime() | formatDateTime:' ':'HH:mm')"
+    [text]="uptime() | uptime: datetime()"
   ></ix-widget-datapoint>
 </div>

--- a/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.spec.ts
@@ -57,7 +57,7 @@ describe('WidgetSystemUptimeComponent', () => {
     it('renders System Uptime for the current system', () => {
       const widget = spectator.query(MockComponent(WidgetDatapointComponent));
       expect(widget).toBeTruthy();
-      expect(widget.text).toBe('23 hours 12 minutes as of 2024-03-15 10:34:11');
+      expect(widget.text).toBe('23 hours 12 minutes as of 10:34');
       expect(widget.label).toBe('System Uptime');
     });
 
@@ -76,7 +76,7 @@ describe('WidgetSystemUptimeComponent', () => {
       const updatedDatetime = spectator.component.datetime();
 
       expect(updatedUptime).toBeGreaterThan(initialUptime);
-      expect(updatedDatetime).toBeGreaterThan(initialDatetime);
+      expect(updatedDatetime).toBe(initialDatetime);
 
       jest.useRealTimers();
     });

--- a/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.ts
@@ -41,13 +41,9 @@ export class WidgetSystemUptimeComponent implements WidgetComponent {
   });
 
   datetime = computed(() => {
-    const [dateValue, timeValue] = this.localeService.getDateAndTime();
-    const extractedDate = this.localeService.getDateFromString(
-      `${dateValue} ${timeValue}`,
-      this.loadedSystemInfo().timezone,
-    );
-
-    return extractedDate.getTime() + (this.realElapsedSeconds() * 1000);
+    this.realElapsedSeconds();
+    const [, timeValue] = this.localeService.getDateAndTime();
+    return `${timeValue.split(':')[0]}:${timeValue.split(':')[1]}`;
   });
 
   constructor(


### PR DESCRIPTION
Testing: 
Go to dashboard, switch tab or open another app. 
Wait 2-3 minutes, return to the WEB UI tab and check that time is not ahead.

_As well - I tried `visibilitychange` listener and `requestAnimationFrame` - but no luck._

<img width="1134" alt="Screenshot 2024-09-10 at 20 02 19" src="https://github.com/user-attachments/assets/69d16960-e93c-42d7-9af1-38e3d317d0c9">


Original PR: https://github.com/truenas/webui/pull/10649
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131016