### PR TITLE
NAS-130571 / 25.04 / Impossible to set dialog width

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.spec.ts
@@ -125,7 +125,7 @@ describe('AppContainersCardComponent', () => {
 
     expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(VolumeMountsDialogComponent, {
       data: app.active_workloads.container_details[0],
-      minWidth: '40vw',
+      minWidth: '60vw',
     });
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.spec.ts
@@ -125,6 +125,7 @@ describe('AppContainersCardComponent', () => {
 
     expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(VolumeMountsDialogComponent, {
       data: app.active_workloads.container_details[0],
+      minWidth: '40vw',
     });
   });
 

--- a/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.ts
@@ -58,7 +58,7 @@ export class AppWorkloadsCardComponent {
 
   volumeButtonPressed(containerDetails: AppContainerDetails): void {
     this.matDialog.open(VolumeMountsDialogComponent, {
-      minWidth: '40vw',
+      minWidth: '60vw',
       data: containerDetails,
     });
   }

--- a/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.ts
@@ -58,6 +58,7 @@ export class AppWorkloadsCardComponent {
 
   volumeButtonPressed(containerDetails: AppContainerDetails): void {
     this.matDialog.open(VolumeMountsDialogComponent, {
+      minWidth: '40vw',
       data: containerDetails,
     });
   }

--- a/src/app/pages/apps/components/installed-apps/app-workloads-card/volume-mounts-dialog/volume-mounts-dialog.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-workloads-card/volume-mounts-dialog/volume-mounts-dialog.component.scss
@@ -21,7 +21,6 @@
 
   th,
   td {
-    max-width: 20vw;
     padding: 0 8px 8px 0;
     text-align: left;
     vertical-align: top;
@@ -29,7 +28,7 @@
 }
 
 .path {
-  min-width: 15vw;
+  min-width: 20vw;
   word-break: break-all;
   word-wrap: break-word;
 }

--- a/src/app/pages/apps/components/installed-apps/app-workloads-card/volume-mounts-dialog/volume-mounts-dialog.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-workloads-card/volume-mounts-dialog/volume-mounts-dialog.component.scss
@@ -21,12 +21,15 @@
 
   th,
   td {
+    max-width: 20vw;
+    padding: 0 8px 8px 0;
     text-align: left;
     vertical-align: top;
   }
 }
 
 .path {
+  min-width: 15vw;
   word-break: break-all;
   word-wrap: break-word;
 }


### PR DESCRIPTION
Tested dialog width setup, it's possible to set width from `matDialog.open()`

I set

```
  volumeButtonPressed(containerDetails: AppContainerDetails): void {
    this.matDialog.open(VolumeMountsDialogComponent, {
      maxWidth: '80vw',
      minWidth: '50vw',
      data: containerDetails,
    });
  }
```

And width is set and it’s working,
we currently have Global Styling to limit modal width to  max-width: 700px;

So I updated `VolumeMountsDialogComponent` view.

Testing:
See ticket.

Result:
Before:
<img width="1728" alt="Screenshot 2024-10-10 at 15 44 19" src="https://github.com/user-attachments/assets/88b6d13a-f2d3-40ad-b226-ac00c44510ae">

After:
<img width="1728" alt="Screenshot 2024-10-10 at 15 44 45" src="https://github.com/user-attachments/assets/3fbe26ab-b351-4215-a104-0a43f3baffa0">

