### PR TITLE
NAS-134428 / 25.04-RC.1 / Only reload explorer node children if going through zvols (by RehanY147)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component.ts
@@ -103,7 +103,8 @@ export class IxExplorerComponent implements OnInit, OnChanges, ControlValueAcces
     node: TreeNode<ExplorerNodeData>,
     $event: MouseEvent,
   ): void => {
-    if (node.isCollapsed && node.hasChildren && node.children) {
+    const path = node.path.reduce((prev, curr) => `${prev}/${curr}`);
+    if (node.isCollapsed && node.hasChildren && node.children && path.includes('/dev/zvol')) {
       node.children = null;
     }
     TREE_ACTIONS.TOGGLE_EXPANDED(tree, node, $event);


### PR DESCRIPTION
**Changes:**

The endpoint we have to load datasets hierarchy only needs to be called once and all datasets are loaded. A recent PR made it so that when loading zvols we reload children when a node is collapsed and expanded again. However, this approach only works for zvols. Doesn't work for datasets and datasets just get loaded again from the root. This will fix that issue so reloading children only happens for zvols and not for datasets.

**Testing:**

See ticket description. Also see the ticket description of https://ixsystems.atlassian.net/browse/NAS-133774 to test that the issue there is still resolved.


Original PR: https://github.com/truenas/webui/pull/11677
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134428