### PR TITLE
NAS-132517 / 24.10.1 / Cloud credentials storJ text does not render link correctly (by AlexKarpov98)

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-provider-description/cloudsync-provider-description.component.html
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-provider-description/cloudsync-provider-description.component.html
@@ -5,5 +5,5 @@
   <div class="name">{{ name }}</div>
 </div>
 <div class="body">
-  <p>{{ description }}</p>
+  <p [innerHTML]="description"></p>
 </div>

--- a/src/app/pages/data-protection/cloudsync/cloudsync-provider-description/cloudsync-provider-description.component.spec.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-provider-description/cloudsync-provider-description.component.spec.ts
@@ -17,8 +17,13 @@ describe('CloudSyncProviderDescriptionComponent', () => {
   it('should have the correct details for Storj', () => {
     spectator.setInput('provider', CloudSyncProviderName.Storj);
 
-    expect(spectator.component.image).toBe('/assets/images/cloudsync/STORJ_IX.png');
-    expect(spectator.component.name).toBe('Storj');
-    expect(spectator.component.description).toBe('StorJ is an S3 compatible, fault tolerant, globally distributed cloud storage platform with a security first approach to backup and recovery - delivering extreme resilience and performance both sustainably and economically. <a href="https://truenas.com/storj" target="_blank">TrueNAS and Storj</a> have partnered to streamline delivery of Hybrid Cloud solutions globally.');
+    const image = spectator.query('.image img');
+    expect(image).toHaveAttribute('src', '/assets/images/cloudsync/STORJ_IX.png');
+
+    const name = spectator.query('.name');
+    expect(name).toHaveText('Storj');
+
+    const description = spectator.query('.body');
+    expect(description).not.toContain('<a href');
   });
 });


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x cf3d06f2733ecab7c26d2a109eaeb7e0a8b82fe1

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8611b31c7805968a471a9c700fcb31547508680b

Code review is enough
<img width="498" alt="Screenshot 2024-11-18 at 11 06 26" src="https://github.com/user-attachments/assets/7bda86ed-cf98-4f5b-8f9e-28d4a6c9df37">


Original PR: https://github.com/truenas/webui/pull/11055
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132517