### PR TITLE
NAS-134752 / 25.04.1 / UI should lock ability to add disks to running VMs (by AlexKarpov98)

### DIFF
--- a/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disks.component.html
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disks.component.html
@@ -7,8 +7,13 @@
     <button
       mat-button
       ixTest="add-disk"
+      [matTooltip]="disksDisabledMessage"
+      [matTooltipDisabled]="!isVmRunning() || isContainer()"
+      [disabled]="isVmRunning()"
       (click)="addDisk()"
-    >{{ 'Add' | translate }}</button>
+    >
+      {{ 'Add' | translate }}
+    </button>
   </mat-card-header>
 
   <mat-card-content>
@@ -22,13 +27,22 @@
             ({{ instance().root_disk_io_bus | mapValue: diskIoBusLabels}})
           }
         </span>
-        <a
+
+        <span
           class="action"
-          ixTest="change-disk-setup"
-          (click)="showRootDiskIncreaseDialog()"
+          [matTooltip]="disksDisabledMessage"
+          [matTooltipDisabled]="!isVmRunning() || isContainer()"
         >
-          {{ 'Change' | translate }}
-        </a>
+          <a
+            ixTest="change-disk-setup"
+            [class.disabled]="isVmRunning()"
+            [attr.tabindex]="isVmRunning() ? -1 : 0"
+            (keydown.enter)="showRootDiskIncreaseDialog()"
+            (click)="showRootDiskIncreaseDialog()"
+          >
+            {{ 'Change' | translate }}
+          </a>
+        </span>
       </div>
     }
 
@@ -49,10 +63,17 @@
             </div>
           }
 
-          <ix-device-actions-menu
-            [device]="disk"
-            (edit)="editDisk(disk)"
-          ></ix-device-actions-menu>
+          <div
+            [matTooltip]="disksDisabledMessage"
+            [matTooltipDisabled]="!isVmRunning() || isContainer()"
+          >
+            <ix-device-actions-menu
+              [isDisabled]="isVmRunning()"
+              [device]="disk"
+              (edit)="editDisk(disk)"
+            ></ix-device-actions-menu>
+          </div>
+
         </div>
       } @empty {
         @if (!instance().root_disk_size) {

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disks.component.scss
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disks.component.scss
@@ -10,9 +10,18 @@
 
   .action {
     color: var(--primary);
-    cursor: pointer;
     margin-left: auto;
     text-decoration: underline;
+
+    a {
+      cursor: pointer;
+
+      &.disabled {
+        cursor: not-allowed;
+        opacity: var(--disabled-opacity);
+        pointer-events: none;
+      }
+    }
   }
 }
 

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disks.component.spec.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disks.component.spec.ts
@@ -6,7 +6,7 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { GiB } from 'app/constants/bytes.constant';
-import { VirtualizationDeviceType, VirtualizationType } from 'app/enums/virtualization.enum';
+import { VirtualizationDeviceType, VirtualizationStatus, VirtualizationType } from 'app/enums/virtualization.enum';
 import { VirtualizationDisk, VirtualizationInstance, VirtualizationProxy } from 'app/interfaces/virtualization.interface';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import {
@@ -151,7 +151,7 @@ describe('InstanceDisksComponent', () => {
     });
 
     it('opens dialog to increase root disk size when Increase link is pressed', () => {
-      const link = spectator.query('.root-disk-size .action')!;
+      const link = spectator.query('.root-disk-size .action a')!;
       expect(link).toHaveText('Change');
 
       spectator.click(link);
@@ -160,6 +160,22 @@ describe('InstanceDisksComponent', () => {
         data: vm,
       });
       expect(spectator.inject(VirtualizationInstancesStore).instanceUpdated).toHaveBeenCalled();
+    });
+
+    it('disables Add button & hides devices actions buttons when VM is running', async () => {
+      const runningInstance = {
+        id: 'my-instance',
+        type: VirtualizationType.Vm,
+        status: VirtualizationStatus.Running,
+      } as VirtualizationInstance;
+
+      spectator.setInput('instance', runningInstance);
+
+      const addButton = await loader.getHarness(MatButtonHarness.with({ text: 'Add' }));
+      expect(await addButton.isDisabled()).toBe(true);
+
+      const actionsMenu = spectator.query(DeviceActionsMenuComponent)!;
+      expect(actionsMenu.isDisabled).toBe(true);
     });
   });
 });

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disks.component.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disks.component.ts
@@ -6,12 +6,15 @@ import {
   MatCard, MatCardContent, MatCardHeader, MatCardTitle,
 } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
