### PR TITLE
NAS-133970 / 25.04-RC.1 / Add error handling for removal the extent association from the iSCSI Targets page (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/iscsi/target/all-targets/target-details/associated-extents-card/associated-extents-card.component.ts
+++ b/src/app/pages/sharing/iscsi/target/all-targets/target-details/associated-extents-card/associated-extents-card.component.ts
@@ -24,6 +24,7 @@ import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
 import { AppLoaderService } from 'app/modules/loader/app-loader.service';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AssociatedTargetFormComponent } from 'app/pages/sharing/iscsi/target/all-targets/target-details/associated-extents-card/associated-target-form/associated-target-form.component';
+import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { IscsiService } from 'app/services/iscsi.service';
 
 @UntilDestroy()
@@ -83,6 +84,7 @@ export class AssociatedExtentsCardComponent {
     private cdr: ChangeDetectorRef,
     private dialogService: DialogService,
     private translate: TranslateService,
+    private errorHandler: ErrorHandlerService,
   ) {
     effect(() => {
       if (this.target()) {
@@ -115,6 +117,7 @@ export class AssociatedExtentsCardComponent {
     }).pipe(
       filter(Boolean),
       switchMap(() => this.iscsiService.deleteTargetExtent(extent.id).pipe(this.loader.withLoader())),
+      this.errorHandler.catchError(),
       untilDestroyed(this),
     ).subscribe(() => this.getTargetExtents());
   }


### PR DESCRIPTION
Testing: see ticket.

```
Updated

I understand the issue when I connected the target through the initiator, it was not possible to remove it. This is a valid reason. But it would be good if there were warning texts about that.
```

https://github.com/user-attachments/assets/a39acc2c-28f8-4a77-8b43-27213d8b4ac0



Original PR: https://github.com/truenas/webui/pull/11477
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133970