### PR TITLE
NAS-132019 / 25.04 / Remove DST gaps from chart reports

### DIFF
--- a/src/app/pages/reports-dashboard/reports.service.spec.ts
+++ b/src/app/pages/reports-dashboard/reports.service.spec.ts
@@ -38,4 +38,46 @@ describe('ReportsService', () => {
       expect(spectator.inject<Window>(WINDOW).open).toHaveBeenCalledWith('/netdata/');
     });
   });
+
+  describe('removeDstGaps', () => {
+    it('returns normal data without changes', () => {
+      expect(spectator.service.removeDstGaps([
+        [1732000500, 0],
+        [1732000501, 1],
+        [1732000502, 2],
+      ])).toEqual([
+        [1732000500, 0],
+        [1732000501, 1],
+        [1732000502, 2],
+      ]);
+    });
+
+    it('removes gap from data', () => {
+      expect(spectator.service.removeDstGaps([
+        [1732000500, 0],
+        [1732000501 + 3600, 1],
+        [1732000502 + 3600, 2],
+      ])).toEqual([
+        [1732000500, 0],
+        [1732000501, 1],
+        [1732000502, 2],
+      ]);
+    });
+
+    it('removes several gaps from data', () => {
+      expect(spectator.service.removeDstGaps([
+        [1732000500, 0],
+        [1732000501 + 3600, 1],
+        [1732000502 + 3600, 2],
+        [1732000503 + 3600 * 2, 3],
+        [1732000504 + 3600 * 2, 4],
+      ])).toEqual([
+        [1732000500, 0],
+        [1732000501, 1],
+        [1732000502, 2],
+        [1732000503, 3],
+        [1732000504, 4],
+      ]);
+    });
+  });
 });

--- a/src/app/pages/reports-dashboard/reports.service.ts
+++ b/src/app/pages/reports-dashboard/reports.service.ts
@@ -67,6 +67,8 @@ export class ReportsService {
           reportingData.data = this.truncateData(reportingData.data as number[][]);
         }
 
+        reportingData.data = this.removeDstGaps(reportingData.data as number[][]);
+
         return reportingData;
       }),
       map((reportingData) => optimizeLegend(reportingData)),
@@ -92,6 +94,22 @@ export class ReportsService {
       }
       index--;
     } while (!finished && data.length > 0);
+
+    return data;
+  }
+
+  removeDstGaps(data: number[][]): number[][] {
+    const hourGap = 3600; // one hour
+
+    data.forEach((_, idx) => {
+      if (idx < data.length - 1) {
+        const delta = data[idx + 1][0] - data[idx][0];
+        if (hourGap < delta) {
+          const gap = Math.floor(delta / hourGap) * hourGap;
+          data[idx + 1][0] = data[idx + 1][0] - gap;
+        }
+      }
+    });
 
     return data;
   }


### PR DESCRIPTION
**Changes:**

Screenshot attached to a ticket depicts the **DST gap**, which occurs when server's internal clock does a transition from time point `1:59` to time point `3:00 GMT+0100`, and timezone info (`GMT+0100`) is lost, resulting in representational **1:01 hour gap** 

In pseudocode:

Actual: 

```typescript
> new Date(`Jan 01 2024 01:59:00`) - new Date(`Jan 01 2024 03:00:00`)
  -> -3660000
```

Expected: 

```typescript
> new Date(`Jan 01 2024 01:59:00 GMT+0000`) - new Date(`Jan 01 2024 03:00:00 GMT+0100`) 
  -> -60000
```


This PR removes DST gaps from reporting time series.

**Testing:**

To simulate DST, you need to add the `addDstGaps` method in the **src/app/pages/reports-dashboard/reports.service.ts** file and apply it to `reportingData.data` as shown below:

![image](https://github.com/user-attachments/assets/8c2a9537-57a4-42e0-a073-48e5d3b79084)

Replace the constant `dstTimestamp` with the value of the DST change time (**in seconds!**).

For example, `1732168676` \<=\> `Thu Nov 21 2024 08:57:56 GMT+0300`.

A gap of one hour should appear on the chart:

![image](https://github.com/user-attachments/assets/f30584a9-0a82-4427-9fa5-2b6e7f9bbf44)

Using the `removeDstGaps` method should remove this gap.

`addDstGaps` method code:


```typescript
addDstGaps(data: number[][]): number[][] {
    data.forEach((item) => {
      const dstTimestamp = new Date().getTime() / 1000 - 10 * 60; // Set DST time, e.g. 1732168676
      if (item[0] > dstTimestamp) {
        item[0] = item[0] + 3600;
      }
    });
    return data;
}
```
