### PR TITLE
NAS-131276 / 24.10.0 / Wrap long text on the login banner (by denysbutenko)

### DIFF
--- a/src/app/modules/dialog/components/full-screen-dialog/full-screen-dialog.component.scss
+++ b/src/app/modules/dialog/components/full-screen-dialog/full-screen-dialog.component.scss
@@ -15,18 +15,22 @@
   align-items: center;
   display: flex;
   flex-direction: column;
+  height: 80%;
   justify-content: center;
   margin-bottom: 16px;
-  width: 50%;
+  width: 80%;
 
   .title {
     font-size: xx-large;
   }
 
   .message {
+    display: block;
+    font-family: var(--font-family-body);
+    max-height: 80%;
+    overflow: auto;
+
     &.pre {
-      display: block;
-      font-family: 'Droid Sans Mono', 'Courier New', Courier, monospace;
       unicode-bidi: isolate;
       white-space: pre;
     }

--- a/src/app/views/sessions/signin/signin.component.ts
+++ b/src/app/views/sessions/signin/signin.component.ts
@@ -47,7 +47,7 @@ export class SigninComponent implements OnInit {
     this.signinStore.loginBanner$.pipe(
       filter(Boolean),
       filter(() => this.window.sessionStorage.getItem('loginBannerDismissed') !== 'true'),
-      switchMap((text) => this.dialog.fullScreenDialog(null, text, true, true).pipe(take(1))),
+      switchMap((text) => this.dialog.fullScreenDialog(null, text, true, false).pipe(take(1))),
       filter(Boolean),
       untilDestroyed(this),
     ).subscribe(() => {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 5e8d72d0e2ee0d23dda570c9d2486a66231a6710

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 42f0d70a35ed54a3d8911ade3cb8bd1a55238569

**Changes:**

Adjust styles to display long text better.

**Testing:**

Setup login banner and check how it renders. Check the ticket for details.

**Preview:**

https://github.com/user-attachments/assets/53c52025-2595-4719-9d42-68ba8742bab8

![image](https://github.com/user-attachments/assets/e4607c71-b0d4-4892-bbe7-6d21c923609d)


Original PR: https://github.com/truenas/webui/pull/10709
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131276