### PR TITLE
NAS-131290 / 25.04 / Add `debounceTime` to `disk.query` subscription update in `enclosure.store.ts`

### DIFF
--- a/src/app/pages/system/enclosure/services/enclosure.store.spec.ts
+++ b/src/app/pages/system/enclosure/services/enclosure.store.spec.ts
@@ -1,3 +1,4 @@
+import { fakeAsync, tick } from '@angular/core/testing';
 import {
   createServiceFactory,
   mockProvider,
@@ -79,7 +80,7 @@ describe('EnclosureStore', () => {
   });
 
   describe('listenForDiskUpdates', () => {
-    it('updates dashboard information when disks are changed', () => {
+    it('updates dashboard information when disks are changed', fakeAsync(() => {
       jest.spyOn(spectator.service, 'patchState').mockImplementation();
       spectator.service.listenForDiskUpdates().subscribe();
 
@@ -88,11 +89,12 @@ describe('EnclosureStore', () => {
         collection: 'disk.query',
       });
 
+      tick(1 * 1000);
       expect(spectator.inject(WebSocketService).subscribe).toHaveBeenCalledWith('disk.query');
       expect(spectator.inject(WebSocketService).call).toHaveBeenLastCalledWith('webui.enclosure.dashboard');
 
       expect(spectator.service.patchState).toHaveBeenLastCalledWith({ enclosures });
-    });
+    }));
   });
 
   describe('selectEnclosure', () => {

--- a/src/app/pages/system/enclosure/services/enclosure.store.ts
+++ b/src/app/pages/system/enclosure/services/enclosure.store.ts
@@ -5,7 +5,7 @@ import { ComponentStore } from '@ngrx/component-store';
 import { produce } from 'immer';
 import { chain } from 'lodash-es';
 import { Observable, switchMap, tap } from 'rxjs';
-import { finalize } from 'rxjs/operators';
+import { debounceTime, finalize } from 'rxjs/operators';
 import { EnclosureElementType, DriveBayLightStatus } from 'app/enums/enclosure-slot-status.enum';
 import { DashboardEnclosure, EnclosureVdevDisk } from 'app/interfaces/enclosure.interface';
 import { EnclosureView } from 'app/pages/system/enclosure/types/enclosure-view.enum';
@@ -125,6 +125,7 @@ export class EnclosureStore extends ComponentStore<EnclosureState> {
 
   listenForDiskUpdates(): Observable<unknown> {
     return this.ws.subscribe('disk.query').pipe(
+      debounceTime(1 * 1000),
       tap(() => this.update()),
     );
   }


### PR DESCRIPTION
**Changes:**

Adds `debounceTime` operator to `enclosure.store.ts` `disk.query` subscription pipe. The method is set to be called every time `disk.query` event emits an event. Sometimes, when enclosure state changes, `disk.query` can emit for all the disks at once. Meaning, you can get dozens of events fired in milliseconds. So, the update method was calling `webui.enclosure.dashboard` method as many times very quickly, causing the `Maximum concurrent calls` error. The `debounceTIme` operator will ensure that any surge of event updates from `disk.query` only cause one eventual `webui.enclosure.dashboard` call.

**Testing:**

Test using the steps in the ticket.