### PR TITLE
NAS-134844 / 25.04.0 / Discover Search, with Category filter returns broken App icons (by AlexKarpov98)

### DIFF
--- a/src/app/constants/catalog.constants.ts
+++ b/src/app/constants/catalog.constants.ts
@@ -1,4 +1,4 @@
 export const customApp = 'ix-app';
 export const customAppTrain = 'stable';
-export const appImagePlaceholder = 'assets/images/truenas_scale_ondark_favicon.png';
+export const appImagePlaceholder = 'assets/images/truenas_favicon.png';
 export const latestVersion = 'latest';

--- a/src/app/constants/catalog.constants.ts
+++ b/src/app/constants/catalog.constants.ts
@@ -1,4 +1,4 @@
 export const customApp = 'ix-app';
 export const customAppTrain = 'stable';
-export const appImagePlaceholder = 'assets/images/truenas_favicon.png';
+export const appImagePlaceholder = 'assets/images/truenas_ondark_favicon.png';
 export const latestVersion = 'latest';

--- a/src/app/pages/apps/components/app-card-logo/app-card-logo.component.html
+++ b/src/app/pages/apps/components/app-card-logo/app-card-logo.component.html
@@ -7,7 +7,6 @@
     [offset]="800"
     [lazyLoad]="url()"
     [defaultImage]="appImagePlaceholder"
-    [customObservable]="scroll$"
     (onStateChange)="onLogoLoaded($event)"
   >
 </div>

--- a/src/app/pages/apps/components/app-card-logo/app-card-logo.component.spec.ts
+++ b/src/app/pages/apps/components/app-card-logo/app-card-logo.component.spec.ts
@@ -16,6 +16,17 @@ describe('AppCardLogoComponent', () => {
     ],
   });
 
+  beforeAll(() => {
+    global.IntersectionObserver = class IntersectionObserver {
+      observe(): void { jest.fn(); }
+      unobserve(): void { jest.fn(); }
+      disconnect(): void { jest.fn(); }
+    } as unknown as {
+      new (callback: IntersectionObserverCallback, options?: IntersectionObserverInit): IntersectionObserver;
+      prototype: IntersectionObserver;
+    };
+  });
+
   beforeEach(() => {
     spectator = createComponent({
       props: {
@@ -25,7 +36,7 @@ describe('AppCardLogoComponent', () => {
   });
 
   it('shows default image', () => {
-    expect(spectator.query('img')).toHaveAttribute('src', 'assets/images/truenas_scale_ondark_favicon.png');
+    expect(spectator.query('img')).toHaveAttribute('src', 'assets/images/truenas_favicon.png');
   });
 
   it('shows app logo', () => {

--- a/src/app/pages/apps/components/app-card-logo/app-card-logo.component.ts
+++ b/src/app/pages/apps/components/app-card-logo/app-card-logo.component.ts
@@ -2,15 +2,8 @@ import {
   ChangeDetectionStrategy, Component, inject, input,
   signal,
 } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import {
-  LAZYLOAD_IMAGE_HOOKS, LazyLoadImageModule, ScrollHooks, StateChange,
-} from 'ng-lazyload-image';
-import {
-  fromEvent, merge, Observable, Subject,
-  timer,
-} from 'rxjs';
+import { UntilDestroy } from '@ngneat/until-destroy';
+import { LazyLoadImageModule, StateChange } from 'ng-lazyload-image';
 import { appImagePlaceholder } from 'app/constants/catalog.constants';
 import { LayoutService } from 'app/modules/layout/layout.service';
 
@@ -22,7 +15,6 @@ import { LayoutService } from 'app/modules/layout/layout.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [LazyLoadImageModule],
-  providers: [{ provide: LAZYLOAD_IMAGE_HOOKS, useClass: ScrollHooks }],
 })
 export class AppCardLogoComponent {
   url = input.required<string>();
@@ -32,26 +24,6 @@ export class AppCardLogoComponent {
 
   protected readonly scrollTarget = this.layoutService.getContentContainer();
   protected readonly appImagePlaceholder = appImagePlaceholder;
-
-  protected readonly initialEmitter$ = new Subject<void>();
-  protected readonly scroll$: Observable<Event | number | void>;
-
-  constructor() {
-    if (this.scrollTarget) {
-      this.scroll$ = merge(
-        fromEvent(this.scrollTarget, 'scroll'),
-        this.initialEmitter$,
-        timer(0),
-      );
-    }
-    toObservable(this.url).pipe(
-      untilDestroyed(this),
-    ).subscribe({
-      next: () => {
-        this.initialEmitter$.next();
-      },
-    });
-  }
 
   protected onLogoLoaded(event: StateChange): void {
     if (event.reason !== 'loading-succeeded') {


### PR DESCRIPTION
Testing: see ticket.

Now we are using the base working-good functionality from `ng-lazyload-image` instead of custom observable.
See that images are loading lazily on scroll, as we expect it to be.

Additional Fix: 
- preloader image is now showing up instead of broken image (incorrect path to un-existing image)

Result:

https://github.com/user-attachments/assets/557e14b4-ceff-4d88-8126-e58dd70026ee



Original PR: https://github.com/truenas/webui/pull/11756
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134844