### PR TITLE
NAS-131812 / 24.10.1 / Remove usage of `descriptor` prop for slots (by RehanY147)

### DIFF
--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
@@ -230,7 +230,7 @@ export class EnclosureSvgComponent implements OnDestroy {
       'aria-label',
       this.translate.instant('Disk Details for {disk} ({descriptor})', {
         disk: slot.dev || this.translate.instant('Empty drive cage'),
-        descriptor: slot.descriptor,
+        descriptor: this.translate.instant('Slot: {slot}', { slot: slot.drive_bay_number }),
       }),
     );
   }

--- a/src/app/pages/system/enclosure/components/pages/enclosure-page/disk-details-overview/disk-details-overview.component.ts
+++ b/src/app/pages/system/enclosure/components/pages/enclosure-page/disk-details-overview/disk-details-overview.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
+import { TranslateService } from '@ngx-translate/core';
 import { EnclosureStore } from 'app/pages/system/enclosure/services/enclosure.store';
 
 @UntilDestroy()
@@ -13,11 +14,13 @@ export class DiskDetailsOverviewComponent {
   readonly selectedSlot = this.store.selectedSlot;
 
   readonly diskName = computed(() => {
-    return this.selectedSlot().dev || this.selectedSlot().descriptor;
+    return this.selectedSlot().dev
+      || this.translate.instant('Slot: {slot}', { slot: this.selectedSlot().drive_bay_number });
   });
 
   constructor(
     private store: EnclosureStore,
+    private translate: TranslateService,
   ) {}
 
   protected closeDetails(): void {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -3617,6 +3617,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2818,6 +2818,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1383,6 +1383,7 @@
   "Size in GiB of the maximum amount of space that may be  consumed by the dataset where the audit dabases are stored.": "",
   "Skip automatic detection of the Endpoint URL region. Set this only if AWS provider does not support regions.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Snapdev": "",
   "Snapshot Read": "",
   "Snapshot Task Read": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3624,6 +3624,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -721,6 +721,7 @@
   "Skip": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -86,6 +86,7 @@
   "Running Jobs": "",
   "SAVE": "",
   "Select the level of severity. Alert notifications send for all warnings matching and above the selected level. For example, a warning level set to Critical triggers notifications for Critical, Alert, and Emergency level warnings.": "",
+  "Slot: {slot}": "",
   "Specifies level of authentication and cryptographic protection. SYS or none should be used if no KDC is available. If a KDC is available, e.g. Active Directory, KRB5 is recommended. If desired KRB5I (integrity protection) and/or KRB5P (privacy protection) may be included with KRB5.": "",
   "StorJ is an S3 compatible, fault tolerant, globally distributed cloud storage platform with a security first approach to backup and recovery - delivering extreme resilience and performance both sustainably and economically. <a href=\"https://truenas.com/storj\" target=\"_blank\">TrueNAS and Storj</a> have partnered to streamline delivery of Hybrid Cloud solutions globally.": "",
   "String of additional smb4.conf parameters not covered by the system's API.": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3546,6 +3546,7 @@
   "Set to to enable support for <a href=\"https://tools.ietf.org/html/rfc3410\" target=\"_blank\">SNMP version 3</a>. See <a href=\"http://net-snmp.sourceforge.net/docs/man/snmpd.conf.html\" target=\"_blank\">snmpd.conf(5)</a> for configuration details.": "",
   "Set to use encryption when replicating data. Additional encryption options will appear.": "",
   "Set to use the <i>Schedule</i> in place  of the <i>Replicate Specific Snapshots</i> time frame. The Schedule values are  read over the <i>Replicate Specific Snapshots</i> time frame.": "",
+  "Slot: {slot}": "",
   "Specify this certificate's valid Key Usages. Web certificates           typically need at least Digital Signature and possibly Key Encipherment           or Key Agreement, while other applications may need other usages.": "",
   "Specify whether the issued certificate should include Authority Key Identifier information,          and whether the extension is critical. Critical extensions must be recognized by the client or be rejected.": "",
   "Specify whether to use the certificate for a Certificate Authority           and whether this extension is critical. Clients must recognize critical extensions           to prevent rejection. Web certificates typically require you to disable           CA and enable Critical Extension.": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3554,6 +3554,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -3563,6 +3563,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3983,6 +3983,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -983,6 +983,7 @@
   "Site Name": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3911,6 +3911,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3929,6 +3929,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2375,6 +2375,7 @@
   "Skip automatic detection of the Endpoint URL region. Set this only if AWS provider does not support regions.": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -2505,6 +2505,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1478,6 +1478,7 @@
   "Skip automatic detection of the Endpoint URL region. Set this only if AWS provider does not support regions.": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3989,6 +3989,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -30,6 +30,7 @@
   "Service Announcement:": "",
   "Set new password:": "",
   "Set to boot a debug kernel after the next system  reboot.": "",
+  "Slot: {slot}": "",
   "StorJ is an S3 compatible, fault tolerant, globally distributed cloud storage platform with a security first approach to backup and recovery - delivering extreme resilience and performance both sustainably and economically. <a href=\"https://truenas.com/storj\" target=\"_blank\">TrueNAS and Storj</a> have partnered to streamline delivery of Hybrid Cloud solutions globally.": "",
   "Successfully exported/disconnected {pool}.": "",
   "Target Mode": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -3335,6 +3335,7 @@
   "Slot": "",
   "Slot {number} is empty.": "",
   "Slot {n}": "",
+  "Slot: {slot}": "",
   "Smart": "",
   "Smart Task": "",
   "Smart Test Result": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 9e5836d0e456afb6ff88aa2d8db361a3a4f0f128
    git cherry-pick -x 53b973c9475289a8b2732b1474fef8afea436c8a
    git cherry-pick -x a685eed510854c7c99807a991f3811d74ec644fd
    git cherry-pick -x 51a146c55799c182192903b54b3cf21dcbc1207c
    git cherry-pick -x 3c2e648de743a50f2f5ca968d2cbbdc34d7dca77

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x d705d0a60d0963f8af19b25fd9f5c98aac3a11b4

**Changes:**

In the ticket, Caleb says that the `descriptor` field is not meant to be consumed by UI in the "Array Device Slots" part of the enclosure data.

**Testing:**

Test for regressions and replacement text to show up in place of the descriptor field for enclosure slots on the enclosure page.

Original PR: https://github.com/truenas/webui/pull/10978
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131812