### PR TITLE
NAS-128601 / 25.04 / Fixes the process to assign GPUs to VMs when creating or editing

### DIFF
--- a/src/app/helpers/operators/options.operators.ts
+++ b/src/app/helpers/operators/options.operators.ts
@@ -8,9 +8,11 @@ import { MapOption, Option } from 'app/interfaces/option.interface';
  * Convert choices to options
  * @returns Option[]
  */
-export function choicesToOptions(): OperatorFunction<Choices, Option[]> {
+export function choicesToOptions(reverseValueAndLabels = false): OperatorFunction<Choices, Option[]> {
   return map((choices) => {
-    return Object.entries(choices).map(([value, label]) => ({ label, value }));
+    return Object.entries(choices).map(
+      ([value, label]) => (reverseValueAndLabels ? ({ label: value, value: label }) : ({ label, value })),
+    );
   });
 }
 

--- a/src/app/helpers/operators/options.operators.ts
+++ b/src/app/helpers/operators/options.operators.ts
@@ -8,10 +8,10 @@ import { MapOption, Option } from 'app/interfaces/option.interface';
  * Convert choices to options
  * @returns Option[]
  */
-export function choicesToOptions(reverseValueAndLabels = false): OperatorFunction<Choices, Option[]> {
+export function choicesToOptions(): OperatorFunction<Choices, Option[]> {
   return map((choices) => {
     return Object.entries(choices).map(
-      ([value, label]) => (reverseValueAndLabels ? ({ label: value, value: label }) : ({ label, value })),
+      ([value, label]) => ({ label, value }),
     );
   });
 }

--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -879,6 +879,7 @@ export interface ApiCallDirectory {
   'vm.device.delete': { params: [number, VmDeviceDelete?]; response: boolean };
   'vm.device.disk_choices': { params: void; response: Choices };
   'vm.device.get_pci_ids_for_gpu_isolation': { params: [string]; response: string[] };
+  'system.advanced.get_gpu_pci_choices': { params: void; response: Choices };
   'vm.device.nic_attach_choices': { params: void; response: Choices };
   'vm.device.passthrough_device_choices': { params: void; response: Record<string, VmPassthroughDeviceChoice> };
   'vm.device.query': { params: QueryParams<VmDevice>; response: VmDevice[] };

--- a/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.spec.ts
+++ b/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.spec.ts
@@ -43,6 +43,10 @@ describe('IsolatedGpuPcisFormComponent', () => {
       }),
       mockWebSocket([
         mockCall('system.advanced.update_gpu_pci_ids'),
+        mockCall('system.advanced.get_gpu_pci_choices', {
+          'Fake HD Graphics [0000:00:01.0]': '0000:00:01.0',
+          'Intel Corporation HD Graphics 510 [0000:00:02.0]': '0000:00:02.0',
+        }),
       ]),
       mockProvider(SystemGeneralService),
       mockProvider(IxChainedSlideInService, {
@@ -76,14 +80,14 @@ describe('IsolatedGpuPcisFormComponent', () => {
     const values = await form.getValues();
 
     expect(values).toEqual({
-      GPUs: ['Intel Corporation HD Graphics 510'],
+      GPUs: ['Intel Corporation HD Graphics 510 [0000:00:02.0]'],
     });
   });
 
   it('saves updated settings when Save is pressed', async () => {
     const form = await loader.getHarness(IxFormHarness);
     await form.fillForm({
-      GPUs: 'Fake HD Graphics',
+      GPUs: 'Fake HD Graphics [0000:00:01.0]',
     });
 
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));

--- a/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
+++ b/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
@@ -7,10 +7,9 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { take } from 'rxjs';
+import { map, take } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
-import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
@@ -56,7 +55,11 @@ export class IsolatedGpusFormComponent implements OnInit {
       asyncValidators: [this.gpuValidator.validateGpu],
     }),
   });
-  readonly options$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(choicesToOptions(true));
+  readonly options$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(map((choices) => {
+    return Object.entries(choices).map(
+      ([value, label]) => ({ value: label, label: value }),
+    );
+  }));
 
   constructor(
     protected ws: WebSocketService,

--- a/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
+++ b/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
@@ -18,7 +18,6 @@ import { IxModalHeader2Component } from 'app/modules/forms/ix-forms/components/i
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { TestDirective } from 'app/modules/test-id/test.directive';
-import { GpuService } from 'app/services/gpu/gpu.service';
 import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-validator.service';
 import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
@@ -68,7 +67,6 @@ export class IsolatedGpusFormComponent implements OnInit {
     private cdr: ChangeDetectorRef,
     private store$: Store<AppState>,
     private gpuValidator: IsolatedGpuValidatorService,
-    private gpuService: GpuService,
     private snackbar: SnackbarService,
     private chainedRef: ChainedRef<unknown>,
   ) { }

--- a/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
+++ b/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
@@ -10,6 +10,7 @@ import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { take } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
+import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
@@ -55,7 +56,7 @@ export class IsolatedGpusFormComponent implements OnInit {
       asyncValidators: [this.gpuValidator.validateGpu],
     }),
   });
