### PR TITLE
NAS-133299 / 24.10.2 / Extend window not showing up for spares

### DIFF
--- a/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.ts
+++ b/src/app/pages/storage/modules/devices/components/disk-details-panel/disk-details-panel.component.ts
@@ -47,7 +47,7 @@ export class DiskDetailsPanelComponent {
   }
 
   get hasSmartTestSupport(): boolean {
-    return this.disksWithSmartTestSupport.includes(this.disk.devname);
+    return this.disk && this.disksWithSmartTestSupport.includes(this.disk.devname);
   }
 
   onCloseMobileDetails(): void {

--- a/src/app/pages/storage/modules/devices/components/zfs-info-card/raidz-extend-dialog/raidz-extend-dialog.component.ts
+++ b/src/app/pages/storage/modules/devices/components/zfs-info-card/raidz-extend-dialog/raidz-extend-dialog.component.ts
@@ -87,6 +87,9 @@ export class RaidzExtendDialogComponent {
 
     const minimumSize = this.data.vdev.children.reduce((acc, topologyDisk) => {
       const disk = diskDictionary[topologyDisk.disk];
+      if (!disk) {
+        return acc;
+      }
       return disk.size < acc ? disk.size : acc;
     }, Number.MAX_SAFE_INTEGER);
 


### PR DESCRIPTION
**Testing:**

1. Replace `ws.service.ts` with attached file.
[ws.service.ts.txt](https://github.com/user-attachments/files/18339620/ws.service.ts.txt)
2. Navigate to `/storage/3/devices/` and test that cards open. Functionality will be limited because of the mock
, but there should not be console errors.