### PR TITLE
NAS-131148 / 25.04 / Audit logs on HA - Add ability to view and export remote controller logs in the WebUI

### DIFF
--- a/src/app/enums/controller-type.enum.ts
+++ b/src/app/enums/controller-type.enum.ts
@@ -1,0 +1,4 @@
+export enum ControllerType {
+  Active = 'ACTIVE',
+  Standby = 'STAND_BY',
+}

--- a/src/app/interfaces/audit/audit.interface.ts
+++ b/src/app/interfaces/audit/audit.interface.ts
@@ -9,6 +9,7 @@ export interface AuditQueryParams {
   services?: AuditService[];
   'query-filters'?: QueryFilters<AuditEntry>;
   'query-options'?: QueryOptions<AuditEntry>;
+  remote_controller?: boolean;
 }
 
 export interface BaseAuditEntry {

--- a/src/app/interfaces/export-params.interface.ts
+++ b/src/app/interfaces/export-params.interface.ts
@@ -5,4 +5,5 @@ export interface ExportParams<T, F = ExportFormat> {
   'query-filters'?: QueryFilters<T>;
   'query-options'?: QueryOptions<T>;
   export_format?: F;
+  remote_controller?: boolean;
 }

--- a/src/app/modules/buttons/export-button/export-button.component.ts
+++ b/src/app/modules/buttons/export-button/export-button.component.ts
@@ -1,11 +1,14 @@
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, Input,
 } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatProgressBar } from '@angular/material/progress-bar';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { catchError, EMPTY, switchMap } from 'rxjs';
+import { ControllerType } from 'app/enums/controller-type.enum';
 import { ExportFormat } from 'app/enums/export-format.enum';
 import { JobState } from 'app/enums/job-state.enum';
 import { ApiCallDirectory } from 'app/interfaces/api/api-call-directory.interface';
@@ -20,6 +23,8 @@ import { TestIdModule } from 'app/modules/test-id/test-id.module';
 import { DownloadService } from 'app/services/download.service';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { WebSocketService } from 'app/services/ws.service';
