### PR TITLE
NAS-133538 / 25.04 / `fromemail` must be specified when setting up OAuth for Outlook Mail

### DIFF
--- a/src/app/pages/system/general-settings/email/email-form/email-form.component.html
+++ b/src/app/pages/system/general-settings/email/email-form/email-form.component.html
@@ -17,7 +17,7 @@
         <ix-input
           formControlName="fromemail"
           [label]="'From Email' | translate"
-          [required]="isSmtp"
+          [required]="isFromEmailRequired"
           [tooltip]="helptext.fromemail.tooltip | translate"
         ></ix-input>
 

--- a/src/app/pages/system/general-settings/email/email-form/email-form.component.spec.ts
+++ b/src/app/pages/system/general-settings/email/email-form/email-form.component.spec.ts
@@ -241,6 +241,16 @@ describe('EmailFormComponent', () => {
       );
     });
 
+    it('disables Save button when no From Email is provided for Outlook OAuth', async () => {
+      await form.fillForm({
+        'Send Mail Method': 'Outlook OAuth',
+        'From Email': '',
+      });
+
+      const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      expect(await saveButton.isDisabled()).toBe(true);
+    });
+
     it('calls removeEventListener when outlook oAuth callback is called', async () => {
       await form.fillForm({
         'Send Mail Method': 'Outlook OAuth',

--- a/src/app/pages/system/general-settings/email/email-form/email-form.component.ts
+++ b/src/app/pages/system/general-settings/email/email-form/email-form.component.ts
@@ -164,14 +164,16 @@ export class EmailFormComponent implements OnInit {
     return this.sendMethodControl.value === MailSendMethod.Smtp;
   }
 
+  get isFromEmailRequired(): boolean {
+    return this.isSmtp || this.sendMethodControl.value === MailSendMethod.Outlook;
+  }
+
   get hasOauthAuthorization(): boolean {
     return !!this.oauthCredentials?.client_id && this.sendMethodControl.value === this.oauthCredentials.provider;
   }
 
   get isValid(): boolean {
-    return this.isSmtp
-      ? this.form.valid
-      : this.hasOauthAuthorization;
+    return !this.isSmtp ? this.hasOauthAuthorization && this.form.valid : this.form.valid;
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
**Testing:**
See ticket.

Result:
<img width="490" alt="Screenshot 2025-01-14 at 12 35 47" src="https://github.com/user-attachments/assets/2542d1b3-2439-4229-a4f2-2c02dc40d6c6" />

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | From Email option is now required for Outlook provider
