### PR TITLE
NAS-131100 / 24.10.0 / Fix installed apps is empty on app install (by denysbutenko)

### DIFF
--- a/src/app/pages/apps/services/applications.service.ts
+++ b/src/app/pages/apps/services/applications.service.ts
@@ -88,7 +88,7 @@ export class ApplicationsService {
     }]);
   }
 
-  getInstalledAppsUpdates(): Observable<ApiEvent> {
+  getInstalledAppsUpdates(): Observable<ApiEvent<App>> {
     return this.ws.subscribe('app.query');
   }
 

--- a/src/app/pages/apps/store/installed-apps-store.service.ts
+++ b/src/app/pages/apps/store/installed-apps-store.service.ts
@@ -153,14 +153,11 @@ export class InstalledAppsStore extends ComponentStore<InstalledAppsState> imple
   private loadInstalledApps(): Observable<unknown> {
     return this.dockerStore.isLoading$.pipe(
       withLatestFrom(this.dockerStore.isDockerStarted$),
-      filter(([loading, isDockerStarted]) => !loading && isDockerStarted !== null),
-      tap(([, isDockerStarted]) => {
-        if (isDockerStarted) {
-          this.appsStats.subscribeToUpdates();
-          this.subscribeToInstalledAppsUpdates();
-        }
-      }),
+      filter(([isLoading, isDockerStarted]) => !isLoading && isDockerStarted !== null),
       switchMap(([, isDockerStarted]) => {
+        this.appsStats.subscribeToUpdates();
+        this.subscribeToInstalledAppsUpdates();
+
         if (!isDockerStarted) {
           return of([]);
         }


### PR DESCRIPTION
**Changes:**

Reload installed apps on first app install

**Testing:**

On fresh nightly system when docker service is not configured and you try to install an app for first time. Ensure apps tree shows newly installed app.

Original PR: https://github.com/truenas/webui/pull/10745
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131100