### PR TITLE
NAS-134869 / 25.10 / Enable rxjs/throw-error

### DIFF
--- a/eslint/eslint-ts-rules-extra.mjs
+++ b/eslint/eslint-ts-rules-extra.mjs
@@ -23,6 +23,7 @@ export const extraRules = {
     "methods": false,
   }],
   "@smarttools/rxjs/prefer-observer": ["error"],
+  "@smarttools/rxjs/throw-error": ["error"],
 
   // Angular
   "@angular-eslint/use-lifecycle-interface": ["error"],

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
@@ -609,13 +609,11 @@ describe('SmbFormComponent', () => {
           case 'sharing.smb.presets':
             return of({ ...presets });
           case 'sharing.smb.create':
-            return throwError(() => ({
-              error: {
-                data: {
-                  reason: '[EINVAL] sharingsmb_create.afp: Apple SMB2/3 protocol extension support is required by this parameter.',
-                },
+            return throwError(() => new ApiCallError({
+              data: {
+                reason: '[EINVAL] sharingsmb_create.afp: Apple SMB2/3 protocol extension support is required by this parameter.',
               },
-            }));
+            } as JsonRpcError));
           default:
             return of(null);
         }
@@ -647,13 +645,11 @@ describe('SmbFormComponent', () => {
       await saveButton.click();
 
       expect(spectator.inject(FormErrorHandlerService).handleValidationErrors).toHaveBeenCalledWith(
-        {
-          error: {
-            data: {
-              reason: '[EINVAL] sharingsmb_create.afp: Apple SMB2/3 protocol extension support is required by this parameter.',
-            },
+        new ApiCallError({
+          data: {
+            reason: '[EINVAL] sharingsmb_create.afp: Apple SMB2/3 protocol extension support is required by this parameter.',
           },
-        },
+        } as JsonRpcError),
         spectator.component.form,
         {},
         'smb-form-toggle-advanced-options',


### PR DESCRIPTION
**Changes:**

Throwing an Error (or a subclass of Error) is better because it properly preserves stack trace.
Most of the code was already updated for it, but here I enable the relevant linter rule.

**Testing:**

Code review.
