### PR TITLE
NAS-131848 / 24.10.0 / Remove the "current password" field from UI for FULL_ADMIN (by AlexKarpov98)

### DIFF
--- a/src/app/modules/layout/components/topbar/change-password-dialog/change-password-dialog.component.html
+++ b/src/app/modules/layout/components/topbar/change-password-dialog/change-password-dialog.component.html
@@ -1,11 +1,13 @@
 <h1 matDialogTitle>{{ 'Change Password' | translate }}</h1>
 <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
-  <ix-input
-    formControlName="old_password"
-    type="password"
-    [label]="'Current Password' | translate"
-    [required]="true"
-  ></ix-input>
+  @if (!(isFullAdminUser$ | async)) {
+    <ix-input
+      formControlName="old_password"
+      type="password"
+      [label]="'Current Password' | translate"
+      [required]="true"
+    ></ix-input>
+  }
 
   <ix-input
     formControlName="new_password"

--- a/src/app/modules/layout/components/topbar/change-password-dialog/change-password-dialog.component.spec.ts
+++ b/src/app/modules/layout/components/topbar/change-password-dialog/change-password-dialog.component.spec.ts
@@ -5,8 +5,10 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { throwError } from 'rxjs';
+import { MockAuthService } from 'app/core/testing/classes/mock-auth.service';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { mockCall, mockWebSocket } from 'app/core/testing/utils/mock-websocket.utils';
+import { Role } from 'app/enums/role.enum';
 import { IxFormsModule } from 'app/modules/forms/ix-forms/ix-forms.module';
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
@@ -41,7 +43,18 @@ describe('ChangePasswordDialogComponent', () => {
     websocket = spectator.inject(WebSocketService);
   });
 
+  it('does not show current password field for full admin', async () => {
+    const authMock = spectator.inject(MockAuthService);
+    authMock.setRoles([Role.FullAdmin]);
+
+    const form = await loader.getHarness(IxFormHarness);
+    expect(await form.getControl('Current Password')).toBeUndefined();
+  });
+
   it('checks current password, updates to new password and closes the dialog when form is saved', async () => {
+    const authMock = spectator.inject(MockAuthService);
+    authMock.setRoles([Role.ReadonlyAdmin]);
+
     const form = await loader.getHarness(IxFormHarness);
     await form.fillForm({
       'Current Password': 'correct',
@@ -61,6 +74,9 @@ describe('ChangePasswordDialogComponent', () => {
   });
 
   it('shows error if any happened during password change request', async () => {
+    const authMock = spectator.inject(MockAuthService);
+    authMock.setRoles([Role.ReadonlyAdmin]);
+
     const error = new Error('error');
     jest.spyOn(websocket, 'call').mockReturnValue(throwError(() => error));
 

--- a/src/app/modules/layout/components/topbar/change-password-dialog/change-password-dialog.component.ts
+++ b/src/app/modules/layout/components/topbar/change-password-dialog/change-password-dialog.component.ts
@@ -3,7 +3,9 @@ import { FormBuilder, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { Role } from 'app/enums/role.enum';
 import { helptextTopbar } from 'app/helptext/topbar';
 import { LoggedInUser } from 'app/interfaces/ds-cache.interface';
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
@@ -22,11 +24,9 @@ import { WebSocketService } from 'app/services/ws.service';
 })
 export class ChangePasswordDialogComponent {
   form = this.fb.group({
-    old_password: ['', [Validators.required]],
+    old_password: [''],
     new_password: ['', [Validators.required]],
-    passwordConfirmation: ['', [
-      Validators.required,
-    ]],
+    passwordConfirmation: ['', [Validators.required]],
   }, {
     validators: [
       matchOthersFgValidator(
@@ -42,6 +42,10 @@ export class ChangePasswordDialogComponent {
   readonly tooltips = {
     password: helptextTopbar.changePasswordDialog.pw_new_pw_tooltip,
   };
+
+  get isFullAdminUser$(): Observable<boolean> {
+    return this.authService.hasRole(Role.FullAdmin);
+  }
 
   constructor(
     private translate: TranslateService,


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 0330deafb5c4358cbc4698c770aa4e432b6e0b63

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x eeb1d5d63b6845c2ab3a6724cf2ab9e4821d7be7

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**
See ticket.
Result:
<img width="422" alt="Screenshot 2024-10-24 at 15 25 45" src="https://github.com/user-attachments/assets/1977d754-e72e-43c9-ba23-1fadc0055f47">


### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Removed the "current password" field from UI for FULL_ADMIN


Original PR: https://github.com/truenas/webui/pull/10920
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131848