### PR TITLE
NAS-131844 / 25.04 / Fix loading state for cpu-model and interface widgets

### DIFF
--- a/src/app/pages/dashboard/widgets/cpu/widget-cpu-model/widget-cpu-model.component.scss
+++ b/src/app/pages/dashboard/widgets/cpu/widget-cpu-model/widget-cpu-model.component.scss
@@ -1,0 +1,11 @@
+:host {
+  align-items: center;
+  background-color: var(--bg2);
+  border: 1px solid var(--lines);
+  box-sizing: border-box;
+  color: var(--fg2);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+}

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.html
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.html
@@ -97,33 +97,22 @@
       </div>
       @if (showChart()) {
         <div class="nic-chart">
-          <div class="chart-body">
-            @if (isLoading()) {
-              <ngx-skeleton-loader
-                class="skeleton"
-                [theme]="{
-                  width: 'calc(100% - 16px)',
-                  height: '184px',
-                  background: 'var(--alt-bg2)',
-                  opacity: 0.25,
-                  margin: '8px 0 0',
-                }"
-              ></ngx-skeleton-loader>
-            } @else {
-              <ix-network-chart [data]="chartData()" [aspectRatio]="aspectRatio()"></ix-network-chart>
-            }
-          </div>
+          @if (isLoading()) {
+            <ngx-skeleton-loader
+              class="skeleton"
+              [theme]="{
+                width: 'calc(100% - 16px)',
+                height: '184px',
+                background: 'var(--alt-bg2)',
+                opacity: 0.25,
+                margin: '8px 0 0',
+              }"
+            ></ngx-skeleton-loader>
+          } @else {
+            <ix-network-chart [data]="chartData()" [aspectRatio]="aspectRatio()"></ix-network-chart>
+          }
         </div>
       }
     </div>
   </mat-card-content>
 </mat-card>
-
-<ng-template #chart>
-  <ix-network-chart [data]="chartData()" [aspectRatio]="aspectRatio()"></ix-network-chart>
-</ng-template>
-
-<ng-template #skeleton>
-  <ngx-skeleton-loader class="skeleton"></ngx-skeleton-loader>
-</ng-template>
-

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.scss
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.scss
@@ -151,6 +151,11 @@
         flex: 1;
         max-width: 100%;
       }
+
+      .skeleton {
+        display: block;
+        flex-grow: 1;
+      }
     }
   }
 


### PR DESCRIPTION
**Changes:**

Fix loading state for cpu-model and interface widgets

**Testing:**

You can tweak `toLoadingState` helper to see loading state.

![image](https://github.com/user-attachments/assets/715f222b-e6f7-4a8a-b11b-c7435cdf044d)
![image](https://github.com/user-attachments/assets/b12c959e-2332-46b6-9f8e-e093d20c456c)
