### PR TITLE
NAS-132648 / 25.04 / query param handling for auth tokens

### DIFF
--- a/src/app/core/guards/websocket-connection.guard.ts
+++ b/src/app/core/guards/websocket-connection.guard.ts
@@ -1,8 +1,9 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
+import { WINDOW } from 'app/helpers/window.helper';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { WebSocketHandlerService } from 'app/services/websocket/websocket-handler.service';
 
@@ -16,9 +17,10 @@ export class WebSocketConnectionGuard {
     private matDialog: MatDialog,
     private dialogService: DialogService,
     private translate: TranslateService,
+    @Inject(WINDOW) private window: Window,
   ) {
     this.wsManager.isClosed$.pipe(untilDestroyed(this)).subscribe((isClosed) => {
-      if (isClosed && this.wsManager.hasOpenedOnce) {
+      if (isClosed) {
         this.resetUi();
         // TODO: Test why manually changing close status is needed
         // Test a shutdown function to see how UI acts when this isn't done
@@ -37,7 +39,9 @@ export class WebSocketConnectionGuard {
   private resetUi(): void {
     this.closeAllDialogs();
     if (!this.wsManager.isSystemShuttingDown) {
-      this.router.navigate(['/signin']);
+      // manually preserve query params
+      const params = new URLSearchParams(this.window.location.search);
+      this.router.navigate(['/signin'], { queryParams: Object.fromEntries(params) });
     }
   }
 

--- a/src/app/core/guards/websocket-connection.guard.ts
+++ b/src/app/core/guards/websocket-connection.guard.ts
@@ -18,7 +18,7 @@ export class WebSocketConnectionGuard {
     private translate: TranslateService,
   ) {
     this.wsManager.isClosed$.pipe(untilDestroyed(this)).subscribe((isClosed) => {
-      if (isClosed) {
+      if (isClosed && this.wsManager.hasOpenedOnce) {
         this.resetUi();
         // TODO: Test why manually changing close status is needed
         // Test a shutdown function to see how UI acts when this isn't done

--- a/src/app/core/testing/utils/empty-auth.service.ts
+++ b/src/app/core/testing/utils/empty-auth.service.ts
@@ -15,5 +15,5 @@ export class EmptyAuthService {
   logout = getMissingInjectionErrorFactory(AuthService.name);
   refreshUser = getMissingInjectionErrorFactory(AuthService.name);
   loginWithToken = getMissingInjectionErrorFactory(AuthService.name);
-  setQueryTokenIfExists = getMissingInjectionErrorFactory(AuthService.name);
+  setQueryToken = getMissingInjectionErrorFactory(AuthService.name);
 }

--- a/src/app/core/testing/utils/empty-auth.service.ts
+++ b/src/app/core/testing/utils/empty-auth.service.ts
@@ -15,4 +15,5 @@ export class EmptyAuthService {
   logout = getMissingInjectionErrorFactory(AuthService.name);
   refreshUser = getMissingInjectionErrorFactory(AuthService.name);
   loginWithToken = getMissingInjectionErrorFactory(AuthService.name);
+  setQueryTokenIfExists = getMissingInjectionErrorFactory(AuthService.name);
 }

--- a/src/app/pages/signin/store/signin.store.spec.ts
+++ b/src/app/pages/signin/store/signin.store.spec.ts
@@ -97,7 +97,6 @@ describe('SigninStore', () => {
       wasAdminSet: true,
       isLoading: false,
       loginBanner: '',
-      queryToken: null as string | null,
     };
     beforeEach(() => {
       spectator.service.setState(initialState);
@@ -145,7 +144,6 @@ describe('SigninStore', () => {
         failover: {
           status: FailoverStatus.Single,
         },
-        queryToken: null,
       });
     });
 
@@ -162,7 +160,6 @@ describe('SigninStore', () => {
         failover: {
           status: FailoverStatus.Single,
         },
-        queryToken: null,
       });
     });
 
@@ -182,7 +179,6 @@ describe('SigninStore', () => {
           ips: ['123.23.44.54'],
           status: FailoverStatus.Master,
         },
-        queryToken: null,
       });
     });
 
@@ -202,14 +198,12 @@ describe('SigninStore', () => {
       expect(spectator.inject(Router).navigateByUrl).not.toHaveBeenCalled();
     });
 
-    it('should call "loginWithToken" if queryToken is not null', async () => {
+    it('should call "loginWithToken" if queryToken is not null', () => {
       isTokenWithinTimeline$.next(false);
       const token = 'token';
       const activatedRoute = spectator.inject(ActivatedRoute);
       jest.spyOn(activatedRoute.snapshot.queryParamMap, 'get').mockImplementationOnce(() => token);
       spectator.service.init();
-      const state = await firstValueFrom(spectator.service.state$);
-      expect(state.queryToken).toBe(token);
       expect(authService.setQueryToken).toHaveBeenCalledWith(token);
       expect(authService.loginWithToken).toHaveBeenCalled();
     });
@@ -247,7 +241,6 @@ describe('SigninStore', () => {
           ips: ['123.23.44.54'],
           status: FailoverStatus.Importing,
         },
-        queryToken: null,
       });
     });
 
@@ -279,7 +272,6 @@ describe('SigninStore', () => {
               ips: ['123.23.44.54'],
               status: FailoverStatus.Master,
             },
-            queryToken: null,
           },
         });
       });

--- a/src/app/pages/signin/store/signin.store.spec.ts
+++ b/src/app/pages/signin/store/signin.store.spec.ts
@@ -1,10 +1,10 @@
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator';
 import { mockProvider } from '@ngneat/spectator/jest';
 import { BehaviorSubject, firstValueFrom, of } from 'rxjs';
 import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { getTestScheduler } from 'app/core/testing/utils/get-test-scheduler.utils';
-import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
+import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { FailoverDisabledReason } from 'app/enums/failover-disabled-reason.enum';
 import { FailoverStatus } from 'app/enums/failover-status.enum';
 import { LoginResult } from 'app/enums/login-result.enum';
@@ -66,6 +66,7 @@ describe('SigninStore', () => {
           },
         },
       },
+      mockProvider(ActivatedRoute, { snapshot: { queryParamMap: { get: jest.fn() } } }),
     ],
   });
 
