### PR TITLE
NAS-134556 / 25.10 / Fix bind_ip for smb service config

### DIFF
--- a/src/app/interfaces/bind-ip.interface.ts
+++ b/src/app/interfaces/bind-ip.interface.ts
@@ -1,3 +1,0 @@
-export interface BindIp {
-  bindIp: string;
-}

--- a/src/app/interfaces/bind-ip.interface.ts
+++ b/src/app/interfaces/bind-ip.interface.ts
@@ -1,3 +1,3 @@
 export interface BindIp {
-  $ipv4_interface: string;
+  bindIp: string;
 }

--- a/src/app/interfaces/smb-config.interface.ts
+++ b/src/app/interfaces/smb-config.interface.ts
@@ -1,10 +1,9 @@
 import { SmbEncryption } from 'app/enums/smb-encryption.enum';
-import { BindIp } from 'app/interfaces/bind-ip.interface';
 
 export interface SmbConfig {
   aapl_extensions: boolean;
   admin_group: string | null;
-  bindip: BindIp[];
+  bindip: string[];
   cifs_SID: string;
   description: string;
   dirmask: string;

--- a/src/app/pages/services/components/service-smb/service-smb.component.html
+++ b/src/app/pages/services/components/service-smb/service-smb.component.html
@@ -131,7 +131,7 @@
                 (delete)="removeBindIp(i)"
               >
                 <ix-select
-                  formControlName="$ipv4_interface"
+                  formControlName="bindIp"
                   [label]="'IP Address' | translate"
                   [options]="bindIpAddressOptions$"
                   [required]="true"

--- a/src/app/pages/services/components/service-smb/service-smb.component.spec.ts
+++ b/src/app/pages/services/components/service-smb/service-smb.component.spec.ts
@@ -8,7 +8,6 @@ import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { SmbEncryption } from 'app/enums/smb-encryption.enum';
-import { BindIp } from 'app/interfaces/bind-ip.interface';
 import { SmbConfig } from 'app/interfaces/smb-config.interface';
 import { User } from 'app/interfaces/user.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -54,7 +53,7 @@ describe('ServiceSmbComponent', () => {
           guest: 'nobody',
           filemask: '',
           dirmask: '',
-          bindip: [] as BindIp[],
+          bindip: [] as string[],
           cifs_SID: 'mockSid',
           ntlmv1_auth: false,
           enable_smb1: false,
@@ -195,10 +194,10 @@ describe('ServiceSmbComponent', () => {
     const bindIpList = await loader.getHarness(IxListHarness.with({ label: 'Bind IP Addresses' }));
     await bindIpList.pressAddButton();
     const bindIpForm1 = await bindIpList.getLastListItem();
-    await bindIpForm1.fillForm({ 'IP Address': '1.1.1.1/32' });
+    await bindIpForm1.fillForm({ 'IP Address': '1.1.1.1' });
     await bindIpList.pressAddButton();
     const bindIpForm2 = await bindIpList.getLastListItem();
-    await bindIpForm2.fillForm({ 'IP Address': '2.2.2.2/32' });
+    await bindIpForm2.fillForm({ 'IP Address': '2.2.2.2' });
 
     const form = await loader.getHarness(IxFormHarness);
     await form.fillForm({
@@ -229,8 +228,8 @@ describe('ServiceSmbComponent', () => {
       aapl_extensions: true,
       admin_group: 'test-group',
       bindip: [
-        { $ipv4_interface: '1.1.1.1/32' },
-        { $ipv4_interface: '2.2.2.2/32' },
+        '1.1.1.1',
+        '2.2.2.2',
       ],
       guest: 'nobody',
       dirmask: '0777',

--- a/src/app/pages/services/components/service-smb/service-smb.component.ts
+++ b/src/app/pages/services/components/service-smb/service-smb.component.ts
@@ -138,8 +138,8 @@ export class ServiceSmbComponent implements OnInit {
     map(([options, config]) => {
       return [
         ...new Set<string>([
-          ...config.bindip.map((item) => item.$ipv4_interface),
-          ...options.map((option) => `${option.value}/32`),
+          ...config.bindip,
+          ...options.map((option) => `${option.value}`),
         ]),
       ].map((value) => ({ label: value, value }));
     }),
@@ -171,7 +171,7 @@ export class ServiceSmbComponent implements OnInit {
     this.api.call('smb.config').pipe(untilDestroyed(this)).subscribe({
       next: (config) => {
         config.bindip.forEach(() => this.addBindIp());
-        this.form.patchValue(config);
+        this.form.patchValue({ ...config, bindip: config.bindip.map((ip) => ({ bindIp: ip })) });
         this.isFormLoading = false;
         this.cdr.markForCheck();
       },
@@ -185,7 +185,7 @@ export class ServiceSmbComponent implements OnInit {
 
   addBindIp(): void {
     this.form.controls.bindip.push(this.fb.group({
-      $ipv4_interface: ['', [Validators.required]],
+      bindIp: ['', [Validators.required]],
     }));
   }
 
@@ -198,7 +198,10 @@ export class ServiceSmbComponent implements OnInit {
   }
 
   onSubmit(): void {
-    const values: SmbConfigUpdate = this.form.value;
+    const values: SmbConfigUpdate = {
+      ...this.form.value,
+      bindip: this.form.value.bindip.map((value) => value.bindIp),
+    };
 
     this.isFormLoading = true;
     this.api.call('smb.update', [values])

--- a/src/app/pages/services/components/service-smb/service-smb.component.ts
+++ b/src/app/pages/services/components/service-smb/service-smb.component.ts
@@ -15,7 +15,6 @@ import { SmbEncryption, smbEncryptionLabels } from 'app/enums/smb-encryption.enu
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextServiceSmb } from 'app/helptext/services/components/service-smb';
-import { BindIp } from 'app/interfaces/bind-ip.interface';
 import { SmbConfigUpdate } from 'app/interfaces/smb-config.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { SimpleAsyncComboboxProvider } from 'app/modules/forms/ix-forms/classes/simple-async-combobox-provider';
@@ -37,6 +36,10 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { UserService } from 'app/services/user.service';
+
+interface BindIp {
+  bindIp: string;
+}
 
 @UntilDestroy({ arrayName: 'subscriptions' })
 @Component({


### PR DESCRIPTION
**Changes:**

Adjusts UI to the response schema from middleware. Removes addition to bind_ip choices.

**Testing:**

Test normal function. Set, unset bind_ip for smb config under System -> Services -> Edit Config (SMB)
