### PR TITLE
NAS-133736 / 25.04-BETA.1 / UI always submits a zero-sized time machine quota for SMB shares (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -467,7 +467,7 @@ export class SmbFormComponent implements OnInit, AfterViewInit {
   submit(): void {
     const smbShare = this.form.value;
 
-    if (!smbShare.timemachine_quota || !smbShare.timemachine) {
+    if (!smbShare.timemachine_quota) {
       smbShare.timemachine_quota = 0;
     }
 


### PR DESCRIPTION
See Comment:

<img width="910" alt="Screenshot 2025-01-24 at 20 33 27" src="https://github.com/user-attachments/assets/7f297ff8-3461-41c2-8d0c-aaa91af4f87f" />


Original PR: https://github.com/truenas/webui/pull/11384
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133736