### PR TITLE
NAS-134755 / 25.04.1 / Incorrect snackbar colors on blue theme (by AlexKarpov98)

### DIFF
--- a/src/assets/styles/other/_material-overrides.scss
+++ b/src/assets/styles/other/_material-overrides.scss
@@ -66,7 +66,7 @@ html .ix-dark {
   --mdc-chip-label-text-color: #000000de;
   --mdc-chip-container-height: 23px;
   --mdc-snackbar-container-color: var(--bg1);
-  --mdc-snackbar-supporting-text-color: var(--primary-txt);
+  --mdc-snackbar-supporting-text-color: var(--fg1);
   --mdc-snackbar-supporting-text-font: var(--mdc-dialog-supporting-text-font);
   --mdc-snackbar-supporting-text-size: 1rem;
   --mat-option-selected-state-layer-color: var(--bg2);


### PR DESCRIPTION
Testing: see ticket.

Result:
<img width="445" alt="Screenshot 2025-03-17 at 17 35 54" src="https://github.com/user-attachments/assets/f5b95bb9-87dd-4d0b-912f-29cb8f97aff1" />


Original PR: https://github.com/truenas/webui/pull/11739
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134755