### PR TITLE
NAS-132672: Containers | Delete instance which has `autostart: true`-> shows error modal

### DIFF
--- a/src/app/pages/virtualization/components/all-instances/instance-details/instance-general-info/instance-general-info.component.ts
+++ b/src/app/pages/virtualization/components/all-instances/instance-details/instance-general-info/instance-general-info.component.ts
@@ -8,7 +8,7 @@ import {
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { switchMap } from 'rxjs';
+import { filter, switchMap } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { virtualizationStatusLabels } from 'app/enums/virtualization.enum';
@@ -70,6 +70,7 @@ export class InstanceGeneralInfoComponent {
       title: this.translate.instant('Delete'),
       message: this.translate.instant('Delete {name}?', { name: this.instance().name }),
     }).pipe(
+      filter(Boolean),
       switchMap(() => {
         return this.dialogService.jobDialog(
           this.api.job('virt.instance.delete', [this.instance().id]),

--- a/src/app/pages/virtualization/components/all-instances/instance-list/instance-list.component.ts
+++ b/src/app/pages/virtualization/components/all-instances/instance-list/instance-list.component.ts
@@ -89,7 +89,7 @@ export class InstanceListComponent {
     }
 
     const instanceId = this.activatedRoute.snapshot.paramMap.get('id');
-    if (instanceId) {
+    if (instanceId && this.instances().some((instance) => instance.id === instanceId)) {
       this.deviceStore.selectInstance(instanceId);
     } else {
       const [firstInstance] = this.instances();

--- a/src/app/pages/virtualization/stores/virtualization-devices.store.ts
+++ b/src/app/pages/virtualization/stores/virtualization-devices.store.ts
@@ -66,7 +66,7 @@ export class VirtualizationDevicesStore extends ComponentStore<VirtualizationIns
       return;
     }
     const oldSelectedInstance = this.selectedInstance();
-    if (!selectedInstance || selectedInstance === oldSelectedInstance) {
+    if (!selectedInstance || selectedInstance?.id === oldSelectedInstance?.id) {
       return;
     }
 

--- a/src/app/pages/virtualization/stores/virtualization-instances.store.ts
+++ b/src/app/pages/virtualization/stores/virtualization-instances.store.ts
@@ -46,7 +46,7 @@ export class VirtualizationInstancesStore extends ComponentStore<VirtualizationI
                   return [...instances, event.fields];
                 case IncomingApiMessageType.Changed:
                   // TODO: Keep it until API improvements
-                  if (Object.keys(event.fields).length === 1 && 'status' in event.fields) {
+                  if (event.fields && Object.keys(event.fields).length === 1 && 'status' in event.fields) {
                     return instances.map((instance) => {
                       if (instance.name === event.id) {
                         return { ...instance, status: event.fields.status };
@@ -54,7 +54,7 @@ export class VirtualizationInstancesStore extends ComponentStore<VirtualizationI
                       return instance;
                     });
                   }
-                  return instances.map((item) => (item.id === event.id ? event.fields : item));
+                  return instances.map((item) => (item.id === event.id ? { ...item, ...event?.fields } : item));
                 case IncomingApiMessageType.Removed:
                   return instances.filter((item) => item.id !== event.id);
                 default:


### PR DESCRIPTION
Testing: see ticket & comments.

Now it works correctly.

See: (no errors now, as well fixed on edit state, notified William about the issue [where we do not receive `fields` prop when editing instance)

https://github.com/user-attachments/assets/cbfe2b0a-9a0b-410d-aacd-d614b9133306