+import { MatTooltip } from '@angular/material/tooltip';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { filter } from 'rxjs/operators';
 import { GiB } from 'app/constants/bytes.constant';
-import { diskIoBusLabels, VirtualizationDeviceType, VirtualizationType } from 'app/enums/virtualization.enum';
+import {
+  diskIoBusLabels, VirtualizationDeviceType, VirtualizationStatus, VirtualizationType,
+} from 'app/enums/virtualization.enum';
 import { VirtualizationDisk, VirtualizationInstance } from 'app/interfaces/virtualization.interface';
 import { FileSizePipe } from 'app/modules/pipes/file-size/file-size.pipe';
 import { MapValuePipe } from 'app/modules/pipes/map-value/map-value.pipe';
@@ -45,6 +48,7 @@ import { VirtualizationInstancesStore } from 'app/pages/instances/stores/virtual
     TranslateModule,
     DeviceActionsMenuComponent,
     FileSizePipe,
+    MatTooltip,
     MapValuePipe,
   ],
 })
@@ -54,11 +58,21 @@ export class InstanceDisksComponent {
   protected readonly isLoadingDevices = this.deviceStore.isLoading;
   protected readonly diskIoBusLabels = diskIoBusLabels;
 
+  protected readonly disksDisabledMessage = this.translate.instant(
+    'VM disks cannot be managed while the instance is running.',
+  );
+
+  protected readonly isVmRunning = computed(() => {
+    return this.instance().status === VirtualizationStatus.Running && this.instance().type === VirtualizationType.Vm;
+  });
+
   protected readonly isVm = computed(() => this.instance().type === VirtualizationType.Vm);
+  protected readonly isContainer = computed(() => this.instance().type === VirtualizationType.Container);
 
   constructor(
     private slideIn: SlideIn,
     private matDialog: MatDialog,
+    private translate: TranslateService,
     private deviceStore: VirtualizationDevicesStore,
     private instanceStore: VirtualizationInstancesStore,
   ) {}

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-general-info/instance-general-info.component.spec.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-general-info/instance-general-info.component.spec.ts
@@ -158,7 +158,7 @@ describe('InstanceGeneralInfoComponent', () => {
     );
     expect(spectator.inject(VirtualizationInstancesStore).instanceUpdated)
       .toHaveBeenCalledWith({ id: 'updated_instance' });
-    expect(spectator.inject(VirtualizationDevicesStore).selectInstance)
+    expect(spectator.inject(VirtualizationDevicesStore).selectInstanceById)
       .toHaveBeenCalledWith('updated_instance');
   });
 });

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-general-info/instance-general-info.component.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-general-info/instance-general-info.component.ts
@@ -77,7 +77,7 @@ export class InstanceGeneralInfoComponent {
       .pipe(map((response) => response.response), filter(Boolean), untilDestroyed(this))
       .subscribe((instance: VirtualizationInstance) => {
         this.instancesStore.instanceUpdated(instance);
-        this.deviceStore.selectInstance(instance.id);
+        this.deviceStore.selectInstanceById(instance.id);
       });
   }
 

--- a/src/app/pages/instances/components/all-instances/instance-list/instance-list.component.spec.ts
+++ b/src/app/pages/instances/components/all-instances/instance-list/instance-list.component.spec.ts
@@ -29,7 +29,7 @@ describe('InstanceListComponent', () => {
         isLoading: jest.fn(() => false),
       }),
       mockProvider(VirtualizationDevicesStore, {
-        selectInstance: jest.fn(),
+        selectInstanceById: jest.fn(),
         selectedInstance: jest.fn(() => null),
       }),
     ],

