### PR TITLE
NAS-132074 / 25.04 / Fix network chart styles

### DIFF
--- a/src/app/pages/dashboard/widgets/network/common/network-chart/network-chart.component.scss
+++ b/src/app/pages/dashboard/widgets/network/common/network-chart/network-chart.component.scss
@@ -1,0 +1,4 @@
+ix-view-chart-area {
+  display: flex;
+  width: 100%;
+}


### PR DESCRIPTION
On **Dashboard** page,

When the **Network widget** renders, but the chart does not scale correctly.

## Steps to Reproduce

Access the dashboard (containing the default Network Interface widget) from the Firefox browser.

## Expected Result

The widget should be displayed correctly (see below)

<img width="338" alt="image" src="https://github.com/user-attachments/assets/4974aa50-f96c-4a15-90a1-c869a59be4a4">

