### PR TITLE
NAS-131308 / 24.10.0 / First time accessing a Minio deployment the webui button launches portal is 0.0.0.0:30001 (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -84,7 +84,7 @@
                 mat-button
                 class="portal-button"
                 [ixTest]="['portal', app().name, portal.key]"
-                (click)="portalLink(app(), portal.key)"
+                (click)="openPortalLink(app(), portal.key)"
               >
                 {{ portal.key }}
               </button>

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -215,4 +215,26 @@ describe('AppInfoCardComponent', () => {
       data: app,
     });
   });
+
+  it('opens a URL with the current host and port when the portal hostname is 0.0.0.0', async () => {
+    spectator.setInput('app', {
+      ...app,
+      portals: {
+        'Web UI': 'http://0.0.0.0:8000/ui?q=ui#yes',
+        'Admin Panel': 'http://0.0.0.0:8000',
+      },
+    });
+
+    const buttons = await loader.getAllHarnesses(MatButtonHarness.with({ ancestor: '.portals' }));
+
+    expect(buttons).toHaveLength(2);
+    expect(await buttons[0].getText()).toBe('Admin Panel');
+    expect(await buttons[1].getText()).toBe('Web UI');
+
+    await buttons[0].click();
+    expect(spectator.inject(RedirectService).openWindow).toHaveBeenCalledWith('http://localhost:8000/');
+
+    await buttons[1].click();
+    expect(spectator.inject(RedirectService).openWindow).toHaveBeenCalledWith('http://localhost:8000/ui?q=ui#yes');
+  });
 });

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -1,5 +1,5 @@
 import {
-  ChangeDetectionStrategy, Component, computed, effect, EventEmitter, Inject, Input, input, InputSignal, Output, output,
+  ChangeDetectionStrategy, Component, computed, effect, EventEmitter, Inject, Input, input, InputSignal, Output,
   signal,
   WritableSignal,
 } from '@angular/core';

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -1,5 +1,5 @@
 import {
-  ChangeDetectionStrategy, Component, computed, effect, EventEmitter, input, Input, InputSignal, Output,
+  ChangeDetectionStrategy, Component, computed, effect, EventEmitter, Inject, Input, input, InputSignal, Output, output,
   signal,
   WritableSignal,
 } from '@angular/core';
@@ -14,6 +14,7 @@ import {
 import { appImagePlaceholder, customApp } from 'app/constants/catalog.constants';
 import { CatalogAppState } from 'app/enums/catalog-app-state.enum';
 import { Role } from 'app/enums/role.enum';
+import { WINDOW } from 'app/helpers/window.helper';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { AppUpgradeDialogConfig } from 'app/interfaces/app-upgrade-dialog-config.interface';
 import { App } from 'app/interfaces/app.interface';
@@ -79,6 +80,7 @@ export class AppInfoCardComponent {
     private translate: TranslateService,
     private router: Router,
     private installedAppsStore: InstalledAppsStore,
+    @Inject(WINDOW) private window: Window,
   ) {}
 
   protected hasUpdates = signal(false);
@@ -88,8 +90,14 @@ export class AppInfoCardComponent {
     return app?.metadata?.name === customApp;
   });
 
-  portalLink(app: App, name = 'web_portal'): void {
-    this.redirect.openWindow(app.portals[name]);
+  openPortalLink(app: App, name = 'web_portal'): void {
+    const portalUrl = new URL(app.portals[name]);
+
+    if (portalUrl.hostname === '0.0.0.0') {
+      portalUrl.hostname = this.window.location.hostname;
+    }
+
+    this.redirect.openWindow(portalUrl.href);
   }
 
   updateButtonPressed(): void {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b2e59647cd4caa2024b32b818a26dbaa63ee5dea
    git cherry-pick -x 6b4d9606328c94b61a188b1d4064985f6bb75a47
    git cherry-pick -x 05ac839f77955423fc7c9b1532de39fc951178a8
    git cherry-pick -x 1e907b8b8e402ddb01884a70f1521b3e9d69b323

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 924743a42d5a67b4b4af6c5b8a6d65ee72537d19

Testing: see ticket.
I updated it for `App Info` card and `Workloads` card (I see there is as well 0.0.0.0 host ip)

Result (instead of 0.0.0.0 we have localhost locally):

https://github.com/user-attachments/assets/7d55932c-ab01-49dc-8dc5-296d51da2335



Original PR: https://github.com/truenas/webui/pull/10769
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131308