### PR TITLE
NAS-132967 / 25.04 / Trusted Store option not present on CSR creation but is on edit

### DIFF
--- a/src/app/pages/credentials/certificates-dash/certificate-authority-add/steps/ca-identifier-and-type/ca-identifier-and-type.component.html
+++ b/src/app/pages/credentials/certificates-dash/certificate-authority-add/steps/ca-identifier-and-type/ca-identifier-and-type.component.html
@@ -26,7 +26,6 @@
   @if (!isIntermediate) {
     <ix-checkbox
       formControlName="add_to_trusted_store"
-      class="add-to-trusted-store"
       [label]="'Add To Trusted Store' | translate"
     ></ix-checkbox>
 

--- a/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.html
+++ b/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.html
@@ -30,12 +30,14 @@
         </div>
       </ix-fieldset>
 
-      <ix-fieldset>
-        <ix-checkbox
-          formControlName="add_to_trusted_store"
-          [label]="'Add to trusted store' | translate"
-        ></ix-checkbox>
-      </ix-fieldset>
+      @if (!isCsr) {
+        <ix-fieldset>
+          <ix-checkbox
+            formControlName="add_to_trusted_store"
+            [label]="'Add to trusted store' | translate"
+          ></ix-checkbox>
+        </ix-fieldset>
+      }
 
       @if (certificate) {
         <ix-fieldset [title]="'Subject' | translate">

--- a/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.spec.ts
@@ -162,6 +162,11 @@ describe('CertificateEditComponent', () => {
       const renewDaysInput = await loader.getHarness(IxInputHarness.with({ label: 'Renew Certificate Days Before Expiry' }));
       expect(await renewDaysInput.getValue()).toBe('');
     });
+
+    it('shows add to trusted store checkbox for ACME certificate', async () => {
+      const addToTrustedStoreCheckbox = await loader.getHarnessOrNull(IxCheckboxHarness.with({ label: 'Add to trusted store' }));
+      expect(addToTrustedStoreCheckbox).toExist();
+    });
   });
 
   describe('CSR', () => {
@@ -176,6 +181,11 @@ describe('CertificateEditComponent', () => {
       });
       spectator.detectChanges();
       loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+    });
+
+    it('does not show add to trusted store checkbox for CSR', async () => {
+      const addToTrustedStoreCheckbox = await loader.getHarnessOrNull(IxCheckboxHarness.with({ label: 'Add to trusted store' }));
+      expect(addToTrustedStoreCheckbox).not.toExist();
     });
 
     it('opens slidein for creating ACME certificates when Create ACME Certificate is pressed', async () => {

--- a/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.ts
+++ b/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.ts
@@ -141,7 +141,13 @@ export class CertificateEditComponent implements OnInit {
   onSubmit(): void {
     this.isLoading = true;
 
-    this.api.job('certificate.update', [this.certificate.id, this.form.value])
+    const payload = this.form.value;
+
+    if (this.isCsr) {
+      delete payload.add_to_trusted_store;
+    }
+
+    this.api.job('certificate.update', [this.certificate.id, payload])
       .pipe(untilDestroyed(this))
       .subscribe({
         complete: () => {

--- a/src/app/pages/credentials/certificates-dash/forms/certificate-add/steps/certificate-identifier-and-type/certificate-identifier-and-type.component.html
+++ b/src/app/pages/credentials/certificates-dash/forms/certificate-add/steps/certificate-identifier-and-type/certificate-identifier-and-type.component.html
@@ -25,7 +25,6 @@
 
   <ix-checkbox
     formControlName="add_to_trusted_store"
-    class="add-to-trusted-store"
     [label]="'Add To Trusted Store' | translate"
   ></ix-checkbox>
 


### PR DESCRIPTION
Testing: see ticket.

I talked with Waqar, he told me that we should remove `Add to Trusted Store` for `CSR` in edit form and not add it for creation form.
<img width="805" alt="Screenshot 2024-12-17 at 13 33 00" src="https://github.com/user-attachments/assets/f26ab967-a895-4c86-8b83-ff71a055236b" />
