### PR TITLE
NAS-133998 / 25.10 / Do not show root disk size field when importing a zvol

### DIFF
--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.html
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.html
@@ -149,7 +149,7 @@
       [label]="'Disks' | translate"
     >
 
-      @if (isVm()) {
+      @if (isVm() && form.value.source_type !== VirtualizationSource.Zvol) {
         <ix-input
           formControlName="root_disk_size"
           type="number"

--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.spec.ts
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.spec.ts
@@ -470,7 +470,6 @@ describe('InstanceWizardComponent', () => {
         vnc_port: null,
         iso_volume: null,
         zvol_path: '/dev/zvol/test',
-        root_disk_size: 10,
       }]);
       expect(spectator.inject(DialogService).jobDialog).toHaveBeenCalled();
       expect(spectator.inject(SnackbarService).success).toHaveBeenCalled();

--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.ts
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.ts
@@ -343,7 +343,10 @@ export class InstanceWizardComponent {
 
     if (this.isVm()) {
       payload.secure_boot = values.secure_boot;
-      payload.root_disk_size = values.root_disk_size;
+
+      if (values.source_type !== VirtualizationSource.Zvol) {
+        payload.root_disk_size = values.root_disk_size;
+      }
 
       if (values.enable_vnc) {
         payload.vnc_password = values.vnc_password;


### PR DESCRIPTION
Testing: see ticket.

Result:

https://github.com/user-attachments/assets/0a8153a3-f2ee-4123-a5e0-57e13f948925

