### PR TITLE
NAS-131790 / 25.04 / Defines `SlideIn2CloseConfirmation` interface for confirmation before closing slide-ins

### DIFF
--- a/src/app/interfaces/slide-in-close-confirmation.interface.ts
+++ b/src/app/interfaces/slide-in-close-confirmation.interface.ts
@@ -1,0 +1,5 @@
+import { Observable } from 'rxjs';
+
+export interface SlideIn2CloseConfirmation {
+  requiresConfirmationOnClose(): Observable<boolean>;
+}

--- a/src/app/modules/forms/ix-forms/components/ix-select/ix-select-with-new-option.directive.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-select/ix-select-with-new-option.directive.ts
@@ -1,6 +1,5 @@
-import { ComponentType } from '@angular/cdk/portal';
 import {
-  AfterViewInit, Directive, Input, OnInit, ViewChild, inject,
+  AfterViewInit, Directive, Input, OnInit, Type, ViewChild, inject,
 } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
@@ -9,6 +8,7 @@ import {
   Observable, distinctUntilChanged, filter, map, switchMap, take, tap,
 } from 'rxjs';
 import { Option } from 'app/interfaces/option.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { IxSelectComponent, IxSelectValue } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import { ChainedComponentResponse, ChainedSlideInService } from 'app/services/chained-slide-in.service';
 
