### PR TITLE
NAS-133011 / 25.04.0 / Network interface graph on Dashboard does not appear to retain network traffic as seen on Reporting page (by bvasilenko)

### DIFF
--- a/src/app/pages/dashboard/services/widget-resources.service.spec.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.spec.ts
@@ -28,6 +28,20 @@ const apps = [
   { id: '2', name: 'app_2' },
 ] as App[];
 
+const interfaceEth0 = {
+  name: 'interface',
+  identifier: 'eth0',
+  legend: ['time', 'received', 'sent'],
+  start: 1735281261,
+  end: 1735281265,
+  data: [
+    [1740117920, 2.2, 0.5],
+    [1740117921, 2.3, 1.2],
+    [1740117922, 2.4, 1.1],
+  ],
+  aggregations: { min: [0], mean: [5], max: [10] },
+};
+
 describe('WidgetResourcesService', () => {
   let spectator: SpectatorService<WidgetResourcesService>;
   let testScheduler: TestScheduler;
@@ -201,6 +215,7 @@ describe('WidgetResourcesService', () => {
         mockCall('app.query', apps),
         mockCall('pool.query', pools),
         mockCall('update.check_available'),
+        mockCall('reporting.netdata_get_data', [interfaceEth0]),
       ]),
     ],
   });
@@ -235,5 +250,13 @@ describe('WidgetResourcesService', () => {
 
   it('returns apps', async () => {
     expect(await firstValueFrom(spectator.service.installedApps$)).toEqual(apps);
+  });
+
+  describe('networkInterfaceLastHourStats', () => {
+    it('returns network interface stats for the last hour', async () => {
+      expect(
+        await firstValueFrom(spectator.service.networkInterfaceLastHourStats('eth0')),
+      ).toEqual([interfaceEth0]);
+    });
   });
 });

--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -3,9 +3,9 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { subHours } from 'date-fns';
 import {
-  Observable, Subject, catchError, combineLatest, combineLatestWith, debounceTime,
+  Observable, Subject, catchError, combineLatest, debounceTime,
   filter,
-  forkJoin, map, of, repeat, shareReplay, startWith, switchMap, take, throttleTime, timer,
+  forkJoin, map, of, repeat, shareReplay, startWith, switchMap, throttleTime, timer,
 } from 'rxjs';
 import { SystemUpdateStatus } from 'app/enums/system-update.enum';
 import { LoadingState, toLoadingState } from 'app/helpers/operators/to-loading-state.helper';
@@ -106,27 +106,17 @@ export class WidgetResourcesService {
     shareReplay({ refCount: false, bufferSize: 1 }),
   );
 
