### PR TITLE
NAS-133774 / 25.04-RC.1 / Reload node children on toggle in ix-explorer (by denysbutenko)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component.html
+++ b/src/app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component.html
@@ -41,7 +41,7 @@
 <div class="tree-container" [class.disabled]="isDisabled" [attr.aria-label]="label()">
   <tree-root
     #tree
-    [nodes]="nodes"
+    [nodes]="nodes()"
     [options]="treeOptions()"
     (select)="onNodeSelect($event)"
     (deselect)="onNodeDeselect($event)"
@@ -80,7 +80,7 @@
 </div>
 
 
-@if (loadingError) {
+@if (loadingError(); as loadingError) {
   <mat-error class="loading-error">
     {{ loadingError }}
   </mat-error>
@@ -91,6 +91,6 @@
   <ix-errors [control]="control" [label]="label()"></ix-errors>
 }
 
-@if (hint()) {
-  <mat-hint>{{ hint() }}</mat-hint>
+@if (hint(); as hintText) {
+  <mat-hint>{{ hintText }}</mat-hint>
 }

--- a/src/app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component.ts
@@ -3,7 +3,7 @@ import {
   ChangeDetectorRef,
   Component, computed, input,
   OnChanges,
-  OnInit, Signal, viewChild,
+  OnInit, signal, Signal, viewChild,
 } from '@angular/core';
 import { ControlValueAccessor, NgControl, ReactiveFormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
@@ -11,12 +11,14 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatError, MatHint } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import {
-  IActionMapping, ITreeOptions, KEYS, TREE_ACTIONS, TreeComponent, TreeModule,
+  IActionMapping, ITreeOptions, KEYS, TREE_ACTIONS, TreeComponent, TreeModel, TreeModule,
 } from '@bugsplat/angular-tree-component';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { firstValueFrom, Observable, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import {
+  firstValueFrom, Observable, of,
+} from 'rxjs';
+import { catchError, filter } from 'rxjs/operators';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { ExplorerNodeType } from 'app/enums/explorer-type.enum';
 import { mntPath } from 'app/enums/mnt-path.enum';
@@ -70,6 +72,7 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
   readonly root = input(mntPath);
   readonly nodeProvider = input.required<TreeNodeProvider>();
   // TODO: Come up with a system of extendable controls.
+  // TODO: Add support for zvols.
   readonly canCreateDataset = input(false);
   readonly createDatasetProps = input<Omit<DatasetCreate, 'name'>>({});
 
@@ -81,8 +84,8 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
   inputValue = '';
   value: string | string[];
   isDisabled = false;
-  nodes: ExplorerNodeData[] = [];
-  loadingError: string | null = null;
+  readonly nodes = signal<ExplorerNodeData[]>([]);
+  readonly loadingError = signal<string | null>(null);
 
   onChange: (value: string | string[]) => void = (): void => {};
   onTouch: () => void = (): void => {};
@@ -95,19 +98,26 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
       || this.isDisabled;
   }
 
+  private toggleExpandNodeFn = (
+    tree: TreeModel,
+    node: TreeNode<ExplorerNodeData>,
+    $event: MouseEvent,
+  ): void => {
+    if (node.isCollapsed && node.hasChildren && node.children) {
+      node.children = null;
+    }
+    TREE_ACTIONS.TOGGLE_EXPANDED(tree, node, $event);
+  };
+
   private readonly actionMapping: IActionMapping = {
     mouse: {
-      dblClick: (tree, node, $event) => {
-        TREE_ACTIONS.TOGGLE_EXPANDED(tree, node, $event);
-      },
-      click: (tree, node, $event) => {
-        TREE_ACTIONS.TOGGLE_SELECTED(tree, node, $event);
-      },
+      expanderClick: this.toggleExpandNodeFn.bind(this),
+      dblClick: this.toggleExpandNodeFn.bind(this),
+      click: TREE_ACTIONS.TOGGLE_SELECTED,
     },
     keys: {
-      [KEYS.ENTER]: (tree, node, $event) => {
-        TREE_ACTIONS.TOGGLE_SELECTED(tree, node, $event);
-      },
+      [KEYS.ENTER]: TREE_ACTIONS.TOGGLE_SELECTED,
+      [KEYS.SPACE]: this.toggleExpandNodeFn.bind(this),
     },
   };
 
@@ -135,7 +145,6 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
   ngOnChanges(changes: IxSimpleChanges<this>): void {
     if ('nodeProvider' in changes || 'root' in changes) {
       this.setInitialNode();
-      this.cdr.markForCheck();
     }
   }
 
@@ -233,7 +242,13 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
   }
 
   parentDatasetName(path: string): string {
-    return (!path || path === this.root()) ? '' : path.replace(`${this.root()}/`, '');
+    if (!path || path === this.root()) {
+      return '';
+    }
+
+    return path
+      .replace(`${this.root()}/`, '')
+      .replace('/mnt/', '');
   }
 
   createDataset(): void {
@@ -243,19 +258,21 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
         dataset: this.createDatasetProps(),
       },
     }).afterClosed()
