### PR TITLE
NAS-133622 / 24.10.2.1 / Add `is_ctldir` to `filesystem.listdir` response

### DIFF
--- a/src/app/services/filesystem.service.spec.ts
+++ b/src/app/services/filesystem.service.spec.ts
@@ -60,7 +60,7 @@ describe('FilesystemService', () => {
           [],
           {
             order_by: ['name'],
-            select: ['name', 'type', 'attributes', 'path'],
+            select: ['name', 'type', 'attributes', 'path', 'is_ctldir'],
             limit: 1000,
           },
         ],

--- a/src/app/services/filesystem.service.ts
+++ b/src/app/services/filesystem.service.ts
@@ -68,7 +68,7 @@ export class FilesystemService {
         [
           node.data.path,
           typeFilter,
-          { order_by: ['name'], limit: 1000, select: ['name', 'type', 'attributes', 'path'] },
+          { order_by: ['name'], limit: 1000, select: ['name', 'type', 'attributes', 'path', 'is_ctldir'] },
         ],
       ).pipe(
         map((files) => {


### PR DESCRIPTION
**Testing:**

Use machine, where the issue was discovered: `r40-1.dc1.ixsystems.net`

Please see video attached to the ticket

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
