### PR TITLE
NAS-134050 / 25.10 / Restart dialog layout shifts because of validation message

### DIFF
--- a/src/app/modules/layout/topbar/power-menu/power-menu.component.spec.ts
+++ b/src/app/modules/layout/topbar/power-menu/power-menu.component.spec.ts
@@ -44,7 +44,7 @@ describe('PowerMenuComponent', () => {
     await restart[0].click();
 
     expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(RebootOrShutdownDialogComponent, {
-      width: '400px',
+      width: '430px',
     });
     expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/system-tasks/restart'], {
       skipLocationChange: true,
@@ -57,7 +57,7 @@ describe('PowerMenuComponent', () => {
     await shutdown[0].click();
 
     expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(RebootOrShutdownDialogComponent, {
-      width: '400px',
+      width: '430px',
       data: true,
     });
     expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/system-tasks/shutdown'], {

--- a/src/app/modules/layout/topbar/power-menu/power-menu.component.ts
+++ b/src/app/modules/layout/topbar/power-menu/power-menu.component.ts
@@ -47,7 +47,7 @@ export class PowerMenuComponent {
 
   onReboot(): void {
     this.matDialog.open(RebootOrShutdownDialogComponent, {
-      width: '400px',
+      width: '430px',
     }).afterClosed().pipe(
       filter(Boolean),
       untilDestroyed(this),
@@ -61,7 +61,7 @@ export class PowerMenuComponent {
 
   onShutdown(): void {
     this.matDialog.open(RebootOrShutdownDialogComponent, {
-      width: '400px',
+      width: '430px',
       data: true,
     }).afterClosed().pipe(
       filter(Boolean),

--- a/src/app/modules/layout/topbar/reboot-or-shutdown-dialog/reboot-or-shutdown-dialog.component.html
+++ b/src/app/modules/layout/topbar/reboot-or-shutdown-dialog/reboot-or-shutdown-dialog.component.html
@@ -22,7 +22,6 @@
     class="confirm"
     [formControl]="form.controls.confirm"
     [label]="'Confirm' | translate"
-    [required]="true"
   ></ix-checkbox>
 
   <button mat-button type="button" matDialogClose ixTest="cancel">


### PR DESCRIPTION
Fixes this:

<img width="410" alt="Снимок экрана 2025-02-05 в 19 19 45" src="https://github.com/user-attachments/assets/d2e6be78-9c9a-4487-bd83-4ffff52e865c" />
