### PR TITLE
NAS-133373 / 25.04 / Storage > Disks > Fix remaining display

### DIFF
--- a/src/app/pages/storage/modules/disks/components/smart-test-result-list/smart-test-result-list.component.spec.ts
+++ b/src/app/pages/storage/modules/disks/components/smart-test-result-list/smart-test-result-list.component.spec.ts
@@ -42,7 +42,7 @@ describe('SmartTestResultListComponent', () => {
       lifetime: 15929,
       lba_of_first_error: null,
       status: SmartTestResultStatus.Success,
-      remaining: 50,
+      remaining: 0.5,
       power_on_hours_ago: 25,
     },
     {
@@ -77,7 +77,7 @@ describe('SmartTestResultListComponent', () => {
       lifetime: 15929,
       lba_of_first_error: null,
       status: SmartTestResultStatus.Success,
-      remaining: 0.5,
+      remaining: 0.005,
       power_on_hours_ago: 25,
     },
     {

--- a/src/app/pages/storage/modules/disks/components/smart-test-result-list/smart-test-result-list.component.ts
+++ b/src/app/pages/storage/modules/disks/components/smart-test-result-list/smart-test-result-list.component.ts
@@ -76,7 +76,7 @@ export class SmartTestResultListComponent implements OnInit {
       propertyName: 'remaining',
       getValue: (row) => {
         if (typeof row.remaining === 'number' && row.remaining >= 0) {
-          return `${row.remaining}%`;
+          return `${row.remaining * 100}%`;
         }
 
         return row.status_verbose ? this.translate.instant(row.status_verbose) : '0%';


### PR DESCRIPTION
**Changes:**

Added factor 100 to "Remaining" column

![image](https://github.com/user-attachments/assets/1d702e7d-95b3-4e65-8d7b-bef59fe3631e)

**Testing:**

Use the following mockup response for  `smart.test.results` call:

```
[{"tests": [{"num": 1, "description": "Short offline", "status_verbose": "Completed without error", "remaining": 0.0, "lifetime": 1677, "lba_of_first_error": null, "status": "SUCCESS"}, {"num": 2, "description": "Extended offline", "status_verbose": "Completed without error", "remaining": 0.0, "lifetime": 1656, "lba_of_first_error": null, "status": "SUCCESS"}, {"num": 3, "description": "Extended offline", "status_verbose": "Aborted by host", "remaining": 0.9, "lifetime": 1627, "lba_of_first_error": null, "status": "ABORTED"}, {"num": 4, "description": "Short offline", "status_verbose": "Aborted by host", "remaining": 0.9, "lifetime": 37, "lba_of_first_error": null, "status": "ABORTED"}, {"num": 5, "description": "Extended offline", "status_verbose": "Completed without error", "remaining": 0.0, "lifetime": 25, "lba_of_first_error": null, "status": "SUCCESS"}, {"num": 6, "description": "Short offline", "status_verbose": "Completed without error", "remaining": 0.0, "lifetime": 0, "lba_of_first_error": null, "status": "SUCCESS"}], "current_test": null, "identifier": "{serial_lunid}XXXXXXXX_0000000000000000", "name": "sda", "subsystem": "scsi", "number": 2048, "serial": "XXXXXXXX", "lunid": "0000000000000000", "size": 20000588955648, "description": "", "transfermode": "Auto", "hddstandby": "30", "advpowermgmt": "128", "togglesmart": true, "smartoptions": "", "expiretime": null, "critical": null, "difference": null, "informational": null, "model": "XYZ", "rotationrate": 7200, "type": "HDD", "zfs_guid": "6383777767142087922", "bus": "ATA", "devname": "sda", "enclosure": null, "supports_smart": null, "pool": null, "disk": "sda"}]
```
