### PR TITLE
NAS-131231 / 24.10.0 / if you enter an invalid AUTH key, tailscale goes into a tight restart loop (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
@@ -78,7 +78,6 @@
       matTooltipPosition="above"
       [ixTest]="[app().name, 'stop']"
       [matTooltip]="'Stop' | translate"
-      [disabled]="inProgress()"
       (click)="stop(); $event.stopPropagation()"
     >
       <ix-icon name="mdi-stop"></ix-icon>

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -135,15 +135,15 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
       .some((app) => app.upgrade_available);
   }
 
-  get startedCheckedApps(): App[] {
+  get activeCheckedApps(): App[] {
     return this.dataSource.filter(
-      (app) => app.state === CatalogAppState.Running && this.selection.isSelected(app.id),
+      (app) => [CatalogAppState.Running, CatalogAppState.Deploying].includes(app.state) && this.selection.isSelected(app.id),
     );
   }
 
   get stoppedCheckedApps(): App[] {
     return this.dataSource.filter(
-      (app) => app.state === CatalogAppState.Stopped && this.selection.isSelected(app.id),
+      (app) => [CatalogAppState.Stopped, CatalogAppState.Crashed].includes(app.state) && this.selection.isSelected(app.id),
     );
   }
 
@@ -353,7 +353,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
   }
 
   onBulkStop(): void {
-    this.startedCheckedApps.forEach((app) => this.stop(app.name));
+    this.activeCheckedApps.forEach((app) => this.stop(app.name));
     this.snackbar.success(this.translate.instant(helptextApps.bulkActions.finished));
     this.toggleAppsChecked(false);
   }

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -138,7 +138,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
   get activeCheckedApps(): App[] {
     return this.dataSource.filter(
       (app) => [
-        CatalogAppState.Running, CatalogAppState.Deploying
+        CatalogAppState.Running, CatalogAppState.Deploying,
       ].includes(app.state) && this.selection.isSelected(app.id),
     );
   }
@@ -146,7 +146,7 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
   get stoppedCheckedApps(): App[] {
     return this.dataSource.filter(
       (app) => [
-        CatalogAppState.Stopped, CatalogAppState.Crashed
+        CatalogAppState.Stopped, CatalogAppState.Crashed,
       ].includes(app.state) && this.selection.isSelected(app.id),
     );
   }

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -137,13 +137,17 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
 
   get activeCheckedApps(): App[] {
     return this.dataSource.filter(
-      (app) => [CatalogAppState.Running, CatalogAppState.Deploying].includes(app.state) && this.selection.isSelected(app.id),
+      (app) => [
+        CatalogAppState.Running, CatalogAppState.Deploying
+      ].includes(app.state) && this.selection.isSelected(app.id),
     );
   }
 
   get stoppedCheckedApps(): App[] {
     return this.dataSource.filter(
-      (app) => [CatalogAppState.Stopped, CatalogAppState.Crashed].includes(app.state) && this.selection.isSelected(app.id),
+      (app) => [
+        CatalogAppState.Stopped, CatalogAppState.Crashed
+      ].includes(app.state) && this.selection.isSelected(app.id),
     );
   }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x dadc83e8342870ee844087f567bad12c48914dfd
    git cherry-pick -x 73295b24bdc6c3432d791862dd0da80d745df4dc

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x b6969a51b0fab9a798dce24eff910b6cb203530b

**Changes:**
Now we are able to stop the app with `Deploying` status.

– The retry of deploying is done by docker.
Only allow stop from the UI is the option to fix this bug.

I've discussed it with @stavros-k .

**Testing:**
See ticket, comments, the only way for now is to allow stopping an app which is in `Deploying` phase.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | We can stop app with `Deploying` status.


Original PR: https://github.com/truenas/webui/pull/10704
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131231