### PR TITLE
NAS-128601 / 24.10.0 / Fixes the process to assign GPUs to VMs when creating or editing (by RehanY147)

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -877,6 +877,7 @@ export interface ApiCallDirectory {
   'vm.device.delete': { params: [number, VmDeviceDelete?]; response: boolean };
   'vm.device.disk_choices': { params: void; response: Choices };
   'vm.device.get_pci_ids_for_gpu_isolation': { params: [string]; response: string[] };
+  'system.advanced.get_gpu_pci_choices': { params: void; response: Choices };
   'vm.device.nic_attach_choices': { params: void; response: Choices };
   'vm.device.passthrough_device_choices': { params: void; response: Record<string, VmPassthroughDeviceChoice> };
   'vm.device.query': { params: QueryParams<VmDevice>; response: VmDevice[] };

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
@@ -1,11 +1,13 @@
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit,
+  signal,
 } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import {
   Observable, forkJoin, map, of, switchMap,
+  tap,
 } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
 import { Role } from 'app/enums/role.enum';
@@ -15,6 +17,7 @@ import {
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
+import { Option } from 'app/interfaces/option.interface';
 import { VirtualMachine, VirtualMachineUpdate } from 'app/interfaces/virtual-machine.interface';
 import { VmPciPassthroughDevice } from 'app/interfaces/vm-device.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -70,12 +73,13 @@ export class VmEditFormComponent implements OnInit {
     gpus: [[] as string[], [], [this.gpuValidator.validateGpu]],
   });
 
+  private readonly gpuOptions = signal<Option[]>([]);
   isLoading = false;
   timeOptions$ = of(mapToOptions(vmTimeNames, this.translate));
   bootloaderOptions$ = this.ws.call('vm.bootloader_options').pipe(choicesToOptions());
   cpuModeOptions$ = of(mapToOptions(vmCpuModeLabels, this.translate));
   cpuModelOptions$ = this.ws.call('vm.cpu_model_choices').pipe(choicesToOptions());
-  gpuOptions$ = this.gpuService.getGpuOptions();
+  gpuOptions$ = this.gpuService.getGpuOptions().pipe(tap((options) => this.gpuOptions.set(options)));
 
   readonly helptext = helptextVmWizard;
 
@@ -137,20 +141,30 @@ export class VmEditFormComponent implements OnInit {
     }
 
     const gpusIds = this.form.value.gpus;
-
-    const pciIdsRequests$ = gpusIds.map((gpu) => {
-      return this.ws.call('vm.device.get_pci_ids_for_gpu_isolation', [gpu]);
-    });
-
     let updateVmRequest$: Observable<unknown>;
 
-    if (pciIdsRequests$.length) {
-      updateVmRequest$ = forkJoin(pciIdsRequests$).pipe(
-        map((pciIds) => pciIds.flat()),
+    if (gpusIds.length) {
+      updateVmRequest$ = this.ws.call('system.advanced.update_gpu_pci_ids', [gpusIds]).pipe(
+        switchMap(() => this.ws.call('system.advanced.get_gpu_pci_choices')),
+        map((choices) => {
+          const pciIds: string[] = [];
+          const gpuOptions = this.gpuOptions();
+          const selectedGpusDesc: string[] = gpuOptions.filter(
+            (gpuOption) => gpusIds.includes(gpuOption.value.toString()),
+          ).map(
+            (option) => `${option.label} [${option.value}]`,
+          );
+
+          for (const selectedGpuDesc of selectedGpusDesc) {
+            pciIds.push(choices[selectedGpuDesc]);
+          }
+
+          return pciIds.flat();
+        }),
         switchMap((pciIds) => forkJoin([
           this.ws.call('vm.update', [this.existingVm.id, vmPayload as VirtualMachineUpdate]),
-          this.vmGpuService.updateVmGpus(this.existingVm, gpusIds.concat(pciIds)),
-          this.gpuService.addIsolatedGpuPciIds(gpusIds.concat(pciIds)),
+          this.vmGpuService.updateVmGpus(this.existingVm, pciIds),
+          this.gpuService.addIsolatedGpuPciIds(pciIds),
         ])),
       );
     } else {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x dea62f4a8ddb52560099849661b110bf205e50fb
    git cherry-pick -x 356a38738edc8a523e42d0512965bcfdc2a3da68
    git cherry-pick -x 897156c420ad175caeb4041739fe511ec0a29f12
    git cherry-pick -x 48870e77083c735f10e0fe6ba48030a9811d9480
    git cherry-pick -x ac61d170925666e7a81f221dce5e481525e9da0d
    git cherry-pick -x c95f3c466d77de267f6c362fe00461b103c1d494
    git cherry-pick -x 22fcb217cc5aa5a8d4e8ae3cddfbd7174960056e
    git cherry-pick -x 13185c2e25413e411378592e3445b0683128467c
    git cherry-pick -x c86dc6c9e473787a5c5c5c83a4d04c54df727458
    git cherry-pick -x 085932bf6f996741f4e661b365a8d97c7aa653ff
    git cherry-pick -x 332cb9225e9e2ecd0969a7dc8d23d40fa4d5f5b7
    git cherry-pick -x b4b175b8ab0c537a33c472f72ef13a5c1f6c916e
    git cherry-pick -x 7674566e608b39d52faebb29d43faf5704e3c2f7
    git cherry-pick -x 0bdb8a16a5d4f66f6b1789d31aed0bb327c4ae88

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x da35a6017c126687332e54c2a4ca1f48a9455923

**Changes:**

Uses new API end points and filtering process to get the right data to be passed to the middleware endpoints

**Testing:**

Create a VM with one or more GPUs.
Edit a VM by removing GPUs and changing them.

Test on the system mentioned in the ticket comments.


Original PR: https://github.com/truenas/webui/pull/10838
Jira URL: https://ixsystems.atlassian.net/browse/NAS-128601