### PR TITLE
NAS-134341 / 25.04.0 / Fangtooth: It is not possible to delete a dataset when it has some files in it (by AlexKarpov98)

### DIFF
--- a/src/app/pages/datasets/components/delete-dataset-dialog/delete-dataset-dialog.component.ts
+++ b/src/app/pages/datasets/components/delete-dataset-dialog/delete-dataset-dialog.component.ts
@@ -10,7 +10,7 @@ import { FormBuilder } from '@ngneat/reactive-forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  combineLatest, EMPTY, Observable, of, throwError,
+  combineLatest, Observable, of,
 } from 'rxjs';
 import { catchError, switchMap, tap } from 'rxjs/operators';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
@@ -93,19 +93,20 @@ export class DeleteDatasetDialogComponent implements OnInit {
 
   onDelete(): void {
     this.deleteDataset().pipe(
+      this.loader.withLoader(),
+      tap(() => this.dialogRef.close(true)),
       catchError((error: unknown) => {
         const apiError = extractApiError(error);
+
         if (apiError?.reason?.includes('Device busy')) {
           return this.askToForceDelete();
         }
 
-        return throwError(() => error);
+        this.dialogRef.close();
+        this.errorHandler.showErrorModal(error);
+
+        return of(error);
       }),
-      this.loader.withLoader(),
-      tap(() => {
-        this.dialogRef.close(true);
-      }),
-      catchError(this.handleDeleteError.bind(this)),
       untilDestroyed(this),
     ).subscribe();
   }
@@ -134,19 +135,6 @@ export class DeleteDatasetDialogComponent implements OnInit {
       buttonText: this.translate.instant('Force Delete'),
       buttonColor: 'warn',
     });
