### PR TITLE
NAS-134422 / 25.04.1 / On Goldeye No close button on the Wipe Disk sd* Disk Wiped successfully dialog (by AlexKarpov98)

### DIFF
--- a/src/app/modules/dialog/components/general-dialog/general-dialog.component.scss
+++ b/src/app/modules/dialog/components/general-dialog/general-dialog.component.scss
@@ -1,3 +1,8 @@
+:host {
+  display: block;
+  min-width: 340px;
+}
+
 .general-dialog-content-container {
   height: calc(100% - 100px);
   overflow: auto !important;

--- a/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.ts
+++ b/src/app/pages/storage/modules/disks/components/disk-wipe-dialog/disk-wipe-dialog.component.ts
@@ -107,7 +107,7 @@ export class DiskWipeDialogComponent {
         this.dialogService.generalDialog({
           title: this.title,
           message: helptextDisks.diskWipeDialogForm.infoContent,
-          hideCancel: true,
+          cancelBtnMsg: this.translate.instant('Close'),
         });
         this.dialogRef.close(true);
       });


### PR DESCRIPTION
Testing: see ticket.

Result:

https://github.com/user-attachments/assets/5cac5cbf-dab9-45ed-92be-6917a7f48242



Original PR: https://github.com/truenas/webui/pull/11829
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134422