### PR TITLE
NAS-132372 / 24.10.3 / Add `/dev/zvol` root for explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@lezer/common": "~1.2.1",
     "@lezer/generator": "~1.7.1",
     "@lezer/lr": "~1.4.2",
+    "@marijn/find-cluster-break": "~1.0.2",
     "@material-design-icons/font": "~0.14.13",
     "@mdi/font": "~7.4.47",
     "@ngbracket/ngx-layout": "~17.0.1",

--- a/src/app/enums/explorer-type.enum.ts
+++ b/src/app/enums/explorer-type.enum.ts
@@ -1,4 +1,5 @@
 export enum ExplorerNodeType {
   Directory = 'directory',
   File = 'file',
+  Symlink = 'symlink',
 }

--- a/src/app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component.html
+++ b/src/app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component.html
@@ -59,6 +59,8 @@
         >
           @if (node.data.type === ExplorerNodeType.File) {
             <ix-icon name="insert_drive_file"></ix-icon>
+          } @else if (node.data.type === ExplorerNodeType.Symlink) {
+            <ix-icon [name]="'mdi-database'"></ix-icon>
           } @else {
             @if (node.data.isLock) {
               <ix-icon name="mdi-folder-lock"></ix-icon>

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.html
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.html
@@ -12,6 +12,7 @@
             [label]="helptext.source_path_placeholder | translate"
             [tooltip]="helptext.source_path_tooltip | translate"
             [required]="true"
+            [root]="'/'"
             [multiple]="false"
             [nodeProvider]="fileNodeProvider"
           ></ix-explorer>

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
@@ -331,7 +331,9 @@ export class CloudBackupFormComponent implements OnInit {
   }
 
   private setFileNodeProvider(): void {
-    this.fileNodeProvider = this.filesystemService.getFilesystemNodeProvider({ directoriesOnly: true });
+    this.fileNodeProvider = this.filesystemService.getFilesystemNodeProvider({
+      datasetsAndZvols: true,
+    });
   }
 
   private setBucketNodeProvider(): void {

--- a/src/app/services/filesystem.service.spec.ts
+++ b/src/app/services/filesystem.service.spec.ts
@@ -28,6 +28,12 @@ describe('FilesystemService', () => {
             type: FileType.File,
             attributes: [FileAttribute.Immutable],
           },
+          {
+            path: '/mnt/parent/zvol',
+            name: 'zvol',
+            type: FileType.Symlink,
+            attributes: [FileAttribute.Immutable],
+          },
         ] as FileRecord[]),
       ]),
     ],
