### PR TITLE
NAS-131266 / 24.10.0 / Cancel button takes back to apps page (by RehanY147)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.spec.ts
@@ -1,11 +1,15 @@
+import { Location } from '@angular/common';
+import { fakeAsync } from '@angular/core/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
-import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
-import { MockComponent, MockModule } from 'ng-mocks';
+import {
+  Spectator, SpectatorFactory, createComponentFactory, mockProvider,
+} from '@ngneat/spectator/jest';
+import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { ToolbarSliderComponent } from 'app/modules/forms/toolbar-slider/toolbar-slider.component';
-import { PageHeaderModule } from 'app/modules/page-header/page-header.module';
+import { PageHeaderComponent } from 'app/modules/page-header/page-title-header/page-header.component';
 import { ContainerLogsComponent } from 'app/pages/apps/components/installed-apps/container-logs/container-logs.component';
 import { LogsDetailsDialogComponent } from 'app/pages/apps/components/logs-details-dialog/logs-details-dialog.component';
 import { WebSocketService } from 'app/services/ws.service';
@@ -13,65 +17,90 @@ import { WebSocketService } from 'app/services/ws.service';
 describe('ContainerLogsComponent', () => {
   let spectator: Spectator<ContainerLogsComponent>;
 
-  const createComponent = createComponentFactory({
-    component: ContainerLogsComponent,
-    imports: [
-      MockModule(PageHeaderModule),
-    ],
-    declarations: [
-      MockComponent(ToolbarSliderComponent),
-    ],
-    providers: [
-      mockProvider(MatDialog, {
-        open: jest.fn(() => ({
-          afterClosed: () => of({
-            tail_lines: 650,
-          } as LogsDetailsDialogComponent['form']['value']),
-        }) as unknown as MatDialogRef<LogsDetailsDialogComponent>),
-      }),
-      mockProvider(WebSocketService, {
-        subscribeToLogs: jest.fn(() => of({
-          fields: {
-            timestamp: '[12:34]',
-            data: 'Some logs.',
+  describe('When dialog is set a value', () => {
+    const createComponent = createComponentFactoryWithDialogResponse(false);
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('subscribes to logs updates', () => {
+      expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(LogsDetailsDialogComponent, { width: '400px' });
+
+      expect(spectator.inject(WebSocketService).subscribeToLogs).toHaveBeenCalledWith(
+        'app.container_log_follow: {"app_name":"ix-test-app","container_id":"ix-test-container","tail_lines":650}',
+      );
+    });
+
+    it('shows meta data', () => {
+      expect(spectator.queryAll('.meta-data .name').map((name) => name.textContent.trim())).toEqual([
+        'ix-test-app',
+        'ix-test-container',
+      ]);
+    });
+
+    it('shows logs', () => {
+      expect(spectator.queryAll('.log-row').map((name) => name.textContent.trim())).toEqual([
+        '[12:34]Some logs.',
+      ]);
+    });
+  });
+
+  describe('When cancel is clicked', () => {
+    const createComponent = createComponentFactoryWithDialogResponse(true);
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('cancelling the dialog should call back method', fakeAsync(() => {
+      expect(spectator.inject(Location).back).toHaveBeenCalled();
+    }));
+  });
+
+  function createComponentFactoryWithDialogResponse(cancel = false): SpectatorFactory<ContainerLogsComponent> {
+    return createComponentFactory({
+      component: ContainerLogsComponent,
+      imports: [
+        MockComponent(PageHeaderComponent),
+      ],
+      declarations: [
+        MockComponent(ToolbarSliderComponent),
+      ],
+      providers: [
+        mockProvider(Location),
+        mockProvider(MatDialog, {
+          open: jest.fn(() => ({
+            afterClosed: jest.fn(() => {
+              if (cancel) {
+                return of(false);
+              }
+
+              return of({
+                tail_lines: 650,
+              } as LogsDetailsDialogComponent['form']['value']);
+            }),
+          }) as unknown as MatDialogRef<LogsDetailsDialogComponent>),
+        }),
+        mockProvider(WebSocketService, {
+          subscribeToLogs: jest.fn(() => of({
+            fields: {
+              timestamp: '[12:34]',
+              data: 'Some logs.',
+            },
+          })),
+        }),
+        mockAuth(),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            parent: {
+              params: of({ appId: 'ix-test-app' }),
+            },
+            params: of({ containerId: 'ix-test-container' }),
           },
-        })),
-      }),
-      mockAuth(),
-      {
-        provide: ActivatedRoute,
-        useValue: {
-          parent: {
-            params: of({ appId: 'ix-test-app' }),
-          },
-          params: of({ containerId: 'ix-test-container' }),
         },
-      },
-    ],
-  });
-
-  beforeEach(() => {
-    spectator = createComponent();
-  });
-
-  it('subscribes to logs updates', () => {
-    expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(LogsDetailsDialogComponent, { width: '400px' });
-
-    expect(spectator.inject(WebSocketService).subscribeToLogs).toHaveBeenCalledWith(
-      'app.container_log_follow: {"app_name":"ix-test-app","container_id":"ix-test-container","tail_lines":650}',
-    );
-  });
-
-  it('shows meta data', () => {
-    expect(spectator.queryAll('.meta-data .name').map((name) => name.textContent.trim())).toEqual([
-      'ix-test-app',
-      'ix-test-container',
-    ]);
-  });
-
-  it('shows logs', () => {
-    expect(spectator.queryAll('.log-row').map((name) => name.textContent.trim())).toEqual([
-      '[12:34]Some logs.',
-    ]);
-  });
+      ],
+    });
+  }
 });

