### PR TITLE
NAS-131214 / 24.10.0 / Do not show keys from `update.get_trains` (by undsoft)

### DIFF
--- a/src/app/pages/system/update/components/train-card/train-card.component.ts
+++ b/src/app/pages/system/update/components/train-card/train-card.component.ts
@@ -80,7 +80,7 @@ export class TrainCardComponent implements OnInit {
         }
 
         this.trains = Object.entries(trains.trains).map(([name, train]) => ({
-          label: `${name} - ${train.description}`,
+          label: train.description,
           value: name,
         }));
         if (this.trains.length > 0) {

--- a/src/app/views/sessions/signin/store/signin.store.ts
+++ b/src/app/views/sessions/signin/store/signin.store.ts
@@ -98,7 +98,7 @@ export class SigninStore extends ComponentStore<SigninState> {
         this.updateService.hardRefreshIfNeeded(),
       ]).pipe(
         tap(() => this.setLoadingState(false)),
-    switchMap(() => this.authService.loginWithToken()),
+        switchMap(() => this.authService.loginWithToken()),
         tap((loginResult) => {
           if (loginResult !== LoginResult.Success) {
             this.authService.clearAuthToken();

--- a/src/app/views/sessions/signin/store/signin.store.ts
+++ b/src/app/views/sessions/signin/store/signin.store.ts
@@ -97,7 +97,8 @@ export class SigninStore extends ComponentStore<SigninState> {
         this.loadFailoverStatus(),
         this.updateService.hardRefreshIfNeeded(),
       ]).pipe(
-        switchMap(() => this.authService.loginWithToken()),
+        tap(() => this.setLoadingState(false)),
+    switchMap(() => this.authService.loginWithToken()),
         tap((loginResult) => {
           if (loginResult !== LoginResult.Success) {
             this.authService.clearAuthToken();
@@ -224,7 +225,6 @@ export class SigninStore extends ComponentStore<SigninState> {
     return this.ws.call('failover.status').pipe(
       switchMap((status) => {
         this.setFailoverStatus(status);
-        this.setLoadingState(false);
 
         if (status === FailoverStatus.Single) {
           return of(null);


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 36566e3f2484d525ab7650d698d3f9c862c21436

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 119af35a4d64256f22b4e5641e2e65ac82277f3a

**Changes:**

Before:

![Снимок экрана 2024-09-16 в 15 14 43](https://github.com/user-attachments/assets/80476daf-c004-40c1-8343-8d066f7f8eaf)

After:

![Снимок экрана 2024-09-16 в 15 14 52](https://github.com/user-attachments/assets/55eac5c7-1f28-45ed-a600-3d84d43fb445)


**Testing:**

1. Build a machine with 24.04.0.
2. Comment out in `SigninStore`
```
    switchMap(() => forkJoin([
      this.checkIfAdminPasswordSet(),
      // this.checkForLoginBanner(),
      this.loadFailoverStatus(),
      // this.updateService.hardRefreshIfNeeded(),
    ])),

```
3. See Update page.

Original PR: https://github.com/truenas/webui/pull/10690
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131214