@@ -47,7 +47,7 @@ export abstract class IxSelectWithNewOption implements OnInit, AfterViewInit {
   abstract getValueFromChainedResponse(
     result: ChainedComponentResponse,
   ): IxSelectValue;
-  abstract getFormComponentType(): ComponentType<unknown>;
+  abstract getFormComponentType(): Type<SlideIn2CloseConfirmation>;
   abstract fetchOptions(): Observable<Option[]>;
   getFormInputData(): Record<string, unknown> {
     return undefined;

--- a/src/app/modules/slide-ins/chained-component-ref.ts
+++ b/src/app/modules/slide-ins/chained-component-ref.ts
@@ -1,4 +1,5 @@
 import { Type } from '@angular/core';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { ChainedComponentResponse as ChainedResponse } from 'app/services/chained-slide-in.service';
 
 export class ChainedRef<T> {
@@ -10,6 +11,6 @@ export class ChainedRef<T> {
    * have the same purpose and return the same response type e.g, form to wizard and
    * wizard to form.
    */
-  swap?: (component: Type<unknown>, wide: boolean, data?: unknown) => void;
+  swap?: (component: Type<SlideIn2CloseConfirmation>, wide: boolean, data?: unknown) => void;
   getData: () => T;
 }

--- a/src/app/modules/slide-ins/components/modal-header2/modal-header2.component.ts
+++ b/src/app/modules/slide-ins/components/modal-header2/modal-header2.component.ts
@@ -70,6 +70,6 @@ export class ModalHeader2Component implements AfterViewInit {
   }
 
   close(): void {
-    this.chainedSlideInRef.close({ response: false, error: null });
+    this.chainedSlideInRef.close({ response: false, error: null, cancelled: true });
   }
 }

--- a/src/app/modules/slide-ins/components/slide-in2/slide-in2.component.ts
+++ b/src/app/modules/slide-ins/components/slide-in2/slide-in2.component.ts
@@ -118,7 +118,7 @@ export class SlideIn2Component implements OnInit, OnDestroy {
   }
 
   private openSlideIn<T, D>(
-    componentType: Type<unknown>,
+    componentType: Type<SlideIn2CloseConfirmation>,
     params?: { wide?: boolean; data?: D },
   ): void {
     if (this.isSlideInOpen) {
@@ -143,7 +143,7 @@ export class SlideIn2Component implements OnInit, OnDestroy {
   }
 
   private createInjector<T, D>(
-    componentType: Type<unknown>,
+    componentType: Type<SlideIn2CloseConfirmation>,
     data?: D,
   ): void {
     const injector = Injector.create({
@@ -152,7 +152,7 @@ export class SlideIn2Component implements OnInit, OnDestroy {
           provide: ChainedRef<D>,
           useValue: {
             close: (response: ChainedComponentResponse) => {
-              this.getConfirmation().pipe(
+              (response.cancelled ? this.getConfirmation() : of(true)).pipe(
                 filter(Boolean),
                 untilDestroyed(this),
               ).subscribe({
@@ -163,7 +163,7 @@ export class SlideIn2Component implements OnInit, OnDestroy {
                 },
               });
             },
-            swap: (component: Type<unknown>, wide = false, incomingComponentData?: unknown) => {
+            swap: (component: Type<SlideIn2CloseConfirmation>, wide = false, incomingComponentData?: unknown) => {
               this.getConfirmation().pipe(
                 filter(Boolean),
                 untilDestroyed(this),
@@ -186,7 +186,7 @@ export class SlideIn2Component implements OnInit, OnDestroy {
         },
       ],
     });
-    this.componentRef = this.slideInBody.createComponent<T>(componentType as Type<T>, { injector });
+    this.componentRef = this.slideInBody.createComponent<T>(componentType as unknown as Type<T>, { injector });
   }
 
   protected onBackdropClicked(): void {

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -11,7 +11,9 @@ import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { combineLatest, of } from 'rxjs';
+import {
+  combineLatest, Observable, of,
+} from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { CloudSyncProviderName } from 'app/enums/cloudsync-provider.enum';
@@ -20,6 +22,7 @@ import { helptextSystemCloudcredentials as helptext } from 'app/helptext/system/
 import { CloudSyncCredential, CloudSyncCredentialUpdate } from 'app/interfaces/cloudsync-credential.interface';
 import { CloudSyncProvider } from 'app/interfaces/cloudsync-provider.interface';
 import { Option } from 'app/interfaces/option.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -68,7 +71,7 @@ export interface CloudCredentialFormInput {
     TranslateModule,
   ],
 })
-export class CloudCredentialsFormComponent implements OnInit {
+export class CloudCredentialsFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.CloudSyncWrite];
 
   commonForm = this.formBuilder.group({
@@ -106,6 +109,10 @@ export class CloudCredentialsFormComponent implements OnInit {
     this.limitProviders = data?.providers;
     // Has to be earlier than potential `setCredentialsForEdit` call
     this.setFormEvents();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.providerForm.form.dirty || this.commonForm.dirty);
   }
 
   get showProviderDescription(): boolean {

--- a/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.ts
@@ -24,6 +24,7 @@ import {
   KeychainCredentialUpdate,
   KeychainSshCredentials,
 } from 'app/interfaces/keychain-credential.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { SshConnectionSetup } from 'app/interfaces/ssh-connection-setup.interface';
 import { SshCredentials } from 'app/interfaces/ssh-credentials.interface';
 import { WebSocketError } from 'app/interfaces/websocket-error.interface';
@@ -74,7 +75,7 @@ const sslCertificationError = 'ESSLCERTVERIFICATIONERROR';
     AsyncPipe,
   ],
 })
-export class SshConnectionFormComponent implements OnInit {
+export class SshConnectionFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.KeychainCredentialWrite];
 
   form = this.formBuilder.group({
@@ -175,6 +176,10 @@ export class SshConnectionFormComponent implements OnInit {
     private snackbar: SnackbarService,
     private chainedRef: ChainedRef<KeychainSshCredentials>,
   ) { }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
+  }
 
   ngOnInit(): void {
     this.existingConnection = this.chainedRef.getData();

--- a/src/app/pages/dashboard/components/widget-group-form/widget-group-form.component.ts
+++ b/src/app/pages/dashboard/components/widget-group-form/widget-group-form.component.ts
@@ -7,7 +7,8 @@ import {
 import { MatButton } from '@angular/material/button';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
-import { tap } from 'rxjs';
+import { Observable, of, tap } from 'rxjs';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxIconGroupComponent } from 'app/modules/forms/ix-forms/components/ix-icon-group/ix-icon-group.component';
@@ -47,7 +48,7 @@ import { WidgetGroupSlotFormComponent } from './widget-group-slot-form/widget-gr
     TranslateModule,
   ],
 })
-export class WidgetGroupFormComponent {
+export class WidgetGroupFormComponent implements SlideIn2CloseConfirmation {
   protected group = signal<WidgetGroup>(
     { layout: WidgetGroupLayout.Full, slots: [{ type: null }] },
   );
@@ -80,6 +81,10 @@ export class WidgetGroupFormComponent {
   ) {
     this.setupLayoutUpdates();
     this.setInitialFormValues();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.layoutControl.dirty);
   }
 
   private setInitialFormValues(): void {

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
@@ -8,7 +8,7 @@ import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  debounceTime, distinctUntilChanged, map, of,
+  debounceTime, distinctUntilChanged, map, Observable, of,
 } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { CloudSyncProviderName } from 'app/enums/cloudsync-provider.enum';
@@ -19,6 +19,7 @@ import { buildNormalizedFileSize } from 'app/helpers/file-size.utils';
 import { helptextCloudBackup } from 'app/helptext/data-protection/cloud-backup/cloud-backup';
 import { CloudBackup, CloudBackupUpdate } from 'app/interfaces/cloud-backup.interface';
 import { SelectOption, newOption } from 'app/interfaces/option.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { ExplorerNodeData, TreeNode } from 'app/interfaces/tree-node.interface';
 import { CloudCredentialsSelectComponent } from 'app/modules/forms/custom-selects/cloud-credentials-select/cloud-credentials-select.component';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -73,7 +74,7 @@ type FormValue = CloudBackupFormComponent['form']['value'];
     TranslateModule,
   ],
 })
-export class CloudBackupFormComponent implements OnInit {
+export class CloudBackupFormComponent implements OnInit, SlideIn2CloseConfirmation {
   get isNew(): boolean {
     return !this.editingTask;
   }
@@ -141,6 +142,10 @@ export class CloudBackupFormComponent implements OnInit {
     private chainedRef: ChainedRef<CloudBackup>,
   ) {
     this.editingTask = chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -29,6 +29,7 @@ import { CloudSyncTask, CloudSyncTaskUi, CloudSyncTaskUpdate } from 'app/interfa
 import { CloudSyncCredential } from 'app/interfaces/cloudsync-credential.interface';
 import { CloudSyncProvider } from 'app/interfaces/cloudsync-provider.interface';
 import { newOption, SelectOption } from 'app/interfaces/option.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { ExplorerNodeData, TreeNode } from 'app/interfaces/tree-node.interface';
 import { WebSocketError } from 'app/interfaces/websocket-error.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -94,7 +95,7 @@ type FormValue = CloudSyncFormComponent['form']['value'];
     TranslateModule,
   ],
 })
-export class CloudSyncFormComponent implements OnInit {
+export class CloudSyncFormComponent implements OnInit, SlideIn2CloseConfirmation {
   get isNew(): boolean {
     return !this.editingTask;
   }
@@ -225,6 +226,10 @@ export class CloudSyncFormComponent implements OnInit {
     private chainedRef: ChainedRef<CloudSyncTaskUi>,
   ) {
     this.editingTask = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   getCredentialsList(): Observable<CloudSyncCredential[]> {

--- a/src/app/pages/data-protection/cloudsync/cloudsync-wizard/cloudsync-wizard.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-wizard/cloudsync-wizard.component.ts
@@ -8,11 +8,13 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
   BehaviorSubject, Observable, merge,
+  of,
 } from 'rxjs';
 import { cloudSyncProviderNameMap } from 'app/enums/cloudsync-provider.enum';
 import { Role } from 'app/enums/role.enum';
 import { CloudSyncTask, CloudSyncTaskUpdate } from 'app/interfaces/cloud-sync-task.interface';
 import { CloudSyncCredential } from 'app/interfaces/cloudsync-credential.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import {
   UseIxIconsInStepperComponent,
@@ -43,7 +45,7 @@ import { CloudSyncProviderComponent } from './steps/cloudsync-provider/cloudsync
     UseIxIconsInStepperComponent,
   ],
 })
-export class CloudSyncWizardComponent {
+export class CloudSyncWizardComponent implements SlideIn2CloseConfirmation {
   @ViewChild(forwardRef(() => CloudSyncWhatAndWhenComponent)) whatAndWhen: CloudSyncWhatAndWhenComponent;
 
   protected readonly requiredRoles = [Role.CloudSyncWrite];
@@ -62,6 +64,10 @@ export class CloudSyncWizardComponent {
     private dialogService: DialogService,
     private errorHandler: ErrorHandlerService,
   ) {}
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.whatAndWhen.form.dirty);
+  }
 
   createTask(payload: CloudSyncTaskUpdate): Observable<CloudSyncTask> {
     return this.ws.call('cloudsync.create', [payload]);

--- a/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
+++ b/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
@@ -6,7 +6,7 @@ import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { merge, of } from 'rxjs';
+import { merge, Observable, of } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Direction } from 'app/enums/direction.enum';
@@ -17,6 +17,7 @@ import { helptextReplicationWizard } from 'app/helptext/data-protection/replicat
 import { CountManualSnapshotsParams } from 'app/interfaces/count-manual-snapshots.interface';
 import { KeychainSshCredentials } from 'app/interfaces/keychain-credential.interface';
 import { ReplicationCreate, ReplicationTask } from 'app/interfaces/replication-task.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { WebSocketError } from 'app/interfaces/websocket-error.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { TreeNodeProvider } from 'app/modules/forms/ix-forms/components/ix-explorer/tree-node-provider.interface';
@@ -74,7 +75,7 @@ import { WebSocketService } from 'app/services/ws.service';
     TranslateModule,
   ],
 })
