### PR TITLE
NAS-130794 / 24.10-RC.1 / Fix Cloud Backup Restore Include From Subfolder (by denysbutenko)

### DIFF
--- a/src/app/interfaces/cloud-backup.interface.ts
+++ b/src/app/interfaces/cloud-backup.interface.ts
@@ -1,3 +1,4 @@
+import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
 import { ApiTimestamp } from 'app/interfaces/api-date.interface';
 import { Job } from 'app/interfaces/job.interface';
 import { BwLimit, BwLimitUpdate, CloudCredential } from './cloud-sync-task.interface';
@@ -50,6 +51,13 @@ export enum SnapshotIncludeExclude {
   ExcludePaths = 'excludePaths',
   ExcludeByPattern = 'excludeByPattern',
 }
+
+export const snapshotIncludeExcludeOptions = new Map<SnapshotIncludeExclude, string>([
+  [SnapshotIncludeExclude.IncludeEverything, T('Include everything')],
+  [SnapshotIncludeExclude.IncludeFromSubFolder, T('Include from subfolder')],
+  [SnapshotIncludeExclude.ExcludePaths, T('Select paths to exclude')],
+  [SnapshotIncludeExclude.ExcludeByPattern, T('Exclude by pattern')],
+]);
 
 export type CloudBackupRestoreParams = [
   id: number,

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.html
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.html
@@ -48,7 +48,7 @@
         @if (isIncludeFromSubfolderSelected) {
           <ix-explorer
             formControlName="includedPaths"
-            [root]="form.controls.subFolder.value || mntPath"
+            [root]="form.controls.subFolder.value || data.backup.path"
             [label]="'Included Paths' | translate"
             [nodeProvider]="snapshotNodeProvider"
             [tooltip]="helptext.tooltips.included_paths"

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.spec.ts
@@ -6,11 +6,11 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { of } from 'rxjs';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockJob, mockWebSocket } from 'app/core/testing/utils/mock-websocket.utils';
-import { SnapshotIncludeExclude } from 'app/interfaces/cloud-backup.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxSlideInRef } from 'app/modules/forms/ix-forms/components/ix-slide-in/ix-slide-in-ref';
 import { SLIDE_IN_DATA } from 'app/modules/forms/ix-forms/components/ix-slide-in/ix-slide-in.token';
 import { IxFormsModule } from 'app/modules/forms/ix-forms/ix-forms.module';
+import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { CloudBackupRestoreFromSnapshotFormComponent } from 'app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component';
 import { FilesystemService } from 'app/services/filesystem.service';
 import { IxSlideInService } from 'app/services/ix-slide-in.service';
@@ -44,7 +44,7 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
         provide: SLIDE_IN_DATA,
         useValue: {
           snapshot: { id: 1 },
-          backup: { id: 1, path: '/mnt/backup/path' },
+          backup: { id: 1, path: '/mnt/dozer' },
         },
       },
     ],
