### PR TITLE
NAS-134253 / 25.04.0 / Rename Console in VMs (by undsoft)

### DIFF
--- a/src/app/pages/instances/components/all-instances/instance-details/instance-tools/instance-tools.component.html
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-tools/instance-tools.component.html
@@ -31,7 +31,7 @@
           [disabled]="isInstanceStopped()"
           [routerLink]="['/instances', 'view', instance().id, 'console']"
         >
-          <span>{{ 'Console' | translate }}</span>
+          <span>{{ 'Serial Console' | translate }}</span>
 
           <ix-icon name="mdi-console"></ix-icon>
         </a>

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-tools/instance-tools.component.spec.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-tools/instance-tools.component.spec.ts
@@ -61,7 +61,7 @@ describe('InstanceToolsComponent', () => {
 
   describe('console', () => {
     it('shows a link to console for VMs', async () => {
-      const consoleLink = await loader.getHarness(MatButtonHarness.with({ text: 'Console' }));
+      const consoleLink = await loader.getHarness(MatButtonHarness.with({ text: 'Serial Console' }));
 
       expect(consoleLink).toBeTruthy();
       expect(await (await consoleLink.host()).getAttribute('href')).toBe('/instances/view/my-instance/console');

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -3328,6 +3328,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",
   "Serial numbers of each disk being edited.": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2886,6 +2886,7 @@
   "Sensitive": "",
   "Sep": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial – Active": "",
   "Serial – Passive": "",
   "Server": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -125,6 +125,7 @@
   "Secure Boot is required to be off for the VM image you selected": "",
   "Select ISO": "",
   "Selected Devices": "",
+  "Serial Console": "",
   "Service = \"SMB\" AND Event = \"CLOSE\"": "",
   "Set New Password": "",
   "Set Up Two-Factor Authentication": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3585,6 +3585,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial number for this disk.": "",
   "Serial numbers of each disk being edited.": "",
   "Serial or USB port connected to the UPS. To  automatically detect and manage the USB port settings, select  <i>auto</i>.<br><br> When an SNMP driver is selected, enter the IP  address or hostname of the SNMP UPS device.": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -657,6 +657,7 @@
   "Send Feedback": "",
   "Send Method": "",
   "Send Test Email": "",
+  "Serial Console": "",
   "Serial – Active": "",
   "Serial – Passive": "",
   "Server error: {error}": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -444,6 +444,7 @@
   "Select the level of severity. Alert notifications send for all warnings matching and above the selected level. For example, a warning level set to Critical triggers notifications for Critical, Alert, and Emergency level warnings.": "",
   "Select the protocol for the instance's network connection.": "",
   "Selected Devices": "",
+  "Serial Console": "",
   "Service started": "",
   "Service stopped": "",
   "Set New Password": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -3700,6 +3700,7 @@
   "Select the device to attach.": "",
   "Select the protocol for the instance's network connection.": "",
   "Selected Devices": "",
+  "Serial Console": "",
   "Service started": "",
   "Service stopped": "",
   "Set New Password": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3538,6 +3538,7 @@
   "Sep": "",
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -56,6 +56,7 @@
   "Secure Boot is required for the VM image you selected": "",
   "Secure Boot is required to be off for the VM image you selected": "",
   "Selected Devices": "",
+  "Serial Console": "",
   "Set to use a snapshot of the dataset before a <i>PUSH</i>.": "",
   "System Cron Read": "",
   "System Cron Write": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3917,6 +3917,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -83,6 +83,7 @@
   "Secure Boot is required to be off for the VM image you selected": "",
   "Select ISO": "",
   "Selected Devices": "",
+  "Serial Console": "",
   "Set New Password": "",
   "Set Up Two-Factor Authentication": "",
   "Set to use a snapshot of the dataset before a <i>PUSH</i>.": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -3851,6 +3851,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3868,6 +3868,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2488,6 +2488,7 @@
   "Sep": "",
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
+  "Serial Console": "",
   "Serial numbers of each disk being edited.": "",
   "Serial or USB port connected to the UPS. To  automatically detect and manage the USB port settings, select  <i>auto</i>.<br><br> When an SNMP driver is selected, enter the IP  address or hostname of the SNMP UPS device.": "",
   "Serial – Active": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -2628,6 +2628,7 @@
   "Send Test Email": "",
   "Sensitive": "",
   "Separate multiple values by pressing <code>Enter</code>.": "",
+  "Serial Console": "",
   "Serial number for this disk.": "",
   "Serial numbers of each disk being edited.": "",
   "Serial – Active": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1713,6 +1713,7 @@
   "Send Method": "",
   "Send Test Email": "",
   "Sensitive": "",
+  "Serial Console": "",
   "Serial – Active": "",
   "Serial – Passive": "",
   "Server error: {error}": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3923,6 +3923,7 @@
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
   "Serial": "",
+  "Serial Console": "",
   "Serial Port": "",
   "Serial Speed": "",
   "Serial number for this disk.": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -159,6 +159,7 @@
   "Select ISO": "",
   "Select the protocol for the instance's network connection.": "",
   "Selected Devices": "",
+  "Serial Console": "",
   "Set New Password": "",
   "Set Up Two-Factor Authentication": "",
   "Set an expiration date for the API key.": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2628,6 +2628,7 @@
   "Sep": "",
   "Separate multiple values by pressing <code>Enter</code>.": "",
   "Separate values with commas, and without spaces.": "",
+  "Serial Console": "",
   "Serial number for this disk.": "",
   "Serial numbers of each disk being edited.": "",
   "Serial or USB port connected to the UPS. To  automatically detect and manage the USB port settings, select  <i>auto</i>.<br><br> When an SNMP driver is selected, enter the IP  address or hostname of the SNMP UPS device.": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x a8f2d4fdfd52b79eb1c0395f1ba129ee6f8f2d56
    git cherry-pick -x 18960db723d237e22af67c188c287511ef7a61ce

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x b141f3f46fff35011e8f933f87a6458cf50a9daf

**Changes:**

Renames a button. Code review is enough.

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Renames a button.


Original PR: https://github.com/truenas/webui/pull/11616
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134253