### PR TITLE
NAS-131595 / 25.04 / Prepare redirect URL for IPv6

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -13,6 +13,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { Router, RouterLink } from '@angular/router';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import ipRegex from 'ip-regex';
 import { ImgFallbackModule } from 'ngx-img-fallback';
 import {
   filter, map, switchMap, take, tap,
@@ -109,7 +110,9 @@ export class AppInfoCardComponent {
     const portalUrl = new URL(app.portals[name]);
 
     if (portalUrl.hostname === '0.0.0.0') {
-      portalUrl.hostname = this.window.location.hostname;
+      const hostname = this.window.location.hostname;
+      const isIpv6 = ipRegex.v6().test(hostname);
+      portalUrl.hostname = isIpv6 ? `[${hostname}]` : hostname;
     }
 
     this.redirect.openWindow(portalUrl.href);


### PR DESCRIPTION
## Testing

User configures an app to use IPv6 Address for it's web interface. 

**Steps to replicate**


1. When logging into the front-end by entering IPv4 address ( 127.0.0.1:4200 ) into the address bar, 
2. User configures some app to use IPv6 Address for it's web interface
3. User logs out. And then logs in again, but by entering IPv6 address of the server into the address bar
4. Go to **Apps**, choose this App, and click button to access app's web interface.

    Please also see video attachment in the ticket.

**Expected Result**


- The Apps can be accessed using both Ipv4 and IPv6 URL's