@@ -58,7 +58,7 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
 
     it('submits backup restore from snapshot with `Include Everything`', async () => {
       spectator.component.form.patchValue({
-        target: '/mnt/my pool',
+        target: '/mnt/bulldozer',
       });
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -67,20 +67,18 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
       expect(spectator.inject(WebSocketService).job).toHaveBeenCalledWith('cloud_backup.restore', [
         1,
         1,
-        '/mnt/backup/path',
-        '/mnt/my pool',
+        '/mnt/dozer',
+        '/mnt/bulldozer',
         {},
       ]);
     });
 
     it('submits backup restore from snapshot with `Select paths to exclude`', async () => {
-      spectator.component.form.patchValue({
-        target: '/mnt/my pool',
-        includeExclude: SnapshotIncludeExclude.ExcludePaths,
-      });
-
-      spectator.component.form.patchValue({
-        excludedPaths: ['/mnt/another'],
+      const form = await loader.getHarness(IxFormHarness);
+      await form.fillForm({
+        Target: '/mnt/bulldozer',
+        'Include/Exclude': 'Select paths to exclude',
+        'Excluded Paths': '/mnt/dozer/another',
       });
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -89,25 +87,23 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
       expect(spectator.inject(WebSocketService).job).toHaveBeenCalledWith('cloud_backup.restore', [
         1,
         1,
-        '/mnt/backup/path',
-        '/mnt/my pool',
+        '/mnt/dozer',
+        '/mnt/bulldozer',
         {
           exclude: [
-            '/mnt/another',
+            '/another',
           ],
         },
       ]);
     });
 
     it('submits backup restore from snapshot with `Include from subfolder`', async () => {
-      spectator.component.form.patchValue({
-        target: '/mnt/my pool',
-        includeExclude: SnapshotIncludeExclude.IncludeFromSubFolder,
-      });
-
-      spectator.component.form.patchValue({
-        subFolder: '/test',
-        includedPaths: ['/test/first'],
+      const form = await loader.getHarness(IxFormHarness);
+      await form.fillForm({
+        Target: '/mnt/bulldozer',
+        'Include/Exclude': 'Include from subfolder',
+        Subfolder: '/mnt/dozer',
+        'Included Paths': '/mnt/dozer/a',
       });
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -116,24 +112,47 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
       expect(spectator.inject(WebSocketService).job).toHaveBeenCalledWith('cloud_backup.restore', [
         1,
         1,
-        '/test',
-        '/mnt/my pool',
+        '/mnt/dozer',
+        '/mnt/bulldozer',
         {
           include: [
-            '/test/first',
+            '/a',
+          ],
+        },
+      ]);
+    });
+
+    it('submits backup restore from snapshot with `Include from subfolder` matches paths', async () => {
+      const form = await loader.getHarness(IxFormHarness);
+      await form.fillForm({
+        Target: '/mnt/bulldozer',
+        'Include/Exclude': 'Include from subfolder',
+        Subfolder: '/mnt/dozer/a',
+        'Included Paths': '/mnt/dozer/a',
+      });
+
+      const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await saveButton.click();
+
+      expect(spectator.inject(WebSocketService).job).toHaveBeenCalledWith('cloud_backup.restore', [
+        1,
+        1,
+        '/mnt/dozer/a',
+        '/mnt/bulldozer',
+        {
+          include: [
+            '/',
           ],
         },
       ]);
     });
 
     it('submits backup restore from snapshot with `Exclude by pattern`', async () => {
-      spectator.component.form.patchValue({
-        target: '/mnt/my pool',
-        includeExclude: SnapshotIncludeExclude.ExcludeByPattern,
-      });
-
-      spectator.component.form.patchValue({
-        excludePattern: 'pattern',
+      const form = await loader.getHarness(IxFormHarness);
+      await form.fillForm({
+        Target: '/mnt/bulldozer',
+        'Include/Exclude': 'Exclude by pattern',
+        Pattern: 'pattern',
       });
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -142,8 +161,8 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
       expect(spectator.inject(WebSocketService).job).toHaveBeenCalledWith('cloud_backup.restore', [
         1,
         1,
-        '/mnt/backup/path',
-        '/mnt/my pool',
+        '/mnt/dozer',
+        '/mnt/bulldozer',
         {
           exclude: [
             'pattern',

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.ts
@@ -19,6 +19,7 @@ import {
   CloudBackupSnapshot,
   CloudBackupSnapshotDirectoryFileType,
   SnapshotIncludeExclude,
+  snapshotIncludeExcludeOptions,
 } from 'app/interfaces/cloud-backup.interface';
 import { DatasetCreate } from 'app/interfaces/dataset.interface';
 import { ExplorerNodeData, TreeNode } from 'app/interfaces/tree-node.interface';
@@ -44,13 +45,7 @@ export class CloudBackupRestoreFromSnapshotFormComponent implements OnInit {
   fileNodeProvider: TreeNodeProvider;
   snapshotNodeProvider: TreeNodeProvider;
 
-  readonly includeExcludeOptions = new Map<SnapshotIncludeExclude, string>([
-    [SnapshotIncludeExclude.IncludeEverything, this.translate.instant('Include everything')],
-    [SnapshotIncludeExclude.IncludeFromSubFolder, this.translate.instant('Include from subfolder')],
-    [SnapshotIncludeExclude.ExcludePaths, this.translate.instant('Select paths to exclude')],
-    [SnapshotIncludeExclude.ExcludeByPattern, this.translate.instant('Exclude by pattern')],
-  ]);
-  readonly includeExcludeOptions$ = of(mapToOptions(this.includeExcludeOptions, this.translate));
+  readonly includeExcludeOptions$ = of(mapToOptions(snapshotIncludeExcludeOptions, this.translate));
 
   get title(): string {
     return this.translate.instant('Restore from Snapshot');
@@ -61,7 +56,7 @@ export class CloudBackupRestoreFromSnapshotFormComponent implements OnInit {
     includeExclude: [SnapshotIncludeExclude.IncludeEverything, Validators.required],
     excludedPaths: [[] as string[], Validators.required],
     excludePattern: [null as string | null, Validators.required],
-    subFolder: [mntPath],
+    subFolder: [this.data.backup.path],
     includedPaths: [[] as string[]],
   });
 
@@ -105,11 +100,15 @@ export class CloudBackupRestoreFromSnapshotFormComponent implements OnInit {
   onSubmit(): void {
     this.isLoading = true;
 
+    const subfolder = this.isIncludeFromSubfolderSelected ? this.form.controls.subFolder.value : this.data.backup.path;
+
     const options = {
       exclude: this.isExcludeByPatternSelected
         ? [this.form.controls.excludePattern.value]
-        : this.form.controls.excludedPaths.value,
-      include: this.isIncludeFromSubfolderSelected ? this.form.value.includedPaths : null,
+        : this.form.controls.excludedPaths.value.map((path) => path.replace(subfolder, '') || '/'),
+      include: this.isIncludeFromSubfolderSelected
+        ? this.form.value.includedPaths.map((path) => path.replace(subfolder, '') || '/')
+        : null,
     };
 
     if (!options.exclude?.length) delete options.exclude;
@@ -118,11 +117,10 @@ export class CloudBackupRestoreFromSnapshotFormComponent implements OnInit {
     const params: CloudBackupRestoreParams = [
       this.data.backup.id,
       this.data.snapshot.id,
-      this.isIncludeFromSubfolderSelected ? this.form.controls.subFolder.value : this.data.backup.path,
+      subfolder,
       this.form.controls.target.value,
       options,
     ];
-
     this.ws.job('cloud_backup.restore', params)
       .pipe(untilDestroyed(this))
       .subscribe({


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 230ad4d68c98b933680f4f92b894eaa0b6a46ec8
    git cherry-pick -x 362aa54513240399c0cbc2e303bebb0e5ab8d199
    git cherry-pick -x f270c0b192923a03a045212062b4ce6269f2ff13
    git cherry-pick -x 6cc233ecb64a89eaa46e34f1719fd48cbc0f956a
    git cherry-pick -x fd6c5a5cfcd5c5503e8e3fad0954bd99dc440b4e
    git cherry-pick -x ca586bacd30b2aa377f641dd40163480ef00c9e3
    git cherry-pick -x b44bf5bab0683a8076170d105674585185c4528f
    git cherry-pick -x ce7678279bb2136a4da87d4437ee1c40ef1e64a0

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 25da2b42caf62ae14295c0ca5fc368fabcaec821

**Changes:**

Fix Cloud Backup Restore Include From Subfolder

**Testing:**

Try to restore cloud backup with `Include from subfolder` option and use `Included Paths`.

Original PR: https://github.com/truenas/webui/pull/10610
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130794