### PR TITLE
NAS-131712 / 24.10.1 / Apps | shell button is missing when application "Starting" (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.html
@@ -48,20 +48,17 @@
             </div>
             @if (app().state === AppState.Running || app().state === AppState.Deploying) {
               <div class="container-action">
-                <!-- TODO: https://ixsystems.atlassian.net/browse/NAS-130392 -->
-                @if (container.state === AppContainerState.Running) {
-                  <button
-                    *ixRequiresRoles="requiredRoles"
-                    mat-icon-button
-                    matTooltipPosition="above"
-                    [attr.aria-label]="'Shell' | translate"
-                    [ixTest]="[container.service_name, 'shell']"
-                    [matTooltip]="'Shell' | translate"
-                    (click)="shellButtonPressed(container.id)"
-                  >
-                    <ix-icon name="mdi-console"></ix-icon>
-                  </button>
-                }
+                <button
+                  *ixRequiresRoles="requiredRoles"
+                  mat-icon-button
+                  matTooltipPosition="above"
+                  [attr.aria-label]="'Shell' | translate"
+                  [ixTest]="[container.service_name, 'shell']"
+                  [matTooltip]="'Shell' | translate"
+                  (click)="shellButtonPressed(container.id)"
+                >
+                  <ix-icon name="mdi-console"></ix-icon>
+                </button>
                 <button
                   mat-icon-button
                   matTooltipPosition="above"
@@ -72,7 +69,7 @@
                 >
                   <ix-icon name="mdi-folder-outline"></ix-icon>
                 </button>
-                
+
 
                 <button
                   mat-icon-button
@@ -85,7 +82,7 @@
                   <ix-icon name="mdi-text-box"></ix-icon>
                 </button>
 
-                
+
               </div>
             }
           </div>


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x bebf231138e12a8830eb8635aa581cdc92fe849c

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 009012d9e944feb5f6c619492b38cf20857a76f7

Testing: 

See ticket, result:

<img width="1359" alt="Screenshot 2024-10-14 at 00 05 00" src="https://github.com/user-attachments/assets/d45f404d-4047-4769-bb0f-91d79ca22d46">


Original PR: https://github.com/truenas/webui/pull/10855
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131712