### PR TITLE
NAS-134042: Add a warning when failover is unhealthy to RebootRequiredDialogComponent

### DIFF
--- a/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.html
+++ b/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.html
@@ -3,6 +3,20 @@
 </h3>
 
 <div mat-dialog-content>
+  @if (isHaLicensed() && !canFailover()) {
+    <div class="failover-reasons">
+      <p class="dialog-message error">
+        <span>{{ 'Failover is unhealthy. Rebooting now will cause a production outage.' | translate }}</span>
+      </p>
+
+      @for (reason of failoverDisabledReasons(); track reason) {
+        <li>
+          {{ reason | mapValue: disabledReasonExplanations | translate }}
+        </li>
+      }
+    </div>
+  }
+
   @if(thisNodeRebootReasons()?.length) {
     <div class="reasons">
       <p class="dialog-message">

--- a/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.scss
+++ b/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.scss
@@ -2,9 +2,14 @@
   margin-bottom: 5px;
   margin-top: 0;
   padding: 0;
+
+  &.error {
+    color: var(--error);
+  }
 }
 
-.reasons {
+.reasons,
+.failover-reasons {
   padding: 0 12px 12px;
 }
 

--- a/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.ts
+++ b/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.ts
@@ -7,11 +7,14 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { map } from 'rxjs';
+import { failoverDisabledReasonLabels } from 'app/enums/failover-disabled-reason.enum';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
+import { MapValuePipe } from 'app/modules/pipes/map-value/map-value.pipe';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { FipsService } from 'app/services/fips.service';
 import { AppState } from 'app/store';
+import { selectCanFailover, selectHaStatus, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import { selectOtherNodeRebootInfo, selectThisNodeRebootInfo } from 'app/store/reboot-info/reboot-info.selectors';
 
 @UntilDestroy()
@@ -28,6 +31,7 @@ import { selectOtherNodeRebootInfo, selectThisNodeRebootInfo } from 'app/store/r
     IxCheckboxComponent,
     MatButton,
     TestDirective,
+    MapValuePipe,
     FormActionsComponent,
   ],
 })
@@ -38,6 +42,13 @@ export class RebootRequiredDialogComponent {
 
   otherNodeRebootReasons = toSignal(this.store$.select(selectOtherNodeRebootInfo).pipe(
     map((info) => info?.reboot_required_reasons || []),
+  ));
+
+  protected readonly disabledReasonExplanations = failoverDisabledReasonLabels;
+  protected readonly isHaLicensed = toSignal(this.store$.select(selectIsHaLicensed));
+  protected readonly canFailover = toSignal(this.store$.select(selectCanFailover));
+  protected readonly failoverDisabledReasons = toSignal(this.store$.select(selectHaStatus).pipe(
+    map((status) => status?.reasons || []),
   ));
 
   form = this.fb.group({

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1450,6 +1450,7 @@
   "Failover Read": "",
   "Failover Write": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1340,6 +1340,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -2,6 +2,7 @@
   "": "",
   "Add Instances": "",
   "Archs": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Flash Identify Light": "",
   "Key Cert Sign": "",
   "Key Usage Config": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1691,6 +1691,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -239,6 +239,7 @@
   "Failover Now": "",
   "Failover Read": "",
   "Failover Write": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Feedback Type": "",
   "Fibre Channel": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -188,6 +188,7 @@
   "FTP Service": "",
   "Failed to configure certificate in system UI": "",
   "Failed to renew certificate": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fibre Channel": "",
   "Fibre Channel Connections": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1698,6 +1698,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1621,6 +1621,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1,6 +1,7 @@
 {
   "": "",
   "Add Instances": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Name cannot be changed after instance is created": "",
   "Uploading": "",
   "Volume with this name already exists.": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1870,6 +1870,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -21,6 +21,7 @@
   "Edit App YAML": "",
   "Edition": "",
   "Enterprise": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Finish": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1827,6 +1827,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1821,6 +1821,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1024,6 +1024,7 @@
   "Failed to load datasets": "",
   "Failed to renew certificate": "",
   "Failover Group": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Feature Request": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1173,6 +1173,7 @@
   "Failover Read": "",
   "Failover Write": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -784,6 +784,7 @@
   "Failover Read": "",
   "Failover Write": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Feature Request": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1876,6 +1876,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -61,6 +61,7 @@
   "Expires on {date}": "",
   "Failed to configure certificate in system UI": "",
   "Failed to renew certificate": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Finish": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1142,6 +1142,7 @@
   "Failover Write": "",
   "Failover is administratively disabled.": "",
   "Failover is recommended for new FIPS setting to take effect. Would you like to failover now?": "",
+  "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Fast Storage": "",
   "Fatal error! Check logs.": "",
   "Faulted": "",


### PR DESCRIPTION
Testing: see ticket.

I worked with mocked data.

We need to have such data in store:
```
export const selectHaStatus = createSelector(
  selectHaInfoState,
  (state) => ({
    ...state?.haStatus,
    reasons: [FailoverDisabledReason.MismatchDisks],
  }),
);

export const selectCanFailover = createSelector(
  selectHaInfoState,
  () => false,
);
```

Example:
<img width="433" alt="Screenshot 2025-02-12 at 08 46 42" src="https://github.com/user-attachments/assets/9f359693-c9fa-4a73-bda7-ba3ec522f577" />

