### PR TITLE
Pass location.hostname as host_ip to app.query

### DIFF
--- a/src/app/pages/apps/services/applications.service.ts
+++ b/src/app/pages/apps/services/applications.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import {
   Observable, OperatorFunction, filter, map, pipe,
 } from 'rxjs';
 import { customApp } from 'app/constants/catalog.constants';
 import { AppExtraCategory } from 'app/enums/app-extra-category.enum';
+import { WINDOW } from 'app/helpers/window.helper';
 import { ApiEvent } from 'app/interfaces/api-message.interface';
 import {
   App, AppStartQueryParams, AppUpgradeParams,
@@ -31,6 +32,7 @@ export class ApplicationsService {
   constructor(
     private api: ApiService,
     private translate: TranslateService,
+    @Inject(WINDOW) private window: Window,
   ) {}
 
   checkIfAppIxVolumeExists(appName: string): Observable<boolean> {
@@ -65,7 +67,7 @@ export class ApplicationsService {
     return this.api.call('app.query', [[], {
       extra: {
         retrieve_config: true,
-        host_ip: window.location.hostname,
+        host_ip: this.window.location.hostname,
       },
     }]);
   }
@@ -75,7 +77,7 @@ export class ApplicationsService {
       extra: {
         include_app_schema: true,
         retrieve_config: true,
-        host_ip: window.location.hostname,
+        host_ip: this.window.location.hostname,
       },
     }]);
   }

--- a/src/app/pages/apps/services/applications.service.ts
+++ b/src/app/pages/apps/services/applications.service.ts
@@ -62,7 +62,12 @@ export class ApplicationsService {
   }
 
   getAllApps(): Observable<App[]> {
-    return this.api.call('app.query', [[], { extra: { retrieve_config: true } }]);
+    return this.api.call('app.query', [[], {
+      extra: {
+        retrieve_config: true,
+        host_ip: window.location.hostname,
+      },
+    }]);
   }
 
   getApp(name: string): Observable<App[]> {
@@ -70,6 +75,7 @@ export class ApplicationsService {
       extra: {
         include_app_schema: true,
         retrieve_config: true,
+        host_ip: window.location.hostname,
       },
     }]);
   }


### PR DESCRIPTION
**Changes:**

Pass location.hostname to the `host_ip` argument to `app.query` API calls. This makes it so that portals use a URL based on the hostname used to access the TrueNAS web UI, rather than a URL based on the IP address which is the default when not passing a `host_ip`.

I believe that this was the intention of the existing code, since https://github.com/truenas/webui/blob/master/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts#L116-L126 already replaces `0.0.0.0` with `window.location.hostname`. However, after https://github.com/truenas/middleware/pull/14057, the portal URI which we get from the back-end is already transformed to replace `0.0.0.0` with the value passed from `host_ip`, so that code doesn't have an effect anymore.

**Testing:**

Click a portal (e.g "Web UI") for an installed app using a domain name (typically, `<truenas hostname>.local` will work thanks to mDNS). Before this PR, it will take you to a URL containing the IPv4 address of the TrueNAS host (or do nothing if the websocket uses IPv6; see https://ixsystems.atlassian.net/browse/NAS-133655). After this PR, it should take you to a URL containing the domain you used to access the TrueNAS web UI.