### PR TITLE
NAS-133011 / 25.10 / Network interface graph on Dashboard does not appear to retain network traffic as seen on Reporting page

### DIFF
--- a/src/app/pages/dashboard/services/widget-resources.service.spec.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.spec.ts
@@ -11,7 +11,6 @@ import { App } from 'app/interfaces/app.interface';
 import { Pool } from 'app/interfaces/pool.interface';
 import { SystemInfo } from 'app/interfaces/system-info.interface';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
-import { systemInfoLoaded, systemInfoUpdated } from 'app/store/system-info/system-info.actions';
 import { selectSystemInfo } from 'app/store/system-info/system-info.selectors';
 
 const pools = [
@@ -87,19 +86,6 @@ describe('WidgetResourcesService', () => {
       expect(
         await firstValueFrom(spectator.service.networkInterfaceLastHourStats('eth0')),
       ).toEqual([interfaceEth0]);
-    });
-
-    it('resets and updates system info', async () => {
-      const store$ = spectator.inject(Store);
-      jest.spyOn(store$, 'dispatch');
-      await firstValueFrom(spectator.service.networkInterfaceLastHourStats('eth0'));
-
-      expect(store$.dispatch).toHaveBeenCalledWith(
-        systemInfoLoaded({ systemInfo: null }),
-      );
-      expect(store$.dispatch).toHaveBeenCalledWith(
-        systemInfoUpdated(),
-      );
     });
   });
 });

--- a/src/app/pages/dashboard/services/widget-resources.service.spec.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.spec.ts
@@ -1,12 +1,18 @@
 import {
   createServiceFactory,
+  mockProvider,
   SpectatorService,
 } from '@ngneat/spectator/jest';