-  readonly serverTime$ = this.store$.pipe(
-    waitForSystemInfo,
-    map((systemInfo) => new Date(systemInfo.datetime.$date)),
-    combineLatestWith(this.refreshInterval$),
-    map(([serverTime]) => {
-      serverTime.setSeconds(serverTime.getSeconds() + 5);
-      return serverTime;
-    }),
-  );
-
   networkInterfaceLastHourStats(interfaceName: string): Observable<ReportingData[]> {
-    return this.serverTime$.pipe(
-      take(1),
-      switchMap((serverTime) => {
-        const end = Math.floor(serverTime.getTime() / 1000);
-        const start = Math.floor(subHours(serverTime, 1).getTime() / 1000);
-        return this.api.call('reporting.netdata_get_data', [[{
-          identifier: interfaceName,
-          name: 'interface',
-        }], { end, start }]);
-      }),
+    const now = new Date();
+    now.setSeconds(now.getSeconds() + 5);
+
+    const end = Math.floor(now.getTime() / 1000);
+    const start = Math.floor(subHours(now, 1).getTime() / 1000);
+
+    return this.api.call('reporting.netdata_get_data', [[{
+      identifier: interfaceName,
+      name: 'interface',
+    }], { end, start }]).pipe(
       shareReplay({ bufferSize: 1, refCount: true }),
     );
   }

--- a/src/app/pages/dashboard/widgets/apps/widget-app-cpu/widget-app-cpu.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app-cpu/widget-app-cpu.component.spec.ts
@@ -52,7 +52,6 @@ describe('WidgetAppCpuComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of({
           cpu: 55,

--- a/src/app/pages/dashboard/widgets/apps/widget-app-info/widget-app-info.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app-info/widget-app-info.component.spec.ts
@@ -46,7 +46,6 @@ describe('WidgetAppInfoComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of(),
       }),

--- a/src/app/pages/dashboard/widgets/apps/widget-app-memory/widget-app-memory.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app-memory/widget-app-memory.component.spec.ts
@@ -47,7 +47,6 @@ describe('WidgetAppMemoryComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of({
           cpu: 55,

--- a/src/app/pages/dashboard/widgets/apps/widget-app-network/widget-app-network.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app-network/widget-app-network.component.spec.ts
@@ -53,7 +53,6 @@ describe('WidgetAppNetworkComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of({
           network: {

--- a/src/app/pages/dashboard/widgets/apps/widget-app/widget-app.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/widget-app/widget-app.component.spec.ts
@@ -60,7 +60,6 @@ describe('WidgetAppComponent', () => {
     providers: [
       mockProvider(ErrorHandlerService),
       mockProvider(WidgetResourcesService, {
-        serverTime$: of(new Date()),
         getApp: () => of(app),
         getAppStats: () => of({}),
         getAppStatusUpdates: () => of(),

--- a/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
@@ -17,7 +17,7 @@ import { JobState } from 'app/enums/job-state.enum';
 import { Role } from 'app/enums/role.enum';
 import { tapOnce } from 'app/helpers/operators/tap-once.operator';
 import { Job } from 'app/interfaces/job.interface';
-import { RsyncTaskUi, RsyncTaskUpdate } from 'app/interfaces/rsync-task.interface';
+import { RsyncTask, RsyncTaskUi, RsyncTaskUpdate } from 'app/interfaces/rsync-task.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EmptyService } from 'app/modules/empty/empty.service';
 import { iconMarker } from 'app/modules/ix-icon/icon-marker.util';
@@ -205,6 +205,7 @@ export class RsyncTaskCardComponent implements OnInit {
       hideCheckbox: true,
     }).pipe(
       filter(Boolean),
+      tap(() => this.updateRowStateAndJob(row, JobState.Running, row.job)),
       tap(() => row.state = { state: JobState.Running }),
       switchMap(() => this.api.job('rsynctask.run', [row.id])),
       tapOnce(() => this.snackbar.success(
@@ -219,8 +220,7 @@ export class RsyncTaskCardComponent implements OnInit {
       }),
       untilDestroyed(this),
     ).subscribe((job: Job) => {
-      row.state = { state: job.state };
-      row.job = job;
+      this.updateRowStateAndJob(row, job.state, job);
       if (this.jobStates.get(job.id) !== job.state) {
         this.getRsyncTasks();
       }
@@ -259,5 +259,19 @@ export class RsyncTaskCardComponent implements OnInit {
           this.dialogService.error(this.errorHandler.parseError(err));
         },
       });
+  }
+
+  private updateRowStateAndJob(row: RsyncTask, state: JobState, job: Job | null): void {
+    this.rsyncTasks = this.rsyncTasks.map((task) => {
+      if (task.id === row.id) {
+        return {
+          ...task,
+          state: { state },
+          job,
+        };
+      }
+      return task;
+    });
+    this.dataProvider.setRows(this.rsyncTasks);
   }
 }


### PR DESCRIPTION
**Summary** 

This is a fix for a network widget chart.

Apart from the main issue with the chart, this PR contains a fix for an additional issue, mentioned in the last line of "Testing" section below ("...status should properly refresh and display **Success**")


**Testing:**

In this scenario user will copy the files from 1st `m40g3-137` machine to 2nd `m50-143a` machine.

1. (Skip first, do later) On 2nd server clean the destination directory in **System \> Shell**

   ```
   rm /mnt/z/iso/*.iso
   ```

2. On 1st server open and watch the chart at **Dashboard** \> **widget** "**Interface** `eno1np0` **"**
2. On 1st server click **Data Protection \> Rsync Tasks \> `mnt/pewl/iso` item \> "Run job" icon**
3. At the tab opened in pt "2"
   1. ensure you can see a traffic peak displayed on 00:13 second of the video,
   2. leave the page (by clicking **Storage** menu item)
   3. go back to the page **without** pressing F5
   4. notice you see a traffic peak (which was previously missing at 00:25 second of the video)

Video captured before the fix:

   https://github.com/user-attachments/assets/740465f0-15d9-4116-a471-7a13d3731134

**Expected result:**

1. After going to back to the page **without** pressing F5, chart in the widget should display the freshly loaded state
   
   ![image](https://github.com/user-attachments/assets/d96f0528-8a32-40c5-8f69-83c2e0e5fc53)

2. After user waits more time, chart in widget should update
3. To verify that additional issue is also fixed: For `/mnt/pewl/iso` item in **Rsync Tasks** UI block:\
   status should properly refresh and display **Success** while user is not leaving the page

Original PR: https://github.com/truenas/webui/pull/11598
Jira URL: https://ixsystems.atlassian.net/browse/NAS-133011