### PR TITLE
NAS-131746 / 25.04 / RAIDZ Expansion Dialog cannot be minimized or "backgrounded" preventing further UI operations

### DIFF
--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.ts
@@ -75,7 +75,7 @@ export class ExtendDialogComponent {
 
     this.dialogService.jobDialog(
       this.ws.job('pool.attach', [this.data.poolId, payload]),
-      { title: this.translate.instant('Extending VDEV') },
+      { title: this.translate.instant('Extending VDEV'), canMinimize: true },
     )
       .afterClosed()
       .pipe(


### PR DESCRIPTION
Testing: see ticket, result:

<img width="460" alt="Screenshot 2024-10-14 at 00 37 24" src="https://github.com/user-attachments/assets/12476791-5948-4105-82ea-2f7957cf39b3">
