### PR TITLE
NAS-134363: Empty "reboot required" screen stays after system upgrade

### DIFF
--- a/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.html
+++ b/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.html
@@ -40,7 +40,7 @@
   }
 </div>
 
-@if(thisNodeRebootReasons()?.length || otherNodeRebootReasons()?.length) {
+@if (thisNodeRebootReasons()?.length || otherNodeRebootReasons()?.length) {
   <ix-form-actions mat-dialog-actions class="form-actions">
     <ix-checkbox
       class="confirm"
@@ -65,7 +65,7 @@
       </button>
     }
 
-    @if(otherNodeRebootReasons()?.length) {
+    @if (otherNodeRebootReasons()?.length) {
       <button
         mat-button
         color="primary"

--- a/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.spec.ts
+++ b/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.spec.ts
@@ -1,8 +1,15 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
+import { of } from 'rxjs';
 import { FailoverDisabledReason } from 'app/enums/failover-disabled-reason.enum';
 import { SystemRebootInfo } from 'app/interfaces/reboot-info.interface';
 import { RebootRequiredDialog } from 'app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component';
+import { IxCheckboxHarness } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.harness';
+import { RebootService } from 'app/services/reboot.service';
 import { selectCanFailover, selectHaStatus, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
   selectOtherNodeRebootInfo,
@@ -27,6 +34,7 @@ const fakeOtherNodeRebootInfo: SystemRebootInfo = {
 
 describe('RebootRequiredDialogComponent', () => {
   let spectator: Spectator<RebootRequiredDialog>;
+  let loader: HarnessLoader;
 
   const createComponent = createComponentFactory({
     component: RebootRequiredDialog,
@@ -46,11 +54,16 @@ describe('RebootRequiredDialogComponent', () => {
           { selector: selectHaStatus, value: { reasons: [FailoverDisabledReason.MismatchNics] } },
         ],
       }),
+      mockProvider(RebootService, {
+        restartRemote: jest.fn(() => of(undefined)),
+      }),
+      mockProvider(MatDialogRef),
     ],
   });
 
   beforeEach(() => {
     spectator = createComponent();
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   });
 
   it('shows failover warning when failover is unhealthy', () => {
@@ -62,7 +75,7 @@ describe('RebootRequiredDialogComponent', () => {
       .toContain('Network interfaces do not match between storage controllers.');
   });
 
-  it('shows reasons', () => {
+  it('shows reasons why reboot is required', () => {
     expect(
       spectator.queryAll('.reasons li').map((item) => item.textContent!.trim()),
     ).toEqual([
@@ -71,5 +84,16 @@ describe('RebootRequiredDialogComponent', () => {
       'Test Reason 3',
       'Test Reason 4',
     ]);
+  });
+
+  it('reboots another node and closes dialog when Reboot Remote is pressed', async () => {
+    const confirmCheckbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Confirm' }));
+    await confirmCheckbox.setValue(true);
+
+    const rebootRemoteButton = await loader.getHarness(MatButtonHarness.with({ text: 'Reboot Remote' }));
+    await rebootRemoteButton.click();
+
+    expect(spectator.inject(RebootService).restartRemote).toHaveBeenCalled();
+    expect(spectator.inject(MatDialogRef).close).toHaveBeenCalled();
   });
 });

--- a/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.ts
+++ b/src/app/modules/dialog/components/reboot-required-dialog/reboot-required-dialog.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
-import { MatDialogModule } from '@angular/material/dialog';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
@@ -12,7 +12,7 @@ import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { MapValuePipe } from 'app/modules/pipes/map-value/map-value.pipe';
 import { TestDirective } from 'app/modules/test-id/test.directive';
-import { FipsService } from 'app/services/fips.service';
+import { RebootService } from 'app/services/reboot.service';
 import { AppState } from 'app/store';
 import { selectCanFailover, selectHaStatus, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import { selectOtherNodeRebootInfo, selectThisNodeRebootInfo } from 'app/store/reboot-info/reboot-info.selectors';
@@ -57,15 +57,18 @@ export class RebootRequiredDialog {
 
   constructor(
     private store$: Store<AppState>,
-    private fips: FipsService,
+    private reboot: RebootService,
     private fb: NonNullableFormBuilder,
+    private dialogRef: MatDialogRef<RebootRequiredDialog>,
   ) {}
 
   rebootLocalNode(): void {
-    this.fips.restart();
+    this.reboot.restart();
   }
 
   rebootRemoteNode(): void {
-    this.fips.restartRemote().pipe(untilDestroyed(this)).subscribe();
+    this.reboot.restartRemote().pipe(untilDestroyed(this)).subscribe(() => {
+      this.dialogRef.close();
+    });
   }
 }

--- a/src/app/services/reboot.service.spec.ts
+++ b/src/app/services/reboot.service.spec.ts
@@ -10,12 +10,12 @@ import { mockJob, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { AuthService } from 'app/modules/auth/auth.service';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { ApiService } from 'app/modules/websocket/api.service';
-import { FipsService } from 'app/services/fips.service';
+import { RebootService } from 'app/services/reboot.service';
 
-describe('FipsService', () => {
-  let spectator: SpectatorService<FipsService>;
+describe('RebootService', () => {
+  let spectator: SpectatorService<RebootService>;
   const createService = createServiceFactory({
-    service: FipsService,
+    service: RebootService,
     providers: [
       mockProvider(DialogService, {
         confirm: jest.fn(() => of(true)),

--- a/src/app/services/reboot.service.ts
+++ b/src/app/services/reboot.service.ts
@@ -14,7 +14,7 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 @Injectable({
   providedIn: 'root',
 })
-export class FipsService {
+export class RebootService {
   /**
    * Multiple dialogs may happen because of multiple events from failover.disabled.reasons.
    */
@@ -105,7 +105,7 @@ export class FipsService {
       .pipe(
         this.errorHandler.withErrorHandler(),
         tap(() => {
-          this.snackbar.success(this.translate.instant('System Security Settings Updated.'));
+          this.snackbar.success(this.translate.instant('Remote Node Restarted'));
         }),
       );
   }

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -2807,6 +2807,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -2601,6 +2601,7 @@
   "Remote Controller": "",
   "Remote Host Key": "",
   "Remote machine": "",
+  "Remote Node Restarted": "",
   "Remove {label} item": "",
   "Remove {value} from recent searches": "",
   "Remove device": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -45,6 +45,7 @@
   "Privilege Read": "",
   "Privilege Write": "",
   "Pull": "",
+  "Remote Node Restarted": "",
   "Renames the ZFS dataset to a path in the `ix-virt` dataset in which the zvol is located.": "",
   "Replication Task Write Pull": "",
   "Search Logs": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -3135,6 +3135,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -691,6 +691,7 @@
   "Readonly Admin": "",
   "Rear": "",
   "Release": "",
+  "Remote Node Restarted": "",
   "Renames the ZFS dataset to a path in the `ix-virt` dataset in which the zvol is located.": "",
   "Replication Admin": "",
   "Replication Settings": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -491,6 +491,7 @@
   "Registration finalization timed out": "",
   "Regularly scheduled system checks and updates.": "",
   "Release": "",
+  "Remote Node Restarted": "",
   "Remove extent association": "",
   "Remove Images": "",
   "Remove iXVolumes": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -34,6 +34,7 @@
   "No TrueNAS Access": "",
   "No Two-Factor Authentication": "",
   "Preserve Power Management settings": "",
+  "Remote Node Restarted": "",
   "Renames the ZFS dataset to a path in the `ix-virt` dataset in which the zvol is located.": "",
   "Search Logs": "",
   "Select Volume": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -3130,6 +3130,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1,5 +1,6 @@
 {
   "": "",
+  "Remote Node Restarted": "",
   "\n              It looks like your session has been inactive for more than {lifetime} seconds.<br>\n              For security reasons we will log you out at {time}.\n            ": "세션의 비활성화 시간이 {lifetime}초를 넘었습니다.<br />보안을 위해 {time}에 로그아웃 되었습니다.",
   " as of {dateTime}": " ({dateTime} 기준)",
   " bytes.": " 바이트입니다.",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -3429,6 +3429,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -144,6 +144,7 @@
   "Preserve Power Management settings": "",
   "Privilege Read": "",
   "Privilege Write": "",
+  "Remote Node Restarted": "",
   "Renames the ZFS dataset to a path in the `ix-virt` dataset in which the zvol is located.": "",
   "Root Disk": "",
   "Root Disk I/O Bus": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -81,6 +81,7 @@
   "Open a port for SSH connection requests.": "",
   "Passwords cannot contain a <b>?</b>.": "",
   "Preserve Power Management settings": "",
+  "Remote Node Restarted": "",
   "Renames the ZFS dataset to a path in the `ix-virt` dataset in which the zvol is located.": "",
   "Root Disk I/O Bus": "",
   "Same": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -3382,6 +3382,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -2180,6 +2180,7 @@
   "Release Notes": "",
   "Remote Controller": "",
   "Remote Host Key": "",
+  "Remote Node Restarted": "",
   "Remote syslog server DNS hostname or IP address. Nonstandard port numbers can be used by adding a colon and the port number to the hostname, like <samp>mysyslogserver:1928</samp>. Log entries are written to local logs and sent to the remote syslog server.": "",
   "Remote system SSH key for this system to  authenticate the connection. When all other fields are properly  configured, click <b>DISCOVER REMOTE HOST KEY</b> to query the remote  system and automatically populate this field.": "",
   "Remove {label} item": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -2377,6 +2377,7 @@
   "Remote Controller": "",
   "Remote Host Key": "",
   "Remote machine": "",
+  "Remote Node Restarted": "",
   "Remove {label} item": "",
   "Remove {value} from recent searches": "",
   "Remove device": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -1625,6 +1625,7 @@
   "Release Notes": "",
   "Remote Host Key": "",
   "Remote machine": "",
+  "Remote Node Restarted": "",
   "Remove {label} item": "",
   "Remove {value} from recent searches": "",
   "Remove extent association": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -3435,6 +3435,7 @@
   "Remote machine": "",
   "Remote Module Name": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote Path": "",
   "Remote Port": "",
   "Remote SSH Port": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -217,6 +217,7 @@
   "Registration finalization failed": "",
   "Registration finalization successful": "",
   "Registration finalization timed out": "",
+  "Remote Node Restarted": "",
   "Renames the ZFS dataset to a path in the `ix-virt` dataset in which the zvol is located.": "",
   "Restart is required after changing these settings.": "",
   "Root Disk": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -2315,6 +2315,7 @@
   "Remote Host Key": "",
   "Remote machine": "",
   "Remote Monitor": "",
+  "Remote Node Restarted": "",
   "Remote syslog server DNS hostname or IP address. Nonstandard port numbers can be used by adding a colon and the port number to the hostname, like <samp>mysyslogserver:1928</samp>. Log entries are written to local logs and sent to the remote syslog server.": "",
   "Remote system SSH key for this system to  authenticate the connection. When all other fields are properly  configured, click <b>DISCOVER REMOTE HOST KEY</b> to query the remote  system and automatically populate this field.": "",
   "Remove {label} item": "",


### PR DESCRIPTION
**Testing:**

1. Create an HA VM with 24.10.2.
2. Update one controller and failover, but do not continue with the update.
3. Connect UI to the machine now and finish the update.
