### PR TITLE
NAS-131800 / 24.10.1 / App details page does not scale / cropped on mobile (by AlexKarpov98)

### DIFF
--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -93,13 +93,13 @@
     .label {
       font-weight: bold;
       margin-right: 5px;
-      white-space: nowrap;
+      white-space: normal;
     }
 
     .value {
       font-weight: normal;
       margin-right: 5px;
-      white-space: nowrap;
+      white-space: normal;
     }
 
     a {


### PR DESCRIPTION
Testing: see ticket, 
Result:

<img width="378" alt="Screenshot 2024-10-21 at 12 20 03" src="https://github.com/user-attachments/assets/789573e7-2cad-4a64-aae1-0c1435db6a5c">



Original PR: https://github.com/truenas/webui/pull/10903
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131800