-export class ReplicationFormComponent implements OnInit {
+export class ReplicationFormComponent implements OnInit, SlideIn2CloseConfirmation {
   @ViewChild(GeneralSectionComponent, { static: true }) generalSection: GeneralSectionComponent;
   @ViewChild(TransportSectionComponent, { static: true }) transportSection: TransportSectionComponent;
   @ViewChild(SourceSectionComponent, { static: true }) sourceSection: SourceSectionComponent;
@@ -110,6 +111,16 @@ export class ReplicationFormComponent implements OnInit {
     private chainedRef: ChainedRef<ReplicationTask>,
   ) {
     this.existingReplication = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(
+      this.generalSection.form.dirty
+      || this.transportSection.form.dirty
+      || this.sourceSection.form.dirty
+      || this.targetSection.form.dirty
+      || this.scheduleSection.form.dirty,
+    );
   }
 
   ngOnInit(): void {

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
@@ -30,6 +30,7 @@ import { CountManualSnapshotsParams, EligibleManualSnapshotsCount, TargetUnmatch
 import { PeriodicSnapshotTask, PeriodicSnapshotTaskCreate } from 'app/interfaces/periodic-snapshot-task.interface';
 import { ReplicationCreate, ReplicationTask } from 'app/interfaces/replication-task.interface';
 import { Schedule } from 'app/interfaces/schedule.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { CreateZfsSnapshot, ZfsSnapshot } from 'app/interfaces/zfs-snapshot.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import {
@@ -69,7 +70,7 @@ import { WebSocketService } from 'app/services/ws.service';
     UseIxIconsInStepperComponent,
   ],
 })
-export class ReplicationWizardComponent {
+export class ReplicationWizardComponent implements SlideIn2CloseConfirmation {
   @ViewChild(ReplicationWhatAndWhereComponent) whatAndWhere: ReplicationWhatAndWhereComponent;
   @ViewChild(ReplicationWhenComponent) when: ReplicationWhenComponent;
 
@@ -97,6 +98,11 @@ export class ReplicationWizardComponent {
     private chainedSlideInRef: ChainedRef<unknown>,
     private authService: AuthService,
   ) {}
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    const steps = this.getSteps();
+    return of(steps.some((step) => step.form.dirty));
+  }
 
   getSteps(): [
     ReplicationWhatAndWhereComponent,

--- a/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.ts
@@ -16,6 +16,7 @@ import { RsyncMode, RsyncSshConnectMode } from 'app/enums/rsync-mode.enum';
 import { helptextRsyncForm } from 'app/helptext/data-protection/rsync/rsync-form';
 import { newOption } from 'app/interfaces/option.interface';
 import { RsyncTask, RsyncTaskUpdate } from 'app/interfaces/rsync-task.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { SshCredentialsSelectComponent } from 'app/modules/forms/custom-selects/ssh-credentials-select/ssh-credentials-select.component';
 import { UserComboboxProvider } from 'app/modules/forms/ix-forms/classes/user-combobox-provider';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -68,7 +69,7 @@ import { WebSocketService } from 'app/services/ws.service';
     TranslateModule,
   ],
 })
-export class RsyncTaskFormComponent implements OnInit {
+export class RsyncTaskFormComponent implements OnInit, SlideIn2CloseConfirmation {
   readonly requiredRoles = [Role.FullAdmin];
 
   get isNew(): boolean {
@@ -152,6 +153,10 @@ export class RsyncTaskFormComponent implements OnInit {
     private chainedSlideInRef: ChainedRef<RsyncTask>,
   ) {
     this.editingTask = this.chainedSlideInRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   get isModuleMode(): boolean {

--- a/src/app/pages/system/advanced/access/access-form/access-form.component.ts
+++ b/src/app/pages/system/advanced/access/access-form/access-form.component.ts
@@ -8,10 +8,11 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  filter, finalize, forkJoin, Observable, take,
+  filter, finalize, forkJoin, Observable, of, take,
 } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -55,7 +56,7 @@ import { selectAdvancedConfig, selectGeneralConfig } from 'app/store/system-conf
     TranslateModule,
   ],
 })
-export class AccessFormComponent implements OnInit {
+export class AccessFormComponent implements OnInit, SlideIn2CloseConfirmation {
   readonly requiredRoles = [Role.AuthSessionsWrite];
 
   isLoading = false;
@@ -86,6 +87,10 @@ export class AccessFormComponent implements OnInit {
     private authService: AuthService,
     private chainedSlideInRef: ChainedRef<unknown>,
   ) {}
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
+  }
 
   ngOnInit(): void {
     this.store$.select(selectPreferences).pipe(untilDestroyed(this)).subscribe((preferences) => {

--- a/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-form/allowed-addresses-form.component.ts
+++ b/src/app/pages/system/advanced/allowed-addresses/allowed-addresses-form/allowed-addresses-form.component.ts
@@ -15,6 +15,7 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemAdvanced } from 'app/helptext/system/advanced';
 import { helptextSystemGeneral } from 'app/helptext/system/general';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { WebSocketError } from 'app/interfaces/websocket-error.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -53,7 +54,7 @@ import { generalConfigUpdated } from 'app/store/system-config/system-config.acti
     TranslateModule,
   ],
 })
-export class AllowedAddressesFormComponent implements OnInit {
+export class AllowedAddressesFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
   protected readonly helpText = helptextSystemAdvanced;
 
@@ -73,6 +74,10 @@ export class AllowedAddressesFormComponent implements OnInit {
     private translate: TranslateService,
     private slideInRef: ChainedRef<unknown>,
   ) {}
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
+  }
 
   ngOnInit(): void {
     this.ws.call('system.general.config').pipe(untilDestroyed(this)).subscribe({

--- a/src/app/pages/system/advanced/audit/audit-form/audit-form.component.ts
+++ b/src/app/pages/system/advanced/audit/audit-form/audit-form.component.ts
@@ -10,6 +10,8 @@ import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
   EMPTY,
+  Observable,
+  of,
 } from 'rxjs';
 import {
   catchError, tap,
@@ -18,6 +20,7 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemAdvanced as helptext } from 'app/helptext/system/advanced';
 import { AuditConfig } from 'app/interfaces/audit/audit.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -52,7 +55,7 @@ import { advancedConfigUpdated } from 'app/store/system-config/system-config.act
     TranslateModule,
   ],
 })
-export class AuditFormComponent implements OnInit {
+export class AuditFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.SystemAuditWrite];
 
   isFormLoading = false;
@@ -85,6 +88,10 @@ export class AuditFormComponent implements OnInit {
     private formErrorHandler: FormErrorHandlerService,
     private chainedRef: ChainedRef<unknown>,
   ) {}
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
+  }
 
   ngOnInit(): void {
     this.loadForm();

--- a/src/app/pages/system/advanced/console/console-form/console-form.component.ts
+++ b/src/app/pages/system/advanced/console/console-form/console-form.component.ts
@@ -8,11 +8,12 @@ import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { of, Subscription } from 'rxjs';
+import { Observable, of, Subscription } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { helptextSystemAdvanced as helptext } from 'app/helptext/system/advanced';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -50,7 +51,7 @@ import { advancedConfigUpdated } from 'app/store/system-config/system-config.act
     TranslateModule,
   ],
 })