@@ -82,6 +83,7 @@ describe('SigninStore', () => {
     });
     jest.spyOn(authService, 'loginWithToken').mockReturnValue(of(LoginResult.Success));
     jest.spyOn(authService, 'clearAuthToken').mockReturnValue(null);
+    jest.spyOn(authService, 'setQueryTokenIfExists').mockReturnValue(undefined)
   });
 
   describe('selectors', () => {

--- a/src/app/pages/signin/store/signin.store.ts
+++ b/src/app/pages/signin/store/signin.store.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { ComponentStore } from '@ngrx/component-store';
 import { Actions, ofType } from '@ngrx/effects';
@@ -81,6 +81,7 @@ export class SigninStore extends ComponentStore<SigninState> {
     private authService: AuthService,
     private updateService: UpdateService,
     private actions$: Actions,
+    private activatedRoute: ActivatedRoute,
     @Inject(WINDOW) private window: Window,
   ) {
     super(initialState);
@@ -240,6 +241,9 @@ export class SigninStore extends ComponentStore<SigninState> {
   }
 
   private handleLoginWithToken(): Observable<LoginResult> {
+    this.authService.setQueryTokenIfExists(
+      this.activatedRoute.snapshot.queryParamMap.get('token'),
+    );
     return this.tokenLastUsedService.isTokenWithinTimeline$.pipe(take(1)).pipe(
       filter((isTokenWithinTimeline) => {
         if (!isTokenWithinTimeline) {

--- a/src/app/services/auth/auth-guard.service.spec.ts
+++ b/src/app/services/auth/auth-guard.service.spec.ts
@@ -1,0 +1,47 @@
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import {
+  createServiceFactory,
+  mockProvider,
+  SpectatorService,
+} from '@ngneat/spectator/jest';
+import { BehaviorSubject } from 'rxjs';
+import { AuthGuardService } from 'app/services/auth/auth-guard.service';
+import { AuthService } from 'app/services/auth/auth.service';
+
+describe('AuthGuardService', () => {
+  const redirectUrl = 'storage/disks';
+  const isAuthenticated$ = new BehaviorSubject(false);
+  const arSnapshot = { queryParams: {} } as ActivatedRouteSnapshot;
+  const state = { url: redirectUrl } as RouterStateSnapshot;
+
+  let spectator: SpectatorService<AuthGuardService>;
+  const createService = createServiceFactory({
+    service: AuthGuardService,
+    providers: [mockProvider(AuthService, { isAuthenticated$ })],
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+    isAuthenticated$.next(false);
+  });
+
+  describe('canActivate', () => {
+    it('allows activation if the user is logged in', () => {
+      expect(spectator.service.canActivate(arSnapshot, state)).toBe(false);
+      isAuthenticated$.next(true);
+      expect(spectator.service.canActivate(arSnapshot, state)).toBe(true);
+    });
+
+    it('if the user is not logged in, the redirect URL is saved to sessionStorage', () => {
+      spectator.service.canActivate(arSnapshot, state);
+      expect(sessionStorage.getItem('redirectUrl')).toEqual(redirectUrl);
+    });
+
+    it('if the user is not logged in, the user is redirected to signin', () => {
+      const router = spectator.inject(Router);
+      const navigateSpy = jest.spyOn(router, 'navigate');
+      spectator.service.canActivate(arSnapshot, state);
+      expect(navigateSpy).toHaveBeenCalledWith(['/signin'], { queryParams: {} });
+    });
+  });
+});

--- a/src/app/services/auth/auth-guard.service.ts
+++ b/src/app/services/auth/auth-guard.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { WINDOW } from 'app/helpers/window.helper';
 import { AuthService } from 'app/services/auth/auth.service';
@@ -20,13 +20,13 @@ export class AuthGuardService {
     });
   }
 
-  canActivate(_: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+  canActivate({ queryParams }: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
     if (this.isAuthenticated) {
       return true;
     }
 
-    this.window.sessionStorage.setItem('redirectUrl', state.url);
-    this.router.navigate(['/signin']);
+    this.window.sessionStorage.setItem('redirectUrl', state.url.split('?')[0]);
+    this.router.navigate(['/signin'], { queryParams });
 
     return false;
   }

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -131,6 +131,16 @@ export class AuthService {
     );
   }
 
+  setQueryTokenIfExists(token: string | null): void {
+    if (!token || this.window.location.protocol !== 'https:') {
+      return;
+    }
+
+    this.token = token;
+    this.tokenLastUsedService.updateTokenLastUsed();
+    this.latestTokenGenerated$.next(token);
+  }
+
   loginWithToken(): Observable<LoginResult> {
     if (!this.token) {
       return of(LoginResult.NoToken);

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -131,14 +131,12 @@ export class AuthService {
     );
   }
 
-  setQueryTokenIfExists(token: string | null): void {
+  setQueryToken(token: string | null): void {
     if (!token || this.window.location.protocol !== 'https:') {
       return;
     }
 
     this.token = token;
-    this.tokenLastUsedService.updateTokenLastUsed();
-    this.latestTokenGenerated$.next(token);
   }
 
   loginWithToken(): Observable<LoginResult> {

--- a/src/app/services/websocket/websocket-handler.service.ts
+++ b/src/app/services/websocket/websocket-handler.service.ts
@@ -67,6 +67,11 @@ export class WebSocketHandlerService {
     return this.wsConnection.stream$ as Observable<IncomingApiMessage>;
   }
 
+  private hasOpened = false;
+  get hasOpenedOnce(): boolean {
+    return this.hasOpened;
+  }
+
   private readonly triggerNextCall$ = new Subject<void>();
   private activeCalls = 0;
   private readonly queuedCalls: { id: string; [key: string]: unknown }[] = [];
@@ -228,6 +233,7 @@ export class WebSocketHandlerService {
   }
 
   private onOpen(): void {
+    this.hasOpened = true;
     if (this.reconnectTimerSubscription) {
       this.wsConnection.close();
       return;

--- a/src/app/services/websocket/websocket-handler.service.ts
+++ b/src/app/services/websocket/websocket-handler.service.ts
@@ -67,11 +67,6 @@ export class WebSocketHandlerService {
     return this.wsConnection.stream$ as Observable<IncomingApiMessage>;
   }
 
-  private hasOpened = false;
-  get hasOpenedOnce(): boolean {
-    return this.hasOpened;
-  }
-
   private readonly triggerNextCall$ = new Subject<void>();
   private activeCalls = 0;
   private readonly queuedCalls: { id: string; [key: string]: unknown }[] = [];
@@ -233,7 +228,6 @@ export class WebSocketHandlerService {
   }
 
   private onOpen(): void {
-    this.hasOpened = true;
     if (this.reconnectTimerSubscription) {
       this.wsConnection.close();
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   provideRouter,
   PreloadAllModules,
   withComponentInputBinding,
+  withDebugTracing,
 } from '@angular/router';
 import { provideEffects } from '@ngrx/effects';
 import { provideRouterStore } from '@ngrx/router-store';
@@ -121,6 +122,6 @@ bootstrapApplication(AppComponent, {
     provideCharts(withDefaultRegisterables()),
     provideHttpClient(withInterceptorsFromDi()),
     provideAnimations(),
-    provideRouter(rootRoutes, withPreloading(PreloadAllModules), withComponentInputBinding()),
+    provideRouter(rootRoutes, withPreloading(PreloadAllModules), withComponentInputBinding(), withDebugTracing()),
   ],
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,11 +7,7 @@ import { MAT_SNACK_BAR_DEFAULT_OPTIONS, MatSnackBarConfig } from '@angular/mater
 import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import {
-  withPreloading,
-  provideRouter,
-  PreloadAllModules,
-  withComponentInputBinding,
-  withDebugTracing,
+  withPreloading, provideRouter, PreloadAllModules, withComponentInputBinding,
 } from '@angular/router';
 import { provideEffects } from '@ngrx/effects';
 import { provideRouterStore } from '@ngrx/router-store';
@@ -122,6 +118,6 @@ bootstrapApplication(AppComponent, {
     provideCharts(withDefaultRegisterables()),
     provideHttpClient(withInterceptorsFromDi()),
     provideAnimations(),
-    provideRouter(rootRoutes, withPreloading(PreloadAllModules), withComponentInputBinding(), withDebugTracing()),
+    provideRouter(rootRoutes, withPreloading(PreloadAllModules), withComponentInputBinding()),
   ],
 });


### PR DESCRIPTION
**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**
One method:
* clear `localStorage`
* you'll have to comment out the `https:` check in `AuthService.setQueryToken`
* `midclt call auth.generate_token`
* append the token to an app route: `localhost:4200/storage/disks?token=<token>`

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
