### PR TITLE
NAS-133861 / 25.04-RC.1 / Cannot create VM with GPU selected (by AlexKarpov98)

### DIFF
--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.spec.ts
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.spec.ts
@@ -17,6 +17,7 @@ import { mockCall, mockJob, mockApi } from 'app/core/testing/utils/mock-api.util
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import {
   VirtualizationDeviceType,
+  VirtualizationGpuType,
   VirtualizationNicType,
   VirtualizationProxyProtocol,
   VirtualizationSource,
@@ -232,7 +233,7 @@ describe('InstanceWizardComponent', () => {
           },
           { dev_type: VirtualizationDeviceType.Nic, nic_type: VirtualizationNicType.Bridged, parent: 'nic1' },
           { dev_type: VirtualizationDeviceType.Usb, product_id: '0003' },
-          { dev_type: VirtualizationDeviceType.Gpu, pci: 'pci_0000_01_00_0' },
+          { dev_type: VirtualizationDeviceType.Gpu, pci: 'pci_0000_01_00_0', gpu_type: VirtualizationGpuType.Physical },
         ],
         image: 'almalinux/8/cloud',
         memory: GiB,
@@ -381,7 +382,7 @@ describe('InstanceWizardComponent', () => {
           },
           { dev_type: VirtualizationDeviceType.Nic, nic_type: VirtualizationNicType.Bridged, parent: 'nic1' },
           { dev_type: VirtualizationDeviceType.Usb, product_id: '0003' },
-          { dev_type: VirtualizationDeviceType.Gpu, pci: 'pci_0000_01_00_0' },
+          { dev_type: VirtualizationDeviceType.Gpu, pci: 'pci_0000_01_00_0', gpu_type: VirtualizationGpuType.Physical },
         ],
         image: 'almalinux/8/cloud',
         memory: GiB,

--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.ts
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.ts
@@ -390,11 +390,12 @@ export class InstanceWizardComponent {
       });
     }
 
-    const gpuDevices: { pci: string; dev_type: VirtualizationDeviceType }[] = [];
+    const gpuDevices: { pci: string; dev_type: VirtualizationDeviceType; gpu_type: VirtualizationGpuType }[] = [];
     for (const pci of this.form.controls.gpu_devices.value) {
       gpuDevices.push({
         pci,
         dev_type: VirtualizationDeviceType.Gpu,
+        gpu_type: VirtualizationGpuType.Physical,
       });
     }
     const macVlanNics: { parent: string; dev_type: VirtualizationDeviceType; nic_type: VirtualizationNicType }[] = [];


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 75d4a4bdaf0dbc768729a68318cba86067fcab60
    git cherry-pick -x f706d0df52e76d0b04d19496ea5278325739dbaf
    git cherry-pick -x c79c45e4de9fce44060f9586886f7e65c8df0e18

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 4d874471319814c5d0a79f863aa55a060f0e509d

Testing: see ticket.

Added missing `gpu_type` field for GPU devices.
Currently only `PHYSICAL` is acceptable.

Same applies for the GPU devices list:
```
gpuDevices$ = this.api.call(
    'virt.device.gpu_choices',
    [VirtualizationGpuType.Physical],
  )
``` 


Original PR: https://github.com/truenas/webui/pull/11462
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133861