### PR TITLE
NAS-133869 / 25.10 / Fix return value of `user.create` and `user.update`

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -861,8 +861,8 @@ export interface ApiCallDirectory {
   'ups.update': { params: [UpsConfigUpdate]; response: UpsConfig };
 
   // User
-  'user.create': { params: [UserUpdate]; response: User };
-  'user.update': { params: [id: number, update: UserUpdate]; response: User };
+  'user.create': { params: [UserUpdate]; response: number };
+  'user.update': { params: [id: number, update: UserUpdate]; response: number };
   'user.delete': { params: DeleteUserParams; response: number };
   'user.get_next_uid': { params: void; response: number };
   'user.get_user_obj': { params: [{ username?: string; uid?: number }]; response: DsUncachedUser };


### PR DESCRIPTION
**Summary**

Adapted to changes in middleware: `user.create` and `user.update` requests now return an `id` instead of a `User` object.

**Testing:**

Please see ticket  for replication steps and expected results