### PR TITLE
NAS-131437 / 24.10.0 / Restarting Plex container breaks migration mounts (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/app-wizard/app-wizard.component.spec.ts
+++ b/src/app/pages/apps/components/app-wizard/app-wizard.component.spec.ts
@@ -69,7 +69,6 @@ const appVersion121 = {
         schema: {
           default: 'OnFailure',
           enum: [],
-          hidden: true,
           show_if: [
             ['workloadType', '!=', 'Deployment'],
           ],
@@ -207,15 +206,27 @@ const appVersion120 = {
         name: 'Networking',
       },
     ],
-    questions: [{
-      group: 'Networking',
-      label: 'Provide access to node network namespace for the workload Another Version',
-      schema: {
-        default: true,
-        type: 'boolean',
+    questions: [
+      {
+        group: 'Networking',
+        label: 'Provide access to node network namespace for the workload Another Version',
+        schema: {
+          default: true,
+          type: 'boolean',
+        },
+        variable: 'hostNetworkDifferentVersion',
       },
-      variable: 'hostNetworkDifferentVersion',
-    }],
+      {
+        group: 'Networking',
+        label: 'Provide access hidden',
+        schema: {
+          default: true,
+          type: 'boolean',
+          hidden: true,
+        },
+        variable: 'hostNetworkDifferentVersionHidden',
+      },
+    ],
   },
 } as CatalogAppVersion;
 
@@ -417,8 +428,7 @@ describe('AppWizardComponent', () => {
       });
     });
 
-    // TODO:
-    it.skip('creating when form is submitted', async () => {
+    it('creating when form is submitted', async () => {
       const form = await loader.getHarness(IxFormHarness);
       await form.fillForm({
         'Application Name': 'appname',
@@ -446,11 +456,11 @@ describe('AppWizardComponent', () => {
       expect(spectator.inject(WebSocketService).job).toHaveBeenCalledWith(
         'app.create',
         [{
-          catalog: 'TRUENAS',
-          item: 'ipfs',
-          release_name: 'appname',
+          app_name: 'appname',
+          catalog_app: 'ipfs',
           train: 'stable',
           values: {
+            livenessProbe: {},
             release_name: 'appname',
             service: {
               apiPort: 9599,
@@ -458,6 +468,7 @@ describe('AppWizardComponent', () => {
               swarmPort: 9401,
             },
             updateStrategy: 'Recreate',
+            workloadType: 'Deployment',
           },
           version: '1.2.1',
         }],
@@ -479,6 +490,32 @@ describe('AppWizardComponent', () => {
         Version: '1.2.0',
         'Provide access to node network namespace for the workload Another Version': true,
       });
+    });
+
+    it('submits form with hidden: true values as well since they should be a part of a request', async () => {
+      const form = await loader.getHarness(IxFormHarness);
+
+      await form.fillForm({
+        Version: '1.2.0',
+      });
+
+      spectator.component.onSubmit();
+
+      expect(spectator.inject(DialogService).jobDialog).toHaveBeenCalled();
+      expect(spectator.inject(WebSocketService).job).toHaveBeenCalledWith(
+        'app.create',
+        [{
+          app_name: 'ipfs',
+          catalog_app: 'ipfs',
+          train: 'stable',
+          values: {
+            hostNetworkDifferentVersion: true,
+            hostNetworkDifferentVersionHidden: true,
+            release_name: 'ipfs',
+          },
+          version: '1.2.0',
+        }],
+      );
     });
 
     it('shows Docker Hub Rate Limit Info Dialog when remaining_pull_limit is less then 5', () => {

--- a/src/app/pages/apps/components/app-wizard/app-wizard.component.spec.ts
+++ b/src/app/pages/apps/components/app-wizard/app-wizard.component.spec.ts
@@ -148,9 +148,9 @@ const appVersion121 = {
         label: 'Liveness Probe',
         schema: {
           attrs: [],
-          default: null,
+          default: false,
           hidden: true,
-          type: 'dict',
+          type: 'boolean',
         },
         variable: 'livenessProbe',
       },
@@ -460,7 +460,7 @@ describe('AppWizardComponent', () => {
           catalog_app: 'ipfs',
           train: 'stable',
           values: {
-            livenessProbe: {},
+            livenessProbe: false,
             release_name: 'appname',
             service: {
               apiPort: 9599,

--- a/src/app/services/schema/app-schema.service.ts
+++ b/src/app/services/schema/app-schema.service.ts
@@ -537,10 +537,12 @@ export class AppSchemaService {
     const { formGroup, chartSchemaNode } = payload;
 
     const formField = (formGroup.controls[chartSchemaNode.variable] as CustomUntypedFormField);
-    if (!formField.hidden$) {
-      formField.hidden$ = new BehaviorSubject<boolean>(false);
-    }
-    formField.hidden$.next(true);
+
+    /**
+     * There's no need to emit it as hidden$ = true since it's static and cannot be changed.
+     * Reason: It will be removed during the "app.update" query, which is incorrect.
+     * We can just disable the field and don't emit hidden$.next(true).
+     */
     formField.disable();
   }
 


### PR DESCRIPTION
Testing: 
See comments from Stavros Kois in the ticket.

_Side note: we discussed with @stavros-k that it's not possible to use `hidden: true` all together with `show_if` logic._

1. Install app via Shell:
```
midclt call -job app.create '{"train":"stable","catalog_app":"plex","values":{"storage":{"data":{"type":"ix_volume","ix_volume_config":{"dataset_name":"ix-custom-data"}},"config":{"type":"ix_volume","ix_volume_config":{"dataset_name":"ix-custom-config"}},"logs":{"type":"temporary"},"transcode":{"type":"temporary"}}},"app_name":"plex"}'
```

2. Go to the app edit page, hit submit.

3. You should see something like below as a data payload for `app.update`:
```
{
  "config": {
    "storage": {
      "additional_storage": [],
      "config": {
        "ix_volume_config": {
          "acl_enable": false,
          "dataset_name": "ix-custom-config" <-- hidden field to be included
        },
        "type": "ix_volume"
      },
      "data": {
        "ix_volume_config": {
          "acl_enable": false,
          "dataset_name": "ix-custom-data" <-- hidden field to be included
        },
        "type": "ix_volume"
      },
      "logs": {
        "type": "temporary"
      },
      "transcode": {
        "type": "temporary"
      }
    }
  }
}
```

Original PR: https://github.com/truenas/webui/pull/10778
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131437