### PR TITLE
NAS-135011 / 25.04.1 / [BUG] email showing wrong SMTP server than what is configured. (by AlexKarpov98)

### DIFF
--- a/src/app/pages/system/general-settings/email/email-card/email-card.component.html
+++ b/src/app/pages/system/general-settings/email/email-card/email-card.component.html
@@ -34,7 +34,7 @@
             <span *ixWithLoadingState="emailConfig$ as emailConfig" class="value">
               {{ emailConfig.fromname }}
               {{
-                emailConfig.outgoingserver && emailConfig.fromemail
+                emailConfig.outgoingserver && emailConfig.fromemail && !emailConfig?.oauth?.client_id
                   ? ('{email} via {server}' | translate : { email: emailConfig.fromemail, server: emailConfig.outgoingserver })
                   : emailConfig.fromemail || '-'
               }}

--- a/src/app/pages/system/general-settings/email/email-card/email-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/email/email-card/email-card.component.spec.ts
@@ -92,7 +92,7 @@ describe('EmailCardComponent with Gmail OAuth', () => {
 
     expect(itemTexts).toEqual([
       'Send Mail Method: GMail OAuth',
-      'From: Test root@truenas.local via google.com',
+      'From: Test root@truenas.local',
     ]);
   });
 });
@@ -126,7 +126,7 @@ describe('EmailCardComponent with Outlook OAuth', () => {
 
     expect(itemTexts).toEqual([
       'Send Mail Method: Outlook OAuth',
-      'From: Test root@truenas.local via google.com',
+      'From: Test root@truenas.local',
     ]);
   });
 });


### PR DESCRIPTION
Testing: see ticket.

Result:
<img width="736" alt="NAS-135011-after" src="https://github.com/user-attachments/assets/3e5fbdef-b768-4f26-b083-0485d4250e35" />
Before:
<img width="737" alt="NAS-135011-before" src="https://github.com/user-attachments/assets/d80147f0-3186-4758-a715-ce952bbacbae" />


Original PR: https://github.com/truenas/webui/pull/11814
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135011