### PR TITLE
NAS-133998 / 25.04-RC.1 / Do not show root disk size field when importing a zvol (by AlexKarpov98)

### DIFF
--- a/src/app/pages/credentials/users/user-api-keys/user-api-keys.component.spec.ts
+++ b/src/app/pages/credentials/users/user-api-keys/user-api-keys.component.spec.ts
@@ -115,7 +115,7 @@ describe('UserApiKeysComponent', () => {
   it('should show table rows', async () => {
     const expectedRows = [
       ['Name', 'Username', 'Local', 'Revoked', 'Created Date', 'Expires On', ''],
-      ['first-api-key', 'root', 'Yes', 'No', '2002-01-03 07:36:50', 'in 7 years', ''],
+      ['first-api-key', 'root', 'Yes', 'No', '2002-01-03 07:36:50', 'in almost 7 years', ''],
       ['second-api-key', 'root', 'No', 'Yes', '2002-01-14 21:23:30', 'Never', ''],
     ];
 

--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.html
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.html
@@ -149,7 +149,7 @@
       [label]="'Disks' | translate"
     >
 
-      @if (isVm()) {
+      @if (isVm() && form.value.source_type !== VirtualizationSource.Zvol) {
         <ix-input
           formControlName="root_disk_size"
           type="number"

--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.spec.ts
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.spec.ts
@@ -470,7 +470,6 @@ describe('InstanceWizardComponent', () => {
         vnc_port: null,
         iso_volume: null,
         zvol_path: '/dev/zvol/test',
-        root_disk_size: 10,
       }]);
       expect(spectator.inject(DialogService).jobDialog).toHaveBeenCalled();
       expect(spectator.inject(SnackbarService).success).toHaveBeenCalled();

--- a/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.ts
+++ b/src/app/pages/virtualization/components/instance-wizard/instance-wizard.component.ts
@@ -343,8 +343,11 @@ export class InstanceWizardComponent {
     } as CreateVirtualizationInstance;
 
     if (this.isVm()) {
-      payload.root_disk_size = values.root_disk_size;
       payload.secure_boot = values.secure_boot;
+
+      if (values.source_type !== VirtualizationSource.Zvol) {
+        payload.root_disk_size = values.root_disk_size;
+      }
 
       if (values.enable_vnc) {
         payload.vnc_password = values.vnc_password;


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 34347528ab58f189c954831abdfe604f60defb16

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 7f930817eb4480df83e5f75c6ee0515378525731

Testing: see ticket.

Result:

https://github.com/user-attachments/assets/0a8153a3-f2ee-4123-a5e0-57e13f948925



Original PR: https://github.com/truenas/webui/pull/11489
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133998