### PR TITLE
NAS-131636 / 24.10.0 / Loader is not closed when there are errors when stopping … (by undsoft)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.ts
@@ -30,7 +30,6 @@ export class AppRowComponent {
   protected readonly imagePlaceholder = appImagePlaceholder;
   protected readonly requiredRoles = [Role.AppsWrite];
 
-  readonly hasUpdates = computed(() => this.app().upgrade_available);
   readonly isAppStopped = computed(() => {
     return this.app().state === CatalogAppState.Stopped || this.app().state === CatalogAppState.Crashed;
   });

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.ts
@@ -19,14 +19,12 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  combineLatest, filter,
+  combineLatest, filter, finalize,
   Observable,
 } from 'rxjs';
 import { CatalogAppState } from 'app/enums/catalog-app-state.enum';
 import { EmptyType } from 'app/enums/empty-type.enum';
-import { JobState } from 'app/enums/job-state.enum';
 import { Role } from 'app/enums/role.enum';
-import { tapOnce } from 'app/helpers/operators/tap-once.operator';
 import { WINDOW } from 'app/helpers/window.helper';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { App, AppStartQueryParams, AppStats } from 'app/interfaces/app.interface';
@@ -326,19 +324,19 @@ export class InstalledAppsComponent implements OnInit, AfterViewInit {
   }
 
   stop(name: string): void {
+    this.loader.open(this.translate.instant('Stopping "{app}"', { app: name }));
     this.appService.stopApplication(name)
       .pipe(
-        tapOnce(() => this.loader.open(this.translate.instant('Stopping "{app}"', { app: name }))),
+        finalize(() => this.loader.close()),
         this.errorHandler.catchError(),
         untilDestroyed(this),
       )
-      .subscribe((job: Job<void, AppStartQueryParams>) => {
-        if (job.state !== JobState.Running) {
-          this.loader.close();
-        }
-        this.appJobs.set(name, job);
-        this.sortChanged(this.sortingInfo);
-        this.cdr.markForCheck();
+      .subscribe({
+        next: (job: Job<void, AppStartQueryParams>) => {
+          this.appJobs.set(name, job);
+          this.sortChanged(this.sortingInfo);
+          this.cdr.markForCheck();
+        },
       });
   }
 

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -2384,7 +2384,6 @@
   "Theme": "",
   "There are no alerts.": "",
   "There are no records to show.": "",
-  "There are no tasks.": "",
   "There are {sessions} active iSCSI connections.": "",
   "These IP Addresses were removed: {uniqueIPs}. The listed services will be changed to listen on 0.0.0.0: {affectedServices}": "",
   "These disks do not support S.M.A.R.T. tests:": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -65,6 +65,7 @@
   "Refresh Catalog": "",
   "Remove iX Volumes": "",
   "Restoring backup": "",
+  "Running Jobs": "",
   "SAVE": "",
   "Select the level of severity. Alert notifications send for all warnings matching and above the selected level. For example, a warning level set to Critical triggers notifications for Critical, Alert, and Emergency level warnings.": "",
   "Specifies level of authentication and cryptographic protection. SYS or none should be used if no KDC is available. If a KDC is available, e.g. Active Directory, KRB5 is recommended. If desired KRB5I (integrity protection) and/or KRB5P (privacy protection) may be included with KRB5.": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 0d16e59303e50bd74216f5655c0b4817a901c729

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x f838c9c53f95873291f2d32a3049a1ccd9514b94

When I created an app with the following yaml:
```
version: '3.8'
services:
  nginx:
    image: nginx:1-alpine
    ports:
      - 8089:80
    volumes:
      - ./html5up-stellar/:/usr/share/nginx/html
```
I couldn't afterwards stop it and loader won't disappear.
If this yaml doens't work for you, you can just add throws manually.


Known issue: starting an app may flash Crashed status. This will be fixed by middleware.


Original PR: https://github.com/truenas/webui/pull/10816
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131636