### PR TITLE
NAS-135044 / 25.04.1 / Too many quotas are reported in Dataset Space Management card (by undsoft)

### DIFF
--- a/src/app/helpers/storage.helper.spec.ts
+++ b/src/app/helpers/storage.helper.spec.ts
@@ -1,0 +1,45 @@
+import { VdevType } from 'app/enums/v-dev-type.enum';
+import { DatasetQuota } from 'app/interfaces/dataset-quota.interface';
+import { isQuotaSet, isTopologyLimitedToOneLayout } from './storage.helper';
+
+describe('Storage Helper', () => {
+  describe('isTopologyLimitedToOneLayout', () => {
+    it('returns true for Spare type', () => {
+      expect(isTopologyLimitedToOneLayout(VdevType.Spare)).toBe(true);
+    });
+
+    it('returns true for Cache type', () => {
+      expect(isTopologyLimitedToOneLayout(VdevType.Cache)).toBe(true);
+    });
+
+    it('returns false for other types', () => {
+      expect(isTopologyLimitedToOneLayout(VdevType.Dedup)).toBe(false);
+    });
+  });
+
+  describe('isQuotaSet', () => {
+    it('returns true when quota > 0', () => {
+      const quota = {
+        quota: 10,
+        obj_quota: 0,
+      } as DatasetQuota;
+      expect(isQuotaSet(quota)).toBe(true);
+    });
+
+    it('returns true when obj_quota > 0', () => {
+      const quota = {
+        quota: 0,
+        obj_quota: 10,
+      } as DatasetQuota;
+      expect(isQuotaSet(quota)).toBe(true);
+    });
+
+    it('returns false when both quota and obj_quota = 0', () => {
+      const quota = {
+        quota: 0,
+        obj_quota: 0,
+      } as DatasetQuota;
+      expect(isQuotaSet(quota)).toBe(false);
+    });
+  });
+});

--- a/src/app/helpers/storage.helper.ts
+++ b/src/app/helpers/storage.helper.ts
@@ -1,7 +1,12 @@
 import { VdevType } from 'app/enums/v-dev-type.enum';
+import { DatasetQuota } from 'app/interfaces/dataset-quota.interface';
 
 export function isTopologyLimitedToOneLayout(type: VdevType): boolean {
   return type === VdevType.Spare || type === VdevType.Cache;
 }
 
 export const zvolPath = '/dev/zvol';
+
+export function isQuotaSet(quota: DatasetQuota): boolean {
+  return quota.quota > 0 || quota.obj_quota > 0;
+}

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.html
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.html
@@ -127,7 +127,11 @@
           @if (checkQuotas()) {
             @if (!isLoadingQuotas) {
               <div class="value">
-                {{ 'Quotas set for {n, plural, one {# user} other {# users} }' | translate: { n: userQuotas } }}
+                @if (userQuotas) {
+                  {{ 'Quotas set for {n, plural, one {# user} other {# users} }' | translate: { n: userQuotas } }}
+                } @else {
+                  {{ 'None' | translate }}
+                }
               </div>
             } @else {
               <ngx-skeleton-loader class="value-placeholder"></ngx-skeleton-loader>
@@ -150,7 +154,11 @@
         @if (checkQuotas()) {
           @if (!isLoadingQuotas) {
             <div class="value">
-              {{ 'Quotas set for {n, plural, one {# group} other {# groups} }' | translate: { n: groupQuotas } }}
+              @if (groupQuotas) {
+                {{ 'Quotas set for {n, plural, one {# group} other {# groups} }' | translate: { n: groupQuotas } }}
+              } @else {
+                {{ 'None' | translate }}
+              }
             </div>
           } @else {
             <ngx-skeleton-loader class="value-placeholder"></ngx-skeleton-loader>

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.spec.ts
@@ -72,8 +72,8 @@ describe('DatasetCapacityManagementCardComponent', () => {
       mockAuth(),
       mockApi([
         mockCall('pool.dataset.get_quota', [
-          { id: 1 },
-          { id: 2 },
+          { id: 1, quota: 200 },
+          { id: 2, quota: 200 },
         ] as DatasetQuota[]),
       ]),
       mockProvider(DialogService),

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.ts
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.ts
@@ -19,6 +19,7 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { DatasetType, DatasetQuotaType } from 'app/enums/dataset.enum';
 import { Role } from 'app/enums/role.enum';
+import { isQuotaSet } from 'app/helpers/storage.helper';
 import { DatasetDetails } from 'app/interfaces/dataset.interface';
 import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -128,8 +129,8 @@ export class DatasetCapacityManagementCardComponent implements OnChanges, OnInit
       untilDestroyed(this),
     ).subscribe({
       next: ([userQuotas, groupQuotas]) => {
-        this.userQuotas = userQuotas.length;
-        this.groupQuotas = groupQuotas.length;
+        this.userQuotas = userQuotas.filter(isQuotaSet).length;
+        this.groupQuotas = groupQuotas.filter(isQuotaSet).length;
         this.isLoadingQuotas = false;
         this.cdr.markForCheck();
       },

--- a/src/app/pages/datasets/components/dataset-quotas/dataset-quotas-list/dataset-quotas-list.component.ts
+++ b/src/app/pages/datasets/components/dataset-quotas/dataset-quotas-list/dataset-quotas-list.component.ts
@@ -18,6 +18,7 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { DatasetQuotaType } from 'app/enums/dataset.enum';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { Role } from 'app/enums/role.enum';
+import { isQuotaSet } from 'app/helpers/storage.helper';
 import { helpTextQuotas } from 'app/helptext/storage/volumes/datasets/dataset-quotas';
 import { DatasetQuota, SetDatasetQuota } from 'app/interfaces/dataset-quota.interface';
 import { ConfirmOptions } from 'app/interfaces/dialog.interface';
@@ -234,7 +235,7 @@ export class DatasetQuotasListComponent implements OnInit {
       .pipe(untilDestroyed(this)).subscribe({
         next: (quotas: DatasetQuota[]) => {
           this.isLoading = false;
-          this.quotas = quotas.filter((quota) => quota.quota > 0 || quota.obj_quota > 0);
+          this.quotas = quotas.filter(isQuotaSet);
 
           if (this.showAllQuotas) {
             this.quotas = quotas;


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 145e160afbd3d28ec65f20dc92d88223cd88d232
    git cherry-pick -x 290dc5610ffc375b843b601bb68d5f9f4bf2cc28
    git cherry-pick -x 6f99d514b9fa5b079e7eccc1577077605298fd0b
    git cherry-pick -x 77b58f20cfaec3367869bf11f3f2f5440c39aa60
    git cherry-pick -x c7738f7a1ef61462b3495cabed996b516edf184d

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 025a1ab7a22013dcbe5e387e65e5ede7c2211c8a

**Changes:**

Previously Dataset Space Management card would report too many quotas.

Original PR: https://github.com/truenas/webui/pull/11812
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135044