### PR TITLE
NAS-130834 / 24.10.0 / App version vs Version is confusing (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/app-detail-view/app-available-info-card/app-available-info-card.component.html
+++ b/src/app/pages/apps/components/app-detail-view/app-available-info-card/app-available-info-card.component.html
@@ -5,7 +5,7 @@
   @if (isLoading$() | async) {
     <ngx-skeleton-loader></ngx-skeleton-loader>
   } @else {
-    {{ app()?.latest_app_version | orNotAvailable }}
+    {{ app()?.latest_version | orNotAvailable }}
   }
 </div>
 <div class="app-list-item sources">

--- a/src/app/pages/apps/components/app-detail-view/app-available-info-card/app-available-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/app-detail-view/app-available-info-card/app-available-info-card.component.spec.ts
@@ -52,7 +52,7 @@ describe('AppAvailableInfoCardComponent', () => {
   });
 
   it('shows card details', () => {
-    expect(spectator.queryAll('.app-list-item')[0]).toHaveText('Version: 2023.5.3');
+    expect(spectator.queryAll('.app-list-item')[0]).toHaveText('Version: 1.0.9');
     expect(spectator.queryAll('.app-list-item')[1]).toHaveText('Source:github.com/home-assistant/home-assistant');
     expect(spectator.queryAll('.app-list-item')[2]).toHaveText('Last App Update: 05/15/2023');
 

--- a/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.html
+++ b/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.html
@@ -50,6 +50,14 @@
     }
   </div>
   <div class="app-list-item">
+    <span class="label">{{ 'Version' | translate }}:</span>
+    @if (isLoading()) {
+      <ngx-skeleton-loader></ngx-skeleton-loader>
+    } @else {
+      {{ app()?.latest_version | orNotAvailable }}
+    }
+  </div>
+  <div class="app-list-item">
     <span class="label">{{ 'Keywords' | translate }}:</span>
     @if (isLoading$ | async) {
       <ngx-skeleton-loader></ngx-skeleton-loader>

--- a/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.html
+++ b/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.html
@@ -51,10 +51,10 @@
   </div>
   <div class="app-list-item">
     <span class="label">{{ 'Version' | translate }}:</span>
-    @if (isLoading()) {
+    @if (isLoading$ | async) {
       <ngx-skeleton-loader></ngx-skeleton-loader>
     } @else {
-      {{ app()?.latest_version | orNotAvailable }}
+      {{ app?.latest_version | orNotAvailable }}
     }
   </div>
   <div class="app-list-item">

--- a/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.spec.ts
+++ b/src/app/pages/apps/components/app-detail-view/app-details-header/app-details-header.component.spec.ts
@@ -30,7 +30,8 @@ describe('AppDetailsHeaderComponent', () => {
   const application = {
     icon_url: 'http://github.com/truenas/icon.png',
     name: 'SETI@home',
-    latest_app_version: '1.0.0',
+    latest_app_version: '1.0.5',
+    latest_version: '1.0.0',
     tags: ['aliens', 'ufo'],
     train: 'stable',
     home: 'https://www.seti.org',
@@ -153,19 +154,23 @@ describe('AppDetailsHeaderComponent', () => {
 
     describe('other elements', () => {
       it('shows app version', () => {
-        expect(spectator.queryAll('.app-list-item')[0]).toHaveText('App Version: 1.0.0');
+        expect(spectator.queryAll('.app-list-item')[0]).toHaveText('App Version: 1.0.5');
+      });
+
+      it('shows version', () => {
+        expect(spectator.queryAll('.app-list-item')[1]).toHaveText('Version: 1.0.0');
       });
 
       it('shows app keywords', () => {
-        expect(spectator.queryAll('.app-list-item')[1]).toHaveText('Keywords: aliens, ufo');
+        expect(spectator.queryAll('.app-list-item')[2]).toHaveText('Keywords: aliens, ufo');
       });
 
       it('shows app train', () => {
-        expect(spectator.queryAll('.app-list-item')[2]).toHaveText('Train: stable');
+        expect(spectator.queryAll('.app-list-item')[3]).toHaveText('Train: stable');
       });
 
       it('shows app homepage', () => {
-        expect(spectator.queryAll('.app-list-item')[3]).toHaveText('Homepage:seti.org');
+        expect(spectator.queryAll('.app-list-item')[4]).toHaveText('Homepage:seti.org');
       });
 
       it('shows app description', () => {

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -53,7 +53,7 @@
           <div class="label">{{ 'Version' | translate }}:</div>
           <div class="value">
             @if (!isCustomApp()) {
-              {{ app()?.version | appVersion | orNotAvailable }}
+              {{ app()?.version | orNotAvailable }}
             }
           </div>
         </div>

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -49,6 +49,14 @@
             }
           </div>
         </div>
+        <div class="details-item">
+          <div class="label">{{ 'Version' | translate }}:</div>
+          <div class="value">
+            @if (!isCustomApp()) {
+              {{ app()?.version | appVersion | orNotAvailable }}
+            }
+          </div>
+        </div>
         <div class="details-item sources">
           <div class="label">{{ 'Source' | translate }}:</div>
           <div class="value">

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -137,7 +137,7 @@ describe('AppInfoCardComponent', () => {
       },
       {
         label: 'Version:',
-        value: 'v1.2.3',
+        value: '1.2.3',
       },
       {
         label: 'Source:',

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -35,13 +35,13 @@ describe('AppInfoCardComponent', () => {
     name: 'test-user-app-name',
     human_version: '1.2.3_3.2.1',
     upgrade_available: true,
+    version: '1.2.3',
     metadata: {
       name: 'ix-test-app',
       icon: '',
       sources: [
         'http://github.com/ix-test-app/ix-test-app/',
       ],
-      version: '1.2.3',
       app_version: '3.2.1',
       train: 'stable',
     },
@@ -134,6 +134,10 @@ describe('AppInfoCardComponent', () => {
       {
         label: 'App Version:',
         value: '3.2.1',
+      },
+      {
+        label: 'Version:',
+        value: 'v1.2.3',
       },
       {
         label: 'Source:',


### PR DESCRIPTION
Testing: see ticket.

I talked with @stavros-k about this and we agreed to have `App Version` and `Version` in some places together and in some places - only Version.

So, we should mainly show the version (which is our packaged app version).
The `app_version` should show as additional information in:
- the application info card
- the upgrade dialog
- the main app page (where you can see the "install button"

Original PR: https://github.com/truenas/webui/pull/10793
Jira URL: https://ixsystems.atlassian.net/browse/NAS-130834