### PR TITLE
NAS-134405 / 25.04.0 / Incorrect name hyperlink in apps (by undsoft)

### DIFF
--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -48,9 +48,13 @@
       <div class="details-list">
         <div class="details-item">
           <div class="label">{{ 'Name' | translate }}:</div>
-          <a class="value" [ixTest]="[app().name, 'name-details']" [routerLink]="appDetailsRouterUrl()">
-            {{ app()?.name | orNotAvailable }}
-          </a>
+          @if (app().custom_app) {
+            <span class="value">{{ name() | orNotAvailable }}</span>
+          } @else {
+            <a class="value" [ixTest]="[app().name, 'name-details']" [routerLink]="appDetailsRouterUrl()">
+              {{ name() | orNotAvailable }}
+            </a>
+          }
         </div>
         <div class="details-item">
           <div class="label">{{ 'App Version' | translate }}:</div>

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.spec.ts
@@ -101,12 +101,41 @@ describe('AppInfoCardComponent', () => {
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   }
 
-  it('shows app name as a link', () => {
-    setupTest(fakeApp);
-    spectator.detectChanges();
-    const appNameLink = spectator.query('.details-list a.value');
-    expect(appNameLink).toHaveText('test-user-app-name');
-    expect(appNameLink).toHaveAttribute('href', '/apps/available/stable/ix-test-app');
+  describe('name', () => {
+    it('shows app name as a link when app name matches image name', () => {
+      setupTest({
+        ...fakeApp,
+        name: 'test-user-app-name',
+        metadata: {
+          ...fakeApp.metadata,
+          name: 'test-user-app-name',
+        },
+      });
+      spectator.detectChanges();
+      const appNameLink = spectator.query('.details-list a.value');
+      expect(appNameLink).toHaveText('test-user-app-name');
+      expect(appNameLink).toHaveAttribute('href', '/apps/available/stable/test-user-app-name');
+    });
+
+    it('shows both name and image name when they are different', () => {
+      setupTest(fakeApp);
+
+      spectator.detectChanges();
+      const appNameLink = spectator.query('.details-list a.value');
+      expect(appNameLink).toHaveText('test-user-app-name (ix-test-app)');
+    });
+
+    it('shows name as a static text for custom apps', () => {
+      setupTest({
+        ...fakeApp,
+        custom_app: true,
+      });
+
+      spectator.detectChanges();
+      const appNameLink = spectator.query('.details-list .value');
+      expect(appNameLink.tagName.toLowerCase()).toBe('span');
+      expect(appNameLink).toHaveText('test-user-app-name');
+    });
   });
 
   it('shows details', () => {
@@ -116,10 +145,10 @@ describe('AppInfoCardComponent', () => {
       label: element.querySelector('.label')!.textContent!,
       value: element.querySelector('.value')!.textContent!.trim(),
     }));
-    expect(details).toEqual([
+    expect(details).toMatchObject([
       {
         label: 'Name:',
-        value: 'test-user-app-name',
+        value: 'test-user-app-name (ix-test-app)',
       },
       {
         label: 'App Version:',

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -95,7 +95,19 @@ export class AppInfoCardComponent {
 
   protected readonly appDetailsRouterUrl = computed<string[]>(() => {
     const app = this.app();
-    return ['/apps', 'available', app.metadata.train, app.id];
+    return ['/apps', 'available', app.metadata.train, app.metadata.name];
+  });
+
+  protected readonly name = computed(() => {
+    if (this.app().name === this.app().metadata.name) {
+      return this.app().name;
+    }
+
+    if (this.app().custom_app) {
+      return this.app().name;
+    }
+
+    return `${this.app().name} (${this.app().metadata.name})`;
   });
 
   constructor(

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1961,7 +1961,6 @@
   "Error In Apps Service": "Errore nel Servizio delle App",
   "Error Updating Production Status": "Errore nell'Aggiornamento dello Stato di Produzione",
   "Error counting eligible snapshots.": "Errore nel conteggio degli snapshot idonei.",
-  "Error deleting dataset {datasetName}.": "Errore durante l'eliminazione del dataset {datasetName}.",
   "Error details for ": "Dettagli dell'errore per ",
   "Error detected reading App": "Errore rilevato durante la lettura dell'App",
   "Error exporting the Private Key": "Errore durante l'esportazione della Chiave Privata",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 2b1c89cc9ab9f0e73a3bc528f223b65df44a3669

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 2b9b106848c8747a68ab8d109885b9e751976838

**Testing:**

Install an app (custom or not) and give it a different name. 

Original PR: https://github.com/truenas/webui/pull/11631
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134405