-  readonly options$ = this.gpuService.getGpuOptions();
+  readonly options$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(choicesToOptions(true));
 
   constructor(
     protected ws: WebSocketService,

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
@@ -171,7 +171,7 @@ describe('VmEditFormComponent', () => {
 
       'Hide from MSR': false,
       'Ensure Display Device': true,
-      GPUs: ['GeForce'],
+      GPUs: ['GeForce [0000:02:00.0]'],
     });
   });
 
@@ -249,7 +249,7 @@ describe('VmEditFormComponent', () => {
 
   it('updates GPU devices when form is edited and saved', async () => {
     await form.fillForm({
-      GPUs: ['Intel Arc'],
+      GPUs: ['Intel Arc [0000:03:00.0]'],
     });
 
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
@@ -92,6 +92,7 @@ describe('VmEditFormComponent', () => {
           { label: 'GeForce', value: '0000:02:00.0' },
           { label: 'Intel Arc', value: '0000:03:00.0' },
         ])),
+        addIsolatedGpuPciIds: jest.fn(() => of({})),
         getIsolatedGpuPciIds: jest.fn(() => of([
           '0000:02:00.0',
         ])),
@@ -257,9 +258,8 @@ describe('VmEditFormComponent', () => {
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
-    expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith(
-      'system.advanced.update_gpu_pci_ids',
-      [['0000:02:00.0', '0000:03:00.0']],
+    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(
+      ['0000:03:00.0'],
     );
     expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith(existingVm, ['0000:03:00.0']);
   });

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
@@ -89,8 +89,8 @@ describe('VmEditFormComponent', () => {
       mockProvider(DialogService),
       mockProvider(GpuService, {
         getGpuOptions: jest.fn(() => of([
-          { label: 'GeForce', value: '0000:02:00.0' },
-          { label: 'Intel Arc', value: '0000:03:00.0' },
+          { label: 'GeForce [0000:02:00.0]', value: '0000:02:00.0' },
+          { label: 'Intel Arc [0000:03:00.0]', value: '0000:03:00.0' },
         ])),
         addIsolatedGpuPciIds: jest.fn(() => of({})),
         getIsolatedGpuPciIds: jest.fn(() => of([

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
@@ -88,11 +88,14 @@ describe('VmEditFormComponent', () => {
       mockAuth(),
       mockProvider(DialogService),
       mockProvider(GpuService, {
-        getGpuOptions: () => of([
+        getGpuOptions: jest.fn(() => of([
           { label: 'GeForce', value: '0000:02:00.0' },
           { label: 'Intel Arc', value: '0000:03:00.0' },
-        ]),
-        getAllGpus: () => of([
+        ])),
+        getIsolatedGpuPciIds: jest.fn(() => of([
+          '0000:02:00.0',
+        ])),
+        getAllGpus: jest.fn(() => of([
           {
             addr: {
               pci_slot: '0000:02:00.0',
@@ -117,8 +120,7 @@ describe('VmEditFormComponent', () => {
               },
             ],
           },
-        ]),
-        addIsolatedGpuPciIds: jest.fn(() => of(undefined)),
+        ])),
       }),
       mockProvider(VmGpuService, {
         updateVmGpus: jest.fn(() => of(undefined)),
@@ -255,7 +257,10 @@ describe('VmEditFormComponent', () => {
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
+    expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith(
+      'system.advanced.update_gpu_pci_ids',
+      [['0000:02:00.0', '0000:03:00.0']],
+    );
     expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith(existingVm, ['0000:03:00.0']);
-    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0']);
   });
 });

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
@@ -79,6 +79,11 @@ describe('VmEditFormComponent', () => {
         }),
         mockCall('vm.update'),
         mockCall('vm.device.get_pci_ids_for_gpu_isolation', ['10DE:1401']),
+        mockCall('system.advanced.update_gpu_pci_ids'),
+        mockCall('system.advanced.get_gpu_pci_choices', {
+          'GeForce [0000:02:00.0]': '0000:02:00.0',
+          'Intel Arc [0000:03:00.0]': '0000:03:00.0',
+        }),
       ]),
       mockAuth(),
       mockProvider(DialogService),
@@ -250,7 +255,7 @@ describe('VmEditFormComponent', () => {
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
-    expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith(existingVm, ['0000:03:00.0', '10DE:1401']);
-    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0', '10DE:1401']);
+    expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith(existingVm, ['0000:03:00.0']);
+    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0']);
   });
 });

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
@@ -9,7 +9,6 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
   Observable, forkJoin, map, of, switchMap,
-  take,
   tap,
 } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
@@ -178,12 +177,7 @@ export class VmEditFormComponent implements OnInit {
     let updateVmRequest$: Observable<unknown>;
 
     if (gpusIds.length) {
-      updateVmRequest$ = this.gpuService.getIsolatedGpuPciIds().pipe(
-        take(1),
-        switchMap((isolatedPciIds) => {
-          const gpuPciIds = new Set([...isolatedPciIds, ...gpusIds]);
-          return this.ws.call('system.advanced.update_gpu_pci_ids', [Array.from(gpuPciIds)]);
-        }),
+      updateVmRequest$ = this.gpuService.addIsolatedGpuPciIds(gpusIds).pipe(
         switchMap(() => forkJoin([
           this.ws.call('vm.update', [this.existingVm.id, vmPayload as VirtualMachineUpdate]),
           this.vmGpuService.updateVmGpus(this.existingVm, gpusIds),

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
@@ -8,7 +8,7 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  Observable, forkJoin, of, switchMap,
+  Observable, forkJoin, map, of, switchMap,
   tap,
 } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
@@ -106,7 +106,11 @@ export class VmEditFormComponent implements OnInit {
   cpuModeOptions$ = of(mapToOptions(vmCpuModeLabels, this.translate));
   cpuModelOptions$ = this.ws.call('vm.cpu_model_choices').pipe(choicesToOptions());
   gpuOptions$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(
-    choicesToOptions(true),
+    map((choices) => {
+      return Object.entries(choices).map(
+        ([value, label]) => ({ value: label, label: value }),
+      );
+    }),
     tap((options) => this.gpuOptions.set(options)),
   );
 

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
@@ -8,7 +8,7 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  Observable, forkJoin, map, of, switchMap,
+  Observable, forkJoin, of, switchMap,
   tap,
 } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
@@ -105,7 +105,10 @@ export class VmEditFormComponent implements OnInit {
   bootloaderOptions$ = this.ws.call('vm.bootloader_options').pipe(choicesToOptions());
   cpuModeOptions$ = of(mapToOptions(vmCpuModeLabels, this.translate));
   cpuModelOptions$ = this.ws.call('vm.cpu_model_choices').pipe(choicesToOptions());
-  gpuOptions$ = this.gpuService.getGpuOptions().pipe(tap((options) => this.gpuOptions.set(options)));
+  gpuOptions$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(
+    choicesToOptions(true),
+    tap((options) => this.gpuOptions.set(options)),
+  );
 
   readonly helptext = helptextVmWizard;
 
@@ -171,26 +174,10 @@ export class VmEditFormComponent implements OnInit {
 
     if (gpusIds.length) {
       updateVmRequest$ = this.ws.call('system.advanced.update_gpu_pci_ids', [gpusIds]).pipe(
-        switchMap(() => this.ws.call('system.advanced.get_gpu_pci_choices')),
-        map((choices) => {
-          const pciIds: string[] = [];
-          const gpuOptions = this.gpuOptions();
-          const selectedGpusDesc: string[] = gpuOptions.filter(
-            (gpuOption) => gpusIds.includes(gpuOption.value.toString()),
-          ).map(
-            (option) => `${option.label} [${option.value}]`,
-          );
-
-          for (const selectedGpuDesc of selectedGpusDesc) {
-            pciIds.push(choices[selectedGpuDesc]);
-          }
-
-          return pciIds.flat();
-        }),
-        switchMap((pciIds) => forkJoin([
+        switchMap(() => forkJoin([
           this.ws.call('vm.update', [this.existingVm.id, vmPayload as VirtualMachineUpdate]),
-          this.vmGpuService.updateVmGpus(this.existingVm, pciIds),
-          this.gpuService.addIsolatedGpuPciIds(pciIds),
+          this.vmGpuService.updateVmGpus(this.existingVm, gpusIds),
+          this.gpuService.addIsolatedGpuPciIds(gpusIds),
         ])),
       );
     } else {

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
@@ -1,6 +1,5 @@
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit,
-  signal,
 } from '@angular/core';
 import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
@@ -8,8 +7,7 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  Observable, forkJoin, map, of, switchMap,
-  tap,
+  Observable, forkJoin, of, switchMap,
 } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
@@ -20,7 +18,6 @@ import {
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
-import { Option } from 'app/interfaces/option.interface';
 import { VirtualMachine, VirtualMachineUpdate } from 'app/interfaces/virtual-machine.interface';
 import { VmPciPassthroughDevice } from 'app/interfaces/vm-device.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -99,20 +96,12 @@ export class VmEditFormComponent implements OnInit {
     gpus: [[] as string[], [], [this.gpuValidator.validateGpu]],
   });
 
-  private readonly gpuOptions = signal<Option[]>([]);
   isLoading = false;
   timeOptions$ = of(mapToOptions(vmTimeNames, this.translate));
   bootloaderOptions$ = this.ws.call('vm.bootloader_options').pipe(choicesToOptions());
   cpuModeOptions$ = of(mapToOptions(vmCpuModeLabels, this.translate));
   cpuModelOptions$ = this.ws.call('vm.cpu_model_choices').pipe(choicesToOptions());
-  gpuOptions$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(
-    map((choices) => {
-      return Object.entries(choices).map(
-        ([value, label]) => ({ value: label, label: value }),
-      );
-    }),
-    tap((options) => this.gpuOptions.set(options)),
-  );
+  gpuOptions$ = this.gpuService.getGpuOptions();
 
   readonly helptext = helptextVmWizard;
 

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.spec.ts
@@ -4,6 +4,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
+import { mockCall, mockWebSocket } from 'app/core/testing/utils/mock-websocket.utils';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { GpuStepComponent } from 'app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component';
 import { GpuService } from 'app/services/gpu/gpu.service';
@@ -30,6 +31,12 @@ describe('GpuStepComponent', () => {
       mockProvider(IsolatedGpuValidatorService, {
         validateGpu: () => of(null),
       }),
+      mockWebSocket([
+        mockCall('system.advanced.get_gpu_pci_choices', {
+          'GeForce GTX 1080 [0000:03:00.0]': '0000:03:00.0',
+          'GeForce GTX 1080 Ti [0000:04:00.0]': '0000:04:00.0',
+        }),
+      ]),
     ],
   });
 
@@ -43,7 +50,7 @@ describe('GpuStepComponent', () => {
     await form.fillForm({
       'Hide from MSR': true,
       'Ensure Display Device': true,
-      GPUs: ['GeForce GTX 1080 Ti'],
+      GPUs: ['GeForce GTX 1080 Ti [0000:04:00.0]'],
     });
   }
 

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.spec.ts
@@ -24,8 +24,8 @@ describe('GpuStepComponent', () => {
       CdkStepper,
       mockProvider(GpuService, {
         getGpuOptions: () => of([
-          { label: 'GeForce GTX 1080', value: '0000:03:00.0' },
-          { label: 'GeForce GTX 1080 Ti', value: '0000:04:00.0' },
+          { label: 'GeForce GTX 1080 [0000:03:00.0]', value: '0000:03:00.0' },
+          { label: 'GeForce GTX 1080 Ti [0000:04:00.0]', value: '0000:04:00.0' },
         ]),
       }),
       mockProvider(IsolatedGpuValidatorService, {

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
@@ -5,15 +5,14 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { map } from 'rxjs';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import { SummaryProvider, SummarySection } from 'app/modules/summary/summary.interface';
 import { TestDirective } from 'app/modules/test-id/test.directive';
+import { GpuService } from 'app/services/gpu/gpu.service';
 import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-validator.service';
-import { WebSocketService } from 'app/services/ws.service';
 
 @Component({
   selector: 'ix-gpu-step',
@@ -42,19 +41,13 @@ export class GpuStepComponent implements SummaryProvider {
   });
 
   readonly helptext = helptextVmWizard;
-  readonly gpuOptions$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(
-    map((choices) => {
-      return Object.entries(choices).map(
-        ([value, label]) => ({ value: label, label: value }),
-      );
-    }),
-  );
+  readonly gpuOptions$ = this.gpuService.getGpuOptions();
 
   constructor(
     private formBuilder: FormBuilder,
     private gpuValidator: IsolatedGpuValidatorService,
     private translate: TranslateService,
-    private ws: WebSocketService,
+    private gpuService: GpuService,
   ) {}
 
   getSummary(): SummarySection {

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
@@ -5,7 +5,7 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { choicesToOptions } from 'app/helpers/operators/options.operators';
+import { map } from 'rxjs';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -42,7 +42,13 @@ export class GpuStepComponent implements SummaryProvider {
   });
 
   readonly helptext = helptextVmWizard;
-  readonly gpuOptions$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(choicesToOptions(true));
+  readonly gpuOptions$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(
+    map((choices) => {
+      return Object.entries(choices).map(
+        ([value, label]) => ({ value: label, label: value }),
+      );
+    }),
+  );
 
   constructor(
     private formBuilder: FormBuilder,

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
@@ -5,14 +5,15 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
+import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import { SummaryProvider, SummarySection } from 'app/modules/summary/summary.interface';
 import { TestDirective } from 'app/modules/test-id/test.directive';
-import { GpuService } from 'app/services/gpu/gpu.service';
 import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-validator.service';
+import { WebSocketService } from 'app/services/ws.service';
 
 @Component({
   selector: 'ix-gpu-step',
@@ -41,13 +42,13 @@ export class GpuStepComponent implements SummaryProvider {
   });
 
   readonly helptext = helptextVmWizard;
-  readonly gpuOptions$ = this.gpuService.getGpuOptions();
+  readonly gpuOptions$ = this.ws.call('system.advanced.get_gpu_pci_choices').pipe(choicesToOptions(true));
 
   constructor(
     private formBuilder: FormBuilder,
     private gpuValidator: IsolatedGpuValidatorService,
-    private gpuService: GpuService,
     private translate: TranslateService,
+    private ws: WebSocketService,
   ) {}
 
   getSummary(): SummarySection {

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
@@ -94,6 +94,10 @@ describe('VmWizardComponent', () => {
           eno2: 'eno2',
         }),
         mockCall('vm.device.get_pci_ids_for_gpu_isolation', ['10DE:1401']),
+        mockCall('system.advanced.update_gpu_pci_ids'),
+        mockCall('system.advanced.get_gpu_pci_choices', {
+          'GeForce GTX 1080 [0000:03:00.0]': '0000:03:00.0',
+        }),
       ]),
       mockProvider(GpuService, {
         getGpuOptions: () => of([
@@ -319,8 +323,8 @@ describe('VmWizardComponent', () => {
         web: true,
       },
     }]);
-    expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith({ id: 4 }, ['0000:03:00.0', '10DE:1401']);
-    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0', '10DE:1401']);
+    expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith({ id: 4 }, ['0000:03:00.0']);
+    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0']);
     expect(spectator.inject(IxSlideInRef).close).toHaveBeenCalled();
   });
 });

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
@@ -97,13 +97,16 @@ describe('VmWizardComponent', () => {
         mockCall('system.advanced.update_gpu_pci_ids'),
         mockCall('system.advanced.get_gpu_pci_choices', {
           'GeForce GTX 1080 [0000:03:00.0]': '0000:03:00.0',
+          'GeForce GTX 1070 [0000:02:00.0]': '0000:02:00.0',
         }),
       ]),
       mockProvider(GpuService, {
         getGpuOptions: () => of([
           { label: 'GeForce GTX 1080', value: '0000:03:00.0' },
         ]),
-        addIsolatedGpuPciIds: jest.fn(() => of(undefined)),
+        getIsolatedGpuPciIds: jest.fn(() => of([
+          '0000:02:00.0',
+        ])),
       }),
       mockProvider(FilesystemService, {
         getFilesystemNodeProvider: jest.fn(),
@@ -323,8 +326,11 @@ describe('VmWizardComponent', () => {
         web: true,
       },
     }]);
+    expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith(
+      'system.advanced.update_gpu_pci_ids',
+      [['0000:02:00.0', '0000:03:00.0']],
+    );
     expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith({ id: 4 }, ['0000:03:00.0']);
-    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(['0000:03:00.0']);
     expect(spectator.inject(IxSlideInRef).close).toHaveBeenCalled();
   });
 });

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
@@ -102,7 +102,8 @@ describe('VmWizardComponent', () => {
       ]),
       mockProvider(GpuService, {
         getGpuOptions: () => of([
-          { label: 'GeForce GTX 1080', value: '0000:03:00.0' },
+          { label: 'GeForce GTX 1080 [0000:03:00.0]', value: '0000:03:00.0' },
+          { label: 'GeForce GTX 1070 [0000:02:00.0]', value: '0000:02:00.0' },
         ]),
         addIsolatedGpuPciIds: jest.fn(() => of({})),
         getIsolatedGpuPciIds: jest.fn(() => of([

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
@@ -104,6 +104,7 @@ describe('VmWizardComponent', () => {
         getGpuOptions: () => of([
           { label: 'GeForce GTX 1080', value: '0000:03:00.0' },
         ]),
+        addIsolatedGpuPciIds: jest.fn(() => of({})),
         getIsolatedGpuPciIds: jest.fn(() => of([
           '0000:02:00.0',
         ])),
@@ -326,9 +327,8 @@ describe('VmWizardComponent', () => {
         web: true,
       },
     }]);
-    expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith(
-      'system.advanced.update_gpu_pci_ids',
-      [['0000:02:00.0', '0000:03:00.0']],
+    expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(
+      ['0000:03:00.0'],
     );
     expect(spectator.inject(VmGpuService).updateVmGpus).toHaveBeenCalledWith({ id: 4 }, ['0000:03:00.0']);
     expect(spectator.inject(IxSlideInRef).close).toHaveBeenCalled();

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
@@ -169,7 +169,7 @@ describe('VmWizardComponent', () => {
     await updateStepHarnesses();
 
     await form.fillForm({
-      GPUs: ['GeForce GTX 1080'],
+      GPUs: ['GeForce GTX 1080 [0000:03:00.0]'],
     });
     await nextButton.click();
   }

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -310,10 +310,12 @@ export class VmWizardComponent implements OnInit {
       }),
     ).pipe(
       defaultIfEmpty([]),
-      switchMap((pciIds) => forkJoin([
-        this.vmGpuService.updateVmGpus(vm, gpusIds.concat(pciIds)),
-        this.gpuService.addIsolatedGpuPciIds(gpusIds.concat(pciIds)),
-      ])),
+      switchMap((pciIds) => {
+        return forkJoin([
+          this.vmGpuService.updateVmGpus(vm, pciIds),
+          this.gpuService.addIsolatedGpuPciIds(pciIds),
+        ]);
+      }),
     );
   }
 

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -12,7 +12,7 @@ import { pick } from 'lodash-es';
 import {
   forkJoin, Observable, of, switchMap,
 } from 'rxjs';
-import { catchError, defaultIfEmpty, take } from 'rxjs/operators';
+import { catchError, defaultIfEmpty } from 'rxjs/operators';
 import { GiB, MiB } from 'app/constants/bytes.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
@@ -285,12 +285,7 @@ export class VmWizardComponent implements OnInit {
   private getGpuRequests(vm: VirtualMachine): Observable<unknown> {
     const gpusIds = this.gpuForm.gpus as unknown as string[];
 
-    return this.gpuService.getIsolatedGpuPciIds().pipe(
-      take(1),
-      switchMap((isolatedPciIds) => {
-        const gpuPciIds = new Set([...isolatedPciIds, ...gpusIds]);
-        return this.ws.call('system.advanced.update_gpu_pci_ids', [Array.from(gpuPciIds)]);
-      }),
+    return this.gpuService.addIsolatedGpuPciIds(gpusIds).pipe(
       defaultIfEmpty([]),
       switchMap(() => this.vmGpuService.updateVmGpus(vm, gpusIds)),
     );

--- a/src/app/services/gpu/gpu-service.spec.ts
+++ b/src/app/services/gpu/gpu-service.spec.ts
@@ -1,4 +1,5 @@
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { Store } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
@@ -9,6 +10,7 @@ import { AdvancedConfig } from 'app/interfaces/advanced-config.interface';
 import { Device } from 'app/interfaces/device.interface';
 import { GpuService } from 'app/services/gpu/gpu.service';
 import { WebSocketService } from 'app/services/ws.service';
+import { advancedConfigUpdated } from 'app/store/system-config/system-config.actions';
 import { selectAdvancedConfig } from 'app/store/system-config/system-config.selectors';
 
 describe('GpuService', () => {
@@ -35,6 +37,10 @@ describe('GpuService', () => {
       mockWebSocket([
         mockCall('system.advanced.update_gpu_pci_ids'),
         mockCall('device.get_info', allGpus),
+        mockCall('system.advanced.get_gpu_pci_choices', {
+          'GeForce [0000:01:00.0]': '0000:01:00.0',
+          'Radeon [0000:02:00.0]': '0000:02:00.0',
+        }),
       ]),
       provideMockStore({
         selectors: [
@@ -65,10 +71,12 @@ describe('GpuService', () => {
 
   describe('getGpuOptions', () => {
     it('returns an observable with a list of options for GPU select', async () => {
+      const store$ = spectator.inject(Store);
+      jest.spyOn(store$, 'dispatch');
       const options = await firstValueFrom(spectator.service.getGpuOptions());
       expect(options).toEqual([
-        { label: 'GeForce', value: '0000:01:00.0' },
-        { label: 'Radeon', value: '0000:02:00.0' },
+        { label: 'GeForce [0000:01:00.0]', value: '0000:01:00.0' },
+        { label: 'Radeon [0000:02:00.0]', value: '0000:02:00.0' },
       ]);
     });
   });
@@ -94,12 +102,15 @@ describe('GpuService', () => {
 
   describe('addIsolatedGpuPciIds', () => {
     it('adds new ids of new isolated gpu devices in addition to ones that were previously isolated', async () => {
+      const store$ = spectator.inject(Store);
+      jest.spyOn(store$, 'dispatch');
       await firstValueFrom(spectator.service.addIsolatedGpuPciIds(['0000:01:00.0']));
 
       expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith(
         'system.advanced.update_gpu_pci_ids',
         [['0000:02:00.0', '0000:01:00.0']],
       );
+      expect(spectator.inject(Store).dispatch).toHaveBeenCalledWith(advancedConfigUpdated());
     });
 
     it('does nothing when new gpu has already been isolated', () => {

--- a/src/app/services/gpu/gpu.service.ts
+++ b/src/app/services/gpu/gpu.service.ts
@@ -41,12 +41,11 @@ export class GpuService {
   }
 
   getGpuOptions(): Observable<Option[]> {
-    return this.getAllGpus().pipe(
-      map((gpus) => {
-        return gpus.map((gpu) => ({
-          label: gpu.description,
-          value: gpu.addr.pci_slot,
-        }));
+    return this.ws.call('system.advanced.get_gpu_pci_choices').pipe(
+      map((choices) => {
+        return Object.entries(choices).map(
+          ([value, label]) => ({ value: label, label: value }),
+        );
       }),
     );
   }

--- a/src/app/services/gpu/gpu.service.ts
+++ b/src/app/services/gpu/gpu.service.ts
@@ -5,12 +5,14 @@ import {
 } from 'rxjs';
 import {
   map, shareReplay, switchMap, take,
+  tap,
 } from 'rxjs/operators';
 import { DeviceType } from 'app/enums/device-type.enum';
 import { Device } from 'app/interfaces/device.interface';
 import { Option } from 'app/interfaces/option.interface';
 import { WebSocketService } from 'app/services/ws.service';
 import { AppState } from 'app/store';
+import { advancedConfigUpdated } from 'app/store/system-config/system-config.actions';
 import { waitForAdvancedConfig } from 'app/store/system-config/system-config.selectors';
 
 @Injectable({
@@ -82,8 +84,11 @@ export class GpuService {
           return EMPTY;
         }
 
-        return this.ws.call('system.advanced.update_gpu_pci_ids', [Array.from(newIsolatedGpuIds)]);
+        return this.ws.call('system.advanced.update_gpu_pci_ids', [Array.from(newIsolatedGpuIds)]).pipe(
+          tap(() => this.store$.dispatch(advancedConfigUpdated())),
+        );
       }),
+
     );
   }
 }


### PR DESCRIPTION
**Changes:**

Uses new API end points and filtering process to get the right data to be passed to the middleware endpoints

**Testing:**

Create a VM with one or more GPUs.
Edit a VM by removing GPUs and changing them.

Test on the system mentioned in the ticket comments.
