### PR TITLE
NAS-131307 / 24.10.0 / Text does not fit in network widget (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.scss
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.scss
@@ -87,11 +87,14 @@
       .info-list-item {
         display: grid;
         font-size: 16px;
-        grid-template-columns: minmax(50px, 25%) minmax(100px, 75%);
+        grid-template-columns: minmax(50px, 50%) minmax(100px, 50%);
 
         span:first-child {
           font-weight: bold;
           text-align: right;
+          white-space: normal;
+          word-break: break-word;
+          word-wrap: break-word;
         }
       }
     }
@@ -127,8 +130,8 @@
     }
 
     .nic-info {
-      flex: 1 1 30%;
-      max-width: 30%;
+      flex: 1 1 35%;
+      max-width: 35%;
 
       @media (max-width: $breakpoint-xs) {
         flex: 1;
@@ -139,9 +142,9 @@
     .nic-chart {
       align-items: center;
       display: flex;
-      flex: 1 1 70%;
+      flex: 1 1 65%;
       justify-content: center;
-      max-width: 70%;
+      max-width: 65%;
 
       @media (max-width: $breakpoint-xs) {
         flex: 1;


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 6bf2079d2a3cae36558e8ab6b795fb322fd37f10

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 2afce47e22a34742b02f389acd312894a9880945

Testing: See ticket

Before:
<img width="566" alt="before-NAS-131307" src="https://github.com/user-attachments/assets/c77f9ac5-0306-4d55-a0fa-321c94c04c62">

After:
<img width="566" alt="after-NAS-131307" src="https://github.com/user-attachments/assets/752f9672-fd9d-4085-8f49-5d8f31c48b19">


Original PR: https://github.com/truenas/webui/pull/10751
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131307