### PR TITLE
NAS-132322: Adapt to API changes made to `acme.dns.authenticator` service

### DIFF
--- a/src/app/enums/dns-authenticator-type.enum.ts
+++ b/src/app/enums/dns-authenticator-type.enum.ts
@@ -1,4 +1,6 @@
 export enum DnsAuthenticatorType {
   Route53 = 'route53',
   Cloudflare = 'cloudflare',
+  Ovh = 'OVH',
+  Shell = 'shell',
 }

--- a/src/app/helpers/get-dynamic-form-schema-node.ts
+++ b/src/app/helpers/get-dynamic-form-schema-node.ts
@@ -2,9 +2,9 @@ import { DynamicFormSchemaType } from 'app/enums/dynamic-form-schema-type.enum';
 import { SchemaType } from 'app/enums/schema.enum';
 import { toHumanReadableKey } from 'app/helpers/object-keys-to-human-readable.helper';
 import { DynamicFormSchemaCheckbox, DynamicFormSchemaInput, DynamicFormSchemaNode } from 'app/interfaces/dynamic-form-schema.interface';
-import { Schema } from 'app/interfaces/schema.interface';
+import { Schema, SchemaProperties } from 'app/interfaces/schema.interface';
 
-export function getDynamicFormSchemaNode(schema: Schema): DynamicFormSchemaNode {
+export function getDynamicFormSchemaNode(schema: SchemaProperties | Schema): DynamicFormSchemaNode {
   const baseSchema = {
     controlName: schema._name_,
     type: DynamicFormSchemaType.Input,

--- a/src/app/interfaces/dns-authenticator.interface.ts
+++ b/src/app/interfaces/dns-authenticator.interface.ts
@@ -1,36 +1,16 @@
 import { DnsAuthenticatorType } from 'app/enums/dns-authenticator-type.enum';
 import { Schema } from 'app/interfaces/schema.interface';
 
-export type DnsAuthenticator = CloudflareDnsAuthenticator | Route53DnsAuthenticator;
-
-export interface CloudflareDnsAuthenticator {
+export interface DnsAuthenticator {
   id: number;
   name: string;
-  authenticator: DnsAuthenticatorType.Cloudflare;
-  attributes: {
-    // Either
-    api_token?: string;
-
-    // Or
-    cloudflare_email?: string;
-    api_key?: string;
-  };
-}
-
-export interface Route53DnsAuthenticator {
-  id: number;
-  name: string;
-  authenticator: DnsAuthenticatorType.Route53;
-  attributes: {
-    access_key_id: string;
-    secret_access_key: string;
-  };
+  attributes: Record<string, string>;
 }
 
 export interface AuthenticatorSchema {
   key: DnsAuthenticatorType;
-  schema: Schema[];
+  schema: Schema;
 }
 
 export type CreateDnsAuthenticator = Omit<DnsAuthenticator, 'id'>;
-export type UpdateDnsAuthenticator = Omit<DnsAuthenticator, 'id' | 'authenticator'>;
+export type UpdateDnsAuthenticator = Omit<DnsAuthenticator, 'id'>;

--- a/src/app/interfaces/schema.interface.ts
+++ b/src/app/interfaces/schema.interface.ts
@@ -1,7 +1,23 @@
 import { SchemaType } from 'app/enums/schema.enum';
 
-export interface Schema {
+export type Schema = {
+  properties: Record<string, SchemaProperties>;
+} & OldSchema;
+
+/**
+ * @deprecated Remove after "reporting.exporters.exporter_schemas" refactoring.
+ */
+export interface OldSchema {
   title: string;
+  type: SchemaType | SchemaType[];
+  _name_: string;
+  _required_: boolean;
+
+}
+
+export interface SchemaProperties {
+  title: string;
+  description?: string;
   type: SchemaType | SchemaType[];
   _name_: string;
   _required_: boolean;

--- a/src/app/pages/credentials/certificates-dash/acme-dns-authenticator-list/acme-dns-authenticator-list.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/acme-dns-authenticator-list/acme-dns-authenticator-list.component.spec.ts
@@ -23,7 +23,9 @@ import { SlideInService } from 'app/services/slide-in.service';
 const authenticators = Array.from({ length: 10 }).map((_, index) => ({
   id: index + 1,
   name: `dns-authenticator-${index}`,
-  authenticator: DnsAuthenticatorType.Cloudflare,
+  attributes: {
+    authenticator: DnsAuthenticatorType.Cloudflare,
+  },
 })) as DnsAuthenticator[];
 
 describe('AcmeDnsAuthenticatorListComponent', () => {

--- a/src/app/pages/credentials/certificates-dash/acme-dns-authenticator-list/acme-dns-authenticator-list.component.ts
+++ b/src/app/pages/credentials/certificates-dash/acme-dns-authenticator-list/acme-dns-authenticator-list.component.ts
@@ -69,7 +69,7 @@ export class AcmeDnsAuthenticatorListComponent implements OnInit {
     }),
     textColumn({
       title: this.translate.instant('Authenticator'),
-      propertyName: 'authenticator',
+      getValue: (row) => row.attributes?.authenticator,
     }),
     actionsColumn({
       actions: [

--- a/src/app/pages/credentials/certificates-dash/forms/acmedns-form/acmedns-form.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/acmedns-form/acmedns-form.component.spec.ts
@@ -8,7 +8,8 @@ import {
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { DnsAuthenticatorType } from 'app/enums/dns-authenticator-type.enum';
-import { AuthenticatorSchema, DnsAuthenticator } from 'app/interfaces/dns-authenticator.interface';
+import { SchemaType } from 'app/enums/schema.enum';
+import { DnsAuthenticator } from 'app/interfaces/dns-authenticator.interface';
 import { Option } from 'app/interfaces/option.interface';
 import { Schema } from 'app/interfaces/schema.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -49,29 +50,33 @@ describe('AcmednsFormComponent', () => {
         mockCall('acme.dns.authenticator.create'),
         mockCall('acme.dns.authenticator.update'),
         mockCall('acme.dns.authenticator.authenticator_schemas', [{
-          key: 'cloudflare' as DnsAuthenticatorType,
-          schema: [
-            {
-              _name_: 'cloudflare_email', _required_: false, title: 'Cloudflare Email', type: 'string',
+          key: DnsAuthenticatorType.Cloudflare,
+          schema: {
+            properties: {
+              cloudflare_email: {
+                _name_: 'cloudflare_email', _required_: false, title: 'Cloudflare Email', type: SchemaType.String,
+              },
+              api_key: {
+                _name_: 'api_key', _required_: false, title: 'API Key', type: SchemaType.String,
+              },
+              api_token: {
+                _name_: 'api_token', _required_: false, title: 'API Token', type: SchemaType.String,
+              },
             },
-            {
-              _name_: 'api_key', _required_: false, title: 'API Key', type: 'string',
-            },
-            {
-              _name_: 'api_token', _required_: false, title: 'API Token', type: 'string',
-            },
-          ] as Schema[],
+          } as unknown as Schema,
         }, {
-          key: 'route53' as DnsAuthenticatorType,
-          schema: [
-            {
-              _name_: 'access_key_id', _required_: true, title: 'Access Key ID', type: 'string',
+          key: DnsAuthenticatorType.Route53,
+          schema: {
+            properties: {
+              access_key_id: {
+                _name_: 'access_key_id', _required_: true, title: 'Access Key ID', type: SchemaType.String,
+              },
+              secret_access_key: {
+                _name_: 'secret_access_key', _required_: true, title: 'Secret Access Key', type: SchemaType.String,
+              },
             },
-            {
-              _name_: 'secret_access_key', _required_: true, title: 'Secret Access Key', type: 'string',
-            },
-          ] as Schema[],
-        }] as AuthenticatorSchema[]),
+          } as unknown as Schema,
+        }]),
       ]),
       mockAuth(),
     ],
@@ -138,6 +143,7 @@ describe('AcmednsFormComponent', () => {
           {
             name: 'name_edit',
             attributes: {
+              authenticator: 'cloudflare',
               api_token: 'new_api_token',
             },
           },
@@ -167,8 +173,8 @@ describe('AcmednsFormComponent', () => {
 
       expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('acme.dns.authenticator.create', [{
         name: 'name_new',
-        authenticator: 'cloudflare',
         attributes: {
+          authenticator: 'cloudflare',
           api_key: 'new_api_key',
           cloudflare_email: 'aaa@aaa.com',
         },

--- a/src/app/pages/credentials/certificates-dash/forms/acmedns-form/acmedns-form.component.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/acmedns-form/acmedns-form.component.ts
@@ -140,7 +140,7 @@ export class AcmednsFormComponent implements OnInit {
 
   private createAuthenticatorControls(schemas: AuthenticatorSchema[]): void {
     schemas.forEach((schema) => {
-      schema.schema.forEach((input) => {
+      Object.values(schema.schema.properties).forEach((input) => {
         this.form.controls.attributes.addControl(input._name_, new FormControl('', input._required_ ? [Validators.required] : []));
       });
     });
@@ -157,11 +157,11 @@ export class AcmednsFormComponent implements OnInit {
   }
 
   parseSchemaForDynamicSchema(schema: AuthenticatorSchema): DynamicFormSchemaNode[] {
-    return schema.schema.map((input) => getDynamicFormSchemaNode(input));
+    return Object.values(schema.schema.properties).map((input) => getDynamicFormSchemaNode(input));
   }
 
   parseSchemaForDnsAuthList(schema: AuthenticatorSchema): DnsAuthenticatorList {
-    const variables = schema.schema.map((input) => input._name_);
+    const variables = Object.values(schema.schema.properties).map((input) => input._name_);
     return { key: schema.key, variables };
   }
 
@@ -191,12 +191,11 @@ export class AcmednsFormComponent implements OnInit {
 
   onSubmit(): void {
     const values = {
-      ...this.form.value,
+      name: this.form.value.name,
+      attributes: this.form.value.attributes,
     };
 
-    if (!this.isNew) {
-      delete values.authenticator;
-    }
+    values.attributes.authenticator = this.form.value.authenticator;
 
     for (const [key, value] of Object.entries(values.attributes)) {
       if (value == null || value === '') {


### PR DESCRIPTION
**Testing**

Go to **Credentials > Certificates > ACME DNS-Authenticators**.
Add entries with different `Authenticator` values ​​(eg `cloudflare`, `route53`, etc.).

1. Entries should be added successfully.

2. The entries should appear in a table.
   
![image](https://github.com/user-attachments/assets/fd66a5f2-5a31-41ad-b582-5f58ffeb90c9)

3. Entries can be successfully edited.