### PR TITLE
NAS-134675 / 25.04.0 / [master-detail] UI, when items are filtered continues to show prior selection details, even when not shown in the list (by AlexKarpov98)

### DIFF
--- a/src/app/interfaces/device-nested-data-node.interface.ts
+++ b/src/app/interfaces/device-nested-data-node.interface.ts
@@ -6,6 +6,7 @@ export interface VDevGroup {
   guid: VdevType;
   children: TopologyItem[];
   isRoot?: boolean;
+  disk?: string;
 }
 
 export type DeviceNestedDataNode = TopologyItem | VDevGroup;

--- a/src/app/modules/master-detail-view/master-detail-view.component.html
+++ b/src/app/modules/master-detail-view/master-detail-view.component.html
@@ -3,7 +3,7 @@
     <ng-content select="[master]"></ng-content>
   </div>
 
-  @if (selectedItem()) {
+  @if (selectedItem() && showDetails()) {
     <div
       class="details-container"
       ixDetailsHeight

--- a/src/app/modules/master-detail-view/master-detail-view.component.ts
+++ b/src/app/modules/master-detail-view/master-detail-view.component.ts
@@ -32,6 +32,7 @@ import { FocusService } from 'app/services/focus.service';
 })
 export class MasterDetailViewComponent<T> implements AfterViewInit {
   readonly selectedItem = input<T | null>(null);
+  readonly showDetails = input<boolean | null>(true);
   readonly showMobileDetails = signal<boolean>(false);
   readonly isMobileView = signal<boolean>(false);
 

--- a/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.ts
@@ -112,6 +112,10 @@ export class InstalledAppsListComponent implements OnInit {
     title: helptextApps.message.loading,
   };
 
+  get isSelectedAppVisible(): boolean {
+    return this.filteredApps?.some((app) => app.id === this.selectedApp?.id);
+  }
+
   get filteredApps(): App[] {
     return this.dataSource
       .filter((app) => app?.name?.toLocaleLowerCase().includes(this.filterString.toLocaleLowerCase()));

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.html
@@ -1,5 +1,6 @@
 <ix-page-header [pageTitle]="'Installed' | translate">
   <ix-docker-status></ix-docker-status>
+
   @if (hasUpdates) {
     <div class="global-update">
       <button
@@ -19,6 +20,7 @@
       </button>
     </div>
   }
+
   <ix-app-settings-button></ix-app-settings-button>
   <a
     mat-button
@@ -31,10 +33,11 @@
 
 <ix-master-detail-view
   #masterDetailView="masterDetailViewContext"
+  [showDetails]="masterList.isSelectedAppVisible"
   [selectedItem]="selectedApp"
 >
   <ix-installed-apps-list
-    #installedAppsList
+    #masterList
     master
     [isMobileView]="masterDetailView.isMobileView()"
     (toggleShowMobileDetails)="masterDetailView.toggleShowMobileDetails($event)"
@@ -48,7 +51,7 @@
   }
 
   <ng-container detail>
-    @if (selectedApp && (!installedAppsList.filterString || selectedApp.name.toLowerCase().includes(installedAppsList.filterString.toLowerCase()))) {
+    @if (selectedApp) {
       <ix-app-details-panel
         [app]="selectedApp"
         (startApp)="start(selectedApp.name)"

--- a/src/app/pages/data-protection/cloud-backup/all-cloud-backups/all-cloud-backups.component.html
+++ b/src/app/pages/data-protection/cloud-backup/all-cloud-backups/all-cloud-backups.component.html
@@ -11,11 +11,16 @@
   </button>
 </ix-page-header>
 
+@let cloudBackup = dataProvider?.expandedRow;
+@let showDetails = !masterList.searchQuery() || cloudBackup.description.toLowerCase().includes(masterList.searchQuery().toLowerCase());
+
 <ix-master-detail-view
   #masterDetailView="masterDetailViewContext"
-  [selectedItem]="dataProvider?.expandedRow"
+  [showDetails]="showDetails"
+  [selectedItem]="cloudBackup"
 >
   <ix-cloud-backup-list
+    #masterList
     master
     [dataProvider]="dataProvider"
     [cloudBackups]="cloudBackups()"
@@ -24,12 +29,14 @@
   ></ix-cloud-backup-list>
 
   <ng-container detail-header>
-    {{ 'Task Details for {task}' | translate: { task: dataProvider?.expandedRow?.description} }}
+    @if (cloudBackup) {
+      {{ 'Task Details for {task}' | translate: { task: cloudBackup?.description} }}
+    }
   </ng-container>
 
   <ng-container detail>
-    @if (dataProvider.expandedRow) {
-      <ix-cloud-backup-details [backup]="dataProvider.expandedRow"></ix-cloud-backup-details>
+    @if (cloudBackup) {
+      <ix-cloud-backup-details [backup]="cloudBackup"></ix-cloud-backup-details>
     }
   </ng-container>
 </ix-master-detail-view>

--- a/src/app/pages/instances/components/all-instances/all-instances.component.html
+++ b/src/app/pages/instances/components/all-instances/all-instances.component.html
@@ -4,9 +4,11 @@
 
 <ix-master-detail-view
   #masterDetailView="masterDetailViewContext"
+  [showDetails]="masterList.isSelectedInstanceVisible()"
   [selectedItem]="selectedInstance()"
 >
   <ix-instance-list
+    #masterList
     master
     [ixUiSearch]="searchableElements.elements.list"
     [isMobileView]="masterDetailView.isMobileView()"

--- a/src/app/pages/instances/components/all-instances/all-instances.component.spec.ts
+++ b/src/app/pages/instances/components/all-instances/all-instances.component.spec.ts
@@ -11,7 +11,6 @@ import { MockMasterDetailViewComponent } from 'app/modules/master-detail-view/te
 import { AllInstancesHeaderComponent } from 'app/pages/instances/components/all-instances/all-instances-header/all-instances-header.component';
 import { AllInstancesComponent } from 'app/pages/instances/components/all-instances/all-instances.component';
 import { InstanceDetailsComponent } from 'app/pages/instances/components/all-instances/instance-details/instance-details.component';
-import { InstanceListComponent } from 'app/pages/instances/components/all-instances/instance-list/instance-list.component';
 import { VirtualizationConfigStore } from 'app/pages/instances/stores/virtualization-config.store';
 import { VirtualizationDevicesStore } from 'app/pages/instances/stores/virtualization-devices.store';
 import { VirtualizationInstancesStore } from 'app/pages/instances/stores/virtualization-instances.store';
@@ -32,7 +31,6 @@ describe('AllInstancesComponent', () => {
         MockMasterDetailViewComponent,
         AllInstancesHeaderComponent,
         InstanceDetailsComponent,
-        InstanceListComponent,
       ),
     ],
     providers: [
@@ -57,6 +55,8 @@ describe('AllInstancesComponent', () => {
       }),
       mockProvider(VirtualizationInstancesStore, {
         initialize: jest.fn(),
+        instances: jest.fn(() => []),
+        isLoading: jest.fn(() => false),
       }),
       mockProvider(VirtualizationDevicesStore, {
         selectedInstance: jest.fn(() => ({ id: 'instance1' } as VirtualizationInstance)),

--- a/src/app/pages/instances/components/all-instances/instance-list/instance-list.component.ts
+++ b/src/app/pages/instances/components/all-instances/instance-list/instance-list.component.ts
@@ -51,7 +51,7 @@ export class InstanceListComponent {
   readonly isMobileView = input<boolean>();
   readonly toggleShowMobileDetails = output<boolean>();
 
-  protected readonly searchQuery = signal<string>('');
+  readonly searchQuery = signal<string>('');
   protected readonly window = inject<Window>(WINDOW);
   protected readonly selection = new SelectionModel<string>(true, []);
 
@@ -59,6 +59,7 @@ export class InstanceListComponent {
   protected readonly isLoading = this.store.isLoading;
 
   protected readonly selectedInstance = this.deviceStore.selectedInstance;
+
   get isAllSelected(): boolean {
     return this.selection.selected.length === this.filteredInstances().length;
   }
@@ -70,6 +71,10 @@ export class InstanceListComponent {
       })
       .filter((instance) => !!instance);
   }
+
+  readonly isSelectedInstanceVisible = computed(() => {
+    return this.filteredInstances()?.some((instance) => instance.id === this.selectedInstance()?.id);
+  });
 
   protected readonly filteredInstances = computed(() => {
     return (this.instances() || []).filter((instance) => {

--- a/src/app/pages/sharing/iscsi/target/all-targets/all-targets.component.html
+++ b/src/app/pages/sharing/iscsi/target/all-targets/all-targets.component.html
@@ -1,8 +1,13 @@
+@let target = dataProvider.expandedRow;
+@let showDetails = !masterList.filterString || target.name.toLowerCase().includes(masterList.filterString.toLowerCase());
+
 <ix-master-detail-view
   #masterDetailView="masterDetailViewContext"
-  [selectedItem]="dataProvider.expandedRow"
+  [selectedItem]="target"
+  [showDetails]="showDetails"
 >
   <ix-iscsi-target-list
+    #masterList
     master
     [dataProvider]="dataProvider"
     [targets]="targets()"
@@ -11,12 +16,12 @@
   ></ix-iscsi-target-list>
 
   <div detail-header class="detail-header">
-    <span>
-      {{ 'Details for' | translate }}
-      {{ dataProvider.expandedRow?.name }}
-    </span>
+    @if (target) {
+      <span>
+        {{ 'Details for' | translate }}
+        {{ target?.name }}
+      </span>
 
-    @if (dataProvider.expandedRow; as target) {
       <div class="detail-actions">
         <button
           *ixRequiresRoles="requiredRoles"
@@ -40,8 +45,8 @@
   </div>
 
   <ng-container detail>
-    @if (dataProvider.expandedRow) {
-      <ix-target-details [target]="dataProvider.expandedRow"></ix-target-details>
+    @if (target) {
+      <ix-target-details [target]="target"></ix-target-details>
     }
   </ng-container>
 </ix-master-detail-view>

--- a/src/app/pages/sharing/iscsi/target/all-targets/all-targets.component.ts
+++ b/src/app/pages/sharing/iscsi/target/all-targets/all-targets.component.ts
@@ -60,6 +60,7 @@ export class AllTargetsComponent implements OnInit {
   ngOnInit(): void {
     const targets$ = this.iscsiService.getTargets().pipe(
       tap((targets) => {
+        this.targets.set(targets);
         const firstTarget = targets[targets.length - 1];
         if (!this.dataProvider.expandedRow && firstTarget) {
           this.dataProvider.expandedRow = firstTarget;

--- a/src/app/pages/storage/modules/devices/devices.component.html
+++ b/src/app/pages/storage/modules/devices/devices.component.html
@@ -11,6 +11,8 @@
 </ix-page-header>
 
 @let selectedNode = selectedNode$ | async;
+@let showDetails = !filterString || selectedNode.disk.toLowerCase().includes(filterString.toLowerCase());
+
 <div class="container">
   <div class="table-container">
     <ix-fake-progress-bar
@@ -145,7 +147,7 @@
     ixDetailsHeight
     [class.details-container-mobile]="showMobileDetails"
   >
-    @if (selectedNode) {
+    @if (selectedNode && showDetails) {
       <ix-disk-details-panel
         [topologyItem]="selectedNode | cast"
         [topologyParentItem]="selectedParentNode$ | async | cast"

--- a/src/app/pages/storage/modules/devices/devices.component.ts
+++ b/src/app/pages/storage/modules/devices/devices.component.ts
@@ -99,6 +99,7 @@ export class DevicesComponent implements OnInit, AfterViewInit {
   dataSource: NestedTreeDataSource<DeviceNestedDataNode>;
   poolId: number;
   poolName: string;
+  filterString = '';
 
   treeControl = new NestedTreeControl<DeviceNestedDataNode, string>((vdev) => vdev.children, {
     trackBy: (vdev) => vdev.guid,
@@ -175,6 +176,7 @@ export class DevicesComponent implements OnInit, AfterViewInit {
   }
 
   onSearch(query: string): void {
+    this.filterString = query;
     this.dataSource.filter(query);
   }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b39a5c742f54c1e366952ca99d5ddcad1aedbf58
    git cherry-pick -x e62b55ddb744ce22a87b2019d5672e35c4b8b31f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 0db3e3a3f47cab3a7c6ad7fad5f9e56d11ca1bba

Testing: see ticket.

Result:

https://github.com/user-attachments/assets/cff8a7e3-d7c8-4ab1-adc2-45e44a52b520



Original PR: https://github.com/truenas/webui/pull/11706
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134675