-      .pipe(untilDestroyed(this))
+      .pipe(filter(Boolean), untilDestroyed(this))
       .subscribe((dataset: Dataset) => {
-        if (!dataset) {
-          return;
+        const parentNode = this.tree().treeModel.selectedLeafNodes[0] as TreeNode<ExplorerNodeData>;
+        if (parentNode?.isExpanded) {
+          parentNode.collapse();
         }
 
-        const parentNode = this.tree().treeModel.selectedLeafNodes[0] as TreeNode<ExplorerNodeData>;
-        parentNode?.expand();
+        // This code is necessary to make sure that newly created dataset appears
+        // in the tree if tree has already been expanded.
+        parentNode.data.children = null;
+        parentNode.treeModel.update();
+        parentNode.expand();
 
-        this.setInitialNode();
-        this.writeValue(`${this.root()}/${dataset.name}`);
+        this.writeValue(dataset.mountpoint);
         this.onChange(this.value);
-        this.tree().treeModel.update();
       });
   }
 
@@ -267,7 +284,7 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
   }
 
   private setInitialNode(): void {
-    this.nodes = [
+    this.nodes.set([
       {
         path: this.root(),
         name: this.root(),
@@ -275,7 +292,7 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
         type: ExplorerNodeType.Directory,
         isMountpoint: true,
       },
-    ];
+    ]);
   }
 
   private updateInputValue(): void {
@@ -292,17 +309,16 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
   }
 
   private loadChildren(node: TreeNode<ExplorerNodeData>): Observable<ExplorerNodeData[]> {
-    this.loadingError = null;
-    this.cdr.markForCheck();
+    const provider = this.nodeProvider();
+    this.loadingError.set(null);
 
-    if (!this.nodeProvider()) {
+    if (!provider) {
       return of([]);
     }
 
-    return this.nodeProvider()(node).pipe(
+    return provider(node).pipe(
       catchError((error: unknown) => {
-        this.loadingError = this.errorHandler.getFirstErrorMessage(error);
-        this.cdr.markForCheck();
+        this.loadingError.set(this.errorHandler.getFirstErrorMessage(error));
         return of([]);
       }),
     );

--- a/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.ts
+++ b/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.ts
@@ -29,6 +29,7 @@ import { ZfsEncryptionCardComponent } from 'app/pages/datasets/modules/encryptio
 import { PermissionsCardComponent } from 'app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component';
 import { DatasetTreeStore } from 'app/pages/datasets/store/dataset-store.service';
 import { doesDatasetHaveShares, isIocageMounted } from 'app/pages/datasets/utils/dataset.utils';
+import { FilesystemService } from 'app/services/filesystem.service';
 
 @UntilDestroy()
 @Component({
@@ -68,6 +69,7 @@ export class DatasetDetailsPanelComponent {
     private datasetStore: DatasetTreeStore,
     private router: Router,
     private slideIn: SlideIn,
+    private filesystem: FilesystemService,
   ) { }
 
   protected readonly hasRoles = computed(() => {

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.spec.ts
@@ -35,6 +35,7 @@ import {
   QuotasSectionComponent,
 } from 'app/pages/datasets/components/dataset-form/sections/quotas-section/quotas-section.component';
 import { DatasetFormService } from 'app/pages/datasets/components/dataset-form/utils/dataset-form.service';
+import { FilesystemService } from 'app/services/filesystem.service';
 import { checkIfServiceIsEnabled } from 'app/store/services/services.actions';
 
 describe('DatasetFormComponent', () => {
@@ -121,6 +122,7 @@ describe('DatasetFormComponent', () => {
       }),
       mockProvider(Router),
       mockProvider(SlideInRef, slideInRef),
+      mockProvider(FilesystemService),
       mockAuth(),
     ],
   });

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
@@ -41,6 +41,7 @@ import {
 import { DatasetFormService } from 'app/pages/datasets/components/dataset-form/utils/dataset-form.service';
 import { getDatasetLabel } from 'app/pages/datasets/utils/dataset.utils';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
+import { FilesystemService } from 'app/services/filesystem.service';
 import { AppState } from 'app/store';
 import { checkIfServiceIsEnabled } from 'app/store/services/services.actions';
 
@@ -138,6 +139,7 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
     private snackbar: SnackbarService,
     private translate: TranslateService,
     private store$: Store<AppState>,
+    private filesystem: FilesystemService,
     public slideInRef: SlideInRef<{ datasetId: string; isNew?: boolean } | undefined, Dataset>,
   ) {
     this.slideInRef.requireConfirmationWhen(() => {

--- a/src/app/pages/datasets/components/zvol-form/zvol-form.component.spec.ts
+++ b/src/app/pages/datasets/components/zvol-form/zvol-form.component.spec.ts
@@ -16,6 +16,7 @@ import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ZvolFormComponent } from 'app/pages/datasets/components/zvol-form/zvol-form.component';
+import { FilesystemService } from 'app/services/filesystem.service';
 
 describe('ZvolFormComponent', () => {
   let loader: HarnessLoader;
@@ -120,6 +121,7 @@ describe('ZvolFormComponent', () => {
       }),
       mockProvider(DialogService),
       mockProvider(SlideInRef, slideInRef),
+      mockProvider(FilesystemService),
       mockAuth(),
     ],
   });

--- a/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
+++ b/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
@@ -41,6 +41,7 @@ import { ApiService } from 'app/modules/websocket/api.service';
 import { getDatasetLabel } from 'app/pages/datasets/utils/dataset.utils';
 import { CloudCredentialService } from 'app/services/cloud-credential.service';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
+import { FilesystemService } from 'app/services/filesystem.service';
 
 interface ZvolFormData {
   name?: string;
@@ -228,6 +229,7 @@ export class ZvolFormComponent implements OnInit {
     private formErrorHandler: FormErrorHandlerService,
     private errorHandler: ErrorHandlerService,
     protected snackbar: SnackbarService,
+    private filesystem: FilesystemService,
     public slideInRef: SlideInRef<{ isNew: boolean; parentId: string } | undefined, Dataset>,
   ) {
     this.slideInRef.requireConfirmationWhen(() => {

--- a/src/app/pages/instances/components/instance-wizard/instance-wizard.component.html
+++ b/src/app/pages/instances/components/instance-wizard/instance-wizard.component.html
@@ -166,7 +166,7 @@
         [formArray]="form.controls.disks"
         (add)="addDisk()"
       >
-        @for (disk of form.controls.disks.controls; track disk; let i = $index) {
+        @for (disk of form.controls.disks.controls; track disk.value; let i = $index) {
           <ix-list-item
             [label]="'Disk' | translate"
             [formGroupName]="i"

--- a/src/app/pages/instances/components/instance-wizard/instance-wizard.component.ts
+++ b/src/app/pages/instances/components/instance-wizard/instance-wizard.component.ts
@@ -190,11 +190,11 @@ export class InstanceWizardComponent {
   protected readonly isVm = computed(() => this.instanceType() === VirtualizationType.Vm);
 
   readonly directoryNodeProvider = computed(() => {
-    if (this.isVm()) {
-      return this.filesystem.getFilesystemNodeProvider({ zvolsOnly: true });
-    }
+    const providerOptions = this.isVm()
+      ? { zvolsOnly: true }
+      : { datasetsAndZvols: true };
 
-    return this.filesystem.getFilesystemNodeProvider({ datasetsAndZvols: true });
+    return this.filesystem.getFilesystemNodeProvider(providerOptions);
   });
 
   protected defaultIpv4Network = computed(() => {

--- a/src/app/services/filesystem.service.spec.ts
+++ b/src/app/services/filesystem.service.spec.ts
@@ -88,5 +88,28 @@ describe('FilesystemService', () => {
         },
       ]);
     });
+
+    it('check for updating the tree', async () => {
+      const treeNodeProvider = spectator.service.getFilesystemNodeProvider({ datasetsAndZvols: true });
+
+      await lastValueFrom(treeNodeProvider({
+        data: {
+          path: '/mnt/parent',
+        },
+      } as TreeNode<ExplorerNodeData>));
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith(
+        'filesystem.listdir',
+        [
+          '/mnt/parent',
+          [],
+          {
+            select: ['attributes', 'is_ctldir', 'name', 'path', 'type'],
+            order_by: ['name'],
+            limit: 1000,
+          },
+        ],
+      );
+    });
   });
 });


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 644082303a78a74bc4e67ab4bc188711c7aac78f
    git cherry-pick -x d72d33acbe429dbe96386660c3543911c1d2b8da
    git cherry-pick -x 553356aacb9f12dc011e6c47f98bd0fd69ba39ce
    git cherry-pick -x 9bb480b6117b93d5268678677fbbc9046c2f6c03
    git cherry-pick -x 862a7870b70f7ebc645700927d14dd67cf7f109b
    git cherry-pick -x 9e39dc8ecc35a34e7c185b8c5798690a13ec7485
    git cherry-pick -x 39582aeff4782b2641f197175c1e9ca49d9a9247

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x fa8238843452499b49b4f269a95549cb98401a5b

**Changes:**

**IxExplorer**: Reload node children on toggle

**Testing:**

Check any page with `ix-explorer` and then create new zvol/dataset in the second tab.
See ticket for expected results.

Original PR: https://github.com/truenas/webui/pull/11463
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133774