### PR TITLE
NAS-133815 / 25.04-RC.1 / Code editor gets marked dirty incorrectly (by AlexKarpov98)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-code-editor/ix-code-editor.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-code-editor/ix-code-editor.component.ts
@@ -135,11 +135,13 @@ export class IxCodeEditorComponent implements OnChanges, OnInit, AfterViewInit, 
 
   initEditor(): void {
     const updateListener = EditorView.updateListener.of((update) => {
-      if (!update.docChanged) {
+      const updatedValue = update.state.doc.toString();
+
+      if (!update.docChanged || updatedValue === this.controlDirective.control?.value) {
         return;
       }
 
-      this.onChange(update.state.doc.toString());
+      this.onChange(updatedValue);
     });
 
     const extensions: Extension[] = [

--- a/src/app/modules/forms/ix-forms/components/ix-code-editor/ix-code-editor.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-code-editor/ix-code-editor.spec.ts
@@ -75,5 +75,9 @@ describe('IxCodeEditor', () => {
 
       expect(spectator.component.editorView.state.doc.toString()).toBe('new value');
     });
+
+    it('does not mark form control as dirty initially', () => {
+      expect(formControl.dirty).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Testing: see ticket.

Result:

https://github.com/user-attachments/assets/e38f74e3-1f5a-48f3-bf99-2eb3d86be275



Original PR: https://github.com/truenas/webui/pull/11437
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133815