### PR TITLE
NAS-131020 / 25.04 / Network Widget doesn't show autoconfigured IPv6 address

### DIFF
--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
@@ -73,7 +73,7 @@ describe('WidgetInterfaceIpComponent', () => {
 
       const widget = spectator.query(MockComponent(WidgetDatapointComponent));
       expect(widget).toBeTruthy();
-      expect(widget.text).toBe('192.168.1.10\n192.168.1.11');
+      expect(widget.text).toBe('N/A');
     });
 
     it('renders IPv6 addresses for the selected network interface', () => {

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
@@ -19,16 +19,20 @@ describe('WidgetInterfaceIpComponent', () => {
           value: [
             {
               name: 'eth0',
-              aliases: [
-                { type: NetworkInterfaceAliasType.Inet, address: '192.168.1.1' },
-                { type: NetworkInterfaceAliasType.Inet, address: '192.168.1.2' },
-              ],
+              state: {
+                aliases: [
+                  { type: NetworkInterfaceAliasType.Inet, address: '192.168.1.1' },
+                  { type: NetworkInterfaceAliasType.Inet, address: '192.168.1.2' },
+                ],
+              },
             },
             {
               name: 'eth1',
-              aliases: [
-                { type: NetworkInterfaceAliasType.Inet6, address: 'fe80::1' },
-              ],
+              state: {
+                aliases: [
+                  { type: NetworkInterfaceAliasType.Inet6, address: 'fe80::1' },
+                ],
+              },
             },
             {
               name: 'eth2',
@@ -73,7 +77,7 @@ describe('WidgetInterfaceIpComponent', () => {
 
       const widget = spectator.query(MockComponent(WidgetDatapointComponent));
       expect(widget).toBeTruthy();
-      expect(widget.text).toBe('N/A');
+      expect(widget.text).toBe('192.168.1.10\n192.168.1.11');
     });
 
     it('renders IPv6 addresses for the selected network interface', () => {

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
@@ -58,9 +58,9 @@ export class WidgetInterfaceIpComponent implements WidgetComponent<WidgetInterfa
       return this.translate.instant('Network interface {interface} not found.', { interface: interfaceId });
     }
 
-    const ipAliases = networkInterface.aliases.filter((alias) => alias.type === this.interfaceType());
+    const ipAliases = networkInterface?.state?.aliases.filter((alias) => alias.type === this.interfaceType());
 
-    if (!ipAliases.length) {
+    if (!ipAliases?.length) {
       return this.translate.instant('N/A');
     }
 

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
@@ -3,6 +3,7 @@ import {
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
+import uniqBy from 'lodash-es/uniqBy';
 import { NetworkInterfaceAliasType } from 'app/enums/network-interface.enum';
 import { NetworkInterface } from 'app/interfaces/network-interface.interface';
 import { mapLoadedValue } from 'app/modules/loader/directives/with-loading-state/map-loaded-value.utils';
@@ -40,7 +41,7 @@ export class WidgetInterfaceIpComponent implements WidgetComponent<WidgetInterfa
   protected ips = computed(() => {
     const interfaceId = this.interfaceId();
 
-    return mapLoadedValue(this.interfaces(), (interfaces) => this.getIp4Addresses(interfaces, interfaceId));
+    return mapLoadedValue(this.interfaces(), (interfaces) => this.getIpAddresses(interfaces, interfaceId));
   });
 
   private interfaces = toSignal(this.resources.networkInterfaces$);
@@ -50,26 +51,19 @@ export class WidgetInterfaceIpComponent implements WidgetComponent<WidgetInterfa
     private translate: TranslateService,
   ) {}
 
-  private getIp4Addresses(interfaces: NetworkInterface[], interfaceId: string): string {
-    // TODO: Show widget error if interfaceId is empty
+  private getIpAddresses(interfaces: NetworkInterface[], interfaceId: string): string {
     const networkInterface = interfaces.find((nic) => nic.name === interfaceId);
 
     if (!networkInterface) {
-      // TODO: Show as widget error.
       return this.translate.instant('Network interface {interface} not found.', { interface: interfaceId });
     }
 
-    let networkInterfaceAlias = networkInterface.aliases;
-    if (!networkInterfaceAlias.length && networkInterface?.state?.aliases?.length) {
-      networkInterfaceAlias = networkInterface.state.aliases;
-    }
-
-    const ipAliases = networkInterfaceAlias.filter((alias) => alias.type === this.interfaceType());
+    const ipAliases = networkInterface.aliases.filter((alias) => alias.type === this.interfaceType());
 
     if (!ipAliases.length) {
       return this.translate.instant('N/A');
     }
 
-    return ipAliases.map((alias) => alias.address).join('\n');
+    return uniqBy(ipAliases, 'address').map((alias) => alias.address).join('\n');
   }
 }


### PR DESCRIPTION
Testing: 

See ticket & comments.

Comment from @yocalebo: 👇 

UI is using incorrect logic. The aliases key is the addresses that have been assigned statically via our API and exist in our database. The state.aliases key are the addresses that actually are assigned to the network interface according to the OS.

For a network widget you should only use state.aliases key.

---

Based on that I've updated UI logic.
We should rely on `networkInterface?.state?.aliases` but not on `networkInterface?.aliases`
<img width="565" alt="Screenshot 2024-10-03 at 13 20 09" src="https://github.com/user-attachments/assets/6d63f9b0-dcba-4041-9e6e-76cb307d1d42">
