### PR TITLE
NAS-132203 / 25.10 / Changing the owner group of a dataset with an AD group does not work if the AD cache is disabled.

### DIFF
--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -35,7 +35,7 @@ export class UserService {
     let queryArgs: QueryFilter<Group>[] = [];
     search = search.trim();
     if (search.length > 0) {
-      queryArgs = [['group', '^', search]];
+      queryArgs = [['group', '~', `(?i)${search.replaceAll('\\', '\\\\')}`]];
     }
     if (hideBuiltIn) {
       queryArgs = queryArgs.concat([['builtin', '=', false]]);

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -35,7 +35,7 @@ export class UserService {
     let queryArgs: QueryFilter<Group>[] = [];
     search = search.trim();
     if (search.length > 0) {
-      queryArgs = [['group', '~', `(?i)${search.replaceAll('\\', '\\\\')}`]];
+      queryArgs = [['group', '~', `(?i).*${search.replaceAll('\\', '\\\\')}`]];
     }
     if (hideBuiltIn) {
       queryArgs = queryArgs.concat([['builtin', '=', false]]);


### PR DESCRIPTION
**Summary**

In the middleware API the only suitable operator is `~`, which resolved into a Python's `re.match`, which has baked-in logic to find a substring exactly at the beginning of the string. 

So the regular expression pattern consists of:
- `.*` - to workaround limitation of `re.match`, and find a substring at arbitrary index within the string
- `(?i)` - for case insensivity

**Testing:**

1. User ensures that **Disable AD cache** is **checked** at **Credentials > Directory Services > Settings > Advanced Options.** _Note:_ you'll need to spin up a new AD connected machine

3. User types in from a keyboard `Domain Users` or `Domain Admins` into **Datasets > (Choose a dataset)  Permissions** at sidebar **> Edit  > Edit ACL > Owner Group** field

**Expected result:** user is able to set the value of `Owner Group` when AD cache is disabled