### PR TITLE
NAS-131214 / 25.04 / Do not show keys from `update.get_trains`

### DIFF
--- a/src/app/pages/signin/store/signin.store.ts
+++ b/src/app/pages/signin/store/signin.store.ts
@@ -94,6 +94,7 @@ export class SigninStore extends ComponentStore<SigninState> {
       this.loadFailoverStatus(),
       this.updateService.hardRefreshIfNeeded(),
     ])),
+    tap(() => this.setLoadingState(false)),
     switchMap(() => this.handleLoginWithToken()),
   ));
 
@@ -196,7 +197,6 @@ export class SigninStore extends ComponentStore<SigninState> {
     return this.ws.call('failover.status').pipe(
       switchMap((status) => {
         this.setFailoverStatus(status);
-        this.setLoadingState(false);
 
         if (status === FailoverStatus.Single) {
           return of(null);

--- a/src/app/pages/system/update/components/train-card/train-card.component.ts
+++ b/src/app/pages/system/update/components/train-card/train-card.component.ts
@@ -80,7 +80,7 @@ export class TrainCardComponent implements OnInit {
         }
 
         this.trains = Object.entries(trains.trains).map(([name, train]) => ({
-          label: `${name} - ${train.description}`,
+          label: train.description,
           value: name,
         }));
         if (this.trains.length > 0) {


### PR DESCRIPTION
**Changes:**

Before:

![Снимок экрана 2024-09-16 в 15 14 43](https://github.com/user-attachments/assets/80476daf-c004-40c1-8343-8d066f7f8eaf)

After:

![Снимок экрана 2024-09-16 в 15 14 52](https://github.com/user-attachments/assets/55eac5c7-1f28-45ed-a600-3d84d43fb445)


**Testing:**

1. Build a machine with 24.04.0.
2. Comment out in `SigninStore`
```
    switchMap(() => forkJoin([
      this.checkIfAdminPasswordSet(),
      // this.checkForLoginBanner(),
      this.loadFailoverStatus(),
      // this.updateService.hardRefreshIfNeeded(),
    ])),

```
3. See Update page.