### PR TITLE
Fix logs header in light theme in Container Logs

### DIFF
--- a/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.scss
+++ b/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.scss
@@ -1,6 +1,5 @@
 :host ::ng-deep {
   .logs-wrapper {
-    color: white;
     height: calc(100% - 121px);
     margin-left: 8px;
     margin-right: 8px;
@@ -9,6 +8,7 @@
 
   .logs {
     background: black;
+    color: white;
     font-family: var(--font-family-monospace);
     height: calc(100% - 70px);
     overflow: auto;


### PR DESCRIPTION
**Changes:**
The text here is unreadable in the white theme:
![obraz](https://github.com/user-attachments/assets/ed190d32-d28e-4f26-b8eb-21812e30035c)

It was due to `color: #fff` being on parent `.logs-wrapper` instead of actual child `.logs` element where it's needed to counteract the black background of terminal window.

**Testing:**
Use light theme and ensure text after header is readable and not white. The logs output should still be white on black.

### Downstream
nothing?

## Please backport this to the upcoming 24.10.0 too.
