### PR TITLE
NAS-132805 / 24.10.1 / Hide "take snapshot" for TrueCloud backup

### DIFF
--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.html
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.html
@@ -112,11 +112,6 @@
           class="fieldset"
           [title]="helptext.fieldset_advanced_options| translate"
         >
-          <ix-checkbox
-            formControlName="snapshot"
-            [label]="helptext.snapshot_placeholder | translate"
-            [tooltip]="helptext.snapshot_tooltip | translate"
-          ></ix-checkbox>
           <ix-textarea
             formControlName="pre_script"
             [label]="helptext.pre_script_placeholder | translate"

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
@@ -168,7 +168,6 @@ describe('CloudBackupFormComponent', () => {
           minute: '0',
           month: '*',
         },
-        snapshot: false,
         transfer_setting: CloudsyncTransferSetting.Default,
       }]);
       expect(chainedComponentRef.close).toHaveBeenCalledWith({ response: existingTask, error: null });
@@ -185,7 +184,6 @@ describe('CloudBackupFormComponent', () => {
         Folder: '/',
         Enabled: false,
         Bucket: 'bucket1',
-        'Take Snapshot': true,
         Exclude: ['/test'],
         'Transfer Setting': 'Fast Storage',
       });
@@ -213,7 +211,6 @@ describe('CloudBackupFormComponent', () => {
           minute: '0',
           month: '*',
         },
-        snapshot: true,
         transfer_setting: CloudsyncTransferSetting.FastStorage,
       }]);
       expect(chainedComponentRef.close).toHaveBeenCalledWith({ response: existingTask, error: null });
@@ -248,7 +245,6 @@ describe('CloudBackupFormComponent', () => {
         'Pre-script': '',
         Schedule: 'Weekly (0 0 * * sun)  On Sundays at 00:00 (12:00 AM)',
         'Source Path': '/mnt/my pool',
-        'Take Snapshot': false,
         'Transfer Setting': 'Performance',
       });
     });
@@ -288,7 +284,6 @@ describe('CloudBackupFormComponent', () => {
           minute: '0',
           month: '*',
         },
-        snapshot: false,
         transfer_setting: CloudsyncTransferSetting.Performance,
       }]);
       expect(chainedComponentRef.close).toHaveBeenCalledWith({ response: existingTask, error: null });

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
@@ -299,6 +299,8 @@ export class CloudBackupFormComponent implements OnInit {
       delete (value as unknown as FormValue)[key];
     });
 
+    delete value.snapshot;
+
     return value;
   }
 


### PR DESCRIPTION
**Changes:**

Hides "Take Snapshot" option from the UI as requested in the ticket.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Removes an option from Truecloud Backup form.
