### PR TITLE
NAS-134638 / 25.04.0 / If the browser is not refreshed after changing the hostname, the debug file downloads as the old hostname (by AlexKarpov98)

### DIFF
--- a/src/app/pages/network/components/configuration/configuration.component.ts
+++ b/src/app/pages/network/components/configuration/configuration.component.ts
@@ -34,6 +34,7 @@ import { ErrorHandlerService } from 'app/services/error-handler.service';
 import { SystemGeneralService } from 'app/services/system-general.service';
 import { AppState } from 'app/store';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
+import { systemInfoUpdated } from 'app/store/system-info/system-info.actions';
 
 @UntilDestroy()
 @Component({
@@ -353,6 +354,7 @@ export class NetworkConfigurationComponent implements OnInit {
       .subscribe({
         next: () => {
           this.isFormLoading = false;
+          this.store$.dispatch(systemInfoUpdated());
           this.cdr.markForCheck();
           this.slideInRef.close({ response: true, error: null });
         },


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 1ae7c3e34395924a5257cc386a2551764aaa177f

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x e132f0d8720bf5faae25cbcd18565115cf12445c

Testing: see ticket.

You may `.log()` the hostname directly in `private saveDebug(): Observable<Blob> {` to see that it uses latest value.

Original PR: https://github.com/truenas/webui/pull/11711
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134638