### PR TITLE
NAS-132245 / 24.10.1 / Apps without ixVolumes cannot be removed (by undsoft)

### DIFF
--- a/src/app/interfaces/dialog.interface.ts
+++ b/src/app/interfaces/dialog.interface.ts
@@ -11,7 +11,7 @@ export interface ConfirmOptions {
 }
 
 export interface ConfirmOptionsWithSecondaryCheckbox extends ConfirmOptions {
-  secondaryCheckbox: true;
+  secondaryCheckbox: boolean;
   secondaryCheckboxText?: string;
 }
 

--- a/src/app/modules/dialog/components/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/src/app/modules/dialog/components/confirm-dialog/confirm-dialog.component.spec.ts
@@ -165,4 +165,36 @@ describe('ConfirmDialogComponent', () => {
       });
     });
   });
+
+  describe('secondary checkbox present, but false', () => {
+    const secondaryCheckboxOptions = {
+      ...options,
+      secondaryCheckbox: false,
+      secondaryCheckboxText: 'Secondary checkbox',
+    } as ConfirmOptionsWithSecondaryCheckbox;
+
+    beforeEach(() => {
+      spectator = createComponent({
+        providers: [
+          {
+            provide: MAT_DIALOG_DATA,
+            useValue: secondaryCheckboxOptions,
+          },
+        ],
+      });
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+    });
+
+    it('closes dialog with an object even when `secondaryCheckbox` is false, but present in options', async () => {
+      const checkbox = await loader.getHarness(MatCheckboxHarness.with({ label: options.confirmationCheckboxText }));
+      await checkbox.check();
+
+      const button = await loader.getHarness(MatButtonHarness.with({ text: options.buttonText }));
+      await button.click();
+      expect(spectator.inject(MatDialogRef).close).toHaveBeenCalledWith({
+        confirmed: true,
+        secondaryCheckbox: false,
+      });
+    });
+  });
 });

--- a/src/app/modules/dialog/components/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/modules/dialog/components/confirm-dialog/confirm-dialog.component.ts
@@ -36,7 +36,7 @@ export class ConfirmDialogComponent {
       this.dialogRef.disableClose = options.hideCancel;
     }
 
-    if (options.secondaryCheckbox) {
+    if (this.withSecondaryCheckbox) {
       // Don't allow user to close via backdrop to ensure that object is returned.
       this.dialogRef.disableClose = true;
     }
@@ -54,7 +54,7 @@ export class ConfirmDialogComponent {
   }
 
   onCancel(): void {
-    const result = this.options.secondaryCheckbox
+    const result = this.withSecondaryCheckbox
       ? {
         confirmed: false,
         secondaryCheckbox: this.isSecondaryCheckboxChecked,
@@ -65,7 +65,7 @@ export class ConfirmDialogComponent {
   }
 
   onSubmit(): void {
-    const result = this.options.secondaryCheckbox
+    const result = this.withSecondaryCheckbox
       ? {
         confirmed: true,
         secondaryCheckbox: this.isSecondaryCheckboxChecked,
@@ -73,5 +73,9 @@ export class ConfirmDialogComponent {
       : true;
 
     this.dialogRef.close(result);
+  }
+
+  private get withSecondaryCheckbox(): boolean {
+    return 'secondaryCheckbox' in this.options;
   }
 }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 98bc80e3bcb9acc23906abe77bb145e4cd0bd077
    git cherry-pick -x 5c24f6c356a1a123fad36bc525c7b7918538ef23
    git cherry-pick -x f2f8d9a96f2bea50c12bf0d1e1830be337226e1a

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 7f7405c8f75610c98d06c896338bbfdaef52b7af

**Changes:**

1. Install nginx from test train.
2. Try to remove it.
AR: Nothing happens after confirmation dialog.

There has been a mismatch between types and actual return value in `confirm` when `secondaryCheckbox` key was false.

**Testing:**

You may need to replace implementation of getLacksNvidiaDrivers() with of(false) in DockerStore due to an unrelated issue.

Original PR: https://github.com/truenas/webui/pull/10973
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132245