### PR TITLE
NAS-131713 / 25.04 / Apps | when an app is in crashed state all buttons for the container is missing

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.html
@@ -46,7 +46,7 @@
             <div class="container-state">
               {{ container.state | mapValue: appContainerStateLabels | translate  }}
             </div>
-            @if (app().state === AppState.Running || app().state === AppState.Deploying) {
+            @if (app().state === AppState.Running || app().state === AppState.Deploying || app().state === AppState.Crashed) {
               <div class="container-action">
                 @if (container.state === AppContainerState.Running) {
                   <button


### PR DESCRIPTION
Testing: 
See ticket, result:

<img width="1154" alt="Screenshot 2024-10-14 at 00 26 16" src="https://github.com/user-attachments/assets/59395d2e-bf59-4be2-a6a0-66911d9e5ea7">
