### PR TITLE
NAS-131848 / 25.04 / Remove the "current password" field from UI for FULL_ADMIN

### DIFF
--- a/src/app/modules/layout/topbar/change-password-dialog/change-password-dialog.component.html
+++ b/src/app/modules/layout/topbar/change-password-dialog/change-password-dialog.component.html
@@ -1,11 +1,13 @@
 <h1 matDialogTitle>{{ 'Change Password' | translate }}</h1>
 <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
-  <ix-input
-    formControlName="old_password"
-    type="password"
-    [label]="'Current Password' | translate"
-    [required]="true"
-  ></ix-input>
+  @if (!(isFullAdminUser$ | async)) {
+    <ix-input
+      formControlName="old_password"
+      type="password"
+      [label]="'Current Password' | translate"
+      [required]="true"
+    ></ix-input>
+  }
 
   <ix-input
     formControlName="new_password"

--- a/src/app/modules/layout/topbar/change-password-dialog/change-password-dialog.component.ts
+++ b/src/app/modules/layout/topbar/change-password-dialog/change-password-dialog.component.ts
@@ -1,10 +1,13 @@
+import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { MatDialogRef, MatDialogTitle, MatDialogClose } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { Role } from 'app/enums/role.enum';
 import { helptextTopbar } from 'app/helptext/topbar';
 import { LoggedInUser } from 'app/interfaces/ds-cache.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -33,15 +36,14 @@ import { WebSocketService } from 'app/services/ws.service';
     MatDialogClose,
     TranslateModule,
     TestDirective,
+    AsyncPipe,
   ],
 })
 export class ChangePasswordDialogComponent {
   form = this.fb.group({
-    old_password: ['', [Validators.required]],
+    old_password: [''],
     new_password: ['', [Validators.required]],
-    passwordConfirmation: ['', [
-      Validators.required,
-    ]],
+    passwordConfirmation: ['', [Validators.required]],
   }, {
     validators: [
       matchOthersFgValidator(
@@ -57,6 +59,10 @@ export class ChangePasswordDialogComponent {
   readonly tooltips = {
     password: helptextTopbar.changePasswordDialog.pw_new_pw_tooltip,
   };
+
+  get isFullAdminUser$(): Observable<boolean> {
+    return this.authService.hasRole(Role.FullAdmin);
+  }
 
   constructor(
     private translate: TranslateService,


### PR DESCRIPTION
**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**
See ticket.
Result:
<img width="422" alt="Screenshot 2024-10-24 at 15 25 45" src="https://github.com/user-attachments/assets/1977d754-e72e-43c9-ba23-1fadc0055f47">


### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Removed the "current password" field from UI for FULL_ADMIN
