### PR TITLE
NAS-135110 / 25.04.1 / Audit Event Data widget should include the success value (by AlexKarpov98)

### DIFF
--- a/src/app/pages/audit/audit.component.scss
+++ b/src/app/pages/audit/audit.component.scss
@@ -44,7 +44,7 @@
       align-items: center;
       display: grid;
       grid-gap: 8px;
-      grid-template-columns: minmax(auto, 0.8fr) 1fr 1fr 0.8fr 1fr;
+      grid-template-columns: minmax(auto, 0.8fr) 1fr 1fr 0.8fr 1.2fr;
 
       @media (max-width: $breakpoint-sm) {
         grid-template-columns: 1fr 1fr 1fr 1fr 1.2fr;

--- a/src/app/pages/audit/components/audit-list/audit-list.component.html
+++ b/src/app/pages/audit/components/audit-list/audit-list.component.html
@@ -34,6 +34,22 @@
         <span>{{ audit.username }}</span>
       </div>
     </ng-template>
+
+    <ng-template
+      let-audit
+      ix-table-cell
+      [columnIndex]="4"
+      [dataProvider]="dataProvider()"
+    >
+      <div class="event-data" [matTooltip]="getEventDataForLog(audit) | translate">
+        @if (audit.success) {
+          <ix-icon name="mdi-check-circle"></ix-icon>
+        } @else {
+          <ix-icon class="error-color" name="mdi-close-circle"></ix-icon>
+        }
+        <span>{{ getEventDataForLog(audit) | translate }}</span>
+      </div>
+    </ng-template>
   </tbody>
 </ix-table>
 

--- a/src/app/pages/audit/components/audit-list/audit-list.component.scss
+++ b/src/app/pages/audit/components/audit-list/audit-list.component.scss
@@ -21,3 +21,18 @@
     }
   }
 }
+
+.event-data {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-top: -5px;
+
+  ix-icon {
+    width: 15px;
+
+    &.error-color {
+      color: var(--red);
+    }
+  }
+}

--- a/src/app/pages/audit/components/audit-list/audit-list.component.ts
+++ b/src/app/pages/audit/components/audit-list/audit-list.component.ts
@@ -6,12 +6,13 @@ import {
 import { MatTooltip } from '@angular/material/tooltip';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { UntilDestroy } from '@ngneat/until-destroy';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { toSvg } from 'jdenticon';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { auditServiceLabels, auditEventLabels } from 'app/enums/audit.enum';
 import { AuditEntry } from 'app/interfaces/audit/audit.interface';
 import { EmptyService } from 'app/modules/empty/empty.service';
+import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
 import { IxTableComponent } from 'app/modules/ix-table/components/ix-table/ix-table.component';
 import { dateColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-date/ix-cell-date.component';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
@@ -45,6 +46,8 @@ import { getLogImportantData } from 'app/pages/audit/utils/get-log-important-dat
     NgTemplateOutlet,
     UiSearchDirective,
     AuditSearchComponent,
+    TranslateModule,
+    IxIconComponent,
   ],
 })
 export class AuditListComponent {
@@ -84,7 +87,6 @@ export class AuditListComponent {
     textColumn({
       title: this.translate.instant('Event Data'),
       disableSorting: true,
-      getValue: (row) => this.translate.instant(this.getEventDataForLog(row)),
     }),
   ], {
     uniqueRowTag: (row) => `audit-${row.service}-${row.username}-${row.event}-${row.audit_id}`,
@@ -97,7 +99,7 @@ export class AuditListComponent {
     private translate: TranslateService,
   ) { }
 
-  private getEventDataForLog(row: AuditEntry): string {
+  getEventDataForLog(row: AuditEntry): string {
     return getLogImportantData(row, this.translate);
   }
 

--- a/src/app/pages/audit/components/event-data-details-card/event-data-details-card.component.html
+++ b/src/app/pages/audit/components/event-data-details-card/event-data-details-card.component.html
@@ -4,7 +4,7 @@
       {{ 'Event Data' | translate }}
     </h3>
 
-    <ix-copy-button [text]="yamlContent()" [jsonText]="log().event_data"></ix-copy-button>
+    <ix-copy-button [text]="yamlContent()" [jsonText]="eventData()"></ix-copy-button>
   </mat-card-header>
   <mat-card-content>
     <pre>{{ yamlContent() }}</pre>

--- a/src/app/pages/audit/components/event-data-details-card/event-data-details-card.component.spec.ts
+++ b/src/app/pages/audit/components/event-data-details-card/event-data-details-card.component.spec.ts
@@ -60,7 +60,8 @@ const logEntry = {
   success: true,
 } as AuditEntry;
 
-const yamlContent = `Logon ID: '0'
+const yamlContent = `Success: True
+Logon ID: '0'
 Logon Type: 3
 Local Address: ipv4:10.238.238.168:445
 Remote Address: ipv4:10.220.2.21:10876

--- a/src/app/pages/audit/components/event-data-details-card/event-data-details-card.component.ts
+++ b/src/app/pages/audit/components/event-data-details-card/event-data-details-card.component.ts
@@ -25,7 +25,14 @@ import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button
 export class EventDataDetailsCardComponent {
   readonly log = input.required<AuditEntry>();
 
+  protected eventData = computed(() => {
+    return {
+      success: this.log().success,
+      ...this.log().event_data,
+    };
+  });
+
   protected yamlContent = computed(() => {
-    return jsonToYaml(convertObjectKeysToHumanReadable(this.log().event_data));
+    return jsonToYaml(convertObjectKeysToHumanReadable(this.eventData()));
   });
 }


### PR DESCRIPTION
Testing: see ticket.

it's now easy to see successful and failed operations in a non intrusive way.

Result:
<img width="1728" alt="Screenshot 2025-04-02 at 13 53 38" src="https://github.com/user-attachments/assets/73ff8bef-35dc-4613-8950-12de8368d8ff" />


Original PR: https://github.com/truenas/webui/pull/11833
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135110