### PR TITLE
NAS-132643 / 24.10.2 / Rework `ping` logic

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ import { WINDOW } from 'app/helpers/window.helper';
 import { AuthService } from 'app/services/auth/auth.service';
 import { DetectBrowserService } from 'app/services/detect-browser.service';
 import { LayoutService } from 'app/services/layout.service';
+import { PingService } from 'app/services/ping.service';
 
 @UntilDestroy()
 @Component({
@@ -24,6 +25,7 @@ export class AppComponent implements OnInit {
     private authService: AuthService,
     private detectBrowser: DetectBrowserService,
     private layoutService: LayoutService,
+    private pingService: PingService,
     @Inject(WINDOW) private window: Window,
   ) {
     this.authService.isAuthenticated$.pipe(untilDestroyed(this)).subscribe((isAuthenticated) => {
@@ -59,6 +61,8 @@ export class AppComponent implements OnInit {
       }
       console.error(err);
     };
+
+    this.pingService.setupPing();
   }
 
   ngOnInit(): void {

--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -422,6 +422,7 @@ export interface ApiCallDirectory {
   'core.job_abort': { params: [jobId: number]; response: void };
   'core.job_download_logs': { params: [ id: number, filename: string ]; response: string };
   'core.resize_shell': { params: ResizeShellRequest; response: void };
+  'core.ping': { params: void; response: 'pong' };
 
   // Cronjob
   'cronjob.create': { params: [CronjobUpdate]; response: Cronjob };

--- a/src/app/modules/layout/components/topbar/user-menu/user-menu.component.spec.ts
+++ b/src/app/modules/layout/components/topbar/user-menu/user-menu.component.spec.ts
@@ -32,7 +32,7 @@ describe('UserMenuComponent', () => {
       mockProvider(MatDialog),
       mockWebSocket(),
       mockProvider(AuthService, {
-        logout: jest.fn(() => of()),
+        logout: jest.fn(() => of(null)),
         user$: of(dummyUser),
       }),
       mockProvider(WebSocketConnectionService),

--- a/src/app/modules/layout/components/topbar/user-menu/user-menu.component.ts
+++ b/src/app/modules/layout/components/topbar/user-menu/user-menu.component.ts
@@ -50,8 +50,9 @@ export class UserMenuComponent {
   }
 
   onSignOut(): void {
-    this.authService.logout().pipe(untilDestroyed(this)).subscribe();
-    this.authService.clearAuthToken();
-    this.wsManager.isClosed$ = true;
+    this.authService.logout().pipe(untilDestroyed(this)).subscribe(() => {
+      this.authService.clearAuthToken();
+      this.wsManager.isClosed$ = true;
+    });
   }
 }

--- a/src/app/services/ping.service.spec.ts
+++ b/src/app/services/ping.service.spec.ts
@@ -1,0 +1,51 @@
+import { discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
+import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
+import { BehaviorSubject } from 'rxjs';
+import { mockCall, mockWebSocket } from 'app/core/testing/utils/mock-websocket.utils';
+import { AuthService } from 'app/services/auth/auth.service';
+import { PingService } from 'app/services/ping.service';
+import { WebSocketService } from 'app/services/ws.service';
+
+describe('PingService', () => {
+  let spectator: SpectatorService<PingService>;
+  let websocket: WebSocketService;
+  const isAuthenticated$ = new BehaviorSubject(false);
+
+  const createService = createServiceFactory({
+    service: PingService,
+    providers: [
+      mockWebSocket([
+        mockCall('core.ping', 'pong'),
+      ]),
+      mockProvider(AuthService, {
+        isAuthenticated$,
+      }),
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+    websocket = spectator.inject(WebSocketService);
+  });
+
+  it('sends pings', fakeAsync(() => {
+    spectator.service.setupPing();
+    isAuthenticated$.next(true);
+
+    tick(20 * 1000);
+    expect(websocket.call).toHaveBeenNthCalledWith(1, 'core.ping');
+    expect(websocket.call).toHaveBeenCalledTimes(1);
+    tick(20 * 1000);
+    expect(websocket.call).toHaveBeenNthCalledWith(2, 'core.ping');
+    expect(websocket.call).toHaveBeenCalledTimes(2);
+    tick(20 * 1000);
+    expect(websocket.call).toHaveBeenNthCalledWith(3, 'core.ping');
+    expect(websocket.call).toHaveBeenCalledTimes(3);
+
+    isAuthenticated$.next(false);
+    tick(20 * 1000);
+    expect(websocket.call).toHaveBeenCalledTimes(3);
+
+    discardPeriodicTasks();
+  }));
+});

--- a/src/app/services/ping.service.ts
+++ b/src/app/services/ping.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { filter, interval, switchMap } from 'rxjs';
+import { AuthService } from 'app/services/auth/auth.service';
+import { WebSocketService } from 'app/services/ws.service';
+
+@UntilDestroy()
+@Injectable({
+  providedIn: 'root',
+})
+export class PingService {
+  private readonly pingTimeoutMillis = 20 * 1000;
+
+  constructor(
+    private ws: WebSocketService,
+    private authService: AuthService,
+  ) {}
+
+  setupPing(): void {
+    interval(this.pingTimeoutMillis).pipe(
+      switchMap(() => this.authService.isAuthenticated$),
+      filter(Boolean),
+      switchMap(() => this.ws.call('core.ping')),
+      untilDestroyed(this),
+    ).subscribe();
+  }
+}

--- a/src/app/services/websocket-connection.service.spec.ts
+++ b/src/app/services/websocket-connection.service.spec.ts
@@ -1,6 +1,5 @@
 import { discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
-import { UUID } from 'angular2-uuid';
 import { WebSocketSubject, WebSocketSubjectConfig } from 'rxjs/webSocket';
 import { OutgoingApiMessageType } from 'app/enums/api-message-type.enum';
 import { WEBSOCKET } from 'app/helpers/websocket.helper';
@@ -75,32 +74,6 @@ describe('WebSocketConnectionService', () => {
     expect(nextFakeSocket$.next).not.toHaveBeenCalled();
     expect(nextFakeSocket$.complete).toHaveBeenCalled();
   });
-
-  it('sends pings', fakeAsync(() => {
-    jest.spyOn(nextFakeSocket$, 'next');
-    jest.spyOn(UUID, 'UUID')
-      .mockReturnValueOnce('ping-pong-uuid-1')
-      .mockReturnValueOnce('ping-pong-uuid-2')
-      .mockReturnValueOnce('ping-pong-uuid-3');
-
-    spectator.service.isConnected$.next(true);
-
-    tick(20 * 1000);
-    expect(nextFakeSocket$.next).toHaveBeenNthCalledWith(1, { id: 'ping-pong-uuid-1', msg: OutgoingApiMessageType.Ping });
-    expect(nextFakeSocket$.next).toHaveBeenCalledTimes(1);
-    tick(20 * 1000);
-    expect(nextFakeSocket$.next).toHaveBeenNthCalledWith(2, { id: 'ping-pong-uuid-2', msg: OutgoingApiMessageType.Ping });
-    expect(nextFakeSocket$.next).toHaveBeenCalledTimes(2);
-    tick(20 * 1000);
-    expect(nextFakeSocket$.next).toHaveBeenNthCalledWith(3, { id: 'ping-pong-uuid-3', msg: OutgoingApiMessageType.Ping });
-    expect(nextFakeSocket$.next).toHaveBeenCalledTimes(3);
-
-    spectator.service.isConnected$.next(false);
-    tick(20 * 1000);
-    expect(nextFakeSocket$.next).toHaveBeenCalledTimes(3);
-
-    discardPeriodicTasks();
-  }));
 
   it('resumes calls that were paused because of broken connection', () => {
     jest.spyOn(nextFakeSocket$, 'next');


### PR DESCRIPTION
**Testing:**

Enter login page, authenticate, and then logout. Watch messages sent over websocket in browser's network log

**Expected results:**

1. **ping** should be sent only when user is authenticated. In other words, **ping** should not be sent on "public" pages, such as login screen
2. call `core.ping` should be done instead of sending `{ msg: 'ping' }` 