@@ -37,7 +43,7 @@ describe('FilesystemService', () => {
 
   describe('getFilesystemNodeProvider', () => {
     it('returns a TreeNodeProvider that calls filesystem.listdir to list files and directories', async () => {
-      const treeNodeProvider = spectator.service.getFilesystemNodeProvider();
+      const treeNodeProvider = spectator.service.getFilesystemNodeProvider({ datasetsAndZvols: true });
 
       const childNodes = await lastValueFrom(
         treeNodeProvider({
@@ -65,6 +71,14 @@ describe('FilesystemService', () => {
           name: 'file.txt',
           path: '/mnt/parent/file.txt',
           type: ExplorerNodeType.File,
+          isMountpoint: false,
+          isLock: true,
+        },
+        {
+          hasChildren: false,
+          name: 'zvol',
+          path: '/mnt/parent/zvol',
+          type: ExplorerNodeType.Symlink,
           isMountpoint: false,
           isLock: true,
         },

--- a/src/app/services/filesystem.service.spec.ts
+++ b/src/app/services/filesystem.service.spec.ts
@@ -55,7 +55,15 @@ describe('FilesystemService', () => {
 
       expect(spectator.inject(WebSocketService).call).toHaveBeenCalledWith(
         'filesystem.listdir',
-        ['/mnt/parent', [], { order_by: ['name'], limit: 1000 }],
+        [
+          '/mnt/parent',
+          [],
+          {
+            order_by: ['name'],
+            select: ['name', 'type', 'attributes', 'path'],
+            limit: 1000,
+          },
+        ],
       );
       expect(childNodes).toEqual([
         {

--- a/src/app/services/filesystem.service.ts
+++ b/src/app/services/filesystem.service.ts
@@ -1,13 +1,23 @@
 import { Injectable } from '@angular/core';
-import { map } from 'rxjs';
+import {
+  catchError, map, of, throwError,
+} from 'rxjs';
 import { ExplorerNodeType } from 'app/enums/explorer-type.enum';
 import { FileAttribute } from 'app/enums/file-attribute.enum';
 import { FileType } from 'app/enums/file-type.enum';
 import { FileRecord } from 'app/interfaces/file-record.interface';
 import { QueryFilter } from 'app/interfaces/query-api.interface';
 import { ExplorerNodeData, TreeNode } from 'app/interfaces/tree-node.interface';
+import { WebSocketError } from 'app/interfaces/websocket-error.interface';
 import { TreeNodeProvider } from 'app/modules/forms/ix-forms/components/ix-explorer/tree-node-provider.interface';
 import { WebSocketService } from 'app/services/ws.service';
+
+export interface ProviderOptions {
+  directoriesOnly?: boolean;
+  showHiddenFiles?: boolean;
+  includeSnapshots?: boolean;
+  datasetsAndZvols?: boolean;
+}
 
 @Injectable({ providedIn: 'root' })
 export class FilesystemService {
@@ -18,19 +28,32 @@ export class FilesystemService {
   /**
    * Returns a pre-configured node provider for files and directories.
    */
-  getFilesystemNodeProvider(providerOptions?: {
-    directoriesOnly?: boolean;
-    showHiddenFiles?: boolean;
-    includeSnapshots?: boolean;
-  }): TreeNodeProvider {
-    const options = {
+  getFilesystemNodeProvider(providerOptions?: ProviderOptions): TreeNodeProvider {
+    const options: ProviderOptions = {
       directoriesOnly: false,
       showHiddenFiles: false,
       includeSnapshots: true,
+      datasetsAndZvols: false,
       ...providerOptions,
     };
 
     return (node: TreeNode<ExplorerNodeData>) => {
+      if (options.datasetsAndZvols && node.data.path.trim() === '/') {
+        return of([
+          {
+            path: '/mnt',
+            name: '/mnt',
+            hasChildren: true,
+            type: ExplorerNodeType.Directory,
+          },
+          {
+            path: '/dev/zvol',
+            name: '/dev/zvol',
+            hasChildren: true,
+            type: ExplorerNodeType.Directory,
+          },
+        ] as ExplorerNodeData[]);
+      }
       const typeFilter: [QueryFilter<FileRecord>?] = [];
       if (options.directoriesOnly) {
         typeFilter.push(['type', '=', FileType.Directory]);
@@ -47,25 +70,42 @@ export class FilesystemService {
         map((files) => {
           const children: ExplorerNodeData[] = [];
           files.forEach((file) => {
-            if (file.type === FileType.Symlink || !file.hasOwnProperty('name')) {
+            if ((!options.datasetsAndZvols && file.type === FileType.Symlink) || !file.hasOwnProperty('name')) {
               return;
             }
 
             if (!options.showHiddenFiles && file.name.startsWith('.')) {
               return;
             }
-
+            let fileType: ExplorerNodeType;
+            switch (file.type) {
+              case FileType.Directory:
+                fileType = ExplorerNodeType.Directory;
+                break;
+              case FileType.Symlink:
+                fileType = ExplorerNodeType.Symlink;
+                break;
+              default:
+                fileType = ExplorerNodeType.File;
+                break;
+            }
             children.push({
               path: file.path,
               name: file.name,
               isMountpoint: file.attributes.includes(FileAttribute.MountRoot),
               isLock: file.attributes.includes(FileAttribute.Immutable),
-              type: file.type === FileType.Directory ? ExplorerNodeType.Directory : ExplorerNodeType.File,
+              type: fileType,
               hasChildren: file.type === FileType.Directory,
             });
           });
 
           return children;
+        }),
+        catchError((error: WebSocketError) => {
+          if (error.reason === '[ENOENT] Directory /dev/zvol does not exist') {
+            return of([]);
+          }
+          return throwError(() => (error));
         }),
       );
     };

--- a/src/app/services/filesystem.service.ts
+++ b/src/app/services/filesystem.service.ts
@@ -65,7 +65,11 @@ export class FilesystemService {
 
       return this.ws.call(
         'filesystem.listdir',
-        [node.data.path, typeFilter, { order_by: ['name'], limit: 1000 }],
+        [
+          node.data.path,
+          typeFilter,
+          { order_by: ['name'], limit: 1000, select: ['name', 'type', 'attributes', 'path'] },
+        ],
       ).pipe(
         map((files) => {
           const children: ExplorerNodeData[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,6 +2018,11 @@
   resolved "https://registry.yarnpkg.com/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-3.0.12.tgz#0e06dc23dfe23c4a9d0a9cbcce1b0af74c8884a0"
   integrity sha512-CO3MFV8gUx16NU/CyyuumAKblESwvoGVA2XhQKZ976OTOxaTbb8F8D3f0iiZ4MYqsN74jIrFuCmXpPnpjbhfOQ==
 
+"@marijn/find-cluster-break@~1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz#775374306116d51c0c500b8c4face0f9a04752d8"
+  integrity sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==
+
 "@markuplint/create-rule-helper@2.3.3":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@markuplint/create-rule-helper/-/create-rule-helper-2.3.3.tgz#9385e63f707a9ddc1aacf5d0c4b9c94f30bef070"


### PR DESCRIPTION
**Changes:**

Adds option to load zvols alongside datasets by providing two root paths. `/dev/zvol` alongside `/mnt` when calling `filesystem.listdir` endpoint. `ix-explorer` `root` property should be set to `/` for this. Default `root` for `ix-explorer` is `/mnt`

**Testing:**

Test on the TrueCloud Task Form. The path explorer should show `'/'` as it's root. When expanded, it should show two children paths. `'/mnt'` and `'/dev/zvol'`. When expanded, `'/mnt'` should show the normal datasets and `'/dev/zvol'` should show the zvols.