### PR TITLE
NAS-134064 / 25.10 / Changes login status before clearing subscriptions

### DIFF
--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -191,8 +191,8 @@ export class AuthService {
       tap(() => {
         this.clearAuthToken();
         this.wasOneTimePasswordChanged$.next(false);
-        this.api.clearSubscriptions();
         this.wsStatus.setLoginStatus(false);
+        this.api.clearSubscriptions();
       }),
     );
   }


### PR DESCRIPTION
**Changes:**

Changes login status first before clearing subscriptions so the decision to not make `core.unsubscribe` calls can be made based on updated state

**Testing:**

Test login and then logout and check browser console for errors.