-export class ConsoleFormComponent implements OnInit {
+export class ConsoleFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   isFormLoading = false;
@@ -96,6 +97,10 @@ export class ConsoleFormComponent implements OnInit {
     private chainedRef: ChainedRef<ConsoleConfig>,
   ) {
     this.consoleConfig = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/cron/cron-form/cron-form.component.ts
+++ b/src/app/pages/system/advanced/cron/cron-form/cron-form.component.ts
@@ -6,11 +6,12 @@ import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { helptextCron } from 'app/helptext/system/cron-form';
 import { Cronjob, CronjobUpdate } from 'app/interfaces/cronjob.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { UserComboboxProvider } from 'app/modules/forms/ix-forms/classes/user-combobox-provider';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -52,7 +53,7 @@ import { WebSocketService } from 'app/services/ws.service';
     TranslateModule,
   ],
 })
-export class CronFormComponent implements OnInit {
+export class CronFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   get isNew(): boolean {
@@ -102,6 +103,10 @@ export class CronFormComponent implements OnInit {
     private chainedRef: ChainedRef<Cronjob>,
   ) {
     this.editingCron = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-form/global-two-factor-form.component.ts
+++ b/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-form/global-two-factor-form.component.ts
@@ -9,11 +9,12 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { isEqual } from 'lodash-es';
 import {
-  EMPTY, catchError, filter, of, switchMap, tap,
+  EMPTY, Observable, catchError, filter, of, switchMap, tap,
 } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { WINDOW } from 'app/helpers/window.helper';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { GlobalTwoFactorConfig, GlobalTwoFactorConfigUpdate } from 'app/interfaces/two-factor-config.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -49,7 +50,7 @@ import { WebSocketService } from 'app/services/ws.service';
     TranslateModule,
   ],
 })
