### PR TITLE
NAS-133213: Handle null latest_version for a custom app upgrade

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.html
@@ -4,7 +4,7 @@
       class="icon"
       matTooltipPosition="above"
       name="mdi-alert-circle"
-      [matTooltip]="'{version} is available!' | translate: { version: app().latest_version | appVersion }"
+      [matTooltip]="getVersionMsg(app().latest_version)"
     ></ix-icon>
   } @else {
     <ix-icon

--- a/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-update-cell/app-update-cell.component.ts
@@ -5,7 +5,7 @@ import {
   input,
 } from '@angular/core';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { App } from 'app/interfaces/app.interface';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
 import { AppVersionPipe } from 'app/pages/dashboard/widgets/apps/common/utils/app-version.pipe';
@@ -16,7 +16,8 @@ import { AppVersionPipe } from 'app/pages/dashboard/widgets/apps/common/utils/ap
   styleUrls: ['./app-update-cell.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [TranslateModule, MatTooltipModule, IxIconComponent, AppVersionPipe],
+  providers: [AppVersionPipe],
+  imports: [TranslateModule, MatTooltipModule, IxIconComponent],
 })
 export class AppUpdateCellComponent {
   app = input.required<App>();
@@ -25,5 +26,17 @@ export class AppUpdateCellComponent {
 
   @HostBinding('class') get hostClasses(): string[] {
     return ['update', this.showIcon() ? 'has-icon' : 'has-cell'];
+  }
+
+  constructor(
+    private translate: TranslateService,
+    private appVersionPipe: AppVersionPipe,
+  ) {}
+
+  protected getVersionMsg(version: string): string {
+    return this.translate.instant(
+      '{version} is available!',
+      { version: this.appVersionPipe.transform(version) || 'Upgrade' },
+    );
   }
 }


### PR DESCRIPTION
**Changes:**

Handles case where pipe outputs empty string. Should show "Upgrade is available" when latest_version is not available. This issue seems resolved in master. But this PR adds a the "Upgrade is available" string.

**Testing:**

Code review
