### PR TITLE
NAS-133130 / 25.04-RC.1 / Advanced Cloud Sync Task: "Use Snapshot" checked box does not disappear correctly when direction is pull (by AlexKarpov98)

### DIFF
--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.ts
@@ -269,6 +269,10 @@ export class CloudSyncFormComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    if (!this.editingTask && this.form.controls.direction.value === Direction.Pull) {
+      this.form.controls.snapshot.disable();
+    }
+
     this.getInitialData();
 
     this.isCredentialInvalid$.pipe(untilDestroyed(this)).subscribe((value) => {


### PR DESCRIPTION
Testing: see ticket.

It shows as expected now, on form start:
<img width="804" alt="Screenshot 2025-01-27 at 17 44 57" src="https://github.com/user-attachments/assets/e484dc8f-c7be-483a-ab4a-61343d365828" />


Original PR: https://github.com/truenas/webui/pull/11418
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133130