### PR TITLE
NAS-134165 / 25.04-RC.1 / New TrueNAS logo does not sit well in mobile (by AlexKarpov98)

### DIFF
--- a/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.scss
+++ b/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.scss
@@ -49,6 +49,7 @@
 
   .app-link {
     .logo {
+      align-items: center;
       width: 28px;
     }
 


### PR DESCRIPTION
Testing:

<img width="397" alt="NAS-134165" src="https://github.com/user-attachments/assets/fb879d4d-d755-4178-930e-695e3fac5795" />


Original PR: https://github.com/truenas/webui/pull/11558
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134165