### PR TITLE
NAS-134072 / 25.04-RC.1 / Remove CPU netdata call from main dashboard (by denysbutenko)

### DIFF
--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { subHours, subMinutes } from 'date-fns';
+import { subHours } from 'date-fns';
 import {
   Observable, Subject, catchError, combineLatestWith, debounceTime,
   filter,
@@ -94,19 +94,6 @@ export class WidgetResourcesService {
       return serverTime;
     }),
   );
-
-  cpuLastMinuteStats(minutes = 1): Observable<ReportingData[]> {
-    return this.serverTime$.pipe(
-      take(1),
-      switchMap((serverTime) => {
-        const end = Math.floor(serverTime.getTime() / 1000);
-        const start = Math.floor(subMinutes(serverTime, minutes).getTime() / 1000);
-
-        return this.api.call('reporting.netdata_get_data', [[{ name: 'cpu' }], { end, start }]);
-      }),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-  }
 
   networkInterfaceLastHourStats(interfaceName: string): Observable<ReportingData[]> {
     return this.serverTime$.pipe(

--- a/src/app/pages/dashboard/widgets/cpu/widget-cpu-usage-recent/widget-cpu-usage-recent.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/cpu/widget-cpu-usage-recent/widget-cpu-usage-recent.component.spec.ts
@@ -24,19 +24,6 @@ describe('WidgetCpuUsageRecentComponent', () => {
       mockProvider(
         WidgetResourcesService,
         {
-          cpuLastMinuteStats: jest.fn(() => of([
-            {
-              name: 'cpu',
-              data: [
-                [0, 80.1, 12.2],
-                [0, 50.3, 15.9],
-                [0, 55.2, 16.8],
-              ],
-              legend: ['time', 'usage'],
-              start: 0,
-              end: 0,
-            },
-          ])),
           realtimeUpdates$: of({
             fields: {
               cpu: {
@@ -83,11 +70,9 @@ describe('WidgetCpuUsageRecentComponent', () => {
       datasets: [
         {
           label: 'Usage',
-          data: [
-            { x: 1721692740000, y: 80.1 },
-            { x: 1721692741000, y: 50.3 },
-            { x: 1721692742000, y: 55.2 },
-          ],
+          data: expect.objectContaining([
+            expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) }),
+          ]),
           pointBackgroundColor: 'blue',
         },
       ],

--- a/src/app/pages/dashboard/widgets/cpu/widget-cpu-usage-recent/widget-cpu-usage-recent.component.ts
+++ b/src/app/pages/dashboard/widgets/cpu/widget-cpu-usage-recent/widget-cpu-usage-recent.component.ts
@@ -7,9 +7,7 @@ import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { ChartData, ChartOptions } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
-import {
-  filter, map, startWith, tap,
-} from 'rxjs';
+import { map, tap } from 'rxjs';
 import { oneMinuteMillis } from 'app/constants/time.constant';
 import { LocaleService } from 'app/modules/language/locale.service';
 import { ThemeService } from 'app/modules/theme/theme.service';
@@ -37,9 +35,7 @@ export class WidgetCpuUsageRecentComponent implements WidgetComponent {
 
   readonly name = cpuUsageRecentWidget.name;
 
-  protected isLoading = computed(() => {
-    return !this.chartData();
-  });
+  protected isLoading = computed(() => !this.chartData());
 
   protected cpuUsage = toSignal(this.resources.realtimeUpdates$.pipe(
     map((update) => update.fields.cpu),
@@ -50,17 +46,9 @@ export class WidgetCpuUsageRecentComponent implements WidgetComponent {
     }),
   ));
 
-  protected initialCpuStats = toSignal(this.resources.cpuLastMinuteStats().pipe(
-    filter((response) => !!response.length),
-    map((response) => {
-      const [update] = response;
-
-      const usageIndex = update.legend.indexOf('usage');
-
-      return (update.data as number[][]).slice(-60).map((item) => ([item[usageIndex]]));
-    }),
-    startWith(Array.from({ length: 60 }, () => ([0, 0]))),
-  ));
+  protected initialCpuStats = computed(() => {
+    return Array.from({ length: 60 }, () => ([0]));
+  });
 
   protected cachedCpuStats = signal<number[][]>([]);
   protected cpuStats = computed(() => {


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b15a63e5dbf4210a61f470f1c9cce1f6ba69d3b3

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8cf15382e26bd99649f87fe2bd8471d41de961d8

**Changes:**

Remove call to `netdata` endpoint from CPU Recent Usage widget.

**Testing:**

Ensure no regressions. 


Original PR: https://github.com/truenas/webui/pull/11569
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134072