### PR TITLE
NAS-128390 / 24.10.2 / Adjust children selection options for draid pools

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.spec.ts
@@ -109,7 +109,7 @@ describe('DraidSelectionComponent', () => {
     expect(await spares.getValue()).toBe('0');
 
     const children = await form.getControl('Children') as IxSelectHarness;
-    expect(await children.getOptionLabels()).toEqual(['4', '5']);
+    expect(await children.getOptionLabels()).toEqual(['3', '4', '5']);
   });
 
   it('updates Children when Spares are selected', async () => {
@@ -122,7 +122,7 @@ describe('DraidSelectionComponent', () => {
     );
 
     const children = await form.getControl('Children') as IxSelectHarness;
-    expect(await children.getOptionLabels()).toEqual(['5']);
+    expect(await children.getOptionLabels()).toEqual(['4', '5']);
   });
 
   it('defaults Children to optimal number, but only once', async () => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/draid-selection/draid-selection.component.ts
@@ -193,11 +193,10 @@ export class DraidSelectionComponent implements OnInit, OnChanges {
 
     let nextOptions: Option[] = [];
     if ((groupSize + hotSpares) <= maxPossibleWidth && dataDevices) {
-      nextOptions = _.range(groupSize + hotSpares, maxPossibleWidth).map((item) => {
-        const disks = item + 1;
+      nextOptions = _.range(groupSize + hotSpares, maxPossibleWidth + 1).map((noOfChildren) => {
         return {
-          label: String(disks),
-          value: disks,
+          label: String(noOfChildren),
+          value: noOfChildren,
         };
       });
     }


### PR DESCRIPTION
**Changes:**

Adjusts min allowed child count when creating dRaid pools

**Testing:**


The children select's minimum value when creating a draid pool should be calculated based on this formula

```
max = Math.min(maxAvailableDisks, 255)
parity = 1 if dRaid1, 2 if dRaid2, 3 if dRaid3
min = (data vdev disks) + (hot spares count) + parity
```
