### PR TITLE
NAS-134556 / 25.04.0 / Fix bind_ip for smb service config (by RehanY147)

### DIFF
--- a/src/app/interfaces/bind-ip.interface.ts
+++ b/src/app/interfaces/bind-ip.interface.ts
@@ -1,3 +1,0 @@
-export interface BindIp {
-  $ipv4_interface: string;
-}

--- a/src/app/interfaces/smb-config.interface.ts
+++ b/src/app/interfaces/smb-config.interface.ts
@@ -1,10 +1,9 @@
 import { SmbEncryption } from 'app/enums/smb-encryption.enum';
-import { BindIp } from 'app/interfaces/bind-ip.interface';
 
 export interface SmbConfig {
   aapl_extensions: boolean;
   admin_group: string;
-  bindip: BindIp[];
+  bindip: string[];
   cifs_SID: string;
   description: string;
   dirmask: string;

--- a/src/app/pages/services/components/service-smb/service-smb.component.html
+++ b/src/app/pages/services/components/service-smb/service-smb.component.html
@@ -131,7 +131,7 @@
                 (delete)="removeBindIp(i)"
               >
                 <ix-select
-                  formControlName="$ipv4_interface"
+                  formControlName="bindIp"
                   [label]="'IP Address' | translate"
                   [options]="bindIpAddressOptions$"
                   [required]="true"

--- a/src/app/pages/services/components/service-smb/service-smb.component.spec.ts
+++ b/src/app/pages/services/components/service-smb/service-smb.component.spec.ts
@@ -54,7 +54,7 @@ describe('ServiceSmbComponent', () => {
           guest: 'nobody',
           filemask: '',
           dirmask: '',
-          bindip: [],
+          bindip: [] as string[],
           cifs_SID: 'mockSid',
           ntlmv1_auth: false,
           enable_smb1: false,
@@ -196,10 +196,10 @@ describe('ServiceSmbComponent', () => {
     const bindIpList = await loader.getHarness(IxListHarness.with({ label: 'Bind IP Addresses' }));
     await bindIpList.pressAddButton();
     const bindIpForm1 = await bindIpList.getLastListItem();
-    await bindIpForm1.fillForm({ 'IP Address': '1.1.1.1/32' });
+    await bindIpForm1.fillForm({ 'IP Address': '1.1.1.1' });
     await bindIpList.pressAddButton();
     const bindIpForm2 = await bindIpList.getLastListItem();
-    await bindIpForm2.fillForm({ 'IP Address': '2.2.2.2/32' });
+    await bindIpForm2.fillForm({ 'IP Address': '2.2.2.2' });
 
     const form = await loader.getHarness(IxFormHarness);
     await form.fillForm({
@@ -230,8 +230,8 @@ describe('ServiceSmbComponent', () => {
       aapl_extensions: true,
       admin_group: 'test-group',
       bindip: [
-        { $ipv4_interface: '1.1.1.1/32' },
-        { $ipv4_interface: '2.2.2.2/32' },
+        '1.1.1.1',
+        '2.2.2.2',
       ],
       guest: 'nobody',
       dirmask: '0777',


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c01d3faddf0d662e1ff164d9826780efb6b6f452
    git cherry-pick -x 14c81f244ecae7eba8244adb57925e373a8e6446

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x efb6ef317dca378dd920817ff971c7c3b9dfc2b4

**Changes:**

Adjusts UI to the response schema from middleware. Removes addition to bind_ip choices.

**Testing:**

Test normal function. Set, unset bind_ip for smb config under System -> Services -> Edit Config (SMB)


Original PR: https://github.com/truenas/webui/pull/11663
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134556