### PR TITLE
NAS-133330 / 25.04 / Misaligned input/placeholder

### DIFF
--- a/src/assets/styles/other/_material-overrides.scss
+++ b/src/assets/styles/other/_material-overrides.scss
@@ -196,6 +196,7 @@ html .ix-dark {
   }
 
   .mat-mdc-chip-input {
+    min-height: 22px;
     padding: 0;
   }
 


### PR DESCRIPTION
Testing: see ticket. Check another places where `<ix-chip` used.

Result:
<img width="391" alt="Screenshot 2025-01-06 at 11 42 59" src="https://github.com/user-attachments/assets/d2c27558-eaec-4d74-9dff-d9c169bcdb33" />
