### PR TITLE
NAS-134719 / 25.04.0 / Add tooltip to hostname item in sys-info card (by RehanY147)

### DIFF
--- a/src/app/modules/layout/admin-layout/admin-layout.component.html
+++ b/src/app/modules/layout/admin-layout/admin-layout.component.html
@@ -40,7 +40,7 @@
               class="hostname-label"
               matTooltipPosition="above"
               [matTooltip]="'Hostname: {hostname}' | translate: { hostname }"
-            >{{ hostname }}</div>
+            >{{ 'hostname' }}</div>
           }
 
           <p class="product-type">

--- a/src/app/modules/layout/admin-layout/admin-layout.component.html
+++ b/src/app/modules/layout/admin-layout/admin-layout.component.html
@@ -40,7 +40,7 @@
               class="hostname-label"
               matTooltipPosition="above"
               [matTooltip]="'Hostname: {hostname}' | translate: { hostname }"
-            >{{ 'hostname' }}</div>
+            >{{ hostname }}</div>
           }
 
           <p class="product-type">

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -20,7 +20,7 @@
         @if (systemInfo()?.system_serial && isIxHardware()) {
           <div class="hostname">
             @if (isLoaded()) {
-              <span [matTooltip]="systemInfo()?.hostname">
+              <span [matTooltip]="'Hostname: {hostname}' | translate: { hostname: systemInfo()?.hostname }">
                 {{ systemInfo()?.hostname }}
               </span>
             }
@@ -150,7 +150,7 @@
             <mat-list-item>
               <strong>{{ 'Hostname' | translate }}:</strong>
               @if (isLoaded()) {
-                <span [matTooltip]="systemInfo()?.hostname">
+                <span>
                   {{ systemInfo()?.hostname }}
                 </span>
               } @else {

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -20,7 +20,7 @@
         @if (systemInfo()?.system_serial && isIxHardware()) {
           <div class="hostname">
             @if (isLoaded()) {
-              <span>
+              <span [matTooltip]="systemInfo()?.hostname">
                 {{ systemInfo()?.hostname }}
               </span>
             }
@@ -150,7 +150,7 @@
             <mat-list-item>
               <strong>{{ 'Hostname' | translate }}:</strong>
               @if (isLoaded()) {
-                <span>
+                <span [matTooltip]="systemInfo()?.hostname">
                   {{ systemInfo()?.hostname }}
                 </span>
               } @else {

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -20,7 +20,7 @@
         @if (systemInfo()?.system_serial && isIxHardware()) {
           <div class="hostname">
             @if (isLoaded()) {
-              <span [matTooltip]="systemInfo()?.hostname">
+              <span [matTooltip]="'Hostname: {hostname}' | translate: { hostname: systemInfo()?.hostname }">
                 {{ systemInfo()?.hostname }}
               </span>
             }
@@ -145,7 +145,7 @@
             <mat-list-item>
               <strong>{{ 'Hostname' | translate }}:</strong>
               @if (isLoaded()) {
-                <span [matTooltip]="systemInfo()?.hostname">
+                <span>
                   {{ systemInfo()?.hostname }}
                 </span>
               } @else {

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -20,7 +20,7 @@
         @if (systemInfo()?.system_serial && isIxHardware()) {
           <div class="hostname">
             @if (isLoaded()) {
-              <span>
+              <span [matTooltip]="systemInfo()?.hostname">
                 {{ systemInfo()?.hostname }}
               </span>
             }
@@ -145,7 +145,7 @@
             <mat-list-item>
               <strong>{{ 'Hostname' | translate }}:</strong>
               @if (isLoaded()) {
-                <span>
+                <span [matTooltip]="systemInfo()?.hostname">
                   {{ systemInfo()?.hostname }}
                 </span>
               } @else {


### PR DESCRIPTION
**Changes:**

Adds tooltip to hostname item in sys-info card

**Testing:**

See that tooltip exists



Original PR: https://github.com/truenas/webui/pull/11731
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134719