### PR TITLE
NAS-131235 / 24.10.0 / Show number of threads (by bvasilenko)

### DIFF
--- a/src/app/pages/dashboard/widgets/cpu/widget-cpu/widget-cpu.component.html
+++ b/src/app/pages/dashboard/widgets/cpu/widget-cpu/widget-cpu.component.html
@@ -35,6 +35,16 @@
             </mat-list-item>
             <mat-list-item>
               <span class="label">
+                <strong>{{ 'Threads' | translate }}:</strong>
+              </span>
+              @if (!isLoading()) {
+                {{ '{threadCount, plural, one {# thread} other {# threads} }' | translate: { threadCount: threadCount() } }}
+              } @else {
+                <ngx-skeleton-loader class="skeleton"></ngx-skeleton-loader>
+              }
+            </mat-list-item>
+            <mat-list-item>
+              <span class="label">
                 <strong>{{ 'Highest Usage' | translate }}:</strong>
               </span>
               @if (!isLoading()) {

--- a/src/app/pages/dashboard/widgets/cpu/widget-cpu/widget-cpu.component.scss
+++ b/src/app/pages/dashboard/widgets/cpu/widget-cpu/widget-cpu.component.scss
@@ -65,6 +65,8 @@
 
       .mat-mdc-list-item {
         border-bottom: none !important;
+        height: 36px;
+        min-height: 36px;
       }
 
       .skeleton {

--- a/src/app/pages/dashboard/widgets/cpu/widget-cpu/widget-cpu.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/cpu/widget-cpu/widget-cpu.component.spec.ts
@@ -68,9 +68,10 @@ describe('WidgetCpuComponent', () => {
 
   it('shows cpu stats for the system', () => {
     const stats = spectator.queryAll('.cpu-data mat-list-item');
-    expect(stats).toHaveLength(3);
+    expect(stats).toHaveLength(4);
     expect(stats[0]).toHaveText('Cores: 2 cores');
-    expect(stats[1]).toHaveText('Highest Usage: 70% (Thread #2)');
-    expect(stats[2]).toHaveText('Hottest: 83°C (2 cores at 83°C)');
+    expect(stats[1]).toHaveText('Threads: 4 threads');
+    expect(stats[2]).toHaveText('Highest Usage: 70% (Thread #2)');
+    expect(stats[3]).toHaveText('Hottest: 83°C (2 cores at 83°C)');
   });
 });

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -4308,6 +4308,7 @@
   "{n, plural, one {# CPU} other {# CPUs}}": "",
   "{n, plural, one {# GPU} other {# GPUs}} isolated": "",
   "{nic} Address": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   " When the <b>UPS Mode</b> is set to <i>slave</i>. Enter the open network port number of the UPS <i>Master</i> system. The default port is <i>3493</i>.": " Pokud je <b>UPS mód</b> ve stavu <i>slave</i>. Vložte otevřený port UPS <i>Master</i> systému. Výchozí port je <i>3493</i>.",
   "% of all cores": "% ze všech jader",
   "(Remove pool from database)": "(Odstranit pool z databáze)",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3687,6 +3687,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -2858,6 +2858,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -4644,6 +4644,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -920,6 +920,7 @@
   "{rate} RPM": "",
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} | {vdevWidth} wide | ": "",
   "{usage}% (All Threads)": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -92,6 +92,7 @@
   "{n, plural, one {# core} other {# cores}}": "",
   "{nic} Address": "",
   "{service} Volume Mounts": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "\n              It looks like your session has been inactive for more than {lifetime} seconds.<br>\n              For security reasons we will log you out at {time}.\n            ": "\n              Tá an chuma ar an scéal go bhfuil do sheisiún neamhghníomhach le níos mó ná {saolré} soicind.<br> Ar chúiseanna slándála, déanfaimid tú a logáil amach ag {time}.\n            ",
   " Est. Usable Raw Capacity": " Est. Cumas Amh Inúsáidte",
   " When the <b>UPS Mode</b> is set to <i>slave</i>. Enter the open network port number of the UPS <i>Master</i> system. The default port is <i>3493</i>.": " Nuair a bheidh an <b>Mód UPS</b> socraithe chun <i>daor</i> . Cuir isteach uimhir chalafoirt líonra oscailte an chórais <i>Máistir</i> UPS. Is é <i>3493</i> an calafort réamhshocraithe.",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3673,6 +3673,7 @@
   "{tasks, plural, =1 {# receive task} other {# receive tasks}}": "",
   "{tasks, plural, =1 {# send task} other {# send tasks}}": "",
   "{temp}°C (Core #{core})": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} | {vdevWidth} wide | ": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -4550,6 +4550,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -4626,6 +4626,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -5035,6 +5035,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1251,6 +1251,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} widget does not support {size} size.": "",
   "{type} widget is not supported.": "",
   "{usage}% (All Threads)": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -4971,6 +4971,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -4992,6 +4992,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3141,6 +3141,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} widget does not support {size} size.": "",
   "{type} widget is not supported.": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -3291,6 +3291,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} widget does not support {size} size.": "",
   "{type} widget is not supported.": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1879,6 +1879,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} widget does not support {size} size.": "",
   "{type} widget is not supported.": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -5052,6 +5052,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -1334,6 +1334,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -4272,6 +4272,7 @@
   "{temp}°C (All Threads)": "",
   "{temp}°C (Core #{core})": "",
   "{temp}°C ({coreCount} cores at {temp}°C)": "",
+  "{threadCount, plural, one {# thread} other {# threads} }": "",
   "{type} VDEVs": "",
   "{type} at {location}": "",
   "{type} widget does not support {size} size.": "",


### PR DESCRIPTION
Backported

**Changes:**

Adds the ability to display the number of threads in the CPU widget on the dashboard.

**Testing:**

Check if the number of threads is displayed correctly


Original PR: https://github.com/truenas/webui/pull/10801
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131235