+import { Store } from '@ngrx/store';
+import { provideMockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { App } from 'app/interfaces/app.interface';
 import { Pool } from 'app/interfaces/pool.interface';
+import { SystemInfo } from 'app/interfaces/system-info.interface';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
+import { systemInfoLoaded, systemInfoUpdated } from 'app/store/system-info/system-info.actions';
+import { selectSystemInfo } from 'app/store/system-info/system-info.selectors';
 
 const pools = [
   { id: 1, name: 'pool_1' },
@@ -17,6 +23,20 @@ const apps = [
   { id: '1', name: 'app_1' },
   { id: '2', name: 'app_2' },
 ] as App[];
+
+const interfaceEth0 = {
+  name: 'interface',
+  identifier: 'eth0',
+  legend: ['time', 'received', 'sent'],
+  start: 1735281261,
+  end: 1735281265,
+  data: [
+    [1740117920, 2.2, 0.5],
+    [1740117921, 2.3, 1.2],
+    [1740117922, 2.4, 1.1],
+  ],
+  aggregations: { min: [0], mean: [5], max: [10] },
+};
 
 describe('WidgetResourcesService', () => {
   let spectator: SpectatorService<WidgetResourcesService>;
@@ -32,7 +52,21 @@ describe('WidgetResourcesService', () => {
         mockCall('webui.main.dashboard.sys_info'),
         mockCall('interface.query'),
         mockCall('update.check_available'),
+        mockCall('reporting.netdata_get_data', [interfaceEth0]),
       ]),
+      mockProvider(Store, {
+        dispatch: jest.fn(),
+      }),
+      provideMockStore({
+        selectors: [
+          {
+            selector: selectSystemInfo,
+            value: {
+              datetime: { $date: 1740117922320 },
+            } as SystemInfo,
+          },
+        ],
+      }),
     ],
   });
 
@@ -46,5 +80,26 @@ describe('WidgetResourcesService', () => {
 
   it('returns apps', async () => {
     expect(await firstValueFrom(spectator.service.installedApps$)).toEqual(apps);
+  });
+
+  describe('networkInterfaceLastHourStats', () => {
+    it('returns network interface stats for the last hour', async () => {
+      expect(
+        await firstValueFrom(spectator.service.networkInterfaceLastHourStats('eth0')),
+      ).toEqual([interfaceEth0]);
+    });
+
+    it('resets and updates system info', async () => {
+      const store$ = spectator.inject(Store);
+      jest.spyOn(store$, 'dispatch');
+      await firstValueFrom(spectator.service.networkInterfaceLastHourStats('eth0'));
+
+      expect(store$.dispatch).toHaveBeenCalledWith(
+        systemInfoLoaded({ systemInfo: null }),
+      );
+      expect(store$.dispatch).toHaveBeenCalledWith(
+        systemInfoUpdated(),
+      );
+    });
   });
 });

--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -19,6 +19,7 @@ import { VolumesData, VolumeData } from 'app/interfaces/volume-data.interface';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { processNetworkInterfaces } from 'app/pages/dashboard/widgets/network/widget-interface/widget-interface.utils';
 import { AppState } from 'app/store';
+import { systemInfoLoaded, systemInfoUpdated } from 'app/store/system-info/system-info.actions';
 import { waitForSystemInfo } from 'app/store/system-info/system-info.selectors';
 
 /**
@@ -96,6 +97,8 @@ export class WidgetResourcesService {
   );
 
   networkInterfaceLastHourStats(interfaceName: string): Observable<ReportingData[]> {
+    this.store$.dispatch(systemInfoLoaded({ systemInfo: null }));
+    this.store$.dispatch(systemInfoUpdated());
     return this.serverTime$.pipe(
       take(1),
       switchMap((serverTime) => {

--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -37,7 +37,7 @@ export class WidgetResourcesService {
   readonly realtimeUpdates$ = this.api.subscribe('reporting.realtime');
 
   readonly refreshInterval$ = timer(0, 5000).pipe(startWith(0));
-  private readonly triggerRefreshSystemInfo$ = new Subject<void>();
+  private readonly triggerRefreshDashboardSystemInfo$ = new Subject<void>();
 
   readonly backups$ = forkJoin([
     this.api.call('replication.query'),
@@ -47,8 +47,8 @@ export class WidgetResourcesService {
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 
-  readonly systemInfo$ = this.api.call('webui.main.dashboard.sys_info').pipe(
-    repeat({ delay: () => this.triggerRefreshSystemInfo$ }),
+  readonly dashboardSystemInfo$ = this.api.call('webui.main.dashboard.sys_info').pipe(
+    repeat({ delay: () => this.triggerRefreshDashboardSystemInfo$ }),
     debounceTime(300),
     toLoadingState(),
     shareReplay({ bufferSize: 1, refCount: true }),
@@ -97,8 +97,7 @@ export class WidgetResourcesService {
   );
 
   networkInterfaceLastHourStats(interfaceName: string): Observable<ReportingData[]> {
-    this.store$.dispatch(systemInfoLoaded({ systemInfo: null }));
-    this.store$.dispatch(systemInfoUpdated());
+    this.refreshSystemInfo();
     return this.serverTime$.pipe(
       take(1),
       switchMap((serverTime) => {
@@ -199,6 +198,11 @@ export class WidgetResourcesService {
   }
 
   refreshSystemInfo(): void {
-    this.triggerRefreshSystemInfo$.next();
+    this.store$.dispatch(systemInfoLoaded({ systemInfo: null }));
+    this.store$.dispatch(systemInfoUpdated());
+  }
+
+  refreshDashboardSystemInfo(): void {
+    this.triggerRefreshDashboardSystemInfo$.next();
   }
 }

--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { subHours } from 'date-fns';
 import {
-  Observable, Subject, catchError, combineLatestWith, debounceTime,
+  Observable, Subject, catchError, debounceTime,
   filter,
-  forkJoin, map, of, repeat, shareReplay, startWith, switchMap, take, throttleTime, timer,
+  forkJoin, map, of, repeat, shareReplay, startWith, switchMap, throttleTime, timer,
 } from 'rxjs';
 import { SystemUpdateStatus } from 'app/enums/system-update.enum';
 import { LoadingState, toLoadingState } from 'app/helpers/operators/to-loading-state.helper';
@@ -19,7 +19,6 @@ import { VolumesData, VolumeData } from 'app/interfaces/volume-data.interface';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { processNetworkInterfaces } from 'app/pages/dashboard/widgets/network/widget-interface/widget-interface.utils';
 import { AppState } from 'app/store';
-import { systemInfoLoaded, systemInfoUpdated } from 'app/store/system-info/system-info.actions';
 import { waitForSystemInfo } from 'app/store/system-info/system-info.selectors';
 
 /**
@@ -86,28 +85,17 @@ export class WidgetResourcesService {
     shareReplay({ refCount: false, bufferSize: 1 }),
   );
 
-  readonly serverTime$ = this.store$.pipe(
-    waitForSystemInfo,
-    map((systemInfo) => new Date(systemInfo.datetime.$date)),
-    combineLatestWith(this.refreshInterval$),
-    map(([serverTime]) => {
-      serverTime.setSeconds(serverTime.getSeconds() + 5);
-      return serverTime;
-    }),
-  );
-
   networkInterfaceLastHourStats(interfaceName: string): Observable<ReportingData[]> {
-    this.refreshSystemInfo();
-    return this.serverTime$.pipe(
-      take(1),
-      switchMap((serverTime) => {
-        const end = Math.floor(serverTime.getTime() / 1000);
-        const start = Math.floor(subHours(serverTime, 1).getTime() / 1000);
-        return this.api.call('reporting.netdata_get_data', [[{
-          identifier: interfaceName,
-          name: 'interface',
-        }], { end, start }]);
-      }),
+    const now = new Date();
+    now.setSeconds(now.getSeconds() + 5);
+
+    const end = Math.floor(now.getTime() / 1000);
+    const start = Math.floor(subHours(now, 1).getTime() / 1000);
+
+    return this.api.call('reporting.netdata_get_data', [[{
+      identifier: interfaceName,
+      name: 'interface',
+    }], { end, start }]).pipe(
       shareReplay({ bufferSize: 1, refCount: true }),
     );
   }
@@ -195,11 +183,6 @@ export class WidgetResourcesService {
       });
     });
     return volumesData;
-  }
-
-  refreshSystemInfo(): void {
-    this.store$.dispatch(systemInfoLoaded({ systemInfo: null }));
-    this.store$.dispatch(systemInfoUpdated());
   }
 
   refreshDashboardSystemInfo(): void {

--- a/src/app/pages/dashboard/widgets/apps/widget-app-cpu/widget-app-cpu.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app-cpu/widget-app-cpu.component.spec.ts
@@ -52,7 +52,6 @@ describe('WidgetAppCpuComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of({
           cpu: 55,

--- a/src/app/pages/dashboard/widgets/apps/widget-app-info/widget-app-info.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app-info/widget-app-info.component.spec.ts
@@ -46,7 +46,6 @@ describe('WidgetAppInfoComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of(),
       }),

--- a/src/app/pages/dashboard/widgets/apps/widget-app-memory/widget-app-memory.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app-memory/widget-app-memory.component.spec.ts
@@ -47,7 +47,6 @@ describe('WidgetAppMemoryComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of({
           cpu: 55,

--- a/src/app/pages/dashboard/widgets/apps/widget-app-network/widget-app-network.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app-network/widget-app-network.component.spec.ts
@@ -53,7 +53,6 @@ describe('WidgetAppNetworkComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of({
           network: {

--- a/src/app/pages/dashboard/widgets/apps/widget-app/widget-app.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app/widget-app.component.spec.ts
@@ -60,7 +60,6 @@ describe('WidgetAppComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of({}),
         getAppStatusUpdates: () => of(),

--- a/src/app/pages/dashboard/widgets/system/widget-hostname-active/widget-hostname-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-hostname-active/widget-hostname-active.component.spec.ts
@@ -20,7 +20,7 @@ describe('WidgetHostnameActiveComponent', () => {
       },
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             value: {
               hostname: 'truenas.com',
             },
@@ -40,7 +40,7 @@ describe('WidgetHostnameActiveComponent', () => {
     spectator = createComponent({
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             value: {} as SystemInfo,
             isLoading: false,
             error: new Error('Fatal error'),

--- a/src/app/pages/dashboard/widgets/system/widget-hostname-active/widget-hostname-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-hostname-active/widget-hostname-active.component.ts
@@ -27,7 +27,7 @@ export class WidgetHostnameActiveComponent implements WidgetComponent {
   size = input.required<SlotSize>();
   readonly name = hostnameActiveWidget.name;
 
-  systemInfo$ = this.resources.systemInfo$;
+  systemInfo$ = this.resources.dashboardSystemInfo$;
 
   constructor(
     private resources: WidgetResourcesService,

--- a/src/app/pages/dashboard/widgets/system/widget-hostname-passive/widget-hostname-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-hostname-passive/widget-hostname-passive.component.spec.ts
@@ -22,7 +22,7 @@ describe('WidgetHostnamePassiveComponent', () => {
       },
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             value: {
               remote_info: {
                 hostname: 'truenas.com',
@@ -44,7 +44,7 @@ describe('WidgetHostnamePassiveComponent', () => {
     spectator = createComponent({
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             isLoading: false,
             error: new Error('Fatal error'),
           } as LoadingState<SystemInfo>),

--- a/src/app/pages/dashboard/widgets/system/widget-hostname-passive/widget-hostname-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-hostname-passive/widget-hostname-passive.component.ts
@@ -29,7 +29,7 @@ export class WidgetHostnamePassiveComponent implements WidgetComponent {
   size = input.required<SlotSize>();
   readonly name = hostnamePassiveWidget.name;
 
-  systemInfo$ = this.resources.systemInfo$;
+  systemInfo$ = this.resources.dashboardSystemInfo$;
 
   constructor(
     private resources: WidgetResourcesService,

--- a/src/app/pages/dashboard/widgets/system/widget-os-version/widget-os-version.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-os-version/widget-os-version.component.spec.ts
@@ -20,7 +20,7 @@ describe('WidgetOsVersionComponent', () => {
       },
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             value: {
               version: 'TrueNAS-SCALE-24.10.0-MASTER-20240518-113154',
             },
@@ -41,7 +41,7 @@ describe('WidgetOsVersionComponent', () => {
     spectator = createComponent({
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             isLoading: false,
             error: new Error('Fatal error'),
           } as LoadingState<SystemInfo>),

--- a/src/app/pages/dashboard/widgets/system/widget-os-version/widget-os-version.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-os-version/widget-os-version.component.ts
@@ -27,7 +27,7 @@ export class WidgetOsVersionComponent implements WidgetComponent {
   size = input.required<SlotSize>();
   readonly name = osVersionWidget.name;
 
-  systemInfo$ = this.resources.systemInfo$;
+  systemInfo$ = this.resources.dashboardSystemInfo$;
 
   constructor(
     private resources: WidgetResourcesService,

--- a/src/app/pages/dashboard/widgets/system/widget-serial-active/widget-serial-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-serial-active/widget-serial-active.component.spec.ts
@@ -22,7 +22,7 @@ describe('WidgetSerialActiveComponent', () => {
       },
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             value: {
               system_serial: '123456',
             },
@@ -42,7 +42,7 @@ describe('WidgetSerialActiveComponent', () => {
     spectator = createComponent({
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             isLoading: false,
             error: new Error('Fatal error'),
           } as LoadingState<SystemInfo>),

--- a/src/app/pages/dashboard/widgets/system/widget-serial-active/widget-serial-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-serial-active/widget-serial-active.component.ts
@@ -29,7 +29,7 @@ export class WidgetSerialActiveComponent implements WidgetComponent {
   size = input.required<SlotSize>();
   readonly name = serialActiveWidget.name;
 
-  systemInfo$ = this.resources.systemInfo$;
+  systemInfo$ = this.resources.dashboardSystemInfo$;
 
   constructor(
     private resources: WidgetResourcesService,

--- a/src/app/pages/dashboard/widgets/system/widget-serial-passive/widget-serial-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-serial-passive/widget-serial-passive.component.spec.ts
@@ -22,7 +22,7 @@ describe('WidgetSerialPassiveComponent', () => {
       },
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             value: {
               remote_info: {
                 system_serial: '123456',
@@ -44,7 +44,7 @@ describe('WidgetSerialPassiveComponent', () => {
     spectator = createComponent({
       providers: [
         mockProvider(WidgetResourcesService, {
-          systemInfo$: of({
+          dashboardSystemInfo$: of({
             isLoading: false,
             error: new Error('Fatal error'),
           } as LoadingState<SystemInfo>),

--- a/src/app/pages/dashboard/widgets/system/widget-serial-passive/widget-serial-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-serial-passive/widget-serial-passive.component.ts
@@ -29,7 +29,7 @@ export class WidgetSerialPassiveComponent implements WidgetComponent {
   size = input.required<SlotSize>();
   readonly name = serialPassiveWidget.name;
 
-  systemInfo$ = this.resources.systemInfo$;
+  systemInfo$ = this.resources.dashboardSystemInfo$;
 
   constructor(
     private resources: WidgetResourcesService,

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
@@ -46,7 +46,7 @@ describe('WidgetSysInfoActiveComponent', () => {
     },
   } as SystemInfo;
 
-  const systemInfo$ = new BehaviorSubject({
+  const dashboardSystemInfo$ = new BehaviorSubject({
     isLoading: false,
     error: null,
     value: systemInfo,
@@ -59,7 +59,7 @@ describe('WidgetSysInfoActiveComponent', () => {
     providers: [
       mockAuth(),
       mockProvider(WidgetResourcesService, {
-        systemInfo$,
+        dashboardSystemInfo$,
         updateAvailable$,
         refreshInterval$,
       }),

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
@@ -65,7 +65,7 @@ export class WidgetSysInfoActiveComponent {
   protected readonly getLabelForContractType = getLabelForContractType;
 
   updateAvailable = toSignal(this.resources.updateAvailable$);
-  systemInfo = toSignal(this.resources.systemInfo$.pipe(
+  systemInfo = toSignal(this.resources.dashboardSystemInfo$.pipe(
     map((state) => state.value),
     filter((value) => !!value),
   ));
@@ -93,7 +93,7 @@ export class WidgetSysInfoActiveComponent {
     private store$: Store<AppState>,
     private localeService: LocaleService,
   ) {
-    this.resources.refreshSystemInfo();
+    this.resources.refreshDashboardSystemInfo();
   }
 
   isFirstRender = true;

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
@@ -30,7 +30,7 @@ describe('WidgetSysInfoPassiveComponent', () => {
   let store$: MockStore;
   const refreshInterval$ = new BehaviorSubject<number>(0);
 
-  const systemInfo = {
+  const dashboardSystemInfo = {
     remote_info: {
       platform: 'TRUENAS-M40-HA',
       version: 'TrueNAS-COMMUNITY_EDITION-25.10.0-MASTER-20250126-184805',
@@ -104,10 +104,10 @@ describe('WidgetSysInfoPassiveComponent', () => {
         },
         providers: [
           mockProvider(WidgetResourcesService, {
-            systemInfo$: of({
+            dashboardSystemInfo$: of({
               isLoading: false,
               error: null,
-              value: systemInfo,
+              value: dashboardSystemInfo,
             } as LoadingState<SystemInfo>),
             updateAvailable$: of(true),
             refreshInterval$,
@@ -174,10 +174,10 @@ describe('WidgetSysInfoPassiveComponent', () => {
         },
         providers: [
           mockProvider(WidgetResourcesService, {
-            systemInfo$: of({
+            dashboardSystemInfo$: of({
               isLoading: false,
               error: null,
-              value: { ...systemInfo, remote_info: null },
+              value: { ...dashboardSystemInfo, remote_info: null },
             } as LoadingState<SystemInfo>),
             updateAvailable$: of(true),
             refreshInterval$,

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
@@ -75,7 +75,7 @@ export class WidgetSysInfoPassiveComponent {
   protected readonly getLabelForContractType = getLabelForContractType;
 
   updateAvailable = toSignal(this.resources.updateAvailable$);
-  systemInfo = toSignal(this.resources.systemInfo$.pipe(
+  systemInfo = toSignal(this.resources.dashboardSystemInfo$.pipe(
     map((state) => state.value?.remote_info),
     filter((value) => !!value),
   ));
@@ -108,7 +108,7 @@ export class WidgetSysInfoPassiveComponent {
   ) {
     effect(() => {
       if (!this.systemInfo() && this.canFailover()) {
-        this.resources.refreshSystemInfo();
+        this.resources.refreshDashboardSystemInfo();
       }
     });
   }

--- a/src/app/pages/dashboard/widgets/system/widget-system-image/widget-system-image.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-system-image/widget-system-image.component.spec.ts
@@ -34,7 +34,7 @@ describe('WidgetSystemImageComponent', () => {
     providers: [
       mockAuth(),
       mockProvider(WidgetResourcesService, {
-        systemInfo$: of({
+        dashboardSystemInfo$: of({
           isLoading: false,
           error: null,
           value: systemInfo,

--- a/src/app/pages/dashboard/widgets/system/widget-system-image/widget-system-image.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-system-image/widget-system-image.component.ts
@@ -39,7 +39,7 @@ export class WidgetSystemImageComponent implements WidgetComponent {
   isHaLicensed = toSignal(this.store$.select(selectIsHaLicensed));
   hasEnclosureSupport = toSignal(this.store$.select(selectHasEnclosureSupport));
 
-  systemInfo = toSignal(this.resources.systemInfo$.pipe(
+  systemInfo = toSignal(this.resources.dashboardSystemInfo$.pipe(
     filter((state) => !state.isLoading),
     map((state) => state.value),
   ));

--- a/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.spec.ts
@@ -28,7 +28,7 @@ describe('WidgetSystemUptimeComponent', () => {
             getDateFromString: (date: string) => new Date(date),
           }),
           mockProvider(WidgetResourcesService, {
-            systemInfo$: of({
+            dashboardSystemInfo$: of({
               value: {
                 uptime_seconds: 83532.938532175,
                 datetime: {
@@ -81,7 +81,7 @@ describe('WidgetSystemUptimeComponent', () => {
             getDateFromString: (date: string) => new Date(date),
           }),
           mockProvider(WidgetResourcesService, {
-            systemInfo$: of({
+            dashboardSystemInfo$: of({
               isLoading: false,
               error: new Error('Fatal error'),
             } as LoadingState<SystemInfo>),

--- a/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-system-uptime/widget-system-uptime.component.ts
@@ -32,7 +32,7 @@ export class WidgetSystemUptimeComponent implements WidgetComponent {
   size = input.required<SlotSize>();
   readonly name = systemUptimeWidget.name;
 
-  systemInfo$ = this.resources.systemInfo$;
+  systemInfo$ = this.resources.dashboardSystemInfo$;
 
   loadedSystemInfo = toSignal(this.systemInfo$.pipe(
     map((state) => state.value),

--- a/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
@@ -17,7 +17,7 @@ import { JobState } from 'app/enums/job-state.enum';
 import { Role } from 'app/enums/role.enum';
 import { tapOnce } from 'app/helpers/operators/tap-once.operator';
 import { Job } from 'app/interfaces/job.interface';
-import { RsyncTaskUi, RsyncTaskUpdate } from 'app/interfaces/rsync-task.interface';
+import { RsyncTask, RsyncTaskUi, RsyncTaskUpdate } from 'app/interfaces/rsync-task.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EmptyService } from 'app/modules/empty/empty.service';
 import { iconMarker } from 'app/modules/ix-icon/icon-marker.util';
@@ -205,6 +205,7 @@ export class RsyncTaskCardComponent implements OnInit {
       hideCheckbox: true,
     }).pipe(
       filter(Boolean),
+      tap(() => this.updateRowStateAndJob(row, JobState.Running, row.job)),
       tap(() => row.state = { state: JobState.Running }),
       switchMap(() => this.api.job('rsynctask.run', [row.id])),
       tapOnce(() => this.snackbar.success(
@@ -219,8 +220,7 @@ export class RsyncTaskCardComponent implements OnInit {
       }),
       untilDestroyed(this),
     ).subscribe((job: Job) => {
-      row.state = { state: job.state };
-      row.job = job;
+      this.updateRowStateAndJob(row, job.state, job);
       if (this.jobStates.get(job.id) !== job.state) {
         this.getRsyncTasks();
       }
@@ -259,5 +259,19 @@ export class RsyncTaskCardComponent implements OnInit {
           this.dialogService.error(this.errorHandler.parseError(err));
         },
       });
+  }
+
+  private updateRowStateAndJob(row: RsyncTask, state: JobState, job: Job | null): void {
+    this.rsyncTasks = this.rsyncTasks.map((task) => {
+      if (task.id === row.id) {
+        return {
+          ...task,
+          state: { state },
+          job,
+        };
+      }
+      return task;
+    });
+    this.dataProvider.setRows(this.rsyncTasks);
   }
 }

--- a/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
@@ -206,7 +206,6 @@ export class RsyncTaskCardComponent implements OnInit {
     }).pipe(
       filter(Boolean),
       tap(() => this.updateRowStateAndJob(row, JobState.Running, row.job)),
-      tap(() => row.state = { state: JobState.Running }),
       switchMap(() => this.api.job('rsynctask.run', [row.id])),
       tapOnce(() => this.snackbar.success(
         this.translate.instant('Rsync task «{name}» has started.', {


### PR DESCRIPTION
**Summary** 

This is a fix for a network widget chart.

Apart from the main issue with the chart, this PR contains a fix for an additional issue, mentioned in the last line of "Testing" section below ("...status should properly refresh and display **Success**")


**Testing:**

In this scenario user will copy the files from 1st `m40g3-137` machine to 2nd `m50-143a` machine.

1. (Skip first, do later) On 2nd server clean the destination directory in **System \> Shell**

   ```
   rm /mnt/z/iso/*.iso
   ```

2. On 1st server open and watch the chart at **Dashboard** \> **widget** "**Interface** `eno1np0` **"**
2. On 1st server click **Data Protection \> Rsync Tasks \> `mnt/pewl/iso` item \> "Run job" icon**
3. At the tab opened in pt "2"
   1. ensure you can see a traffic peak displayed on 00:13 second of the video,
   2. leave the page (by clicking **Storage** menu item)
   3. go back to the page **without** pressing F5
   4. notice you see a traffic peak (which was previously missing at 00:25 second of the video)

Video captured before the fix:

   https://github.com/user-attachments/assets/740465f0-15d9-4116-a471-7a13d3731134

**Expected result:**

1. After going to back to the page **without** pressing F5, chart in the widget should display the freshly loaded state
   
   ![image](https://github.com/user-attachments/assets/d96f0528-8a32-40c5-8f69-83c2e0e5fc53)

2. After user waits more time, chart in widget should update
3. To verify that additional issue is also fixed: For `/mnt/pewl/iso` item in **Rsync Tasks** UI block:\
   status should properly refresh and display **Success** while user is not leaving the page