### PR TITLE
NAS-133740 / 25.04-RC.1 / Permission checks (by undsoft)

### DIFF
--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -107,7 +107,6 @@ export class ServicesComponent implements OnInit {
           iconName: iconMarker('edit'),
           tooltip: this.translate.instant('Edit'),
           onClick: (row) => this.configureService(row),
-          dynamicRequiredRoles: (row) => of(this.servicesService.getRolesRequiredToManage(row.service)),
         },
       ],
     }),

--- a/src/app/pages/sharing/iscsi/iscsi.component.html
+++ b/src/app/pages/sharing/iscsi/iscsi.component.html
@@ -1,6 +1,5 @@
 <ix-page-header [pageTitle]="'iSCSI' | translate">
   <button
-    *ixRequiresRoles="requiredRoles"
     mat-button
     color="default"
     ixTest="global-target-configuration"

--- a/src/app/pages/sharing/iscsi/iscsi.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi.component.ts
@@ -7,7 +7,7 @@ import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { async, Subject } from 'rxjs';
+import { async } from 'rxjs';
 import { filter, map, startWith } from 'rxjs/operators';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
@@ -46,7 +46,6 @@ import { IscsiService } from 'app/services/iscsi.service';
 export class IscsiComponent {
   protected readonly searchableElements = iscsiElements;
   protected readonly requiredRoles = [Role.SharingIscsiWrite];
-  protected readonly needRefresh$ = new Subject<void>();
 
   protected readonly navLinks$ = this.iscsiService.hasFibreChannel().pipe(
     startWith(false),

--- a/src/app/pages/sharing/iscsi/target/all-targets/target-details/associated-extents-card/associated-extents-card.component.html
+++ b/src/app/pages/sharing/iscsi/target/all-targets/target-details/associated-extents-card/associated-extents-card.component.html
@@ -37,6 +37,7 @@
           </p>
 
           <button
+            *ixRequiresRoles="requiredRoles"
             mat-icon-button
             [ixTest]="'remove-extent-association' + extent.extent"
             [title]="'Remove extent association' | translate"

--- a/src/assets/ui-searchable-elements.json
+++ b/src/assets/ui-searchable-elements.json
@@ -2775,9 +2775,7 @@
       "Global Target Configuration"
     ],
     "synonyms": [],
-    "requiredRoles": [
-      "SHARING_ISCSI_WRITE"
-    ],
+    "requiredRoles": [],
     "visibleTokens": [],
     "anchorRouterLink": [
       "/sharing",


### PR DESCRIPTION
**Changes:**

* [NAS-133776: Adds checks for remove association in ISCSI targets.](https://ixsystems.atlassian.net/browse/NAS-133776)
* [NAS-133775: Removes checks for Global Target Configuration button.](https://ixsystems.atlassian.net/browse/NAS-133775)
* [NAS-133740: Removes checks for edit button on the service list.](https://ixsystems.atlassian.net/browse/NAS-133740)

Original PR: https://github.com/truenas/webui/pull/11386
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133740