+import { AppsState } from 'app/store';
+import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 
 @UntilDestroy()
 @Component({
@@ -44,9 +49,12 @@ export class ExportButtonComponent<T, M extends ApiJobMethod> {
   @Input() fileType = 'csv';
   @Input() fileMimeType = 'text/csv';
   @Input() addReportNameArgument = false;
+  @Input() controllerType: ControllerType;
   @Input() downloadMethod?: keyof ApiCallDirectory;
 
   isLoading = false;
+
+  protected readonly isHaLicensed = toSignal(this.store$.select(selectIsHaLicensed));
 
   constructor(
     private ws: WebSocketService,
@@ -54,6 +62,7 @@ export class ExportButtonComponent<T, M extends ApiJobMethod> {
     private errorHandler: ErrorHandlerService,
     private dialogService: DialogService,
     private download: DownloadService,
+    private store$: Store<AppsState>,
   ) {}
 
   onExport(): void {
@@ -100,11 +109,19 @@ export class ExportButtonComponent<T, M extends ApiJobMethod> {
     queryFilters: QueryFilters<T>,
     queryOptions: QueryOptions<T>,
   ): ApiJobParams<M> {
-    return [{
+    const options = {
       'query-filters': queryFilters,
       'query-options': queryOptions,
       export_format: ExportFormat.Csv,
-    }] as unknown as ApiJobParams<M>;
+      remote_controller: this.controllerType === ControllerType.Standby,
+    };
+    const params = [options] as ApiJobParams<M>;
+
+    if (!this.isHaLicensed() || !this.controllerType) {
+      delete options.remote_controller;
+    }
+
+    return params;
   }
 
   private getQueryFilters(searchQuery: SearchQuery<T>): QueryFilters<T> {

--- a/src/app/modules/buttons/export-button/export-button.component.ts
+++ b/src/app/modules/buttons/export-button/export-button.component.ts
@@ -109,19 +109,14 @@ export class ExportButtonComponent<T, M extends ApiJobMethod> {
     queryFilters: QueryFilters<T>,
     queryOptions: QueryOptions<T>,
   ): ApiJobParams<M> {
-    const options = {
+    return [{
       'query-filters': queryFilters,
       'query-options': queryOptions,
       export_format: ExportFormat.Csv,
-      remote_controller: this.controllerType === ControllerType.Standby,
-    };
-    const params = [options] as ApiJobParams<M>;
-
-    if (!this.isHaLicensed() || !this.controllerType) {
-      delete options.remote_controller;
-    }
-
-    return params;
+      ...(this.isHaLicensed() && this.controllerType && {
+        remote_controller: this.controllerType === ControllerType.Standby,
+      }),
+    }] as ApiJobParams<M>;
   }
 
   private getQueryFilters(searchQuery: SearchQuery<T>): QueryFilters<T> {
@@ -133,18 +128,13 @@ export class ExportButtonComponent<T, M extends ApiJobMethod> {
   }
 
   private getQueryOptions(sorting: TableSort<T>): QueryOptions<T> {
-    if (!sorting) {
+    if (!sorting?.propertyName || !sorting?.direction) {
       return {};
     }
 
-    if (sorting.propertyName === null || sorting.direction === null) {
-      return {};
-    }
-
+    const orderPrefix = sorting.direction === SortDirection.Desc ? '-' : '';
     return {
-      order_by: [
-        ((sorting.direction === SortDirection.Desc ? '-' : '') + (sorting.propertyName as string)) as PropertyPath<T>,
-      ],
+      order_by: [`${orderPrefix}${sorting.propertyName as string}` as PropertyPath<T>],
     };
   }
 }

--- a/src/app/pages/audit/audit.module.ts
+++ b/src/app/pages/audit/audit.module.ts
@@ -2,6 +2,7 @@ import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -53,6 +54,7 @@ import { MetadataDetailsCardComponent } from './components/metadata-details-card
     IxTableCellDirective,
     IxTablePagerComponent,
     IxTableHeadComponent,
+    MatButtonToggleModule,
   ],
   exports: [],
   declarations: [

--- a/src/app/pages/audit/components/audit/audit.component.html
+++ b/src/app/pages/audit/components/audit/audit.component.html
@@ -1,4 +1,12 @@
 <ix-page-header>
+  @if (isHaLicensed()) {
+    <p>{{ 'Controller' | translate }}</p>
+    <mat-button-toggle-group [value]="controllerType()" (change)="controllerTypeChanged($event)">
+      <mat-button-toggle [value]="ControllerType.Active">{{ 'Active' | translate }}</mat-button-toggle>
+      <mat-button-toggle [value]="ControllerType.Standby">{{ 'Standby' | translate }}</mat-button-toggle>
+    </mat-button-toggle-group>
+  }
+
   <a ixTest="audit-settings" mat-button fragment="audit-card" [routerLink]="['/system/advanced']">
     {{ 'Audit Settings' | translate }}
   </a>
@@ -106,6 +114,7 @@
       [searchQuery]="searchQuery"
       [sorting]="dataProvider.sorting"
       [defaultFilters]="basicQueryFilters"
+      [controllerType]="controllerType()"
     ></ix-export-button>
   }
 </ng-template>

--- a/src/app/pages/audit/components/audit/audit.component.scss
+++ b/src/app/pages/audit/components/audit/audit.component.scss
@@ -8,6 +8,14 @@
 }
 
 :host ::ng-deep {
+  .header-container .title-container .actions-container {
+    gap: 0 16px;
+
+    p {
+      margin: 0;
+    }
+  }
+
   ix-empty-row {
     height: 100%;
   }

--- a/src/app/pages/audit/utils/audit-api-data-provider.ts
+++ b/src/app/pages/audit/utils/audit-api-data-provider.ts
@@ -1,5 +1,6 @@
 import { isEqual } from 'lodash-es';
 import { Observable, of } from 'rxjs';
+import { ControllerType } from 'app/enums/controller-type.enum';
 import { ApiCallParams } from 'app/interfaces/api/api-call-directory.interface';
 import { AuditEntry, AuditQueryParams } from 'app/interfaces/audit/audit.interface';
 import { QueryFilters } from 'app/interfaces/query-api.interface';
@@ -8,6 +9,8 @@ import { WebSocketService } from 'app/services/ws.service';
 
 export class AuditApiDataProvider extends ApiDataProvider<'audit.query'> {
   lastParams: AuditQueryParams;
+  isHaLicensed: boolean;
+  selectedControllerType: ControllerType;
 
   get isLastOffset(): boolean {
     return Boolean((this.totalRows / this.pagination.pageNumber) < this.pagination.pageSize);
@@ -35,6 +38,10 @@ export class AuditApiDataProvider extends ApiDataProvider<'audit.query'> {
       },
     ] as ApiCallParams<'audit.query'>;
 
+    if (this.isHaLicensed && this.selectedControllerType) {
+      params[0].remote_controller = this.selectedControllerType === ControllerType.Standby;
+    }
+
     return this.ws.call(this.method, params) as unknown as Observable<number>;
   }
 
@@ -45,11 +52,17 @@ export class AuditApiDataProvider extends ApiDataProvider<'audit.query'> {
       ...this.sortingStrategy.getParams(this.sorting),
     };
 
-    return [
+    const apiCallParams: ApiCallParams<'audit.query'> = [
       {
         'query-filters': queryFilters,
         'query-options': queryOptions,
       },
     ];
+
+    if (this.isHaLicensed && this.selectedControllerType) {
+      apiCallParams[0].remote_controller = this.selectedControllerType === ControllerType.Standby;
+    }
+
+    return apiCallParams;
   }
 }

--- a/src/app/pages/audit/utils/audit-api-data-provider.ts
+++ b/src/app/pages/audit/utils/audit-api-data-provider.ts
@@ -31,37 +31,30 @@ export class AuditApiDataProvider extends ApiDataProvider<'audit.query'> {
 
     this.lastParams = this.params[0];
 
-    const params = [
-      {
-        'query-filters': this.params[0] || [],
-        'query-options': { count: true },
-      },
-    ] as ApiCallParams<'audit.query'>;
-
-    if (this.isHaLicensed && this.selectedControllerType) {
-      params[0].remote_controller = this.selectedControllerType === ControllerType.Standby;
-    }
+    const params: ApiCallParams<'audit.query'> = [{
+      'query-filters': (this.params[0] || []) as QueryFilters<AuditEntry>,
+      'query-options': { count: true },
+      ...(this.isHaLicensed && this.selectedControllerType && {
+        remote_controller: this.selectedControllerType === ControllerType.Standby,
+      }),
+    }];
 
     return this.ws.call(this.method, params) as unknown as Observable<number>;
   }
 
   protected override prepareParams(params: ApiCallParams<'audit.query'>): ApiCallParams<'audit.query'> {
-    const queryFilters = (params[0] || []) as QueryFilters<AuditEntry>;
-    const queryOptions = {
-      ...this.paginationStrategy.getParams(this.pagination, this.totalRows),
-      ...this.sortingStrategy.getParams(this.sorting),
-    };
+    const [queryFilters = []] = params as [QueryFilters<AuditEntry>];
 
-    const apiCallParams: ApiCallParams<'audit.query'> = [
-      {
-        'query-filters': queryFilters,
-        'query-options': queryOptions,
+    const apiCallParams: ApiCallParams<'audit.query'> = [{
+      'query-filters': queryFilters,
+      'query-options': {
+        ...this.paginationStrategy.getParams(this.pagination, this.totalRows),
+        ...this.sortingStrategy.getParams(this.sorting),
       },
-    ];
-
-    if (this.isHaLicensed && this.selectedControllerType) {
-      apiCallParams[0].remote_controller = this.selectedControllerType === ControllerType.Standby;
-    }
+      ...(this.isHaLicensed && this.selectedControllerType && {
+        remote_controller: this.selectedControllerType === ControllerType.Standby,
+      }),
+    }];
 
     return apiCallParams;
   }

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -628,6 +628,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -692,6 +692,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -488,6 +488,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -874,6 +874,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -122,6 +122,7 @@
   "Container Shell": "",
   "Container Write": "",
   "Contract Type": "",
+  "Controller": "",
   "Controller Type": "",
   "Cooling": "",
   "Copies": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -23,6 +23,7 @@
   "Container ID": "",
   "Container Logs": "",
   "Container Shell": "",
+  "Controller": "",
   "Crashed": "",
   "Creating custom app": "",
   "Credentials have been successfully added.": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -842,6 +842,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -797,6 +797,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -537,6 +537,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -955,6 +955,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -232,6 +232,7 @@
   "Container Logs": "",
   "Container Shell": "",
   "Contract Type": "",
+  "Controller": "",
   "Controller Type": "",
   "Cooling": "",
   "Copies": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -915,6 +915,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -902,6 +902,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -399,6 +399,7 @@
   "Contents of the uploaded Service Account JSON file.": "",
   "Context menu copy and paste operations     are disabled in the Shell. Copy and paste     shortcuts for Mac are <i>Command+c</i> and     <i>Command+v</i>. For most operating     systems, use <i>Ctrl+Insert</i> to copy and     <i>Shift+Insert</i> to paste.": "",
   "Contract Type": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -564,6 +564,7 @@
   "Content Commitment": "",
   "Continue with the upgrade": "",
   "Contract Type": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -349,6 +349,7 @@
   "Container Write": "",
   "Continue with the upgrade": "",
   "Contract Type": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -961,6 +961,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -238,6 +238,7 @@
   "Container Logs": "",
   "Container Shell": "",
   "Contract Type": "",
+  "Controller": "",
   "Controller Type": "",
   "Cooling": "",
   "Copies": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -788,6 +788,7 @@
   "Continue with the upgrade": "",
   "Contract Type": "",
   "Control": "",
+  "Controller": "",
   "Controller Type": "",
   "Controls whether  <a href=\"https://www.truenas.com/docs/scale/scaleuireference/dataprotection/smarttestsscreensscale/\" target=\"_blank\">SMART monitoring and scheduled SMART tests</a>  are enabled.": "",
   "Controls whether audit messages will be generated for the share. <br><br> <b>Note</b>: Auditing may not be enabled if SMB1 support is enabled for the server.": "",


### PR DESCRIPTION
**Testing:**
See ticket.
Make sure you have latest Fangtooth VM & HA system.
Go to the Audit page.

Result 👇 

https://github.com/user-attachments/assets/ab10975d-47ca-4c09-af5f-1d69da3eea87



|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Added 2 new buttons to show logs based on the HA controller.
