### PR TITLE
NAS-130993 / 25.04 / Make use of a 1/4 size widget in defaults, if possible.

### DIFF
--- a/src/app/pages/dashboard/services/get-default-widgets.spec.ts
+++ b/src/app/pages/dashboard/services/get-default-widgets.spec.ts
@@ -16,6 +16,6 @@ describe('getDefaultWidgets', () => {
 
     expect(result).toHaveLength(8);
     expect(result[0].slots[0].type).toBe(WidgetType.SystemInfoActive);
-    expect(result[1].slots[0].type).toBe(WidgetType.CpuModelWidget);
+    expect(result[1].slots[0].type).toBe(WidgetType.CpuUsageBar);
   });
 });

--- a/src/app/pages/dashboard/services/get-default-widgets.ts
+++ b/src/app/pages/dashboard/services/get-default-widgets.ts
@@ -17,15 +17,16 @@ const defaultWidgets: WidgetGroup[] = [
   {
     layout: WidgetGroupLayout.Halves,
     slots: [
-      { type: WidgetType.CpuModelWidget },
       { type: WidgetType.CpuUsageBar },
+      { type: WidgetType.CpuTemperatureBar },
     ],
   },
   {
-    layout: WidgetGroupLayout.Halves,
+    layout: WidgetGroupLayout.QuartersAndHalf,
     slots: [
+      { type: WidgetType.CpuUsageGauge },
+      { type: WidgetType.CpuModelWidget },
       { type: WidgetType.CpuUsageRecent },
-      { type: WidgetType.CpuTemperatureBar },
     ],
   },
   {


### PR DESCRIPTION
Testing: 

Result:
<img width="1148" alt="NAS-130993" src="https://github.com/user-attachments/assets/e5e3d029-9513-4b3c-b8bf-860231b412b5">
