### PR TITLE
NAS-131913 / 24.10.1 / Fix the sequence of state updates

### DIFF
--- a/src/app/pages/apps/store/docker.store.ts
+++ b/src/app/pages/apps/store/docker.store.ts
@@ -39,7 +39,10 @@ export class DockerStore extends ComponentStore<DockerConfigState> {
   readonly selectedPool$ = this.select((state) => state.dockerConfig?.pool || null);
   readonly nvidiaDriversInstalled$ = this.select((state) => state.nvidiaDriversInstalled);
   readonly lacksNvidiaDrivers$ = this.select((state) => state.lacksNvidiaDrivers);
-  readonly isDockerStarted$ = this.select((state) => DockerStatus.Running === state.statusData.status);
+  readonly isDockerStarted$ = this.select((state) => {
+    return state.statusData.status == null ? null : DockerStatus.Running === state.statusData.status;
+  });
+
   readonly status$ = this.select((state) => state.statusData.status);
   readonly statusDescription$ = this.select((state) => state.statusData.description);
 

--- a/src/app/pages/apps/store/installed-apps-store.service.ts
+++ b/src/app/pages/apps/store/installed-apps-store.service.ts
@@ -3,8 +3,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { ComponentStore } from '@ngrx/component-store';
 import {
   EMPTY,
-  Observable, Subscription, catchError, delay, filter, of, repeat, switchMap, tap,
-  withLatestFrom,
+  Observable, Subscription, catchError, combineLatest, delay, filter, of, repeat, switchMap, tap,
 } from 'rxjs';
 import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
 import { tapOnce } from 'app/helpers/operators/tap-once.operator';
@@ -92,18 +91,20 @@ export class InstalledAppsStore extends ComponentStore<InstalledAppsState> imple
   }
 
   private loadInstalledApps(): Observable<App[]> {
-    return this.dockerStore.isLoading$.pipe(
-      withLatestFrom(this.dockerStore.isDockerStarted$),
+    return combineLatest([
+      this.dockerStore.isLoading$,
+      this.dockerStore.isDockerStarted$,
+    ]).pipe(
       filter(([isLoading, isDockerStarted]) => !isLoading && isDockerStarted !== null),
+      tap(() => this.patchState({ isLoading: true })),
       switchMap(([, isDockerStarted]) => {
-        this.subscribeToInstalledAppsUpdates();
-
         if (!isDockerStarted) {
           return of([]);
         }
 
         return this.appsService.getAllApps().pipe(
           tap((installedApps) => this.patchState({ installedApps })),
+          tap(() => this.subscribeToInstalledAppsUpdates()),
           repeat({
             // TODO: NAS-131676. Remove this workaround after the bug is fixed.
             delay: () => this.appsService.getInstalledAppsUpdates().pipe(


### PR DESCRIPTION
**Changes:**

We were subscribing to only docker store loading boolean. Should also be listening to docker store state update observable to know when to update installed apps store again.

**Testing:**

Testing system and method described in the ticket

