### PR TITLE
NAS-132159 / 24.10.1 / Remove workaround for custom_app (by denysbutenko)

### DIFF
--- a/src/app/pages/apps/store/installed-apps-store.service.ts
+++ b/src/app/pages/apps/store/installed-apps-store.service.ts
@@ -2,8 +2,8 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { ComponentStore } from '@ngrx/component-store';
 import {
-  EMPTY,
-  Observable, Subscription, catchError, combineLatest, delay, filter, of, repeat, switchMap, tap,
+  EMPTY, Observable, Subscription, catchError,
+  combineLatest, filter, of, switchMap, tap,
 } from 'rxjs';
 import { IncomingApiMessageType } from 'app/enums/api-message-type.enum';
 import { tapOnce } from 'app/helpers/operators/tap-once.operator';
@@ -81,15 +81,6 @@ export class InstalledAppsStore extends ComponentStore<InstalledAppsState> imple
     });
   }
 
-  private handleRemovedApps(updatedAppName: string, allApps: AvailableApp[]): AvailableApp[] {
-    return allApps.map((app) => {
-      if (app.name === updatedAppName) {
-        return { ...app, installed: false } as AvailableApp;
-      }
-      return app;
-    });
-  }
-
   private loadInstalledApps(): Observable<App[]> {
     return combineLatest([
       this.dockerStore.isLoading$,
@@ -105,17 +96,6 @@ export class InstalledAppsStore extends ComponentStore<InstalledAppsState> imple
         return this.appsService.getAllApps().pipe(
           tap((installedApps) => this.patchState({ installedApps })),
           tap(() => this.subscribeToInstalledAppsUpdates()),
-          repeat({
-            // TODO: NAS-131676. Remove this workaround after the bug is fixed.
-            delay: () => this.appsService.getInstalledAppsUpdates().pipe(
-              filter((event) => {
-                return (event.msg === IncomingApiMessageType.Added && !('fields' in event))
-                 || (event.msg === IncomingApiMessageType.Changed && event.fields.custom_app);
-              }),
-              tap(() => this.patchState({ isLoading: true })),
-              delay(2000),
-            ),
-          }),
         );
       }),
       tap(() => this.patchState({ isLoading: false })),


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 85ba6784d0a6acf0fcdc47449653394047b63156

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x b7c8c324d28e14c40f4d731461b021e1188fa906

**Changes:**

- https://ixsystems.atlassian.net/browse/NAS-131885 has been fixed.
- Removed workaround to update installed apps when custom app installs.
- 

**Testing:**

Check installed apps list after custom app is installed. Expected are no changes in behavior.

Original PR: https://github.com/truenas/webui/pull/10995
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132159