-export class GlobalTwoFactorAuthFormComponent implements OnInit {
+export class GlobalTwoFactorAuthFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   isFormLoading = false;
@@ -77,6 +78,10 @@ export class GlobalTwoFactorAuthFormComponent implements OnInit {
     @Inject(WINDOW) private window: Window,
   ) {
     this.twoFactorConfig = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/init-shutdown/init-shutdown-form/init-shutdown-form.component.ts
+++ b/src/app/pages/system/advanced/init-shutdown/init-shutdown-form/init-shutdown-form.component.ts
@@ -16,6 +16,7 @@ import { Role } from 'app/enums/role.enum';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextInitShutdown } from 'app/helptext/system/init-shutdown';
 import { InitShutdownScript } from 'app/interfaces/init-shutdown-script.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
@@ -54,7 +55,7 @@ import { WebSocketService } from 'app/services/ws.service';
     AsyncPipe,
   ],
 })
-export class InitShutdownFormComponent implements OnInit {
+export class InitShutdownFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   get isNew(): boolean {
@@ -111,6 +112,10 @@ export class InitShutdownFormComponent implements OnInit {
     private chainedRef: ChainedRef<InitShutdownScript>,
   ) {
     this.editingScript = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
+++ b/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
@@ -7,9 +7,12 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { map, take } from 'rxjs';
+import {
+  map, Observable, of, take,
+} from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
@@ -44,7 +47,7 @@ import { waitForAdvancedConfig } from 'app/store/system-config/system-config.sel
     TranslateModule,
   ],
 })
