### PR TITLE
NAS-131747: "Update available" tooltip for Apps shows wrong version

### DIFF
--- a/src/app/interfaces/app.interface.ts
+++ b/src/app/interfaces/app.interface.ts
@@ -71,6 +71,7 @@ export interface App {
   active_workloads: AppActiveWorkloads;
   state: AppState;
   upgrade_available: boolean;
+  latest_version: string;
   human_version: string;
   metadata: AppMetadata;
   notes: string;

--- a/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.html
@@ -4,7 +4,7 @@
       class="icon"
       matTooltipPosition="above"
       name="mdi-alert-circle"
-      [matTooltip]="'{version} is available!' | translate: { version: app().metadata.app_version | appVersion }"
+      [matTooltip]="'{version} is available!' | translate: { version: app().latest_version | appVersion }"
     ></ix-icon>
   } @else {
     <ix-icon


### PR DESCRIPTION
**Testing:**
See ticket. 

Middleware updated us with `latest_version` field, so we used it.