### PR TITLE
NAS-131101 / 24.10.0 / Help button in the Active Directory menu is not clickable if the translation is too long. (by AlexKarpov98)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component.scss
+++ b/src/app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component.scss
@@ -9,6 +9,13 @@
 
   mat-checkbox {
     max-width: 93%;
+
+    &::ng-deep {
+      label {
+        line-height: normal;
+        max-width: 90%;
+      }
+    }
   }
 
   mat-hint {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 881dd27fc4a9c4a8fd5844c664e62ce688f81793
    git cherry-pick -x ec515577953148b9cab2b02aafb5e12cbdc59488

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x c026cd8a1b88e45222adb89cf6a420bcd0884962

Testing: see ticket. 
Result: 
<img width="490" alt="Screenshot 2024-09-16 at 13 40 13" src="https://github.com/user-attachments/assets/d7b21874-c5ca-498f-9325-16613202795b">


Original PR: https://github.com/truenas/webui/pull/10685
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131101