### PR TITLE
NAS-131392: Dashboard - Initiate Failover button - text overlapping issue

### DIFF
--- a/src/app/pages/dashboard/widgets/system/common/widget-sys-info.scss
+++ b/src/app/pages/dashboard/widgets/system/common/widget-sys-info.scss
@@ -5,6 +5,12 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+
+  button {
+    height: inherit;
+    min-height: var(--mdc-text-button-container-height);
+    white-space: normal;
+  }
 }
 
 :host ::ng-deep {


### PR DESCRIPTION
Testing: see ticket.

Result:

<img width="1123" alt="NAS-131392" src="https://github.com/user-attachments/assets/2aee832d-4f5c-4aa5-8283-f1c64ecebea0">
