### PR TITLE
NAS-134046 / 25.04-RC.1 / Auth error in Export Key is not properly handled (by undsoft)

### DIFF
--- a/src/app/pages/dashboard/widgets/cpu/widget-cpu-usage-bar/widget-cpu-usage-bar.component.scss
+++ b/src/app/pages/dashboard/widgets/cpu/widget-cpu-usage-bar/widget-cpu-usage-bar.component.scss
@@ -14,7 +14,6 @@
   }
 
   h3 {
-    margin-bottom: 10px;
     padding: 16px 0 0;
     width: 100%;
   }

--- a/src/app/pages/datasets/modules/encryption/components/export-dataset-key-dialog/export-dataset-key-dialog.component.spec.ts
+++ b/src/app/pages/datasets/modules/encryption/components/export-dataset-key-dialog/export-dataset-key-dialog.component.spec.ts
@@ -3,7 +3,8 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
+import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
 import { mockCall, mockJob, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { Dataset } from 'app/interfaces/dataset.interface';
@@ -16,8 +17,6 @@ describe('ExportDatasetKeyDialogComponent', () => {
   let loader: HarnessLoader;
   const createComponent = createComponentFactory({
     component: ExportDatasetKeyDialogComponent,
-    imports: [
-    ],
     providers: [
       mockApi([
         mockCall('core.download', [1, 'http://localhost/download']),
@@ -62,5 +61,14 @@ describe('ExportDatasetKeyDialogComponent', () => {
       'dataset_my-dataset_key.json',
       'application/json',
     );
+  });
+
+  it('auto closes dialog if there was an error loading the key', () => {
+    const mockedApi = spectator.inject(MockApiService);
+    jest.spyOn(mockedApi, 'job').mockReturnValue(throwError(() => new Error('Failed to load key')));
+
+    spectator.component.ngOnInit();
+
+    expect(spectator.inject(MatDialogRef).close).toHaveBeenCalled();
   });
 });

--- a/src/app/pages/datasets/modules/encryption/components/export-dataset-key-dialog/export-dataset-key-dialog.component.ts
+++ b/src/app/pages/datasets/modules/encryption/components/export-dataset-key-dialog/export-dataset-key-dialog.component.ts
@@ -88,6 +88,7 @@ export class ExportDatasetKeyDialogComponent implements OnInit {
           this.cdr.markForCheck();
         },
         error: (error: unknown) => {
+          this.dialogRef.close();
           this.dialogService.error(this.errorHandler.parseError(error));
         },
       });


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 8edfb86108554a9fceffda9166dac64c8d45d9ba
    git cherry-pick -x 6066f1cda13dd70c81e29b5bbbb6edec4e3446b9

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 84095d400815e55e27b868e9688641e9e470c209

Original issue:

> 1. Create a dataset with Key encryption.
> 2. Simulate pool.dataset.export_key failing in loadKey in ExportDatasetKeyDialogComponent.
> 3. Click Export Key.
> ER: I see error dialog and I am not prompted to download the key.
> AR: I see error dialog and then I am prompted to download the key.

Original PR: https://github.com/truenas/webui/pull/11505
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134046