### PR TITLE
WidgetResourcesService should only fetch data once per load and reload when needed

### DIFF
--- a/src/app/enums/network-interface.enum.ts
+++ b/src/app/enums/network-interface.enum.ts
@@ -17,12 +17,15 @@ export enum CreateNetworkInterfaceType {
 export enum NetworkInterfaceAliasType {
   Inet = 'INET',
   Inet6 = 'INET6',
+  Link = 'LINK',
 }
 
 export enum NetworkInterfaceFlag {
   Multicast = 'MULTICAST',
   Up = 'UP',
   Broadcast = 'BROADCAST',
+  Running = 'RUNNING',
+  LowerUp = 'LOWER_UP',
 }
 
 export enum LinkAggregationProtocol {

--- a/src/app/pages/dashboard/services/widget-resources.service.spec.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.spec.ts
@@ -3,8 +3,18 @@ import {
   SpectatorService,
 } from '@ngneat/spectator/jest';
 import { firstValueFrom } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { getTestScheduler } from 'app/core/testing/utils/get-test-scheduler.utils';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
+import { CloudSyncProviderName } from 'app/enums/cloudsync-provider.enum';
+import { Direction } from 'app/enums/direction.enum';
+import {
+  LinkState, NetworkInterfaceAliasType, NetworkInterfaceFlag, NetworkInterfaceType,
+} from 'app/enums/network-interface.enum';
+import { TransferMode } from 'app/enums/transfer-mode.enum';
 import { App } from 'app/interfaces/app.interface';
+import { CloudSyncTask } from 'app/interfaces/cloud-sync-task.interface';
+import { NetworkInterface } from 'app/interfaces/network-interface.interface';
 import { Pool } from 'app/interfaces/pool.interface';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
 
@@ -20,17 +30,176 @@ const apps = [
 
 describe('WidgetResourcesService', () => {
   let spectator: SpectatorService<WidgetResourcesService>;
+  let testScheduler: TestScheduler;
+
+  const nics: NetworkInterface[] = [
+    {
+      id: 'ens1',
+      name: 'ens1',
+      fake: false,
+      type: NetworkInterfaceType.Physical,
+      state: {
+        name: 'ens1',
+        orig_name: 'ens1',
+        description: 'ens1',
+        mtu: 1500,
+        cloned: false,
+        flags: [
+          NetworkInterfaceFlag.Broadcast,
+          NetworkInterfaceFlag.Multicast,
+          NetworkInterfaceFlag.Up,
+          NetworkInterfaceFlag.Running,
+          NetworkInterfaceFlag.LowerUp,
+        ],
+        nd6_flags: [
+          'HOMEADDRESS',
+        ],
+        capabilities: [
+          'tx-scatter-gather',
+          'tx-checksum-ipv4',
+          'tx-vlan-hw-insert',
+          'rx-vlan-hw-parse',
+          'tx-generic-segmentation',
+          'rx-gro',
+          'tx-tcp-segmentation',
+          'rx-checksum',
+        ],
+        link_state: LinkState.Up,
+        media_type: 'Ethernet',
+        media_subtype: 'autoselect',
+        active_media_type: 'Ethernet',
+        active_media_subtype: '100Mb/s MII',
+        supported_media: [
+          '10baseT/Half',
+          '10baseT/Full',
+          '100baseT/Half',
+          '100baseT/Full',
+        ],
+        media_options: null,
+        link_address: '52:54:00:2c:4d:f9',
+        aliases: [
+          {
+            type: NetworkInterfaceAliasType.Inet,
+            address: '10.220.38.162',
+            netmask: 22,
+            broadcast: '10.220.39.255',
+          },
+          {
+            type: NetworkInterfaceAliasType.Inet,
+            address: '10.220.39.70',
+            netmask: 32,
+            broadcast: '10.220.39.70',
+          },
+          {
+            type: NetworkInterfaceAliasType.Inet6,
+            address: 'fe80::5054:ff:fe2c:4df9',
+            netmask: 64,
+            broadcast: 'fe80::ffff:ffff:ffff:ffff',
+          },
+          {
+            type: NetworkInterfaceAliasType.Link,
+            address: '52:54:00:2c:4d:f9',
+          },
+        ],
+        vrrp_config: [
+          {
+            address: '10.220.39.70',
+            state: 'MASTER',
+          },
+        ],
+      },
+      aliases: [
+        {
+          type: NetworkInterfaceAliasType.Inet,
+          address: '10.220.38.162',
+          netmask: 22,
+        },
+      ],
+      ipv4_dhcp: false,
+      ipv6_auto: false,
+      description: '',
+      mtu: null,
+      failover_critical: true,
+      failover_vhid: null,
+      failover_group: 1,
+      failover_aliases: [
+        {
+          type: NetworkInterfaceAliasType.Inet,
+          address: '10.220.38.236',
+          netmask: 22,
+        },
+      ],
+      failover_virtual_aliases: [
+        {
+          type: NetworkInterfaceAliasType.Inet,
+          address: '10.220.39.70',
+          netmask: 32,
+        },
+      ],
+    },
+  ] as unknown as NetworkInterface[];
+
+  const cloudsyncTasks: CloudSyncTask[] = [
+    {
+      id: 1,
+      description: 'test',
+      path: '/mnt/dozer',
+      attributes: {
+        folder: '/Folder1',
+        fast_list: false,
+        acknowledge_abuse: false,
+      },
+      pre_script: '',
+      post_script: '',
+      snapshot: false,
+      include: [],
+      exclude: [],
+      args: '',
+      enabled: true,
+      job: null,
+      direction: Direction.Pull,
+      transfer_mode: TransferMode.Copy,
+      bwlimit: [],
+      transfers: 4,
+      encryption: false,
+      filename_encryption: false,
+      encryption_password: '',
+      encryption_salt: '',
+      create_empty_src_dirs: false,
+      follow_symlinks: false,
+      credentials: {
+        id: 2,
+        name: 'Google Drive',
+        provider: {
+          type: CloudSyncProviderName.GoogleDrive,
+          client_id: 'client_id',
+          client_secret: 'secret',
+          token: 'token',
+          team_drive: '',
+        },
+      },
+      schedule: {
+        minute: '0',
+        hour: '0',
+        dom: '*',
+        month: '*',
+        dow: '*',
+      },
+      locked: false,
+    },
+  ];
+
   const createService = createServiceFactory({
     service: WidgetResourcesService,
     providers: [
       mockApi([
+        mockCall('interface.query', nics),
+        mockCall('replication.query', []),
+        mockCall('rsynctask.query', []),
+        mockCall('cloudsync.query', cloudsyncTasks),
+        mockCall('webui.main.dashboard.sys_info'),
         mockCall('app.query', apps),
         mockCall('pool.query', pools),
-        mockCall('replication.query'),
-        mockCall('rsynctask.query'),
-        mockCall('cloudsync.query'),
-        mockCall('webui.main.dashboard.sys_info'),
-        mockCall('interface.query'),
         mockCall('update.check_available'),
       ]),
     ],
@@ -38,6 +207,26 @@ describe('WidgetResourcesService', () => {
 
   beforeEach(() => {
     spectator = createService();
+    testScheduler = getTestScheduler();
+  });
+
+  it('emits backup tasks when getBackups is called', () => {
+    testScheduler.run(({ expectObservable }) => {
+      expectObservable(spectator.service.getBackups()).toBe('a', {
+        a: [[], [], cloudsyncTasks],
+      });
+    });
+  });
+
+  it('emits nics when getNetworkInterfaces is called', () => {
+    testScheduler.run(({ expectObservable }) => {
+      expectObservable(spectator.service.getNetworkInterfaces()).toBe('a', {
+        a: {
+          isLoading: false,
+          value: nics,
+        },
+      });
+    });
   });
 
   it('returns pools', async () => {

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.spec.ts
@@ -143,7 +143,7 @@ describe('WidgetBackupComponent', () => {
         },
         providers: [
           mockProvider(WidgetResourcesService, {
-            backups$: of([[], [], []]),
+            getBackups: () => of([[], [], []]),
           }),
         ],
       });
@@ -170,7 +170,7 @@ describe('WidgetBackupComponent', () => {
         },
         providers: [
           mockProvider(WidgetResourcesService, {
-            backups$: of([replicationTasks, rsyncTasks, cloudSyncTasks]),
+            getBackups: () => of([replicationTasks, rsyncTasks, cloudSyncTasks]),
           }),
         ],
       });
@@ -214,7 +214,7 @@ describe('WidgetBackupComponent', () => {
         },
         providers: [
           mockProvider(WidgetResourcesService, {
-            backups$: of([
+            getBackups: () => of([
               [{
                 id: 1,
                 direction: Direction.Pull,
@@ -257,7 +257,7 @@ describe('WidgetBackupComponent', () => {
         },
         providers: [
           mockProvider(WidgetResourcesService, {
-            backups$: of([
+            getBackups: () => of([
               [{
                 id: 1,
                 direction: Direction.Pull,
@@ -300,7 +300,7 @@ describe('WidgetBackupComponent', () => {
         },
         providers: [
           mockProvider(WidgetResourcesService, {
-            backups$: of([
+            getBackups: () => of([
               [],
               [],
               cloudSyncTasks,

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
@@ -132,7 +132,7 @@ export class WidgetBackupComponent implements OnInit {
 
   getBackups(): void {
     this.isLoading = true;
-    this.widgetResourcesService.backups$
+    this.widgetResourcesService.getBackups()
       .pipe(untilDestroyed(this))
       .subscribe(([replicationTasks, rsyncTasks, cloudSyncTasks]) => {
         this.isLoading = false;

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.spec.ts
@@ -22,7 +22,7 @@ describe('WidgetInterfaceIpSettingsComponent', () => {
         updateSettings: jest.fn(),
       }),
       mockProvider(WidgetResourcesService, {
-        networkInterfaces$: of({
+        getNetworkInterfaces: () => of({
           isLoading: false,
           error: null,
           value: [{

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.ts
@@ -35,7 +35,7 @@ export class WidgetInterfaceIpSettingsComponent implements WidgetSettingsCompone
     interface: [null as string | null, [Validators.required]],
   });
 
-  protected networkInterfaceOptions$ = this.resources.networkInterfaces$.pipe(
+  protected networkInterfaceOptions$ = this.resources.getNetworkInterfaces().pipe(
     filter((state) => !!state.value && !state.isLoading),
     map((state) => state.value),
     startWith([]),

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
@@ -13,7 +13,7 @@ describe('WidgetInterfaceIpComponent', () => {
     component: WidgetInterfaceIpComponent,
     providers: [
       mockProvider(WidgetResourcesService, {
-        networkInterfaces$: of({
+        getNetworkInterfaces: () => of({
           isLoading: false,
           value: [
             {

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
@@ -53,7 +53,7 @@ export class WidgetInterfaceIpComponent implements WidgetComponent<WidgetInterfa
     return mapLoadedValue(this.interfaces(), (interfaces) => this.getIpAddresses(interfaces, interfaceId));
   });
 
-  private interfaces = toSignal(this.resources.networkInterfaces$);
+  private interfaces = toSignal(this.resources.getNetworkInterfaces());
 
   constructor(
     private resources: WidgetResourcesService,

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.ts
@@ -67,7 +67,7 @@ export class WidgetInterfaceComponent implements WidgetComponent<WidgetInterface
 
   protected interfaceId = computed(() => this.settings()?.interface || '');
   private interface$ = toObservable(this.interfaceId).pipe(
-    switchMap((interfaceId) => this.resources.networkInterfaces$.pipe(
+    switchMap((interfaceId) => this.resources.getNetworkInterfaces().pipe(
       map((interfaces) => mapLoadedValue(interfaces, (nics) => getNetworkInterface(nics, interfaceId))),
       catchError((error: unknown) => {
         return of({ isLoading: false, error } as LoadingState<DashboardNetworkInterface>);


### PR DESCRIPTION
**Changes:**

Previously, widget-resource-service was making calls to certain endpoints once per session and then ever updating the data no matter how much time passed and even if the user navigated away. I've changed that so the calls are remade whenever the user navigates to the dashboard page. Furthermore, I've optimized the calls so that multiple widgets asking for the same data only trigger one call. Instead of a new call for every widget.

**Testing:**

Code review. Also, check network logs to ensure that whenever you navigate to the dashboard page via either page refresh, or via navigating away to a different page and then coming back to the dashboard page, interface.query call is made only once and data is updated as per the latest call response. Also, check that every time the user navigates away from the dashboard page or refreshes the tab, the data for backup tasks is fetched and shown updated data on the UI.

