### PR TITLE
NAS-131218 / 24.10.0 / Form Buttons overlap (by AlexKarpov98)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/form-actions/form-actions.component.scss
+++ b/src/app/modules/forms/ix-forms/components/form-actions/form-actions.component.scss
@@ -1,27 +1,24 @@
 :host,
 :host-context(mat-dialog-container .ix-form-container) :host {
   display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
   justify-content: flex-end;
   margin: 0;
-
-  ::ng-deep > * {
-    margin: 0 0 0 8px;
-  }
 }
 
 :host-context(.ix-form-container) :host {
+  flex-wrap: wrap;
+  gap: 8px;
   justify-content: flex-start;
   margin: 0 10px;
-
-  ::ng-deep > * {
-    margin: 0 8px 0 0;
-  }
 }
 
 :host-context(mat-vertical-stepper) :host {
+  flex-wrap: wrap;
   justify-content: flex-start;
 
   ::ng-deep > * {
-    margin: 0 8px 0 0;
+    gap: 8px;
   }
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 82d89d5776de4e69fce7c3e298baadcef0914bd4
    git cherry-pick -x c7065417f8ca3123f20193ef4fe3f7e459ffde6f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x d6612ff725d5e7c5ee6fd9a2119c8ded08eeeca5

Testing: see ticket.

Result:
<img width="441" alt="Screenshot 2024-09-16 at 13 51 00" src="https://github.com/user-attachments/assets/c81364f7-8f9b-4904-9515-651bf46a6bd7">
<img width="353" alt="Screenshot 2024-09-16 at 13 50 48" src="https://github.com/user-attachments/assets/bcb0f780-66ad-443c-9adf-8c74e0426792">


Original PR: https://github.com/truenas/webui/pull/10686
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131218