--- a/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
+++ b/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit, ViewChild,
 } from '@angular/core';
@@ -52,6 +53,7 @@ export class ContainerLogsComponent implements OnInit {
     protected download: DownloadService,
     private errorHandler: ErrorHandlerService,
     private matDialog: MatDialog,
+    private location: Location,
     private cdr: ChangeDetectorRef,
   ) {}
 
@@ -73,6 +75,11 @@ export class ContainerLogsComponent implements OnInit {
     }
 
     this.logsChangedListener = this.matDialog.open(LogsDetailsDialogComponent, { width: '400px' }).afterClosed().pipe(
+      tap((value: LogsDetailsDialogComponent['form']['value'] | boolean) => {
+        if (typeof value === 'boolean' && !value) {
+          this.location.back();
+        }
+      }),
       tap((details: LogsDetailsDialogComponent['form']['value']) => {
         this.subscriptionMethod = `app.container_log_follow: ${JSON.stringify({
           app_name: this.appName,

--- a/src/app/pages/apps/components/logs-details-dialog/logs-details-dialog.component.html
+++ b/src/app/pages/apps/components/logs-details-dialog/logs-details-dialog.component.html
@@ -12,8 +12,8 @@
     <button
       mat-button
       type="button"
-      matDialogClose
       ixTest="cancel"
+      [matDialogClose]="false"
     >
       {{ 'Cancel' | translate }}
     </button>

--- a/src/app/pages/apps/components/logs-details-dialog/logs-details-dialog.component.html
+++ b/src/app/pages/apps/components/logs-details-dialog/logs-details-dialog.component.html
@@ -15,7 +15,7 @@
       matDialogClose
       ixTest="cancel"
     >
-      {{ 'Cancel' | translate }}
+      {{ 'Default' | translate }}
     </button>
     <button
       mat-button
@@ -25,7 +25,7 @@
       [disabled]="form.invalid"
       [matDialogClose]="this.form.value"
     >
-      {{ 'Connect' | translate }}
+      {{ 'OK' | translate }}
     </button>
   </div>
 </form>

--- a/src/app/pages/apps/components/logs-details-dialog/logs-details-dialog.component.html
+++ b/src/app/pages/apps/components/logs-details-dialog/logs-details-dialog.component.html
@@ -15,7 +15,7 @@
       matDialogClose
       ixTest="cancel"
     >
-      {{ 'Default' | translate }}
+      {{ 'Cancel' | translate }}
     </button>
     <button
       mat-button
@@ -25,7 +25,7 @@
       [disabled]="form.invalid"
       [matDialogClose]="this.form.value"
     >
-      {{ 'OK' | translate }}
+      {{ 'Connect' | translate }}
     </button>
   </div>
 </form>


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x b0245879aff71644c50ace0a1a140471c84646b4
    git cherry-pick -x 83fab9993c5280c29ee9b88de1a068c86b5fef44

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~3
    git cherry-pick -x 3c418ee48844ebe5c4237e0366ebde0e83fef341

**Changes:**

When view button for container logs for an app is clicked, user is taken to show container logs. The cancel button previously didn't take them back to the apps page. Now it does.

**Testing:**

See ticket description for testing.


Original PR: https://github.com/truenas/webui/pull/10802
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131266