### PR TITLE
NAS-132593 / 25.04 / Fix how GPU devices are added to containers

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -244,9 +244,9 @@ import {
   VmDisplayWebUriParams, VmPortWizardResult,
 } from 'app/interfaces/virtual-machine.interface';
 import {
-  VirtualizationDevice, VirtualizationGlobalConfig, AvailableGpu,
+  VirtualizationDevice, VirtualizationGlobalConfig,
   VirtualizationImage, VirtualizationImageParams,
-  VirtualizationInstance, VirtualizationNetwork, AvailableUsb,
+  VirtualizationInstance, VirtualizationNetwork, AvailableUsb, AvailableGpus,
 } from 'app/interfaces/virtualization.interface';
 import {
   VmDevice, VmDeviceDelete, VmDeviceUpdate, VmDisplayDevice, VmPassthroughDeviceChoice, VmUsbPassthroughDeviceChoice,
@@ -840,7 +840,7 @@ export interface ApiCallDirectory {
   'virt.device.disk_choices': { params: []; response: Choices };
   'virt.device.gpu_choices': {
     params: [instanceType: VirtualizationType, gpuType: VirtualizationGpuType];
-    response: Record<string, AvailableGpu>;
+    response: AvailableGpus;
   };
   'virt.device.usb_choices': { params: []; response: Record<string, AvailableUsb> };
 

--- a/src/app/interfaces/virtualization.interface.ts
+++ b/src/app/interfaces/virtualization.interface.ts
@@ -177,6 +177,11 @@ export interface AvailableGpu {
   vendor: string | null;
 }
 
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+export interface AvailableGpus {
+  [pci: string]: AvailableGpu;
+}
+
 export interface AvailableUsb {
   vendor_id: string;
   product_id: string;

--- a/src/app/pages/virtualization/components/all-instances/instance-details/instance-devices/add-device-menu/add-device-menu.component.html
+++ b/src/app/pages/virtualization/components/all-instances/instance-details/instance-devices/add-device-menu/add-device-menu.component.html
@@ -24,15 +24,16 @@
       }
     }
 
-    @if (availableGpuDevices().length) {
+    @let gpus = availableGpuDevices() | keyvalue;
+    @if (gpus.length) {
       <h4 class="menu-header">{{ 'GPUs' | translate }}</h4>
-      @for (gpu of availableGpuDevices(); track gpu) {
+      @for (gpu of gpus; track gpu.key) {
         <button
           mat-menu-item
-          [ixTest]="['add-gpu-device', gpu.description]"
-          (click)="addGpu(gpu)"
+          [ixTest]="['add-gpu-device', gpu.value.description]"
+          (click)="addGpu(gpu.key)"
         >
-          {{ gpu.description }}
+          {{ gpu.value.description }}
         </button>
       }
     }

--- a/src/app/pages/virtualization/components/all-instances/instance-details/instance-devices/add-device-menu/add-device-menu.component.spec.ts
+++ b/src/app/pages/virtualization/components/all-instances/instance-details/instance-devices/add-device-menu/add-device-menu.component.spec.ts
@@ -30,10 +30,10 @@ describe('AddDeviceMenuComponent', () => {
           } as AvailableUsb,
         }),
         mockCall('virt.device.gpu_choices', {
-          gpu1: {
+          pci_0000_01_00_0: {
             description: 'NDIVIA XTR 2000',
           } as AvailableGpu,
-          gpu2: {
+          pci_0000_01_00_1: {
             description: 'MAD Galeon 5000',
           } as AvailableGpu,
         }),
@@ -48,6 +48,7 @@ describe('AddDeviceMenuComponent', () => {
           },
           {
             dev_type: VirtualizationDeviceType.Gpu,
+            pci: 'pci_0000_01_00_0',
             description: 'NDIVIA XTR 2000',
           },
         ] as VirtualizationDevice[],
@@ -95,7 +96,7 @@ describe('AddDeviceMenuComponent', () => {
 
     expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('virt.instance.device_add', ['my-instance', {
       dev_type: VirtualizationDeviceType.Gpu,
-      description: 'MAD Galeon 5000',
+      pci: 'pci_0000_01_00_1',
     } as VirtualizationDevice]);
     expect(spectator.inject(VirtualizationInstancesStore).loadDevices).toHaveBeenCalled();
     expect(spectator.inject(SnackbarService).success).toHaveBeenCalledWith('Device was added');

--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.spec.ts
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.spec.ts
@@ -167,7 +167,7 @@ describe('InstanceWizardComponent', () => {
           dest_proto: VirtualizationProxyProtocol.Udp,
         },
         { dev_type: VirtualizationDeviceType.Usb, product_id: '0003' },
-        { dev_type: VirtualizationDeviceType.Gpu, gpu_type: 'NVIDIA Corporation' },
+        { dev_type: VirtualizationDeviceType.Gpu, pci: 'pci_0000_01_00_0' },
       ],
       image: 'almalinux/8/cloud',
       memory: GiB,

--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.ts
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.ts
@@ -94,10 +94,9 @@ export class InstanceWizardComponent implements OnInit {
     'virt.device.gpu_choices',
     [VirtualizationType.Container, VirtualizationGpuType.Physical],
   ).pipe(
-    map((choices: Record<string, AvailableGpu>) => Object.values(choices).map((choice) => ({
-      label: choice.description,
-      // TODO: Incorrect value – doesn't uniquely identify the GPU
-      value: choice.vendor,
+    map((choices: Record<string, AvailableGpu>) => Object.entries(choices).map(([pci, gpu]) => ({
+      label: gpu.description,
+      value: pci,
     }))),
   );
 
@@ -272,9 +271,9 @@ export class InstanceWizardComponent implements OnInit {
 
     const gpuDevices = Object.entries(this.form.controls.gpu_devices.value || {})
       .filter(([_, isSelected]) => isSelected)
-      .map(([gpuType]) => ({
+      .map(([pci]) => ({
+        pci,
         dev_type: VirtualizationDeviceType.Gpu,
-        gpu_type: gpuType,
       }));
 
     const proxies = this.form.controls.proxies.value.map((proxy) => ({


### PR DESCRIPTION
**Changes:**

`virt.device.gpu_choices` returns an object where keys are pci addresses that should be used to add gpus to a container.

**Testing:**

I am not aware of a system that we can use for testing for now, but for now you can inspect code and tests.