-export class IsolatedGpusFormComponent implements OnInit {
+export class IsolatedGpusFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   isFormLoading = false;
@@ -71,6 +74,10 @@ export class IsolatedGpusFormComponent implements OnInit {
     private snackbar: SnackbarService,
     private chainedRef: ChainedRef<unknown>,
   ) { }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.formGroup.dirty);
+  }
 
   ngOnInit(): void {
     this.store$.pipe(

--- a/src/app/pages/system/advanced/kernel/kernel-form/kernel-form.component.ts
+++ b/src/app/pages/system/advanced/kernel/kernel-form/kernel-form.component.ts
@@ -7,9 +7,11 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
+import { Observable, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemAdvanced } from 'app/helptext/system/advanced';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -43,7 +45,7 @@ import { advancedConfigUpdated } from 'app/store/system-config/system-config.act
     TranslateModule,
   ],
 })
-export class KernelFormComponent implements OnInit {
+export class KernelFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   isFormLoading = false;
@@ -71,6 +73,10 @@ export class KernelFormComponent implements OnInit {
     if (chainedRef.getData()) {
       this.debugkernel = true;
     }
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/replication/replication-settings-form/replication-settings-form.component.ts
+++ b/src/app/pages/system/advanced/replication/replication-settings-form/replication-settings-form.component.ts
@@ -6,10 +6,12 @@ import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
+import { Observable, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemAdvanced } from 'app/helptext/system/advanced';
 import { ReplicationConfig } from 'app/interfaces/replication-config.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -41,7 +43,7 @@ import { WebSocketService } from 'app/services/ws.service';
     TranslateModule,
   ],
 })
