### PR TITLE
NAS-134405 / 25.10 / Incorrect name hyperlink in apps

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -48,9 +48,13 @@
       <div class="details-list">
         <div class="details-item">
           <div class="label">{{ 'Name' | translate }}:</div>
-          <a class="value" [ixTest]="[app().name, 'name-details']" [routerLink]="appDetailsRouterUrl()">
-            {{ app().name | orNotAvailable }}
-          </a>
+          @if (app().custom_app) {
+            <span class="value">{{ name() | orNotAvailable }}</span>
+          } @else {
+            <a class="value" [ixTest]="[app().name, 'name-details']" [routerLink]="appDetailsRouterUrl()">
+              {{ name() | orNotAvailable }}
+            </a>
+          }
         </div>
         <div class="details-item">
           <div class="label">{{ 'App Version' | translate }}:</div>

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -101,12 +101,41 @@ describe('AppInfoCardComponent', () => {
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   }
 
-  it('shows app name as a link', () => {
-    setupTest(fakeApp);
-    spectator.detectChanges();
-    const appNameLink = spectator.query('.details-list a.value');
-    expect(appNameLink).toHaveText('test-user-app-name');
-    expect(appNameLink).toHaveAttribute('href', '/apps/available/stable/ix-test-app');
+  describe('name', () => {
+    it('shows app name as a link when app name matches image name', () => {
+      setupTest({
+        ...fakeApp,
+        name: 'test-user-app-name',
+        metadata: {
+          ...fakeApp.metadata,
+          name: 'test-user-app-name',
+        },
+      });
+      spectator.detectChanges();
+      const appNameLink = spectator.query('.details-list a.value');
+      expect(appNameLink).toHaveText('test-user-app-name');
+      expect(appNameLink).toHaveAttribute('href', '/apps/available/stable/test-user-app-name');
+    });
+
+    it('shows both name and image name when they are different', () => {
+      setupTest(fakeApp);
+
+      spectator.detectChanges();
+      const appNameLink = spectator.query('.details-list a.value');
+      expect(appNameLink).toHaveText('test-user-app-name (ix-test-app)');
+    });
+
+    it('shows name as a static text for custom apps', () => {
+      setupTest({
+        ...fakeApp,
+        custom_app: true,
+      });
+
+      spectator.detectChanges();
+      const appNameLink = spectator.query('.details-list .value');
+      expect(appNameLink.tagName.toLowerCase()).toBe('span');
+      expect(appNameLink).toHaveText('test-user-app-name');
+    });
   });
 
   it('shows details', () => {
@@ -116,10 +145,10 @@ describe('AppInfoCardComponent', () => {
       label: element.querySelector('.label')!.textContent!,
       value: element.querySelector('.value')!.textContent!.trim(),
     }));
-    expect(details).toEqual([
+    expect(details).toMatchObject([
       {
         label: 'Name:',
-        value: 'test-user-app-name',
+        value: 'test-user-app-name (ix-test-app)',
       },
       {
         label: 'App Version:',

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -95,7 +95,19 @@ export class AppInfoCardComponent {
 
   protected readonly appDetailsRouterUrl = computed<string[]>(() => {
     const app = this.app();
-    return ['/apps', 'available', app.metadata.train, app.id];
+    return ['/apps', 'available', app.metadata.train, app.metadata.name];
+  });
+
+  protected readonly name = computed(() => {
+    if (this.app().name === this.app().metadata.name) {
+      return this.app().name;
+    }
+
+    if (this.app().custom_app) {
+      return this.app().name;
+    }
+
+    return `${this.app().name} (${this.app().metadata.name})`;
   });
 
   constructor(


### PR DESCRIPTION
**Testing:**

Install an app (custom or not) and give it a different name. 