### PR TITLE
NAS-131968 / 25.04 / Minor-est of issues.  There should be a space between Confirm and *

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component.scss
+++ b/src/app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component.scss
@@ -24,3 +24,7 @@
     margin-top: -8px;
   }
 }
+
+.required {
+  margin-left: 2px;
+}

--- a/src/app/modules/forms/ix-forms/components/ix-slide-toggle/ix-slide-toggle.component.scss
+++ b/src/app/modules/forms/ix-forms/components/ix-slide-toggle/ix-slide-toggle.component.scss
@@ -14,3 +14,7 @@
 .tooltip {
   margin: 0 0 0 8px;
 }
+
+.required {
+  margin-left: 2px;
+}


### PR DESCRIPTION
Testing: 
Code review.
As well noticed same issue for `ix-slide-toggle.component.scss`

Result:
<img width="434" alt="Screenshot 2024-10-25 at 14 21 50" src="https://github.com/user-attachments/assets/f079f9f4-f20f-4fbd-952c-c02c2c1a8ad1">