-export class ReplicationSettingsFormComponent implements OnInit {
+export class ReplicationSettingsFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.ReplicationTaskConfigWrite];
 
   isFormLoading = false;
@@ -66,6 +68,10 @@ export class ReplicationSettingsFormComponent implements OnInit {
     private chainedRef: ChainedRef<ReplicationConfig>,
   ) {
     this.replicationConfig = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/self-encrypting-drive/self-encrypting-drive-form/self-encrypting-drive-form.component.ts
+++ b/src/app/pages/system/advanced/self-encrypting-drive/self-encrypting-drive-form/self-encrypting-drive-form.component.ts
@@ -7,11 +7,12 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { SedUser } from 'app/enums/sed-user.enum';
 import { helptextSystemAdvanced } from 'app/helptext/system/advanced';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
@@ -52,7 +53,7 @@ export interface SedConfig {
     TranslateModule,
   ],
 })
-export class SelfEncryptingDriveFormComponent implements OnInit {
+export class SelfEncryptingDriveFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   isFormLoading = false;
@@ -101,6 +102,10 @@ export class SelfEncryptingDriveFormComponent implements OnInit {
     private chainedRef: ChainedRef<SedConfig>,
   ) {
     this.sedConfig = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/storage/storage-settings-form/storage-settings-form.component.ts
+++ b/src/app/pages/system/advanced/storage/storage-settings-form/storage-settings-form.component.ts
@@ -18,6 +18,7 @@ import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { ServiceStatus } from 'app/enums/service-status.enum';
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -58,7 +59,7 @@ export interface StorageSettings {
     AsyncPipe,
   ],
 })
-export class StorageSettingsFormComponent implements OnInit {
+export class StorageSettingsFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   isFormLoading = false;
@@ -84,6 +85,10 @@ export class StorageSettingsFormComponent implements OnInit {
     private chainedRef: ChainedRef<StorageSettings>,
   ) {
     this.storageSettings = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/sysctl/tunable-form/tunable-form.component.ts
+++ b/src/app/pages/system/advanced/sysctl/tunable-form/tunable-form.component.ts
@@ -6,12 +6,13 @@ import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { TunableType } from 'app/enums/tunable-type.enum';
 import { helptextSystemTunable as helptext } from 'app/helptext/system/tunable';
 import { Job } from 'app/interfaces/job.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { Tunable } from 'app/interfaces/tunable.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -46,7 +47,7 @@ import { WebSocketService } from 'app/services/ws.service';
     TranslateModule,
   ],
 })
-export class TunableFormComponent implements OnInit {
+export class TunableFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   get isNew(): boolean {
@@ -84,6 +85,10 @@ export class TunableFormComponent implements OnInit {
     private chainedRef: ChainedRef<Tunable>,
   ) {
     this.editingTunable = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.ts
+++ b/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.ts
@@ -10,7 +10,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  EMPTY, of, Subscription,
+  EMPTY, Observable, of, Subscription,
 } from 'rxjs';
 import {
   catchError, tap,
@@ -21,6 +21,7 @@ import { SyslogLevel, SyslogTransport } from 'app/enums/syslog.enum';
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { helptextSystemAdvanced, helptextSystemAdvanced as helptext } from 'app/helptext/system/advanced';
 import { AdvancedConfigUpdate } from 'app/interfaces/advanced-config.interface';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -59,7 +60,7 @@ import { advancedConfigUpdated } from 'app/store/system-config/system-config.act
     AsyncPipe,
   ],
 })
-export class SyslogFormComponent implements OnInit {
+export class SyslogFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   isFormLoading = false;
@@ -109,6 +110,10 @@ export class SyslogFormComponent implements OnInit {
     private chainedRef: ChainedRef<SyslogConfig>,
   ) {
     this.syslogConfig = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
+++ b/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
@@ -7,10 +7,11 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { EMPTY, Observable } from 'rxjs';
+import { EMPTY, Observable, of } from 'rxjs';
 import { switchMap, take } from 'rxjs/operators';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { SystemSecurityConfig } from 'app/interfaces/system-security-config.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxSlideToggleComponent } from 'app/modules/forms/ix-forms/components/ix-slide-toggle/ix-slide-toggle.component';
@@ -43,7 +44,7 @@ import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
     TranslateModule,
   ],
 })
