### PR TITLE
NAS-132159 / 25.04 / Remove workaround for custom_app

### DIFF
--- a/src/app/pages/apps/store/installed-apps-store.service.ts
+++ b/src/app/pages/apps/store/installed-apps-store.service.ts
@@ -2,8 +2,8 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { ComponentStore } from '@ngrx/component-store';
 import {
-  EMPTY,
-  Observable, Subscription, catchError, combineLatest, delay, filter, of, repeat, switchMap, tap,
+  EMPTY, Observable, Subscription, catchError,
+  combineLatest, filter, of, switchMap, tap,
 } from 'rxjs';
 import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
 import { tapOnce } from 'app/helpers/operators/tap-once.operator';
@@ -96,17 +96,6 @@ export class InstalledAppsStore extends ComponentStore<InstalledAppsState> imple
         return this.appsService.getAllApps().pipe(
           tap((installedApps) => this.patchState({ installedApps })),
           tap(() => this.subscribeToInstalledAppsUpdates()),
-          repeat({
-            // TODO: NAS-131676. Remove this workaround after the bug is fixed.
-            delay: () => this.appsService.getInstalledAppsUpdates().pipe(
-              filter((event) => {
-                return (event.msg === IncomingApiMessageType.Added && !('fields' in event))
-                  || (event.msg === IncomingApiMessageType.Changed && event.fields.custom_app);
-              }),
-              tap(() => this.patchState({ isLoading: true })),
-              delay(2000),
-            ),
-          }),
         );
       }),
       tap(() => this.patchState({ isLoading: false })),


### PR DESCRIPTION
**Changes:**

- https://ixsystems.atlassian.net/browse/NAS-131885 has been fixed.
- Removed workaround to update installed apps when custom app installs.
- 

**Testing:**

Check installed apps list after custom app is installed. Expected are no changes in behavior.