### PR TITLE
NAS-134022 / 25.04-RC.1 / Long admin names do not fit on the screen (by AlexKarpov98)

### DIFF
--- a/src/app/modules/layout/topbar/user-menu/user-menu.component.scss
+++ b/src/app/modules/layout/topbar/user-menu/user-menu.component.scss
@@ -14,9 +14,15 @@
   .username {
     @include line-clamp(2);
     cursor: pointer;
+    display: inline-block;
     font-size: 14px;
     margin-right: 0.5rem;
-    max-width: 200px;
+    max-width: 105px;
+    min-width: auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: middle;
+    white-space: nowrap;
 
     @media(max-width: $breakpoint-md) {
       display: none;


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x fc30f4835b646307f6b8cdcb78cd7b780d45755c
    git cherry-pick -x 433583e781ffa82f01fe005447e92298edbd2d31
    git cherry-pick -x f431c845b0b0f91f6ce3d7c76be6df2d8b82c3be

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x c8b9cc25b937048668e40941e9a1aa2aeeeecb95

Testing: see ticket.

Result:
<img width="1293" alt="Screenshot 2025-02-07 at 13 33 41" src="https://github.com/user-attachments/assets/beb0f3d8-0344-48d1-9e07-ef689bee7c61" />
<img width="1296" alt="Screenshot 2025-02-07 at 13 33 55" src="https://github.com/user-attachments/assets/be6aa8f9-d4ca-43b6-8e84-8b92886a214e" />


Original PR: https://github.com/truenas/webui/pull/11509
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134022