### PR TITLE
NAS-132124 / 24.10.3 / Switch to remaking backend calls when navigated to dashboard

### DIFF
--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
@@ -106,7 +106,7 @@ export class WidgetBackupComponent implements OnInit {
 
   getBackups(): void {
     this.isLoading = true;
-    this.widgetResourcesService.backups$
+    this.widgetResourcesService.getBackupTasks()
       .pipe(untilDestroyed(this))
       .subscribe(([replicationTasks, rsyncTasks, cloudSyncTasks]) => {
         this.isLoading = false;

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
@@ -106,7 +106,7 @@ export class WidgetBackupComponent implements OnInit {
 
   getBackups(): void {
     this.isLoading = true;
-    this.widgetResourcesService.getBackupTasks()
+    this.widgetResourcesService.backupTasks$
       .pipe(untilDestroyed(this))
       .subscribe(([replicationTasks, rsyncTasks, cloudSyncTasks]) => {
         this.isLoading = false;


### PR DESCRIPTION
**Changes:**

Previously, widget-resource-service was making calls to certain endpoints once per session and then ever updating the data no matter how much time passed and even if the user navigated away. I've changed that so the calls are remade whenever the user navigates to the dashboard page. Furthermore, I've optimized the calls so that multiple widgets asking for the same data only trigger one call. Instead of a new call for every widget.

**Testing:**

Code review. Also, check network logs to ensure that whenever you navigate to the dashboard page via either page refresh, or via navigating away to a different page and then coming back to the dashboard page, `interface.query` call is made only once and data is updated as per the latest call response. Also, check that every time the user navigates away from the dashboard page or refreshes the tab, the data for backup tasks is fetched and shown updated data on the UI.