--- a/src/app/pages/instances/components/all-instances/instance-list/instance-list.component.ts
+++ b/src/app/pages/instances/components/all-instances/instance-list/instance-list.component.ts
@@ -109,15 +109,11 @@ export class InstanceListComponent {
   ) {
     effect(() => {
       const instanceId = this.instanceId();
-      const selectedInstance = this.selectedInstance();
-      if (instanceId && selectedInstance?.id !== instanceId) {
-        this.deviceStore.selectInstance(instanceId);
-      }
-
       const instances = this.instances();
+
       if (instances?.length > 0) {
         if (instanceId) {
-          this.deviceStore.selectInstance(instanceId);
+          this.deviceStore.selectInstanceById(instanceId);
         } else {
           this.navigateToDetails(instances[0]);
         }
@@ -127,7 +123,7 @@ export class InstanceListComponent {
         });
       }
 
-      if (!this.isLoading() && instances?.length > 0 && instanceId && selectedInstance === null) {
+      if (!this.isLoading() && instances?.length > 0 && instanceId && this.selectedInstance() === null) {
         this.router.navigate(['/instances']);
       }
     });
@@ -146,7 +142,7 @@ export class InstanceListComponent {
   }
 
   navigateToDetails(instance: VirtualizationInstance): void {
-    this.deviceStore.selectInstance(instance.id);
+    this.deviceStore.selectInstanceById(instance.id);
     this.router.navigate(['/instances', 'view', instance.id]);
 
     if (this.isMobileView()) {

--- a/src/app/pages/instances/components/all-instances/instance-list/instance-row/instance-row.component.spec.ts
+++ b/src/app/pages/instances/components/all-instances/instance-list/instance-row/instance-row.component.spec.ts
@@ -19,6 +19,7 @@ import {
   StopOptionsDialogComponent,
   StopOptionsOperation,
 } from 'app/pages/instances/components/all-instances/instance-list/stop-options-dialog/stop-options-dialog.component';
+import { VirtualizationDevicesStore } from 'app/pages/instances/stores/virtualization-devices.store';
 
 const instance = {
   id: 'my-instance',
@@ -53,6 +54,10 @@ describe('InstanceRowComponent', () => {
             timeout: -1,
           }),
         })),
+      }),
+      mockProvider(VirtualizationDevicesStore, {
+        selectedInstance: () => instance,
+        setSelectedInstance: jest.fn(),
       }),
       mockProvider(DialogService, {
         jobDialog: jest.fn(() => ({

--- a/src/app/pages/instances/components/all-instances/instance-list/instance-row/instance-row.component.ts
+++ b/src/app/pages/instances/components/all-instances/instance-list/instance-row/instance-row.component.ts
@@ -24,6 +24,7 @@ import { InstanceStatusCellComponent } from 'app/pages/instances/components/all-
 import {
   StopOptionsDialogComponent, StopOptionsOperation,
 } from 'app/pages/instances/components/all-instances/instance-list/stop-options-dialog/stop-options-dialog.component';
+import { VirtualizationDevicesStore } from 'app/pages/instances/stores/virtualization-devices.store';
 import { ErrorHandlerService } from 'app/services/error-handler.service';
 
 @UntilDestroy()
@@ -62,6 +63,7 @@ export class InstanceRowComponent {
     private errorHandler: ErrorHandlerService,
     private matDialog: MatDialog,
     private snackbar: SnackbarService,
+    private deviceStore: VirtualizationDevicesStore,
   ) {}
 
   start(): void {
@@ -75,6 +77,7 @@ export class InstanceRowComponent {
       .pipe(this.errorHandler.catchError(), untilDestroyed(this))
       .subscribe(() => {
         this.snackbar.success(this.translate.instant('Instance started'));
+        this.deviceStore.setSelectedInstance(this.instance());
       });
   }
 
@@ -98,6 +101,7 @@ export class InstanceRowComponent {
       )
       .subscribe(() => {
         this.snackbar.success(this.translate.instant('Instance stopped'));
+        this.deviceStore.setSelectedInstance(this.instance());
       });
   }
 
@@ -121,6 +125,7 @@ export class InstanceRowComponent {
       )
       .subscribe(() => {
         this.snackbar.success(this.translate.instant('Instance restarted'));
+        this.deviceStore.setSelectedInstance(this.instance());
       });
   }
 }

--- a/src/app/pages/instances/components/common/device-actions-menu/device-actions-menu.component.html
+++ b/src/app/pages/instances/components/common/device-actions-menu/device-actions-menu.component.html
@@ -1,13 +1,12 @@
-<div
-  [matTooltip]="canManage() ? '' : manageRestrictedExplanation()"
-  [class.disabled]="!canManage()"
->
+<div [matTooltip]="canManage() ? '' : manageRestrictedExplanation()">
   <button
     mat-icon-button
     type="button"
     [ixTest]="['actions-for', device().description]"
     [matMenuTriggerFor]="menu"
     [disabled]="!canManage()"
+    [class.disabled]="!canManage()"
+    [attr.tabindex]="!canManage() ? -1 : 0"
     [attr.aria-label]="'Actions for {device}' | translate: { device: device().description }"
   >
     <ix-icon name="more_vert"></ix-icon>

--- a/src/app/pages/instances/components/common/device-actions-menu/device-actions-menu.component.scss
+++ b/src/app/pages/instances/components/common/device-actions-menu/device-actions-menu.component.scss
@@ -1,5 +1,7 @@
 .disabled {
+  color: var(--fg2);
   cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .delete-button {

--- a/src/app/pages/instances/components/common/device-actions-menu/device-actions-menu.component.ts
+++ b/src/app/pages/instances/components/common/device-actions-menu/device-actions-menu.component.ts
@@ -42,11 +42,12 @@ import { ErrorHandlerService } from 'app/services/error-handler.service';
 export class DeviceActionsMenuComponent {
   readonly device = input.required<VirtualizationDevice>();
   readonly showEdit = input(true);
+  readonly isDisabled = input(false);
 
   readonly edit = output();
 
   protected readonly canManage = computed(() => {
-    return !this.manageRestrictedExplanation();
+    return !this.manageRestrictedExplanation() && !this.isDisabled();
   });
 
   protected readonly manageRestrictedExplanation = computed(() => {

--- a/src/app/pages/instances/stores/virtualization-devices.store.spec.ts
+++ b/src/app/pages/instances/stores/virtualization-devices.store.spec.ts
@@ -43,7 +43,7 @@ describe('VirtualizationDevicesStore', () => {
   });
 
   it('should load devices when loadDevices is called', () => {
-    spectator.service.selectInstance('instance1');
+    spectator.service.selectInstanceById('instance1');
     spectator.service.loadDevices();
 
     expect(spectator.inject(ApiService).call).toHaveBeenCalled();
@@ -54,10 +54,10 @@ describe('VirtualizationDevicesStore', () => {
     });
   });
 
-  it('selectInstance - selects an instance and loads its devices', () => {
+  it('selectInstanceById - selects an instance and loads its devices', () => {
     jest.spyOn(spectator.service, 'loadDevices');
 
-    spectator.service.selectInstance('instance1');
+    spectator.service.selectInstanceById('instance1');
     spectator.service.loadDevices();
 
     expect(spectator.service.selectedInstance()!.id).toEqual(instances[0].id);
@@ -65,7 +65,7 @@ describe('VirtualizationDevicesStore', () => {
   });
 
   it('loadDevices – loads a list of devices for the selected instance', () => {
-    spectator.service.selectInstance('instance2');
+    spectator.service.selectInstanceById('instance2');
     spectator.service.loadDevices();
 
     expect(spectator.service.devices()).toBe(devices);
@@ -74,7 +74,7 @@ describe('VirtualizationDevicesStore', () => {
   });
 
   it('deviceDeleted – removes a device from list of devices for selected instance', () => {
-    spectator.service.selectInstance('instance1');
+    spectator.service.selectInstanceById('instance1');
     spectator.service.deviceDeleted('device1');
 
     expect(spectator.service.devices()).toEqual([devices[1]]);

--- a/src/app/pages/instances/stores/virtualization-devices.store.ts
+++ b/src/app/pages/instances/stores/virtualization-devices.store.ts
@@ -59,7 +59,7 @@ export class VirtualizationDevicesStore extends ComponentStore<VirtualizationIns
     );
   });
 
-  selectInstance(instanceId: string): void {
+  selectInstanceById(instanceId: string): void {
     const selectedInstance = this.instances()?.find((instance) => instance.id === instanceId);
     if (!selectedInstance?.id) {
       this.resetInstance();
@@ -72,6 +72,10 @@ export class VirtualizationDevicesStore extends ComponentStore<VirtualizationIns
 
     this.patchState({ selectedInstance });
     this.loadDevices();
+  }
+
+  setSelectedInstance(instance: VirtualizationInstance): void {
+    this.patchState({ selectedInstance: instance });
   }
 
   resetInstance(): void {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -4315,6 +4315,7 @@
   "VDEVs have been created through manual disk selection. To view or  edit your selections, press the \"Edit Manual Disk Selection\" button below. To start again with the  automated disk selection, hit the \"Reset\" button.": "",
   "VM Image Options": "",
   "VM Settings": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMs": "",
   "VMware Sync": "",
   "VMware: Extent block size 512b, TPC enabled, no Xen compat mode, SSD speed": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3838,6 +3838,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -256,6 +256,7 @@
   "User who controls the dataset. This user always has permissions to read or write the ACL and read or write attributes. Users created manually or imported from a directory service appear in the drop-down menu.": "",
   "Username associated with this API key.": "",
   "VDEV is highly discouraged and will result in data loss if it fails": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "Volume size cannot be zero.": "",
   "WARNING: Adding data VDEVs with different numbers of disks is not recommended.": "",
   "Wait to stop cleanly": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -4579,6 +4579,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1077,6 +1077,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -782,6 +782,7 @@
   "VDEV is highly discouraged and will result in data loss if it fails": "",
   "VM Image Options": "",
   "VM Settings": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMs": "",
   "VMware: Extent block size 512b, TPC enabled, no Xen compat mode, SSD speed": "",
   "VNC": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -224,6 +224,7 @@
   "User who controls the dataset. This user always has permissions to read or write the ACL and read or write attributes. Users created manually or imported from a directory service appear in the drop-down menu.": "",
   "Username associated with this API key.": "",
   "VDEV is highly discouraged and will result in data loss if it fails": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "Volume size cannot be zero.": "",
   "WARNING: Adding data VDEVs with different numbers of disks is not recommended.": "",
   "Wait to stop cleanly": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -4565,6 +4565,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -224,6 +224,7 @@
   "User who controls the dataset. This user always has permissions to read or write the ACL and read or write attributes. Users created manually or imported from a directory service appear in the drop-down menu.": "",
   "Username associated with this API key.": "",
   "VDEV is highly discouraged and will result in data loss if it fails": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "Volume size cannot be zero.": "",
   "WARNING: Adding data VDEVs with different numbers of disks is not recommended.": "",
   "Wait to stop cleanly": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -4991,6 +4991,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -359,6 +359,7 @@
   "Username associated with this API key.": "",
   "VDEV is highly discouraged and will result in data loss if it fails": "",
   "VM Settings": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMs": "",
   "VNC Password": "",
   "VNC password is not cryptographically secure. You should not rely on it as a single authentication mechanism for your VMs.": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -269,6 +269,7 @@
   "User who controls the dataset. This user always has permissions to read or write the ACL and read or write attributes. Users created manually or imported from a directory service appear in the drop-down menu.": "",
   "Username associated with this API key.": "",
   "VDEV is highly discouraged and will result in data loss if it fails": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "Volume size cannot be zero.": "",
   "WARNING: Adding data VDEVs with different numbers of disks is not recommended.": "",
   "Wait to stop cleanly": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -4947,6 +4947,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -3393,6 +3393,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -3522,6 +3522,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -2378,6 +2378,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -5000,6 +5000,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -446,6 +446,7 @@
   "VDEV is highly discouraged and will result in data loss if it fails": "",
   "VM Image Options": "",
   "VM Settings": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMs": "",
   "VNC": "",
   "VNC Password": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -3565,6 +3565,7 @@
   "VM Read": "",
   "VM Settings": "",
   "VM Write": "",
+  "VM disks cannot be managed while the instance is running.": "",
   "VMWare Sync": "",
   "VMs": "",
   "VMware Snapshot": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b500aaae97c142161fdd4fab8518e86cc6c91b1d
    git cherry-pick -x b746a55c0ba27802b62e0765f9f277ecb8396f6e
    git cherry-pick -x d34082e5e98cfb9d3140e901e94c795c826c02a9
    git cherry-pick -x c6c0df2e0236ac793d6b941006a967cdd881ddd8
    git cherry-pick -x 0ba5d25245841d54e0df791666112d917f11905f
    git cherry-pick -x a01202128c8d0d7db208fab7ee7a89b307fc43e0
    git cherry-pick -x 147c8072e61016277dc07929a26ab2a20b734419
    git cherry-pick -x 71e926bbe4b7cdaa70c03799c0ae5f44cc58fc25

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 9ffe98542af96ccc8e0e0e19a244b99b6b476d88

Testing: see ticket.

Result:

https://github.com/user-attachments/assets/57870882-d02e-4d67-aa1c-28ce6d31045e





Original PR: https://github.com/truenas/webui/pull/11755
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134752