### PR TITLE
NAS-131746 / 24.10.1 / RAIDZ Expansion Dialog cannot be minimized or "backgrounded" preventing further UI operations (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/extend-dialog/extend-dialog.component.ts
@@ -58,7 +58,7 @@ export class ExtendDialogComponent {
 
     this.dialogService.jobDialog(
       this.ws.job('pool.attach', [this.data.poolId, payload]),
-      { title: this.translate.instant('Extending VDEV') },
+      { title: this.translate.instant('Extending VDEV'), canMinimize: true },
     )
       .afterClosed()
       .pipe(


### PR DESCRIPTION
Testing: see ticket, result:

<img width="460" alt="Screenshot 2024-10-14 at 00 37 24" src="https://github.com/user-attachments/assets/12476791-5948-4105-82ea-2f7957cf39b3">


Original PR: https://github.com/truenas/webui/pull/10863
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131746