### PR TITLE
NAS-131851 / 24.10.2 / Custom Apps: Empty info cards (App Metadata) are visible (by AlexKarpov98)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.html
@@ -32,9 +32,9 @@
         <ix-app-notes-card [app]="app()"></ix-app-notes-card>
       }
       @if (
-      app()?.metadata?.host_mounts?.length ||
-      app()?.metadata?.capabilities?.length ||
-      app()?.metadata?.run_as_context?.length
+        app()?.metadata?.host_mounts?.length ||
+        app()?.metadata?.capabilities?.length ||
+        app()?.metadata?.run_as_context?.length
       ) {
         <ix-app-metadata-card
           [appMetadata]="app().metadata"

--- a/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.html
@@ -31,7 +31,11 @@
       @if (app()?.notes) {
         <ix-app-notes-card [app]="app()"></ix-app-notes-card>
       }
-      @if (app()?.metadata) {
+      @if (
+      app()?.metadata?.host_mounts?.length ||
+      app()?.metadata?.capabilities?.length ||
+      app()?.metadata?.run_as_context?.length
+      ) {
         <ix-app-metadata-card
           [appMetadata]="app().metadata"
           [maxHeight]="180"

--- a/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-details-panel/app-details-panel.component.spec.ts
@@ -12,7 +12,11 @@ describe('AppDetailsPanelComponent', () => {
 
   const app = {
     id: 'ix-test-app',
-    metadata: {},
+    metadata: {
+      run_as_context: [{
+        description: 'Run as context',
+      }],
+    },
   } as App;
 
   const createComponent = createComponentFactory({
@@ -51,5 +55,18 @@ describe('AppDetailsPanelComponent', () => {
     const appMetadataCard = spectator.query(AppMetadataCardComponent);
     expect(appMetadataCard).toBeTruthy();
     expect(appMetadataCard.appMetadata).toStrictEqual(app.metadata);
+  });
+
+  it('hides metadata card if metadata props are not set', () => {
+    spectator.setInput('app', {
+      ...app,
+      metadata: {
+        host_mounts: [],
+        capabilities: [],
+        run_as_context: [],
+      },
+    });
+    const appMetadataCard = spectator.query(AppMetadataCardComponent);
+    expect(appMetadataCard).toBeFalsy();
   });
 });


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 2f84efe7391fd52fbeb4df62c3ca27e68e8c5494
    git cherry-pick -x 7864ad7a4f521f7a9ce5749496bead63a620287f
    git cherry-pick -x a0878977874337ff65586e3183f5150a72f26fc3

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 38a0f8bddbe296a0d3cafbb95d98778752e0704e

Testing: 

before:
<img width="1728" alt="Screenshot 2024-12-16 at 17 04 18" src="https://github.com/user-attachments/assets/8ad1e14f-16a6-42a0-8e73-3eedc0c8e113" />

after:
<img width="1728" alt="Screenshot 2024-12-16 at 17 03 54" src="https://github.com/user-attachments/assets/c0e6eca5-eb04-409f-8be2-60ab98b6505d" />

Original PR: https://github.com/truenas/webui/pull/11194
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131851