### PR TITLE
NAS-133107 / 25.04 / Apps UI, when apps are filtered continues to show prior selection details, even when not shown in the list

### DIFF
--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.html
@@ -34,17 +34,14 @@
   [selectedItem]="selectedApp"
 >
   <ix-installed-apps-list
+    #installedAppsList
     master
     [isMobileView]="masterDetailView.isMobileView()"
     (toggleShowMobileDetails)="masterDetailView.toggleShowMobileDetails($event)"
   ></ix-installed-apps-list>
 
-  <ng-container detail-name>
-    {{ selectedApp?.name }}
-  </ng-container>
-
   <ng-container detail>
-    @if (selectedApp) {
+    @if (selectedApp && (!installedAppsList.filterString || selectedApp.name.toLowerCase().includes(installedAppsList.filterString.toLowerCase()))) {
       <ix-app-details-panel
         [app]="selectedApp"
         (startApp)="start(selectedApp.name)"


### PR DESCRIPTION
Testing: 
This is the proposed solution. Similar issue is appearing for all other similar scenarios, like Datasets, Instances.

Result:

https://github.com/user-attachments/assets/93884a3a-82ea-458d-9ade-97e11596acf4

Let's see if we like this solution first.