### PR TITLE
NAS-134729 / 25.10 / Change defaults for Export Password Secret Seed

### DIFF
--- a/src/app/pages/system/general-settings/save-config-dialog/save-config-dialog.component.spec.ts
+++ b/src/app/pages/system/general-settings/save-config-dialog/save-config-dialog.component.spec.ts
@@ -56,7 +56,10 @@ describe('SaveConfigDialogComponent', () => {
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   });
 
-  it('saves configuration when save dialog is submitted', async () => {
+  it('saves configuration when save dialog is submitted is submitted without Export checkbox', async () => {
+    const checkbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Export Password Secret Seed' }));
+    await checkbox.setValue(false);
+
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
@@ -70,9 +73,6 @@ describe('SaveConfigDialogComponent', () => {
   });
 
   it('saves configuration together with password seed when dialog is submitted with Export checkbox', async () => {
-    const checkbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Export Password Secret Seed' }));
-    await checkbox.setValue(true);
-
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 

--- a/src/app/pages/system/general-settings/save-config-dialog/save-config-dialog.component.ts
+++ b/src/app/pages/system/general-settings/save-config-dialog/save-config-dialog.component.ts
@@ -58,7 +58,7 @@ export interface SaveConfigDialogMessages {
 export class SaveConfigDialogComponent {
   protected readonly requiredRoles = [Role.FullAdmin];
 
-  exportSeedCheckbox = new FormControl(false);
+  exportSeedCheckbox = new FormControl(true);
 
   helptext: SaveConfigDialogMessages;
 


### PR DESCRIPTION
Changes defaults for `Export Password Secret Seed` in `Save Configuration` dialog.