### PR TITLE
NAS-130884 / 24.10.0 / Apps | App metadata like `Run As Context` and `Capabilities` should be visible before installation (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/apps.module.ts
+++ b/src/app/pages/apps/apps.module.ts
@@ -47,6 +47,7 @@ import {
 import {
   AppDetailsSimilarComponent,
 } from 'app/pages/apps/components/app-detail-view/app-details-similar/app-details-similar.component';
+import { AppJsonDetailsCardComponent } from 'app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component';
 import { AppWizardComponent } from 'app/pages/apps/components/app-wizard/app-wizard.component';
 import { AppsScopeWrapperComponent } from 'app/pages/apps/components/apps-scope-wrapper.component';
 import { CatalogSettingsComponent } from 'app/pages/apps/components/catalog-settings/catalog-settings.component';
@@ -106,6 +107,7 @@ import { InstalledAppsComponent } from './components/installed-apps/installed-ap
     AppNotesCardComponent,
     AppsScopeWrapperComponent,
     AppAvailableInfoCardComponent,
+    AppJsonDetailsCardComponent,
     ContainerShellComponent,
     ContainerLogsComponent,
     LogsDetailsDialogComponent,

--- a/src/app/pages/apps/components/app-detail-view/app-detail-view.component.html
+++ b/src/app/pages/apps/components/app-detail-view/app-detail-view.component.html
@@ -63,6 +63,19 @@
         [app]="app"
         [isLoading$]="isLoading$"
       ></ix-app-available-info-card>
+
+      <ix-app-json-details-card
+        class="app-info-card"
+        [title]="'Run As Context' | translate"
+        [jsonDetails]="app?.app_metadata?.run_as_context"
+        [isLoading$]="isLoading$"
+      ></ix-app-json-details-card>
+      <ix-app-json-details-card
+        class="app-info-card"
+        [title]="'Capabilities' | translate"
+        [jsonDetails]="app?.app_metadata?.capabilities"
+        [isLoading$]="isLoading$"
+      ></ix-app-json-details-card>
     </section>
   </div>
 </ng-template>

--- a/src/app/pages/apps/components/app-detail-view/app-detail-view.component.spec.ts
+++ b/src/app/pages/apps/components/app-detail-view/app-detail-view.component.spec.ts
@@ -23,6 +23,7 @@ import {
 import {
   AppDetailsSimilarComponent,
 } from 'app/pages/apps/components/app-detail-view/app-details-similar/app-details-similar.component';
+import { AppJsonDetailsCardComponent } from 'app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component';
 import {
   AppResourcesCardComponent,
 } from 'app/pages/apps/components/app-detail-view/app-resources-card/app-resources-card.component';
@@ -67,6 +68,7 @@ describe('AppDetailViewComponent', () => {
         AppAvailableInfoCardComponent,
         AppCardLogoComponent,
         AppDetailsSimilarComponent,
+        AppJsonDetailsCardComponent,
       ),
     ],
     providers: [

--- a/src/app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component.html
+++ b/src/app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component.html
@@ -1,0 +1,22 @@
+<h3>{{ title | translate }}</h3>
+
+@if (isLoading$ | async) {
+  <div class="app-list-item">
+    <ngx-skeleton-loader></ngx-skeleton-loader>
+  </div>
+} @else if (jsonDetails) {
+  @for (item of jsonDetails; track item) {
+    <div class="app-list-wrapper">
+      @for(key of getKeys(item); track key) {
+        <div class="app-list-item">
+          <span class="label">{{ getHumanReadableKey(key) | translate }}:</span>
+          <div>{{ getValueByKey(item, key) | translate }}</div>
+        </div>
+      }
+    </div>
+  }
+} @else {
+  <div class="app-list-item">
+    {{ 'N/A' | translate }}
+  </div>
+}

--- a/src/app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component.scss
+++ b/src/app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component.scss
@@ -1,0 +1,42 @@
+:host {
+  background-color: var(--bg2);
+  box-sizing: border-box;
+  display: block;
+  margin-bottom: 1rem;
+  max-width: 420px;
+  padding: 1rem;
+  width: 100%;
+
+  ::ng-deep {
+    h3 {
+      margin-bottom: 1rem;
+    }
+
+    .app-list-item ngx-skeleton-loader {
+      display: inline-flex;
+      width: 35%;
+
+      span {
+        margin: 0;
+      }
+    }
+  }
+}
+
+.app-list-wrapper {
+  border-bottom: 1px solid var(--lines);
+  margin-bottom: 5px;
+  padding-bottom: 5px;
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  .app-list-item {
+    align-items: flex-start;
+    display: flex;
+    margin: 0.25rem 0;
+  }
+}

--- a/src/app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component.spec.ts
+++ b/src/app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component.spec.ts
@@ -1,0 +1,79 @@
+import { Spectator } from '@ngneat/spectator';
+import { createComponentFactory } from '@ngneat/spectator/jest';
+import { MockComponents } from 'ng-mocks';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
+import { BehaviorSubject } from 'rxjs';
+import { AppJsonDetailsCardComponent } from './app-json-details-card.component';
+
+interface JsonDetails { key: string; value: string }
+
+describe('AppJsonDetailsCardComponent', () => {
+  let spectator: Spectator<AppJsonDetailsCardComponent<JsonDetails>>;
+
+  const isLoading$ = new BehaviorSubject(false);
+
+  const jsonDetails = [
+    { key: 'description', value: 'AdGuard Home is able to bind to a privileged port.' },
+    { key: 'name', value: 'NET_BIND_SERVICE' },
+  ];
+
+  const createComponent = createComponentFactory({
+    component: AppJsonDetailsCardComponent<JsonDetails>,
+    declarations: [
+      MockComponents(
+        NgxSkeletonLoaderComponent,
+      ),
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createComponent({
+      props: {
+        isLoading$,
+        jsonDetails,
+        title: 'Capabilities',
+      },
+    });
+  });
+
+  it('shows header', () => {
+    expect(spectator.query('h3')).toHaveText('Capabilities');
+  });
+
+  it('renders JSON details when not loading', () => {
+    isLoading$.next(false);
+    spectator.detectChanges();
+
+    const items = spectator.queryAll('.app-list-item');
+
+    expect(items).toHaveLength(4);
+
+    expect(items[0].querySelector('.label')).toHaveText('Key:');
+    expect(items[0].querySelector('div')).toHaveText('description');
+
+    expect(items[1].querySelector('.label')).toHaveText('Value:');
+    expect(items[1].querySelector('div')).toHaveText('AdGuard Home is able to bind to a privileged port.');
+
+    expect(items[2].querySelector('.label')).toHaveText('Key:');
+    expect(items[2].querySelector('div')).toHaveText('name');
+
+    expect(items[3].querySelector('.label')).toHaveText('Value:');
+    expect(items[3].querySelector('div')).toHaveText('NET_BIND_SERVICE');
+  });
+
+  it('displays skeleton loader when loading', () => {
+    isLoading$.next(true);
+    spectator.detectChanges();
+
+    expect(spectator.query('ngx-skeleton-loader')).toBeTruthy();
+    expect(spectator.query('.app-list-item')).toBeTruthy();
+  });
+
+  it('hides skeleton loader when not loading', () => {
+    isLoading$.next(false);
+    spectator.detectChanges();
+
+    expect(spectator.query('ngx-skeleton-loader')).toBeFalsy();
+    expect(spectator.query('.app-list-item')).toBeTruthy();
+  });
+});

--- a/src/app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component.ts
+++ b/src/app/pages/apps/components/app-detail-view/app-json-details-card/app-json-details-card.component.ts
@@ -1,0 +1,32 @@
+import {
+  ChangeDetectionStrategy, Component,
+  Input,
+} from '@angular/core';
+import { UntilDestroy } from '@ngneat/until-destroy';
+import { Observable } from 'rxjs';
+import { toHumanReadableKey } from 'app/helpers/object-keys-to-human-readable.helper';
+
+@UntilDestroy()
+@Component({
+  selector: 'ix-app-json-details-card',
+  templateUrl: './app-json-details-card.component.html',
+  styleUrls: ['./app-json-details-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppJsonDetailsCardComponent<T> {
+  @Input() isLoading$: Observable<boolean>;
+  @Input() jsonDetails: T[];
+  @Input() title: string;
+
+  getKeys(item: T): string[] {
+    return Object.keys(item);
+  }
+
+  getHumanReadableKey(key: string): string {
+    return toHumanReadableKey(key);
+  }
+
+  getValueByKey(item: T, key: string): string {
+    return (item as Record<string, string>)[key];
+  }
+}

--- a/src/assets/styles/other/_fn-styles.scss
+++ b/src/assets/styles/other/_fn-styles.scss
@@ -169,6 +169,7 @@ samp {
 }
 
 .mat-mdc-card-header .mat-mdc-card-title {
+  font-family: var(--font-family-header);
   font-size: 1rem;
 }
 


### PR DESCRIPTION
**Changes:**
Added 2 new cards to the App Details page.
Created a generic component which will render JSON data we need.

**Testing:**

See ticket. Currently middleware is not returning that metadata, the ticket is blocked.
But you can test using mocks & update code a bit to return mocked data.

in `app-detail-view.component.ts`
line 86 
update code to be:
```
if (app) {
          this.app = {
            ...app,
            app_metadata: {
              ...app?.app_metadata,
              capabilities: app.app_metadata?.capabilities || [
                {
                  description: 'AdGuard Home is able to bind to a privileged port.',
                  name: 'NET_BIND_SERVICE',
                },
                {
                  description: 'AdGuard Home is able to chown files.',
                  name: 'CHOWN',
                },
                {
                  description: "AdGuard Home is able to bypass permission checks for it's sub-processes.",
                  name: 'FOWNER',
                },
                {
                  description: 'AdGuard Home is able to bypass permission checks.',
                  name: 'DAC_OVERRIDE',
                },
              ],
              run_as_context: app.app_metadata?.run_as_context || [
                {
                  description: 'Tautulli runs as any non-root user.',
                  gid: 568,
                  group_name: 'tautulli',
                  uid: 568,
                  user_name: 'tautulli',
                },
              ],
            },
          };
        }
```

**So without mocked data it will be:**
<img width="1728" alt="Screenshot 2024-09-13 at 11 37 59" src="https://github.com/user-attachments/assets/27200c86-bacf-4f35-81ac-b9e119e8c362">

**With mocked data it will be:**

<img width="1728" alt="Screenshot 2024-09-13 at 11 38 44" src="https://github.com/user-attachments/assets/45f724c3-1c23-4992-94c3-50ec423e989c">

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Added 2 new cards to the App Details page.


Original PR: https://github.com/truenas/webui/pull/10673
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130884