-export class SystemSecurityFormComponent implements OnInit {
+export class SystemSecurityFormComponent implements OnInit, SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.FullAdmin];
 
   form = this.formBuilder.group({
@@ -67,6 +68,10 @@ export class SystemSecurityFormComponent implements OnInit {
     private errorHandler: ErrorHandlerService,
   ) {
     this.systemSecurityConfig = this.chainedRef.getData();
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/virtualization/components/all-instances/all-instances-header/global-config-form/global-config-form.component.ts
+++ b/src/app/pages/virtualization/components/all-instances/all-instances-header/global-config-form/global-config-form.component.ts
@@ -4,10 +4,11 @@ import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { finalize } from 'rxjs';
+import { finalize, Observable, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { VirtualizationGlobalConfig, VirtualizationGlobalConfigUpdate } from 'app/interfaces/virtualization.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -46,7 +47,7 @@ import { WebSocketService } from 'app/services/ws.service';
     IxIpInputWithNetmaskComponent,
   ],
 })
-export class GlobalConfigFormComponent {
+export class GlobalConfigFormComponent implements SlideIn2CloseConfirmation {
   protected readonly requiredRoles = [Role.VirtGlobalWrite];
   protected isLoading = signal(false);
   protected readonly autoBridge = '[AUTO]';
@@ -82,6 +83,10 @@ export class GlobalConfigFormComponent {
       v4_network: currentConfig.v4_network,
       v6_network: currentConfig.v6_network,
     });
+  }
+
+  requiresConfirmationOnClose(): Observable<boolean> {
+    return of(this.form.dirty);
   }
 
   onSubmit(): void {

--- a/src/app/services/chained-slide-in.service.ts
+++ b/src/app/services/chained-slide-in.service.ts
@@ -5,10 +5,11 @@ import { UUID } from 'angular2-uuid';
 import {
   Observable, Subject, take, tap, timer,
 } from 'rxjs';
+import { SlideIn2CloseConfirmation } from 'app/interfaces/slide-in-close-confirmation.interface';
 import { FocusService } from 'app/services/focus.service';
 
 export interface IncomingChainedComponent {
-  component: Type<unknown>;
+  component: Type<SlideIn2CloseConfirmation>;
   wide: boolean;
   data: unknown;
   swapComponentId?: string;
@@ -19,7 +20,7 @@ export interface ChainedSlideInState {
 }
 
 export interface ChainedComponent {
-  component: Type<unknown>;
+  component: Type<SlideIn2CloseConfirmation>;
   close$: Subject<ChainedComponentResponse>;
   wide: boolean;
   data: unknown;
@@ -29,11 +30,12 @@ export interface ChainedComponent {
 export interface ChainedComponentResponse<T = unknown> {
   response: T;
   error: unknown;
+  cancelled?: boolean;
 }
 
 export interface ChainedComponentSerialized {
   id: string;
-  component: Type<unknown>;
+  component: Type<SlideIn2CloseConfirmation>;
   close$: Subject<ChainedComponentResponse>;
   data?: unknown;
   wide?: boolean;
@@ -83,7 +85,7 @@ export class ChainedSlideInService extends ComponentStore<ChainedSlideInState> {
 
   // TODO: Update second argument to options
   open(
-    component: Type<unknown>,
+    component: Type<SlideIn2CloseConfirmation>,
     wide = false,
     data?: unknown,
   ): Observable<ChainedComponentResponse> {

--- a/src/app/services/chained-slide-in.service.ts
+++ b/src/app/services/chained-slide-in.service.ts
@@ -1,4 +1,3 @@
-import { ComponentType } from '@angular/cdk/portal';
 import { Injectable, Type } from '@angular/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { ComponentStore } from '@ngrx/component-store';
@@ -9,7 +8,7 @@ import {
 import { FocusService } from 'app/services/focus.service';
 
 export interface IncomingChainedComponent {
-  component: ComponentType<unknown>;
+  component: Type<unknown>;
   wide: boolean;
   data: unknown;
   swapComponentId?: string;


### PR DESCRIPTION
**Changes:**

Defines `SlideIn2CloseConfirmation` interface for confirmation before closing slide-ins

**Testing:**

Code review
Open the `ssh-connection-form` under `Credentials -> Cloud Credentials` and edit the form and close without saving. You should see a confirmation dialog asking if you're sure
Test on the `ReplicationWizard` under `Data Protection` and edit the form and close without saving. You shouldn't see a confirmation dialog and the dialog should close without a problem.
