### PR TITLE
NAS-131123 / 24.10.0 / Buttons overlap on upgrade page / mobile (by AlexKarpov98)

### DIFF
--- a/src/app/pages/system/update/components/update-actions-card/update-actions-card.component.scss
+++ b/src/app/pages/system/update/components/update-actions-card/update-actions-card.component.scss
@@ -1,5 +1,6 @@
 .buttons-container {
   display: flex;
+  flex-wrap: wrap;
   gap: 6px;
 }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 5c70e43e99a053085f9d1159845ba0be31874c9a
    git cherry-pick -x f59fbc2bfd2674feda3fb67bd4b9b57612d6694b

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x f2bd4a58105af5165950e9f5f8171bc73f84ae20

Testing: see ticket.
Result:
<img width="372" alt="Screenshot 2024-09-16 at 13 29 00" src="https://github.com/user-attachments/assets/09144923-082a-45f0-bae2-539db74d03be">


Original PR: https://github.com/truenas/webui/pull/10684
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131123