-  }
-
-  private handleDeleteError(error: { reason: string; stack: string; [key: string]: unknown }): Observable<void> {
-    this.dialog.error({
-      title: this.translate.instant(
-        'Error deleting dataset {datasetName}.',
-        { datasetName: this.dataset.name },
-      ),
-      message: error.reason,
-      backtrace: error.stack,
-    });
-    this.dialogRef.close(true);
-    return EMPTY;
   }
 
   private loadDatasetRelatedEntities(): void {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1376,7 +1376,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1283,7 +1283,6 @@
   "Error ({code})": "",
   "Error In Apps Service": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error detected reading App": "",
   "Error getting chart data": "",
   "Error occurred": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -1953,7 +1953,6 @@
   "Error In Apps Service": "Error en el servicio de apps",
   "Error Updating Production Status": "Error al actualizar el estado de producción",
   "Error counting eligible snapshots.": "Error al contar las instantáneas elegibles.",
-  "Error deleting dataset {datasetName}.": "Error al eliminar el conjunto de datos {datasetName}.",
   "Error details for ": "Detalles de error para ",
   "Error detected reading App": "Error detectado al leer la app",
   "Error exporting the Private Key": "Error al exportar la clave privada",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1607,7 +1607,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -2493,7 +2493,6 @@
   "Error In Apps Service": "Erreur dans le service d'applications",
   "Error Updating Production Status": "Erreur lors de la mise à jour du statut de production",
   "Error counting eligible snapshots.": "Comptage d'erreurs pour les instantanés éligibles.",
-  "Error deleting dataset {datasetName}.": "Erreur lors de la suppression du dataset {datasetName}.",
   "Error details for ": "Détails de l'erreur pour ",
   "Error detected reading App": "Erreur de lecture détectée sur l'application",
   "Error exporting the Private Key": "Erreur lors de l'exportation de la clé privée",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2235,7 +2235,6 @@
   "Error In Apps Service": "Earráid i Seirbhís Aipeanna",
   "Error Updating Production Status": "Earráid agus Stádas Táirgthe á Nuashonrú",
   "Error counting eligible snapshots.": "Earráid agus grianghraif incháilithe á n-áireamh.",
-  "Error deleting dataset {datasetName}.": "Tharla earráid agus tacar sonraí {datasetName} á scriosadh.",
   "Error details for ": "Sonraí earráide le haghaidh ",
   "Error detected reading App": "Braitheadh earráid agus an Feidhmchlár á léamh",
   "Error exporting the Private Key": "Earráid agus an Eochair Phríobháideach á heaspórtáil",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1608,7 +1608,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1536,7 +1536,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1848,7 +1848,6 @@
   "Error In Apps Service": "앱 서비스 오류",
   "Error Updating Production Status": "운영 상태 갱신 오류",
   "Error counting eligible snapshots.": "적격한 스냅샷을 계산하는 데 오류가 발생했습니다.",
-  "Error deleting dataset {datasetName}.": "데이터셋 {datasetName}을(를) 삭제하는 데 오류가 발생했습니다.",
   "Error details for ": "오류 상세: ",
   "Error detected reading App": "앱을 불러오는 데 오류 감지",
   "Error exporting the Private Key": "개인 키 내보내기 오류",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1780,7 +1780,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1885,7 +1885,6 @@
   "Error In Apps Service": "Fout in Apps service",
   "Error Updating Production Status": "Fout bij het updaten van de productiestatus",
   "Error counting eligible snapshots.": "Fout bij het tellen van in aanmerking komende momentopnamen.",
-  "Error deleting dataset {datasetName}.": "Fout bij het verwijderen van dataset {datasetName}.",
   "Error details for ": "Foutdetails voor ",
   "Error detected reading App": "Fout gedetecteerd bij het lezen van App",
   "Error exporting the Private Key": "Fout bij het exporteren van de persoonlijke sleutel",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -1737,7 +1737,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1731,7 +1731,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -4345,7 +4345,6 @@
   "Enter the IP address of the gateway.": "Insira o endereço IP do gateway.",
   "Environment": "Ambiente",
   "Error": "Erro",
-  "Error deleting dataset {datasetName}.": "Erro ao eliminar o conjunto de dados {datasetName}.",
   "Error details for ": "Detalhes do erro para ",
   "Error detected reading App": "Detetado erroa aler a App",
   "Error exporting the Private Key": "Erro ao exportar a chave privada",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1127,7 +1127,6 @@
   "Error ({code})": "",
   "Error In Apps Service": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error detected reading App": "",
   "Error getting chart data": "",
   "Error occurred": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -3403,7 +3403,6 @@
   "Environment": "Середовище",
   "Error": "Помилка",
   "Error Updating Production Status": "Помилка оновлення виробничого статусу",
-  "Error deleting dataset {datasetName}.": "Помилка видалення набору даних {datasetName}.",
   "Error details for ": "Інформація про помилку для ",
   "Error detected reading App": "Під час читання програми виявлено помилку",
   "Error exporting the Private Key": "Помилка експорту закритого ключа",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1786,7 +1786,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error exporting the Private Key": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -1960,7 +1960,6 @@
   "Error In Apps Service": "应用程序服务错误",
   "Error Updating Production Status": "更新生产状态时出错",
   "Error counting eligible snapshots.": "计算符合条件的快照时出错。",
-  "Error deleting dataset {datasetName}.": "删除数据集 {datasetName} 时出错。",
   "Error details for ": "错误详情",
   "Error detected reading App": "读取应用程序时检测到错误",
   "Error exporting the Private Key": "导出私钥时出错",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1087,7 +1087,6 @@
   "Error In Apps Service": "",
   "Error Updating Production Status": "",
   "Error counting eligible snapshots.": "",
-  "Error deleting dataset {datasetName}.": "",
   "Error details for ": "",
   "Error detected reading App": "",
   "Error getting chart data": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 0bd0b4044230f7c50d413f5b080ef0aa7c763667
    git cherry-pick -x 7c607f7c2dc3039fd28d73b51cba9bba1e7504e0
    git cherry-pick -x dff40eacc36150ce610410386345d700f69aa7d3
    git cherry-pick -x 50ff9ba25976de39c693187dad7a80fae57797c2

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x e17503732af5c4ff149a3c781e79f049f67a4699

Testing: see ticket & comments.

Result:


https://github.com/user-attachments/assets/89e1b4c4-8651-4ba9-a077-e06d4f2f2490



Original PR: https://github.com/truenas/webui/pull/11619
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134341