### PR TITLE
tenant_id should not required for Swift credentials

### DIFF
--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/openstack-swift-provider-form/openstack-swift-provider-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/provider-forms/openstack-swift-provider-form/openstack-swift-provider-form.component.ts
@@ -37,7 +37,7 @@ export class OpenstackSwiftProviderFormComponent extends BaseProviderFormCompone
     user_id: [''],
     domain: [''],
     tenant: [''],
-    tenant_id: ['', Validators.required],
+    tenant_id: [''],
     tenant_domain: [''],
     auth_token: [''],
     region: [''],


### PR DESCRIPTION
**Changes:**

Removed `tenant_id` as required for OpenStack Swift credentials. The [Rclone doc](https://rclone.org/swift/#swift-tenant) says that at least one of `tenant` (i.e. `tenant_name`) or `tenant_id` is required, but not necessarily `tenant_id`.

Related: https://forums.truenas.com/t/cannot-add-cloud-credentials-because-optional-key-is-required-in-ui/38163

