### PR TITLE
NAS-132965 / 24.10.2 / Shell authenticator option for ACME DNS produces invalid fields (by AlexKarpov98)

### DIFF
--- a/src/app/pages/credentials/certificates-dash/forms/acmedns-form/acmedns-form.component.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/acmedns-form/acmedns-form.component.ts
@@ -120,8 +120,13 @@ export class AcmednsFormComponent implements OnInit {
     this.dynamicSection = [{
       name: '',
       description: '',
-      schema: schemas.map((schema) => this.parseSchemaForDynamicSchema(schema))
-        .reduce((all, val) => all.concat(val), []),
+      schema: Array.from(
+        new Map(
+          schemas
+            .flatMap((schema) => this.parseSchemaForDynamicSchema(schema))
+            .map((item) => [item.controlName, item]),
+        ).values(),
+      ),
     }];
 
     this.dnsAuthenticatorList = schemas.map((schema) => this.parseSchemaForDnsAuthList(schema));


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 90fe3fa4d0eb965ceba1a1ed7e7c0aad7942023f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x dce47c7450b10aa57dd6d18f2f77dddd8a0e6d90

Testing: see ticket.

Result:

https://github.com/user-attachments/assets/9045464b-a5d6-40b8-96e0-1ca72cf1d487



Original PR: https://github.com/truenas/webui/pull/11196
Jira URL: https://ixsystems.atlassian.net/browse/NAS-132965