### PR TITLE
NAS-131231 / 25.04 / if you enter an invalid AUTH key, tailscale goes into a tight restart loop

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
@@ -78,7 +78,6 @@
       matTooltipPosition="above"
       [ixTest]="[app().name, 'stop']"
       [matTooltip]="'Stop' | translate"
-      [disabled]="inProgress()"
       (click)="stop(); $event.stopPropagation()"
     >
       <ix-icon name="mdi-stop"></ix-icon>

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -135,13 +135,13 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
 
   get activeCheckedApps(): App[] {
     return this.dataSource.filter(
-      (app) => app.state !== AppState.Stopped && this.selection.isSelected(app.id),
+      (app) => [AppState.Running, AppState.Deploying].includes(app.state) && this.selection.isSelected(app.id),
     );
   }
 
   get stoppedCheckedApps(): App[] {
     return this.dataSource.filter(
-      (app) => app.state === AppState.Stopped && this.selection.isSelected(app.id),
+      (app) => [AppState.Stopped, AppState.Crashed].includes(app.state) && this.selection.isSelected(app.id),
     );
   }
 

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -133,9 +133,9 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
       .some((app) => app.upgrade_available);
   }
 
-  get startedCheckedApps(): App[] {
+  get activeCheckedApps(): App[] {
     return this.dataSource.filter(
-      (app) => app.state === AppState.Running && this.selection.isSelected(app.id),
+      (app) => app.state !== AppState.Stopped && this.selection.isSelected(app.id),
     );
   }
 
@@ -351,7 +351,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
   }
 
   onBulkStop(): void {
-    this.startedCheckedApps.forEach((app) => this.stop(app.name));
+    this.activeCheckedApps.forEach((app) => this.stop(app.name));
     this.snackbar.success(this.translate.instant(helptextApps.bulkActions.finished));
     this.toggleAppsChecked(false);
   }


### PR DESCRIPTION
**Changes:**
Now we are able to stop the app with `Deploying` status.

– The retry of deploying is done by docker.
Only allow stop from the UI is the option to fix this bug.

I've discussed it with @stavros-k .

**Testing:**
See ticket, comments, the only way for now is to allow stopping an app which is in `Deploying` phase.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | We can stop app with `Deploying` status.
