### PR TITLE
NAS-133830 / 25.10 / Renames checkbox "Take Snapshot" to "Use Snapshot"

### DIFF
--- a/src/app/helptext/data-protection/cloud-backup/cloud-backup.ts
+++ b/src/app/helptext/data-protection/cloud-backup/cloud-backup.ts
@@ -36,7 +36,7 @@ export const helptextCloudBackup = {
   post_script_placeholder: T('Post-script'),
   post_script_tooltip: T('Script to execute after running sync.'),
 
-  snapshot_placeholder: T('Take Snapshot'),
+  snapshot_placeholder: T('Use Snapshot'),
   snapshot_tooltip: T('Set to take a snapshot of the dataset before a <i>PUSH</i>.'),
 
   absolute_paths_placeholder: T('Use Absolute Paths'),

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
@@ -130,7 +130,7 @@ describe('CloudBackupFormComponent', () => {
       });
 
       await form.fillForm({
-        'Take Snapshot': true,
+        'Use Snapshot': true,
       });
 
       const useAbsolutePathsControl = await form.getControl('Use Absolute Paths');
@@ -194,7 +194,7 @@ describe('CloudBackupFormComponent', () => {
         Folder: '/',
         Enabled: false,
         Bucket: 'bucket1',
-        'Take Snapshot': false,
+        'Use Snapshot': false,
         'Use Absolute Paths': true,
         Exclude: ['/test'],
         'Transfer Setting': 'Fast Storage',
@@ -259,7 +259,7 @@ describe('CloudBackupFormComponent', () => {
         'Pre-script': '',
         Schedule: 'Weekly (0 0 * * sun)  On Sundays at 00:00 (12:00 AM)',
         'Source Path': '/mnt/my pool',
-        'Take Snapshot': false,
+        'Use Snapshot': false,
         'Use Absolute Paths': true,
         'Transfer Setting': 'Performance',
       });

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1,7 +1,7 @@
 {
   "": "",
-  "Archs": "",
   "API Key copied to clipboard": "",
+  "Archs": "",
   "Are you sure you want to generate a one-time password for \"{username}\" user?": "",
   "Close Change Password Dialog": "",
   "Complete to proceed:": "",


### PR DESCRIPTION
**Changes:**

Renames checkbox "Take Snapshot" to "Use Snapshot". See ticket for instructions

**Testing:**

See that checkbox is renamed

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Renames checkbox "Take Snapshot" to "Use Snapshot" on the TrueCloud Backup Tasks form