### PR TITLE
NAS-133853 / 25.04-RC.1 / ix-blue theme wrong icon colors (by AlexKarpov98)

### DIFF
--- a/src/app/modules/layout/topbar/topbar.component.scss
+++ b/src/app/modules/layout/topbar/topbar.component.scss
@@ -78,16 +78,22 @@ ix-truenas-logo {
   }
 }
 
-:host ::ng-deep .topbar {
+:host ::ng-deep nav mat-toolbar {
   min-height: 48px;
 
   .mat-toolbar-row {
     height: 48px !important;
   }
 
+  button .ix-icon,
+  button span,
   .mat-icon-button,
   .mat-icon-button .ix-icon.logo {
     color: var(--topbar-txt) !important;
+  }
+
+  .ix-logo path {
+    fill: var(--topbar-txt);
   }
 
   .mat-mdc-select-value {

--- a/src/assets/styles/other/_material-overrides.scss
+++ b/src/assets/styles/other/_material-overrides.scss
@@ -82,7 +82,7 @@ html .ix-dark {
   --mat-table-row-item-label-text-color: var(--fg2);
   --mat-table-header-headline-color: var(--fg2);
   --mdc-filled-text-field-input-text-color: var(--alt-fg2);
-  --mat-option-selected-state-label-text-color: var(--fg1);
+  --mat-option-selected-state-label-text-color: var(--primary-txt);
   --mat-menu-item-label-text-line-height: 36px;
   --mat-menu-item-label-text-font: var(--font-family-body);
   --mat-paginator-container-size: unset;


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x f6d21d9f66056551932c252486cd18870c79fcab
    git cherry-pick -x bae4577c6f7d294c97ebee3d6ceb7fe0d337530e
    git cherry-pick -x b808ccab524e91642a6be740d1d21f96e561360e
    git cherry-pick -x 14743758bbc59118661a7b97290baff6de97cc20
    git cherry-pick -x 5111e7706e622748a85bed8a15494d8701d400a7

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x aa8b6b51247f31d487a25fa54198cbacac2d2981

Testing: see ticket.

Result:

https://github.com/user-attachments/assets/917c75e8-aca0-48b0-b892-6c0031014cf1



Original PR: https://github.com/truenas/webui/pull/11461
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133853