### PR TITLE
NAS-132108 / 24.10.1 / Add support for name selection from old pool widgets

### DIFF
--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -125,6 +125,13 @@ export class WidgetResourcesService {
     );
   }
 
+  getPoolByName(poolName: string): Observable<Pool> {
+    return this.ws.call('pool.query', [[['name', '=', poolName]]]).pipe(
+      map((pools) => pools[0]),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+  }
+
   getDatasetById(datasetId: string): Observable<Dataset> {
     return this.ws.call('pool.dataset.query', [[['id', '=', datasetId]]]).pipe(
       map((response) => response[0]),

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/widget-pool.definition.ts
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/widget-pool.definition.ts
@@ -9,6 +9,7 @@ import { WidgetPoolComponent } from 'app/pages/dashboard/widgets/storage/widget-
 
 export interface WidgetPoolSettings {
   poolId: number;
+  name?: string;
 }
 
 export const poolWidget = dashboardWidget<WidgetPoolSettings>({


### PR DESCRIPTION
**Changes:**

Adds support for the new pool widget to get pool by name from old widgets.

**Testing:**

Install 24.04 and add a pool widget on the dashboard. Then upgrade to 24.10 via an update file. Go back to the dashboard and you should see the pool widget still working and showing the pool data correctly.
