### PR TITLE
NAS-131753: Allow user to disable access to snapshot directory in UI

### DIFF
--- a/src/app/enums/dataset.enum.ts
+++ b/src/app/enums/dataset.enum.ts
@@ -53,11 +53,13 @@ export const datasetSyncLabels = new Map<DatasetSync, string>([
 export enum DatasetSnapdir {
   Visible = 'VISIBLE',
   Hidden = 'HIDDEN',
+  Disabled = 'DISABLED',
 }
 
 export const datasetSnapdirLabels = new Map<DatasetSnapdir, string>([
   [DatasetSnapdir.Visible, T('Visible')],
   [DatasetSnapdir.Hidden, T('Invisible')],
+  [DatasetSnapdir.Disabled, T('Disabled')],
 ]);
 
 export enum DatasetSnapdev {

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
@@ -75,7 +75,7 @@ describe('OtherOptionsSectionComponent', () => {
       source: ZfsPropertySource.Inherited,
     },
     snapdir: {
-      value: DatasetSnapdir.Visible,
+      value: DatasetSnapdir.Disabled,
       source: ZfsPropertySource.Inherited,
     },
     snapdev: {
@@ -235,6 +235,10 @@ describe('OtherOptionsSectionComponent', () => {
         parent: parentDataset,
       });
 
+      await form.fillForm({
+        'Snapshot Directory': 'Visible',
+      });
+
       expect(await form.getValues()).toEqual({
         Comments: '',
         'Compression Level': 'LZJB',
@@ -273,7 +277,7 @@ describe('OtherOptionsSectionComponent', () => {
         readonly: OnOff.Off,
         recordsize: inherit,
         snapdev: DatasetSnapdev.Hidden,
-        snapdir: DatasetSnapdir.Visible,
+        snapdir: DatasetSnapdir.Disabled,
         special_small_block_size: inherit,
         aclmode: AclMode.Discard,
         acltype: DatasetAclType.Posix,


### PR DESCRIPTION
**Testing:**
See ticket, result:
<img width="783" alt="Screenshot 2024-10-14 at 00 33 52" src="https://github.com/user-attachments/assets/6038ea20-805d-4856-84ad-1b6988442737">

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | New option in UI
