### PR TITLE
NAS-134061 / 25.04-RC.1 / Apps - UI validates `uri` type more strictly than middleware (by AlexKarpov98)

### DIFF
--- a/src/app/modules/forms/ix-forms/validators/url-validation.service.spec.ts
+++ b/src/app/modules/forms/ix-forms/validators/url-validation.service.spec.ts
@@ -20,6 +20,7 @@ describe('UrlValidationService', () => {
       'https://example.com:8080/path',
       'ftp://ftp.example.com',
       'mqtt://server:1234',
+      'whatever://anything',
       'ws://websocket.server',
       'wss://secure.websocket.server',
     ];

--- a/src/app/modules/forms/ix-forms/validators/url-validation.service.spec.ts
+++ b/src/app/modules/forms/ix-forms/validators/url-validation.service.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+import { UrlValidationService } from './url-validation.service';
+
+describe('UrlValidationService', () => {
+  let service: UrlValidationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UrlValidationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should validate correct URLs', () => {
+    const validUrls = [
+      'http://example.com',
+      'https://example.com',
+      'https://example.com:8080/path',
+      'ftp://ftp.example.com',
+      'mqtt://server:1234',
+      'ws://websocket.server',
+      'wss://secure.websocket.server',
+    ];
+
+    validUrls.forEach((url) => {
+      expect(service.urlRegex.test(url)).toBe(true);
+    });
+  });
+
+  it('should invalidate incorrect URLs', () => {
+    const invalidUrls = [
+      'example.com',
+      'http//invalid.com',
+      '://invalid.com',
+      'http://inva lid.com',
+      'mqtt://server:',
+      'wss://',
+      'ftp://example.com:abc',
+      'http:/example.com',
+    ];
+
+    invalidUrls.forEach((url) => {
+      expect(service.urlRegex.test(url)).toBe(false);
+    });
+  });
+
+  it('should allow URLs with ports', () => {
+    expect(service.urlRegex.test('http://example.com:8080')).toBe(true);
+    expect(service.urlRegex.test('mqtt://server:1883')).toBe(true);
+  });
+
+  it('should allow URLs with paths and query params', () => {
+    expect(service.urlRegex.test('https://example.com/path/to/resource')).toBe(true);
+    expect(service.urlRegex.test('ftp://example.com/files?name=test')).toBe(true);
+  });
+});

--- a/src/app/modules/forms/ix-forms/validators/url-validation.service.ts
+++ b/src/app/modules/forms/ix-forms/validators/url-validation.service.ts
@@ -2,5 +2,5 @@ import { Injectable } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class UrlValidationService {
-  urlRegex = /^(https?|ftp|mqtt|ws|wss):\/\/([a-zA-Z0-9.-]+)(:[0-9]+)?(\/.*)?$/;
+  urlRegex = /^([a-zA-Z][a-zA-Z\d+\-.]*):\/\/([^\s:/?#]+)(:\d{1,5})?(\/[^\s]*)?$/;
 }

--- a/src/app/modules/forms/ix-forms/validators/url-validation.service.ts
+++ b/src/app/modules/forms/ix-forms/validators/url-validation.service.ts
@@ -2,5 +2,5 @@ import { Injectable } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class UrlValidationService {
-  urlRegex = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/;
+  urlRegex = /^(https?|ftp|mqtt|ws|wss):\/\/([a-zA-Z0-9.-]+)(:[0-9]+)?(\/.*)?$/;
 }


### PR DESCRIPTION
Testing: see ticket.

Result, no validation error:

<img width="188" alt="Screenshot 2025-02-10 at 13 41 21" src="https://github.com/user-attachments/assets/ca8f4597-defe-4d39-abd2-012ceb9da8ce" />


Original PR: https://github.com/truenas/webui/pull/11530
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134061