### PR TITLE
Fix requirements on creating certificates

### DIFF
--- a/src/app/pages/credentials/certificates-dash/forms/common-steps/certificate-subject/certificate-subject.component.html
+++ b/src/app/pages/credentials/certificates-dash/forms/common-steps/certificate-subject/certificate-subject.component.html
@@ -2,7 +2,6 @@
   <ix-select
     formControlName="country"
     [label]="'Country' | translate"
-    [required]="true"
     [options]="countries$"
     [tooltip]="helptext.add.country.tooltip | translate"
   ></ix-select>
@@ -10,21 +9,18 @@
   <ix-input
     formControlName="state"
     [label]="'State' | translate"
-    [required]="true"
     [tooltip]="helptext.add.state.tooltip | translate"
   ></ix-input>
 
   <ix-input
     formControlName="city"
     [label]="'Locality' | translate"
-    [required]="true"
     [tooltip]="helptext.add.city.tooltip | translate"
   ></ix-input>
 
   <ix-input
     formControlName="organization"
     [label]="'Organization' | translate"
-    [required]="true"
     [tooltip]="helptext.add.organization.tooltip | translate"
   ></ix-input>
 
@@ -37,20 +33,19 @@
   <ix-input
     formControlName="email"
     [label]="'Email' | translate"
-    [required]="true"
     [tooltip]="helptext.add.email.tooltip | translate"
   ></ix-input>
 
   <ix-input
     formControlName="common"
     [label]="'Common Name' | translate"
+    [required]="true"
     [tooltip]="helptext.add.common.tooltip | translate"
   ></ix-input>
 
   <ix-chips
     formControlName="san"
     [label]="'Subject Alternative Name' | translate"
-    [required]="true"
     [tooltip]="helptext.add.san.tooltip | translate"
   ></ix-chips>
 

--- a/src/app/pages/credentials/certificates-dash/forms/common-steps/certificate-subject/certificate-subject.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/common-steps/certificate-subject/certificate-subject.component.spec.ts
@@ -78,15 +78,17 @@ describe('CertificateSubjectComponent', () => {
         },
         {
           label: 'Subject',
-          value: 'Virus Research Dept, Umbrella Corp, Racoon City, Pennsylvania, US',
+          value: 'virus.umbrella.com, Virus Research Dept, Umbrella Corp, Racoon City, Pennsylvania, US',
         },
       ]);
     });
 
     it('skips some of the fields when they are missing', async () => {
       await form.fillForm({
+        State: '',
+        Locality: '',
         'Organizational Unit': '',
-        'Common Name': '',
+        Email: '',
       });
 
       expect(spectator.component.getSummary()).toEqual([
@@ -95,14 +97,57 @@ describe('CertificateSubjectComponent', () => {
           value: 'jobs.umbrella.com, security.umbrella.com',
         },
         {
-          label: 'Email',
-          value: 'no-reply@umbrella.com',
+          label: 'Common Name',
+          value: 'virus.umbrella.com',
         },
         {
           label: 'Subject',
-          value: 'Umbrella Corp, Racoon City, Pennsylvania, US',
+          value: 'virus.umbrella.com, Umbrella Corp, US',
         },
       ]);
+    });
+
+    it('allows creating Lets Encrypt-compatible subject', async () => {
+      await form.fillForm({
+        Country: '',
+        State: '',
+        Locality: '',
+        Organization: '',
+        'Organizational Unit': '',
+        Email: '',
+        'Common Name': 'umbrella.com',
+        'Subject Alternative Name': ['*.umbrella.com', 'umbrella.com'],
+      });
+
+      expect(spectator.component.form.value).toEqual({
+        country: '',
+        state: '',
+        city: '',
+        organization: '',
+        organizational_unit: '',
+        email: '',
+        common: 'umbrella.com',
+        san: ['*.umbrella.com', 'umbrella.com'],
+      });
+    });
+
+    it('allows creating subject for CA without SANs', async () => {
+      await form.fillForm({
+        'Common Name': 'CA Root',
+        Email: '',
+        'Subject Alternative Name': [],
+      });
+
+      expect(spectator.component.form.value).toEqual({
+        country: 'US',
+        state: 'Pennsylvania',
+        city: 'Racoon City',
+        organization: 'Umbrella Corp',
+        organizational_unit: 'Virus Research Dept',
+        email: '',
+        common: 'CA Root',
+        san: [],
+      });
     });
   });
 });

--- a/src/app/pages/credentials/certificates-dash/forms/common-steps/certificate-subject/certificate-subject.component.ts
+++ b/src/app/pages/credentials/certificates-dash/forms/common-steps/certificate-subject/certificate-subject.component.ts
@@ -35,14 +35,14 @@ import { SystemGeneralService } from 'app/services/system-general.service';
 })
 export class CertificateSubjectComponent implements SummaryProvider {
   form = this.formBuilder.nonNullable.group({
-    country: ['US', Validators.required],
-    state: ['', Validators.required],
-    city: ['', Validators.required],
-    organization: ['', Validators.required],
+    country: ['US'],
+    state: [''],
+    city: [''],
+    organization: [''],
     organizational_unit: [''],
-    email: ['', [Validators.required, emailValidator()]],
-    common: [''],
-    san: [[] as string[], Validators.required],
+    email: ['', [emailValidator()]],
+    common: ['', Validators.required],
+    san: [[] as string[]],
   });
 
   readonly helptext = helptextSystemCertificates;
@@ -65,14 +65,15 @@ export class CertificateSubjectComponent implements SummaryProvider {
       },
     ];
 
-    if (values.common) {
-      summary.push({ label: this.translate.instant('Common Name'), value: values.common });
+    summary.push({ label: this.translate.instant('Common Name'), value: values.common || '' });
+
+    if (values.email) {
+      summary.push({ label: this.translate.instant('Email'), value: values.email });
     }
 
-    summary.push({ label: this.translate.instant('Email'), value: values.email || '' });
-
-    // Dept of Connections, Cisco, New York, NY, Unites States
+    // www.example.com, Dept of Connections, Cisco, New York, NY, Unites States
     const subjectFields = [
+      'common',
       'organizational_unit',
       'organization',
       'city',


### PR DESCRIPTION
**Changes:**

TrueNAS allows creating CA certificates and CSRs. These can be used for internal network purposes, but a CSR from TrueNAS is also a way to get ACME-DNS authorized certificate from Let's Encrypt.

Let's Encrypt accepts only two fields in a CSR: Common Name, and a list of SANs. All the other subject fields are stripped from the generated certificate, so it makes no sense to require for a certificate to have a country, state, locality and organization.

Additionally, when creating a CA certificate, requiring SANs makes no sense, as these are to be used for the leaf certificates.

Common Name, on the other hand, should be required for all kinds of certificates.

**Testing:**

- Create certificate authority with only Common Name filled
- Create CSR with only Common Name and SANs filled

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Not affected, as it does not mention the fields are required. I would suggest thou to mention the required field Common Name.
