### PR TITLE
NAS-131994 / 24.10.2 / Storage: Number of available disks doesn't update after a disconnect/destroy data until screen refresh (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/components/unused-resources/unused-resources.component.html
+++ b/src/app/pages/storage/components/unused-resources/unused-resources.component.html
@@ -3,7 +3,7 @@
     <ix-unused-disk-card
       class="unused-resources"
       [title]="'Unused Disks' | translate"
-      [pools]="pools"
+      [pools]="pools()"
       [disks]="noPoolsDisks"
       (addToStorage)="addNoPoolDisksToStorage()"
     ></ix-unused-disk-card>
@@ -12,7 +12,7 @@
     <ix-unused-disk-card
       class="unused-resources"
       [title]="'Disks with exported pools' | translate"
-      [pools]="pools"
+      [pools]="pools()"
       [disks]="exportedPoolsDisks"
       (addToStorage)="addExportedPoolDisksToStorage()"
     ></ix-unused-disk-card>

--- a/src/app/pages/storage/components/unused-resources/unused-resources.component.spec.ts
+++ b/src/app/pages/storage/components/unused-resources/unused-resources.component.spec.ts
@@ -7,6 +7,11 @@ import { Pool } from 'app/interfaces/pool.interface';
 import { UnusedDiskCardComponent } from 'app/pages/storage/components/unused-resources/unused-disk-card/unused-disk-card.component';
 import { UnusedResourcesComponent } from './unused-resources.component';
 
+const pools = [
+  { id: 1, name: 'DEV' },
+  { id: 2, name: 'TEST' },
+] as Pool[];
+
 describe('UnusedResourcesComponent', () => {
   let spectator: Spectator<UnusedResourcesComponent>;
 
@@ -33,31 +38,30 @@ describe('UnusedResourcesComponent', () => {
   beforeEach(() => {
     spectator = createComponent({
       props: {
-        pools: [
-          { id: 1, name: 'DEV' },
-          { id: 2, name: 'TEST' },
-        ] as Pool[],
+        pools,
       },
     });
   });
 
   it('shows an \'Unused Disks\' card when exists unused disks', () => {
+    spectator.setInput('pools', pools);
     expect(spectator.queryAll('ix-unused-disk-card')).toHaveLength(2);
   });
 
   it('hides an \'Unassigned Disks\' card when does not exist unused disks', () => {
     spectator.inject(MockWebSocketService).mockCall('disk.details', { used: [], unused: [] });
-    spectator.component.ngOnInit();
+    spectator.setInput('pools', []);
     spectator.detectChanges();
 
     expect(spectator.queryAll('ix-unused-disk-card')).toHaveLength(0);
+
     spectator.inject(MockWebSocketService).mockCall('disk.details', {
       used: [],
       unused: [
         { devname: 'sdc', identifier: '{uuid}7ad07324-f0e9-49a4-a7a4-92edd82a4929' },
       ] as DetailsDisk[],
     });
-    spectator.component.ngOnInit();
+    spectator.setInput('pools', []);
     spectator.detectChanges();
 
     expect(spectator.queryAll('ix-unused-disk-card')).toHaveLength(1);

--- a/src/app/pages/storage/components/unused-resources/unused-resources.component.ts
+++ b/src/app/pages/storage/components/unused-resources/unused-resources.component.ts
@@ -1,5 +1,5 @@
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, input, OnInit,
 } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -20,7 +20,8 @@ import { WebSocketService } from 'app/services/ws.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class UnusedResourcesComponent implements OnInit {
-  @Input() pools: Pool[];
+  readonly pools = input.required<Pool[]>();
+
   noPoolsDisks: DetailsDisk[] = [];
   exportedPoolsDisks: DetailsDisk[] = [];
   diskQuerySubscription: Subscription;
@@ -30,10 +31,15 @@ export class UnusedResourcesComponent implements OnInit {
     private errorHandler: ErrorHandlerService,
     private cdr: ChangeDetectorRef,
     private matDialog: MatDialog,
-  ) { }
+  ) {
+    effect(() => {
+      if (this.pools()) {
+        this.updateUnusedDisks();
+      }
+    });
+  }
 
   ngOnInit(): void {
-    this.updateUnusedDisks();
     this.subscribeToDiskQuery();
   }
 
@@ -72,7 +78,7 @@ export class UnusedResourcesComponent implements OnInit {
   private addUnusedDisksToStorage(disks: DetailsDisk[]): void {
     this.matDialog.open(ManageUnusedDiskDialogComponent, {
       data: {
-        pools: this.pools,
+        pools: this.pools(),
         unusedDisks: [...disks],
       },
       width: '600px',


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x ee2da2e7e1bfff679104373555e73d84eba485f6
    git cherry-pick -x eac8c1d7479087176994a3615e8bc021416ea843
    git cherry-pick -x 11f1665f74df5ce7f51bbe877bb9eca6b32af9b5

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8d90712eb4219aafcf54c3fc4d70a8217d376436

Testing: see ticket.

Unused disks now appear/update instantly (without page refresh).
Result:

https://github.com/user-attachments/assets/e3042b4b-6b8d-4680-a61b-819dfaa4d021



Original PR: https://github.com/truenas/webui/pull/11209
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131994