### PR TITLE
NAS-132227 / 24.10.1 / Fix enable change in SMB table (by bvasilenko)

### DIFF
--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { Router } from '@angular/router';
 import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
@@ -141,6 +142,19 @@ describe('SmbListComponent', () => {
     await deleteButton.click();
 
     expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith('sharing.smb.delete', [1]);
+  });
+
+  it('updates SMB Enabled status once mat-toggle is updated', async () => {
+    const toggle = await table.getHarnessInCell(MatSlideToggleHarness, 1, 3);
+
+    expect(await toggle.isChecked()).toBe(true);
+
+    await toggle.uncheck();
+
+    expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith(
+      'sharing.smb.update',
+      [1, { enabled: false }],
+    );
   });
 
   it('should show table rows', async () => {

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -67,20 +67,7 @@ export class SmbListComponent implements OnInit {
       title: this.translate.instant('Enabled'),
       propertyName: 'enabled',
       requiredRoles: this.requiredRoles,
-      onRowToggle: (row) => {
-        this.ws.call('sharing.smb.update', [row.id, { enabled: row.enabled }]).pipe(
-          this.appLoader.withLoader(),
-          untilDestroyed(this),
-        ).subscribe({
-          next: (share) => {
-            row.enabled = share.enabled;
-          },
-          error: (error: unknown) => {
-            this.dataProvider.load();
-            this.dialog.error(this.errorHandler.parseError(error));
-          },
-        });
-      },
+      onRowToggle: (row) => this.onChangeEnabledState(row),
     }),
     yesNoColumn({
       title: this.translate.instant('Audit Logging'),
@@ -231,6 +218,21 @@ export class SmbListComponent implements OnInit {
     this.dialog.error({
       title: this.translate.instant('Error'),
       message: this.translate.instant('The path <i>{path}</i> is in a locked dataset.', { path }),
+    });
+  }
+
+  private onChangeEnabledState(row: SmbShare): void {
+    this.ws.call('sharing.smb.update', [row.id, { enabled: !row.enabled }]).pipe(
+      this.appLoader.withLoader(),
+      untilDestroyed(this),
+    ).subscribe({
+      next: () => {
+        this.dataProvider.load();
+      },
+      error: (error: unknown) => {
+        this.dataProvider.load();
+        this.dialog.error(this.errorHandler.parseError(error));
+      },
     });
   }
 }


### PR DESCRIPTION

**Testing:**

On the **Shares** page

At the **SMB** block, 

1. User sets a share to **Disabled** state.

1. User clicked **View all** to navigate to the distinguished **SMB** page.

2. User sets this share to **Enabled** state.

2. User goes back to **Shares** page, and observes the **SMB** block (and optionally refreshes the page).

- **Expected result:** share is in **Enabled** state


Original PR: https://github.com/truenas/webui/pull/11001
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132227