### PR TITLE
NAS-131550 / 25.04 / Add cache busting to icon sprite

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "cron-parser": "~4.9.0",
     "croner": "~8.1.1",
     "cronstrue": "~2.50.0",
+    "crypto": "~1.0.1",
     "d3": "~7.9.0",
     "date-fns": "~2.28.0",
     "date-fns-tz": "~1.3.8",

--- a/scripts/icon-sprite/make-sprite.ts
+++ b/scripts/icon-sprite/make-sprite.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import fs from 'fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -17,6 +18,7 @@ async function makeSprite(): Promise<void> {
 
     const srcDir = resolve(__dirname, '../../src');
     const targetPath = resolve(__dirname, '../../src/assets/icons/sprite.svg');
+    const configPath = resolve(__dirname, '../../src/assets/icons/sprite-config.json');
 
     const templateIcons = findIconsInTemplates(srcDir);
     const markerIcons = findIconsWithMarker(srcDir);
@@ -40,10 +42,15 @@ async function makeSprite(): Promise<void> {
 
     fs.writeFileSync(targetPath, buffer);
 
+    const hash = crypto.createHash('md5').update(buffer).digest('hex').slice(0, 10);
+    const versionedUrl = `assets/icons/sprite.svg?v=${hash}`;
+
+    fs.writeFileSync(configPath, JSON.stringify({ iconUrl: versionedUrl }, null, 2));
+
     console.info(`Generated icon sprite with ${allIcons.size} icons (${size.toFixed(2)} KiB).`);
-  } catch (error: unknown) {
-    console.error('Error when building the icon sprite:');
-    throw error;
+    console.info(`Versioned sprite URL: ${versionedUrl}`);
+  } catch (error) {
+    console.error('Error when building the icon sprite:', error);
   }
 }
 

--- a/scripts/icon-sprite/make-sprite.ts
+++ b/scripts/icon-sprite/make-sprite.ts
@@ -51,6 +51,7 @@ async function makeSprite(): Promise<void> {
     console.info(`Versioned sprite URL: ${versionedUrl}`);
   } catch (error) {
     console.error('Error when building the icon sprite:', error);
+    throw error;
   }
 }
 

--- a/src/app/modules/ix-icon/ix-icon-registry.service.ts
+++ b/src/app/modules/ix-icon/ix-icon-registry.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
+import iconConfig from 'app/../assets/icons/sprite-config.json';
 
 @Injectable({ providedIn: 'root' })
 export class IxIconRegistry extends MatIconRegistry {
@@ -16,6 +17,6 @@ export class IxIconRegistry extends MatIconRegistry {
   ) {
     super(httpClient, sanitizer, document, errorHandler);
 
-    this.addSvgIconSet(sanitizer.bypassSecurityTrustResourceUrl('assets/icons/sprite.svg'));
+    this.addSvgIconSet(sanitizer.bypassSecurityTrustResourceUrl(iconConfig.iconUrl));
   }
 }

--- a/src/assets/icons/sprite-config.json
+++ b/src/assets/icons/sprite-config.json
@@ -1,0 +1,3 @@
+{
+  "iconUrl": "assets/icons/sprite.svg?v=61e116a29b"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5278,6 +5278,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
+
 css-functions-list@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.2.1.tgz#2eb205d8ce9f9ce74c5c1d7490b66b77c45ce3ea"
@@ -11831,16 +11836,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11970,14 +11966,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13025,7 +13014,7 @@ winston@^3.0.0, winston@^3.11.0:
     triple-beam "^1.3.0"
     winston-transport "^4.7.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13038,15 +13027,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Testing:

See new `sprite-config.json` which holds latest sprite version's url.
The idea here is to update hash if there are any changes to the sprite itself. 
If nothing changed - hash will remain the same.

To see updated hashed url - try to add new/non-used icon somewhere in .html, like `<ix-icon name="mdi-rocket"></ix-icon>`

You will see that `sprite.svg` will be changed as well as hash (`sprite-config.json`).

<img width="512" alt="Screenshot 2024-10-07 at 12 50 14" src="https://github.com/user-attachments/assets/a20b552f-7ac6-48f3-b0bc-750956eb3e7d">

<img width="522" alt="Screenshot 2024-10-07 at 12 50 08" src="https://github.com/user-attachments/assets/4f5dce91-acf8-4bb6-9767-7f137fab644a">
