### PR TITLE
NAS-135098 / 25.04.1 / Instances page UI not loading properly (by AlexKarpov98)

### DIFF
--- a/src/app/pages/instances/components/all-instances/instance-details/instance-idmap/instance-idmap.component.html
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-idmap/instance-idmap.component.html
@@ -15,15 +15,15 @@
           <div class="details-entry">
             <div class="details-item">
               <div class="label">{{ 'Host ID' | translate }}:</div>
-              <div class="value">{{ instance().userns_idmap.uid.hostid }}</div>
+              <div class="value">{{ instance().userns_idmap?.uid?.hostid }}</div>
             </div>
             <div class="details-item">
               <div class="label">{{ 'Maprange' | translate }}:</div>
-              <div class="value">{{ instance().userns_idmap.uid.maprange }}</div>
+              <div class="value">{{ instance().userns_idmap?.uid?.maprange }}</div>
             </div>
             <div class="details-item">
               <div class="label">{{ 'NS ID' | translate }}:</div>
-              <div class="value">{{ instance().userns_idmap.uid.nsid }}</div>
+              <div class="value">{{ instance().userns_idmap?.uid?.nsid }}</div>
             </div>
           </div>
         </div>
@@ -32,15 +32,15 @@
           <div class="details-entry">
             <div class="details-item">
               <div class="label">{{ 'Host ID' | translate }}:</div>
-              <div class="value">{{ instance().userns_idmap.gid.hostid }}</div>
+              <div class="value">{{ instance().userns_idmap?.gid?.hostid }}</div>
             </div>
             <div class="details-item">
               <div class="label">{{ 'Maprange' | translate }}:</div>
-              <div class="value">{{ instance().userns_idmap.gid.maprange }}</div>
+              <div class="value">{{ instance().userns_idmap?.gid?.maprange }}</div>
             </div>
             <div class="details-item">
               <div class="label">{{ 'NS ID' | translate }}:</div>
-              <div class="value">{{ instance().userns_idmap.gid.nsid }}</div>
+              <div class="value">{{ instance().userns_idmap?.gid?.nsid }}</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b59538e29163f4e61351681d7271fb4cc067fbfc
    git cherry-pick -x c973ad178bd0901b2423436a430f9b1eeaef3b52

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 688467c38ecea592cd590b2b8cd0aac88e02ba42

Testing: see ticket.

I was not able to somehow reproduce. For testing you may user the data provided by user in the ticket, to see that page is not broken anymore.

```
    "userns_idmap": {
      "uid": null,
      "gid": null
    },
```



Original PR: https://github.com/truenas/webui/pull/11842
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135098