### PR TITLE
NAS-131392 / 24.10.0 / Dashboard - Initiate Failover button - text overlapping issue (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/widgets/system/common/widget-sys-info.scss
+++ b/src/app/pages/dashboard/widgets/system/common/widget-sys-info.scss
@@ -5,6 +5,12 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+
+  button {
+    height: inherit;
+    min-height: var(--mdc-text-button-container-height);
+    white-space: normal;
+  }
 }
 
 :host ::ng-deep {


### PR DESCRIPTION
Testing: see ticket.

Result:

<img width="1123" alt="NAS-131392" src="https://github.com/user-attachments/assets/2aee832d-4f5c-4aa5-8283-f1c64ecebea0">


Original PR: https://github.com/truenas/webui/pull/10761
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131392