### PR TITLE
NAS-130943 / 25.04 / Fix apps bulk upgrade

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.html
@@ -19,7 +19,11 @@
               <div class="version">
                 <span>{{ bulkItem.value.item.human_version.split('_')[1] }}</span>
                 <ix-icon name="mdi-arrow-right-thin"></ix-icon>
-                <span>{{ form.get(bulkItem.key)?.value }}</span>
+                @if(isItemExpanded(bulkItem)){
+                  <span>{{ form.get(bulkItem.key)?.value }}</span>
+                } @else {
+                  <span>{{ 'Latest version' | translate }}</span>
+                }
               </div>
 
               <div class="logo">
@@ -33,13 +37,15 @@
         </mat-expansion-panel-header>
 
         <div *appLet="upgradeSummaryMap.get(bulkItem.key) as summary" class="expansion-content">
-          <ix-select
-            [formControlName]="bulkItem.key"
-            [label]="'Version to be upgraded to' | translate"
-            [required]="true"
-            [options]="optionsMap.get(bulkItem.key)"
-          ></ix-select>
-
+          @if(isItemExpanded(bulkItem)) {
+            <ix-select
+              [formControlName]="bulkItem.key"
+              [label]="'Version to be upgraded to' | translate"
+              [required]="true"
+              [options]="optionsMap.get(bulkItem.key)"
+            ></ix-select>
+          }
+          
           @if (hasErrors(bulkItem.key)) {
             <span>{{ bulkItem.value.message | translate }}</span>
           }

--- a/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-bulk-upgrade/app-bulk-upgrade.component.spec.ts
@@ -114,9 +114,12 @@ describe('AppBulkUpgradeComponent', () => {
   });
 
   it('checks for the correct payload and success toast', async () => {
+    const expandHeader = spectator.query('mat-expansion-panel-header');
+    expandHeader.dispatchEvent(new Event('click'));
+    spectator.detectChanges();
     const jobArguments: CoreBulkQuery = ['app.upgrade', [
-      ['test-app-one', { app_version: '1.0.8' }],
-      ['test-app-two', { app_version: '1.6.34' }],
+      ['test-app-one', { app_version: '15.3.36' }],
+      ['test-app-two'],
     ]];
 
     const updatedButton = await loader.getHarness(MatButtonHarness.with({ text: 'Upgrade' }));

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2128,6 +2128,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1658,6 +1658,7 @@
   "Last Snapshot": "",
   "Last successful": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Feedback": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1222,6 +1222,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Feedback": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -2159,6 +2159,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -335,6 +335,7 @@
   "LDAP User DN": "",
   "LDAP User DN Password": "",
   "Lan": "",
+  "Latest version": "",
   "Layout": "",
   "Leaving": "",
   "Licensed Serials": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -38,6 +38,7 @@
   "Incoming / Outgoing network traffic": "",
   "Install NDIVIA Drivers": "",
   "Languages other than <i>English</i> are provided by      the community and may be incomplete.      <a href=\"https://github.com/truenas/webui/blob/master/TRANSLATING.md\" target=\"_blank\">Learn how to contribute.</a>": "",
+  "Latest version": "",
   "Login was canceled. Please try again if you want to connect your account.": "",
   "Logs Details": "",
   "Machine Time: {machineTime} \n Browser Time: {browserTime}": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2177,6 +2177,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -2067,6 +2067,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1941,6 +1941,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -2360,6 +2360,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -559,6 +559,7 @@
   "Last Scrub Run": "",
   "Last successful": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Layout": "",
   "Leaving": "",
   "License Update": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2312,6 +2312,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -2306,6 +2306,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1277,6 +1277,7 @@
   "Last Scrub Run": "",
   "Last successful": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1399,6 +1399,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Layout": "",
   "Leave Feedback": "",
   "Leaving": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -859,6 +859,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Layout": "",
   "Leave Feedback": "",
   "Leaving": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -2366,6 +2366,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -584,6 +584,7 @@
   "Last Scrub Run": "",
   "Last successful": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Layout": "",
   "Leaving": "",
   "Legacy feature. <br><br>Privileges are the same as the guest account.  Guest access is disabled by default in Windows 10 version 1709 and  Windows Server version 1903. Additional client-side configuration is  required to provide guest access to these clients.<br><br>  <i>MacOS clients:</i> Attempting to connect as a user that does not  exist in TrueNAS <i>does not</i> automatically connect as the guest  account. The <b>Connect As:</b> <i>Guest</i> option must be  specifically chosen in MacOS to log in as the guest account. See the  <a href=\"https://support.apple.com/guide/mac-help/connect-mac-shared-computers-servers-mchlp1140/\" target=\"_blank\">Apple documentation</a>  for more details.": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1956,6 +1956,7 @@
   "Last successful": "",
   "Last week": "",
   "Last {result} Test": "",
+  "Latest version": "",
   "Launch Docker Image": "",
   "Layout": "",
   "Leave Domain": "",


### PR DESCRIPTION
**Changes:**

Fixes issue where select input exists when the user has not expanded the panel. Makes the form status invalid.

**Testing:**

Add the `test` train. Install older version `1.0.5` or `nginx` app from the `test` train. Install a couple of instances of the same app and same version. Then go to bulk upgrade dialog. Only expand one of the apps panel to choose the exact version to upgrade to. Leave the other app panel alone. Click the upgrade button. Both apps should upgrade correctly.