### PR TITLE
NAS-133860 / 25.10 / Remove customer name from support info card

### DIFF
--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -4,10 +4,6 @@
     class="sys-license-wrapper"
   >
     <div class="sys-info-row">
-      <span class="label">{{ 'Customer Name' | translate }}:</span>
-      <span class="value">{{ license.customer_name }}</span>
-    </div>
-    <div class="sys-info-row">
       <span class="label">{{ 'Features' | translate }}:</span>
       <span class="value">{{ license.features.join(', ') }}</span>
     </div>

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -67,7 +67,6 @@ describe('SysInfoComponent', () => {
 
     expect(sysInfoBlock).not.toBeTruthy();
     expect(infoRows).toEqual({
-      'Customer Name:': licenseInfo.customer_name,
       'Model:': licenseInfo.model,
       'Licensed Serials:': licenseInfo.system_serial,
       'System Serial:': systemInfo.system_serial,

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -824,7 +824,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -862,7 +862,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1,7 +1,7 @@
 {
   "": "",
-  "Archs": "",
   "API Key copied to clipboard": "",
+  "Archs": "",
   "Are you sure you want to generate a one-time password for \"{username}\" user?": "",
   "Close Change Password Dialog": "",
   "Complete to proceed:": "",
@@ -1255,7 +1255,6 @@
   "Custom Value": "Valor personalizado",
   "Custom app config in YAML format.": "Configuración de app personalizada en formato YAML.",
   "Custom schedule": "Horario personalizado",
-  "Customer Name": "Nombre del cliente",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "Personaliza la importancia de la alerta. Cada nivel de importancia tiene un ícono y color diferentes para expresar el nivel de importancia.",
   "DEBUG": "DEPURAR",
   "DEFAULT": "PREDETERMINADO",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1033,7 +1033,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1894,7 +1894,6 @@
   "Custom Value": "Valeur personnalisée",
   "Custom app config in YAML format.": "Configuration d'application personnalisée au format YAML.",
   "Custom schedule": "Calendrier personnalisé",
-  "Customer Name": "Nom du client",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "Personnalise l'importance de l'alerte. Chaque niveau d'importance a une icône et une couleur différentes pour exprimer le niveau d'importance.",
   "DEBUG": "DEBUG",
   "DEFAULT": "DÉFAUT",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -1603,7 +1603,6 @@
   "Custom Transfers": "Aistrithe Saincheaptha",
   "Custom Value": "Luach an Chustaim",
   "Custom schedule": "Sceideal saincheaptha",
-  "Customer Name": "Ainm an Chustaiméara",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "Customizes an tábhacht a bhaineann leis an airdeall. Tá deilbhín agus dath difriúil ag gach leibhéal tábhachta chun an leibhéal tábhachta a chur in iúl.",
   "DEBUG": "DEBUG",
   "DEFAULT": "ROINNT",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1026,7 +1026,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -984,7 +984,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1178,7 +1178,6 @@
   "Custom Value": "사용자 정의 값",
   "Custom app config in YAML format.": "YAML 형식의 사용자 정의 앱 구성입니다.",
   "Custom schedule": "사용자 정의 일정",
-  "Customer Name": "고객 이름",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "경고의 중요도를 사용자화 합니다. 각 단계는 서로 다른 아이콘과 색상으로 중요도를 나타냅니다.",
   "DEBUG": "디버그",
   "DEFAULT": "기본",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1149,7 +1149,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1195,7 +1195,6 @@
   "Custom Value": "Aangepaste waarde",
   "Custom app config in YAML format.": "Aangepaste app-configuratie in YAML-formaat",
   "Custom schedule": "Aangepast schema",
-  "Customer Name": "Klantnaam",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "Past het belang van de waarschuwing aan. Elk niveau van belangrijkheid heeft een ander pictogram en een andere kleur om het belangrijkheidsniveau uit te drukken.",
   "DEBUG": "DEBUG",
   "DEFAULT": "STANDAARD",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1105,7 +1105,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1097,7 +1097,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -551,7 +551,6 @@
   "Custom Reason": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DHCP": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -741,7 +741,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "DEBUG": "",
   "DEFAULT": "",
   "DHCP": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -512,7 +512,6 @@
   "Custom Reason": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "DNS Timeout": "",
   "DS Groups": "",
   "DS Groups Name": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1155,7 +1155,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -1291,7 +1291,6 @@
   "Custom Value": "自定义值",
   "Custom app config in YAML format.": "自定义应用程序配置采用YAML格式。",
   "Custom schedule": "自定义计划",
-  "Customer Name": "客户名称",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "自定义警报的重要性。每个重要性级别都有不同的图标和颜色来表示。",
   "DEBUG": "调试",
   "DEFAULT": "默认",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -635,7 +635,6 @@
   "Custom Value": "",
   "Custom app config in YAML format.": "",
   "Custom schedule": "",
-  "Customer Name": "",
   "Customizes the importance of the alert. Each level of  importance has a different icon and color to express the level of importance.": "",
   "DEBUG": "",
   "DEFAULT": "",


### PR DESCRIPTION
**Changes:**

Removes Customer Name from UI Support Info card under "System -> General Settings"

**Testing:**

See that customer name isn't shown on the card

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Removes Customer Name from Support UI
