### PR TITLE
NAS-131747 / 24.10.1 / "Update available" tooltip for Apps shows wrong version (by AlexKarpov98)

### DIFF
--- a/src/app/interfaces/app.interface.ts
+++ b/src/app/interfaces/app.interface.ts
@@ -71,6 +71,7 @@ export interface App {
   active_workloads: AppActiveWorkloads;
   state: CatalogAppState;
   upgrade_available: boolean;
+  latest_version: string;
   human_version: string;
   metadata: AppMetadata;
   notes: string;

--- a/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.html
@@ -1,11 +1,22 @@
-@if(showIcon()) {
-  <ix-icon
-    matTooltipPosition="above"
-    [name]="hasUpdate() ? 'mdi-alert-circle' : 'mdi-check-circle'"
-    [matTooltip]="hasUpdate()
-      ? ('{version} is available!' | translate: { version: app().metadata.app_version })
-      : ('Up to date' | translate)
-    "
-  ></ix-icon>
+@if (showIcon()) {
+  @if (hasUpdate()) {
+    <ix-icon
+      class="icon"
+      matTooltipPosition="above"
+      name="mdi-alert-circle"
+      [matTooltip]="'{version} is available!' | translate: { version: app().latest_version | appVersion }"
+    ></ix-icon>
+  } @else {
+    <ix-icon
+      matTooltipPosition="above"
+      name="mdi-check-circle"
+      [matTooltip]="'Up to date' | translate"
+    ></ix-icon>
+  }
 }
-<span>{{ hasUpdate() ? ('Update available' | translate) : ('Up to date' | translate) }}</span>
+
+@if (hasUpdate()) {
+  <span>{{ 'Update available' | translate }}</span>
+} @else {
+  <span>{{ 'Up to date' | translate }}</span>
+}

--- a/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.html
@@ -4,7 +4,7 @@
       class="icon"
       matTooltipPosition="above"
       name="mdi-alert-circle"
-      [matTooltip]="'{version} is available!' | translate: { version: app().latest_version | appVersion }"
+      [matTooltip]="'{version} is available!' | translate: { version: app().latest_version }"
     ></ix-icon>
   } @else {
     <ix-icon


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x d5ac62cbc4d57b1c0d3d57f65f31406be4bd88cb

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4099ac75421bdd41e3de29b323eee846c57600a5

**Testing:**
See ticket. 

Middleware updated us with `latest_version` field, so we used it.

Original PR: https://github.com/truenas/webui/pull/10966
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131747