### PR TITLE
NAS-133598 / 25.04-RC.1 / Fix `saveUpdatedPreferences` effect (by bvasilenko)

### DIFF
--- a/src/app/store/preferences/preferences.effects.spec.ts
+++ b/src/app/store/preferences/preferences.effects.spec.ts
@@ -1,0 +1,49 @@
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { ReplaySubject } from 'rxjs';
+import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { ApiService } from 'app/modules/websocket/api.service';
+import { defaultPreferences } from 'app/store/preferences/default-preferences.constant';
+import { lifetimeTokenUpdated } from 'app/store/preferences/preferences.actions';
+import { PreferencesEffects } from 'app/store/preferences/preferences.effects';
+import { selectPreferences } from 'app/store/preferences/preferences.selectors';
+
+describe('PreferencesEffects', () => {
+  let spectator: SpectatorService<PreferencesEffects>;
+
+  const actions$ = new ReplaySubject<unknown>(1);
+  const createService = createServiceFactory({
+    service: PreferencesEffects,
+    providers: [
+      provideMockActions(() => actions$),
+      mockApi([
+        mockCall('auth.set_attribute'),
+      ]),
+      provideMockStore({
+        selectors: [
+          {
+            selector: selectPreferences,
+            value: defaultPreferences,
+          },
+        ],
+      }),
+      mockAuth(),
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+  });
+
+  it('save updated preferences', () => {
+    actions$.next(lifetimeTokenUpdated({ lifetime: defaultPreferences.lifetime }));
+    spectator.service.saveUpdatedPreferences$.subscribe();
+
+    expect(spectator.inject(ApiService).call).toHaveBeenCalledWith(
+      'auth.set_attribute',
+      ['preferences', defaultPreferences],
+    );
+  });
+});

--- a/src/app/store/preferences/preferences.effects.ts
+++ b/src/app/store/preferences/preferences.effects.ts
@@ -4,7 +4,7 @@ import { Store } from '@ngrx/store';
 import { isEqual } from 'lodash';
 import { EMPTY } from 'rxjs';
 import {
-  catchError, filter, map, mergeMap, pairwise, switchMap, take, withLatestFrom,
+  catchError, filter, map, mergeMap, pairwise, startWith, switchMap, withLatestFrom,
 } from 'rxjs/operators';
 import { AuthService } from 'app/modules/auth/auth.service';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -72,10 +72,10 @@ export class PreferencesEffects {
       updateRebootAfterManualUpdate,
       autoRefreshReportsToggled,
     ),
-    withLatestFrom(this.store$.pipe(waitForPreferences, take(1), pairwise())),
+    withLatestFrom(this.store$.pipe(waitForPreferences, startWith(undefined), pairwise())),
     filter(([, [prevPrefs, newPrefs]]) => !isEqual(prevPrefs, newPrefs)),
-    switchMap(([, preferences]) => {
-      return this.api.call('auth.set_attribute', ['preferences', preferences]);
+    switchMap(([, [, newPrefs]]) => {
+      return this.api.call('auth.set_attribute', ['preferences', newPrefs]);
     }),
   ), { dispatch: false });
 


### PR DESCRIPTION
**Testing:**

Steps to reproduce:

1. Go to **Advanced Settings \> Access widget**
2. Click **Configure** and change the value of **Session Timeout**. Save.
3. Refresh the window
4. **Session Timeout** reverts to it's previous value, `300`

**Expected result:** proper value is saved and then loaded

Original PR: https://github.com/truenas/webui/pull/11404
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133598