### PR TITLE
NAS-134842 / 25.04.0 / Explore TrueNAS Enterprise text vanishes (by AlexKarpov98)

### DIFF
--- a/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.html
+++ b/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.html
@@ -7,7 +7,7 @@
     {{ currentMessage() }}
   </span>
 
-  <span class="text-below">
+  <span>
     {{ 'Explore TrueNAS Enterprise' | translate }}
   </span>
 </a>

--- a/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.scss
+++ b/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.scss
@@ -12,7 +12,7 @@ a {
   text-decoration: none;
 
   span {
-    color: var(--primary-txt);
+    color: var(--fg2);
     display: block;
 
     &.text-above {


### PR DESCRIPTION
Testing: see ticket.

Result:
<img width="564" alt="Screenshot 2025-03-18 at 12 14 56" src="https://github.com/user-attachments/assets/1bdf1e30-bba5-4cf5-9a64-5908717293d8" />


Original PR: https://github.com/truenas/webui/pull/11743
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134842