### PR TITLE
NAS-131222 / 25.04 / FT: Local Groups create new GID errors with red text: Input should be a valid integer

### DIFF
--- a/src/app/pages/account/groups/group-form/group-form.component.html
+++ b/src/app/pages/account/groups/group-form/group-form.component.html
@@ -7,6 +7,7 @@
         <ix-input
           formControlName="gid"
           label="GID"
+          type="number"
           [required]="true"
           [tooltip]="tooltips.gid"
         ></ix-input>


### PR DESCRIPTION
Testing: see ticket.