### PR TITLE
NAS-134729 / 25.04.0 / Change defaults for Export Password Secret Seed (by undsoft)

### DIFF
--- a/src/app/pages/system/general-settings/save-config-dialog/save-config-dialog.component.spec.ts
+++ b/src/app/pages/system/general-settings/save-config-dialog/save-config-dialog.component.spec.ts
@@ -61,7 +61,10 @@ describe('SaveConfigDialogComponent', () => {
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   });
 
-  it('saves configuration when save dialog is submitted', async () => {
+  it('saves configuration when save dialog is submitted is submitted without Export checkbox', async () => {
+    const checkbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Export Password Secret Seed' }));
+    await checkbox.setValue(false);
+
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
@@ -79,9 +82,6 @@ describe('SaveConfigDialogComponent', () => {
   });
 
   it('saves configuration together with password seed when dialog is submitted with Export checkbox', async () => {
-    const checkbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Export Password Secret Seed' }));
-    await checkbox.setValue(true);
-
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 

--- a/src/app/pages/system/general-settings/save-config-dialog/save-config-dialog.component.ts
+++ b/src/app/pages/system/general-settings/save-config-dialog/save-config-dialog.component.ts
@@ -59,7 +59,7 @@ export interface SaveConfigDialogMessages {
 export class SaveConfigDialogComponent {
   protected readonly requiredRoles = [Role.FullAdmin];
 
-  exportSeedCheckbox = new FormControl(false);
+  exportSeedCheckbox = new FormControl(true);
 
   helptext: SaveConfigDialogMessages;
 


### PR DESCRIPTION
Changes defaults for `Export Password Secret Seed` in `Save Configuration` dialog.

Original PR: https://github.com/truenas/webui/pull/11725
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134729