### PR TITLE
NAS-131636 / 25.04 / Loader is not closed when there are errors when stopping …

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
@@ -79,7 +79,7 @@
       [ixTest]="[app().name, 'restart']"
       [attr.aria-label]="'Restart App' | translate"
       [matTooltip]="'Restart App' | translate"
-      (click)="restart()"
+      (click)="restart(); $event.stopPropagation()"
     >
       <ix-icon name="mdi-restart"></ix-icon>
     </button>

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
@@ -29,7 +29,6 @@ export class AppRowComponent {
   protected readonly imagePlaceholder = appImagePlaceholder;
   protected readonly requiredRoles = [Role.AppsWrite];
 
-  readonly hasUpdates = computed(() => this.app().upgrade_available);
   readonly isAppStopped = computed(() => {
     return this.app().state === AppState.Stopped || this.app().state === AppState.Crashed;
   });

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -3411,7 +3411,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",
   "Static IPv4 address of the IPMI web interface.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2885,7 +2885,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",
   "Static IPv4 address of the IPMI web interface.": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -2229,7 +2229,6 @@
   "Start service": "",
   "Start session time": "",
   "Start {service} Service": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "Static Route": "",
   "Static Routes": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3738,7 +3738,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",
   "Static IPv4 address of the IPMI web interface.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -709,7 +709,6 @@
   "Specify custom": "",
   "Split": "",
   "Start service": "",
-  "Starting \"{app}\"": "",
   "Static Route": "",
   "Static Routing": "",
   "Step Back": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -82,7 +82,6 @@
   "Set password for TrueNAS administrative user:": "",
   "Specifies level of authentication and cryptographic protection. SYS or none should be used if no KDC is available. If a KDC is available, e.g. Active Directory, KRB5 is recommended. If desired KRB5I (integrity protection) and/or KRB5P (privacy protection) may be included with KRB5.": "",
   "Start service": "",
-  "Starting \"{app}\"": "",
   "Stop service": "",
   "Stopping \"{app}\"": "",
   "String of additional smb4.conf parameters not covered by the system's API.": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3541,7 +3541,6 @@
   "Specify whether to use the certificate for a Certificate Authority           and whether this extension is critical. Clients must recognize critical extensions           to prevent rejection. Web certificates typically require you to disable           CA and enable Critical Extension.": "",
   "Start a dry run test of this cloud sync task? The  system will connect to the cloud service provider and simulate  transferring a file. No data will be sent or received.": "",
   "Start service": "",
-  "Starting \"{app}\"": "",
   "Stop service": "",
   "Storj": "",
   "Storj iX": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3625,7 +3625,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",
   "Static IPv4 address of the IPMI web interface.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3637,7 +3637,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -4055,7 +4055,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -997,7 +997,6 @@
   "Start All Selected": "",
   "Start adding widgets to personalize it. Click on the \"Configure\" button to enter edit mode.": "",
   "Start service": "",
-  "Starting \"{app}\"": "",
   "Static Route": "",
   "Static Routing": "",
   "Step Back": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3983,7 +3983,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -4001,7 +4001,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2434,7 +2434,6 @@
   "Start session time": "",
   "Start time for the replication task.": "",
   "Start {service} Service": "",
-  "Starting \"{app}\"": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",
   "Static IPv4 address of the IPMI web interface.": "",
   "Static Route": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -2561,7 +2561,6 @@
   "Start service": "",
   "Start session time": "",
   "Start {service} Service": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",
   "Static Route": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1513,7 +1513,6 @@
   "Start Over": "",
   "Start adding widgets to personalize it. Click on the \"Configure\" button to enter edit mode.": "",
   "Start service": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "Static Route": "",
   "Static Routing": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -4061,7 +4061,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "State": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -1047,7 +1047,6 @@
   "Start All Selected": "",
   "Start adding widgets to personalize it. Click on the \"Configure\" button to enter edit mode.": "",
   "Start service": "",
-  "Starting \"{app}\"": "",
   "Static Route": "",
   "Static Routing": "",
   "Step Back": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -3398,7 +3398,6 @@
   "Start {service} Service": "",
   "Started": "",
   "Starting": "",
-  "Starting \"{app}\"": "",
   "Starting task": "",
   "Static IP addresses which SMB listens on for connections.  Leaving all unselected defaults to listening on all active interfaces.": "",
   "Static IPv4 address of the IPMI web interface.": "",


### PR DESCRIPTION
When I created an app with the following yaml:
```
version: '3.8'
services:
  nginx:
    image: nginx:1-alpine
    ports:
      - 8089:80
    volumes:
      - ./html5up-stellar/:/usr/share/nginx/html
```
I couldn't afterwards stop it and loader won't disappear.
If this yaml doens't work for you, you can just add throws manually.


Known issue: starting an app may flash Crashed status. This will be fixed by middleware.
