### PR TITLE
NAS-133128 / 24.10.2 / Simplify CPU widget logic

### DIFF
--- a/src/app/pages/dashboard/widgets/cpu/common/cpu-core-bar/cpu-core-bar.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/cpu/common/cpu-core-bar/cpu-core-bar.component.spec.ts
@@ -1,5 +1,4 @@
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { provideMockStore } from '@ngrx/store/testing';
 import { ChartData } from 'chart.js';
 import { MockDirective } from 'ng-mocks';
 import { BaseChartDirective } from 'ng2-charts';
@@ -8,7 +7,6 @@ import { of } from 'rxjs';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
 import { CpuCoreBarComponent } from 'app/pages/dashboard/widgets/cpu/common/cpu-core-bar/cpu-core-bar.component';
 import { ThemeService } from 'app/services/theme/theme.service';
-import { selectSystemInfo } from 'app/store/system-info/system-info.selectors';
 
 describe('CpuCoreBarComponent', () => {
   let spectator: Spectator<CpuCoreBarComponent>;
@@ -41,18 +39,6 @@ describe('CpuCoreBarComponent', () => {
       mockProvider(ThemeService, {
         getRgbBackgroundColorByIndex: () => [0, 0, 0],
       }),
-      provideMockStore({
-        selectors: [
-          {
-            selector: selectSystemInfo,
-            value: {
-              model: 'Intel(R) Xeon(R) Silver 4210R CPU',
-              cores: 4,
-              physical_cores: 2,
-            },
-          },
-        ],
-      }),
     ],
   });
 
@@ -67,10 +53,10 @@ describe('CpuCoreBarComponent', () => {
 
     const data = chart.data as ChartData<'bar'>;
     expect(data).toMatchObject({
-      labels: ['1', '2'],
+      labels: ['1', '2', '3', '4'],
       datasets: [
-        { data: [36, 79] },
-        { data: [31, 83] },
+        { data: [6, 30, 70, 9] },
+        { data: [31, 83, 0, 0] },
       ],
     });
   });

--- a/src/app/pages/dashboard/widgets/cpu/common/cpu-core-bar/cpu-core-bar.component.ts
+++ b/src/app/pages/dashboard/widgets/cpu/common/cpu-core-bar/cpu-core-bar.component.ts
@@ -5,15 +5,12 @@ import {
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { TinyColor } from '@ctrl/tinycolor';
-import { Store } from '@ngrx/store';
 import { ChartData, ChartOptions } from 'chart.js';
 import { map } from 'rxjs';
 import { AllCpusUpdate } from 'app/interfaces/reporting.interface';
 import { GaugeData } from 'app/modules/charts/components/view-chart-gauge/view-chart-gauge.component';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
 import { ThemeService } from 'app/services/theme/theme.service';
-import { AppState } from 'app/store';
-import { waitForSystemInfo } from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-cpu-core-bar',
@@ -24,15 +21,18 @@ export class CpuCoreBarComponent {
   hideTemperature = input<boolean>(false);
   hideUsage = input<boolean>(false);
 
-  protected sysInfo = toSignal(this.store$.pipe(waitForSystemInfo));
-
   protected cpuData = toSignal(this.resources.realtimeUpdates$.pipe(
     map((update) => update.fields.cpu),
   ));
 
-  protected isLoading = computed(() => !this.cpuData() || !this.sysInfo());
-  protected coreCount = computed(() => this.sysInfo().physical_cores);
-  protected hyperthread = computed(() => this.sysInfo().cores !== this.sysInfo().physical_cores);
+  protected isLoading = computed(() => !this.cpuData());
+  protected coreCount = computed(() => {
+    const cpus = Object.keys(this.cpuData())
+      .map(Number)
+      .filter((key) => !Number.isNaN(key));
+
+    return Math.max(...cpus) + 1;
+  });
 
   stats = computed(() => {
     const data = this.parseCpuData(this.cpuData());
@@ -105,7 +105,6 @@ export class CpuCoreBarComponent {
   });
 
   constructor(
-    private store$: Store<AppState>,
     private resources: WidgetResourcesService,
     private theme: ThemeService,
   ) {}
@@ -115,17 +114,11 @@ export class CpuCoreBarComponent {
     const temperatureColumn: GaugeData = ['Temperature'];
 
     for (let i = 0; i < this.coreCount(); i++) {
-      const usageIndex = this.hyperthread() ? i * 2 : i;
+      const usage = parseInt(cpuData[i]?.usage?.toFixed(1) || '0');
+      const temperature = parseInt(cpuData.temperature_celsius?.[i]?.toFixed(0) || '0');
 
-      const usageCore = this.hyperthread()
-        ? (cpuData[usageIndex].usage + cpuData[usageIndex + 1].usage).toFixed(1)
-        : cpuData[usageIndex].usage.toFixed(1);
-
-      usageColumn.push(parseInt(usageCore));
-
-      if (cpuData.temperature_celsius) {
-        temperatureColumn.push(parseInt(cpuData.temperature_celsius[i].toFixed(0)));
-      }
+      usageColumn.push(usage);
+      temperatureColumn.push(temperature);
     }
 
     return [

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.ts
@@ -59,6 +59,7 @@ export class WidgetInterfaceComponent implements WidgetComponent<WidgetInterface
       throttleTime(1000),
       map((update) => update.fields.interfaces[interfaceId]),
     )),
+    filter(Boolean),
     tap((realtimeUpdate) => {
       this.cachedNetworkStats.update((cachedStats) => {
         return [


### PR DESCRIPTION
**Changes:**

Previous UI code assumes that if hyperthreading is enabled, than there must be 2 threads per core. 
This is not the case for newer CPUs that have performance and efficiency cores. In Intel processors efficiency cores are single-threaded.

This PR simplifies the logic to just showing what middleware sends us.

**Testing:**

Test CPU widgets for regressions.
You can also use mock data from the ticket in `WidgetResourcesService`.
