### PR TITLE
NAS-135157 / 25.10 / Remember user selected columns in tables

### DIFF
--- a/src/app/interfaces/preferences.interface.ts
+++ b/src/app/interfaces/preferences.interface.ts
@@ -1,16 +1,8 @@
 import { SidenavStatusData } from 'app/interfaces/events/sidenav-status-event.interface';
 
-interface Column {
-  name: string;
-  prop: string;
-  hidden: boolean;
-  maxWidth: number;
-  minWidth: number;
-}
-
 export interface TableDisplayedColumns {
   title: string;
-  cols: Column[];
+  columns: string[];
 }
 
 /**

--- a/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.html
+++ b/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.html
@@ -12,7 +12,7 @@
     <button
       mat-menu-item
       [ixTest]="['toggle-all-columns']"
-      (click)="toggleAll()"
+      (click)="toggleAll(); saveColumnPreferences(); enableResetButton();"
     >
       <ix-icon [name]="!isAllSelected ? 'remove' : 'check_circle'"></ix-icon>
       @if (isAllSelected) {
@@ -29,7 +29,7 @@
         <button
           mat-menu-item
           [ixTest]="['toggle-column', column.title]"
-          (click)="toggle(column)"
+          (click)="toggle(column); saveColumnPreferences(); enableResetButton();"
         >
           <ix-icon [name]="isSelected(column) ? 'remove' : 'check_circle'"></ix-icon>
           <span>{{ column.title | translate }}</span>
@@ -42,7 +42,8 @@
     <button
       mat-menu-item
       [ixTest]="['reset-columns-to-defaults']"
-      (click)="resetToDefaults()"
+      [disabled]="isResetToDefaultDisabled()"
+      (click)="resetToDefaults(); saveColumnPreferences()"
     >
       <ix-icon name="mdi-undo"></ix-icon>
       <span>{{ 'Reset to Defaults' | translate }}</span>

--- a/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
+++ b/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
@@ -81,11 +81,19 @@ describe('IxTableColumnsSelectorComponent', () => {
     expect(columnsChangeSpy).toHaveBeenCalled();
   });
 
+  it('"Reset to Defaults" is disabled initially', async () => {
+    jest.spyOn(spectator.component, 'resetToDefaults').mockImplementation();
+    await menu.clickItem({ text: 'Reset to Defaults' });
+    expect(spectator.component.resetToDefaults).not.toHaveBeenCalled();
+  });
+
   it('checks when "Reset to Defaults" is pressed', async () => {
+    await menu.clickItem({ text: 'Users' });
+
     jest.spyOn(spectator.component, 'resetToDefaults').mockImplementation();
     await menu.clickItem({ text: 'Reset to Defaults' });
 
-    expect(spectator.component.hiddenColumns.selected).toHaveLength(2);
+    expect(spectator.component.hiddenColumns.selected).toHaveLength(3);
     expect(spectator.component.resetToDefaults).toHaveBeenCalled();
   });
 

--- a/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
+++ b/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.spec.ts
@@ -4,12 +4,14 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory } from '@ngneat/spectator/jest';
+import { Store } from '@ngrx/store';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { yesNoColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-yes-no/ix-cell-yes-no.component';
 import { IxTableColumnsSelectorComponent } from 'app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component';
 import { Column, ColumnComponent } from 'app/modules/ix-table/interfaces/column-component.class';
 import { createTable } from 'app/modules/ix-table/utils';
 import { CronjobRow } from 'app/pages/system/advanced/cron/cron-list/cronjob-row.interface';
+import { preferredColumnsUpdated } from 'app/store/preferences/preferences.actions';
 
 describe('IxTableColumnsSelectorComponent', () => {
   let spectator: Spectator<IxTableColumnsSelectorComponent>;
@@ -105,5 +107,21 @@ describe('IxTableColumnsSelectorComponent', () => {
 
     await menu.clickItem({ text: 'Enabled' });
     expect(spectator.component.hiddenColumns.selected).toHaveLength(2);
+  });
+
+  it('saves column preferences when columnPreferencesKey is provided', async () => {
+    const store$ = spectator.inject(Store);
+    jest.spyOn(store$, 'dispatch');
+
+    spectator.setInput('columnPreferencesKey', 'test-key');
+
+    await menu.clickItem({ text: 'Description' });
+
+    expect(store$.dispatch).toHaveBeenCalledWith(preferredColumnsUpdated({
+      tableDisplayedColumns: [{
+        title: 'test-key',
+        columns: ['Users', 'Command', 'Description', 'Schedule'],
+      }],
+    }));
   });
 });

--- a/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
+++ b/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
@@ -73,7 +73,7 @@ export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges, 
     this.store$.pipe(
       waitForPreferences,
       map((config) => config.tableDisplayedColumns?.find((column) => column.title === this.columnPreferencesKey())),
-      filter((config) => !!config.columns),
+      filter((config) => !!config.columns?.length),
       untilDestroyed(this),
     ).subscribe((displayedColumns) => {
       this.columns().forEach((column) => {
@@ -82,6 +82,10 @@ export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges, 
           this.hiddenColumns.select(column);
         }
       });
+
+      if (displayedColumns.columns.every((column) => !this.columns().some((col) => col.title === column))) {
+        this.hiddenColumns.clear();
+      }
     });
   }
 

--- a/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
+++ b/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
@@ -1,16 +1,21 @@
 import { SelectionModel } from '@angular/cdk/collections';
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, model, OnChanges, output,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, input, model, OnChanges, OnInit, output,
 } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { cloneDeep } from 'lodash-es';
+import { filter, map } from 'rxjs';
 import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
 import { Column, ColumnComponent } from 'app/modules/ix-table/interfaces/column-component.class';
 import { TestDirective } from 'app/modules/test-id/test.directive';
+import { AppState } from 'app/store';
+import { preferredColumnsUpdated } from 'app/store/preferences/preferences.actions';
+import { waitForPreferences } from 'app/store/preferences/preferences.selectors';
 
 @UntilDestroy()
 @Component({
@@ -29,8 +34,9 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
     TestDirective,
   ],
 })
-export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges {
+export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges, OnInit {
   readonly columns = model.required<Column<T, ColumnComponent<T>>[]>();
+  readonly columnPreferencesKey = input<string>();
 
   readonly columnsChange = output<Column<T, ColumnComponent<T>>[]>();
 
@@ -45,15 +51,38 @@ export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges {
     return !this.columns().filter((column) => column.hidden && !!column.title).length;
   }
 
-  constructor(private cdr: ChangeDetectorRef) {
+  constructor(
+    private cdr: ChangeDetectorRef,
+    private store$: Store<AppState>,
+  ) {
     this.subscribeToColumnsChange();
   }
 
   ngOnChanges(changes: IxSimpleChanges<this>): void {
     if (changes.columns.firstChange) {
       this.defaultColumns = changes.columns.currentValue;
-      this.setInitialState();
     }
+  }
+
+  ngOnInit(): void {
+    if (!this.columnPreferencesKey()) {
+      this.setInitialState();
+      return;
+    }
+
+    this.store$.pipe(
+      waitForPreferences,
+      map((config) => config.tableDisplayedColumns?.find((column) => column.title === this.columnPreferencesKey())),
+      filter((config) => !!config.columns),
+      untilDestroyed(this),
+    ).subscribe((displayedColumns) => {
+      this.columns().forEach((column) => {
+        column.hidden = !displayedColumns.columns.includes(column.title);
+        if (column.hidden) {
+          this.hiddenColumns.select(column);
+        }
+      });
+    });
   }
 
   toggleAll(): void {
@@ -101,24 +130,24 @@ export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges {
   }
 
   private subscribeToColumnsChange(): void {
-    this.hiddenColumns.changed
-      .pipe(untilDestroyed(this))
-      .subscribe((values) => {
-        if (values.removed.length) {
-          const columnToShow = this.columns().find((column) => column.title === values.removed[0].title);
-          if (columnToShow) {
-            columnToShow.hidden = false;
-          }
-        }
-        if (values.added.length) {
-          const columnToHide = this.columns().find((column) => column.title === values.added[0].title);
-          if (columnToHide) {
-            columnToHide.hidden = true;
-          }
-        }
-        this.emitColumnsChange();
-        this.cdr.markForCheck();
+    this.hiddenColumns.changed.pipe(untilDestroyed(this)).subscribe(() => {
+      this.columns().forEach((col) => {
+        col.hidden = this.hiddenColumns.isSelected(col);
       });
+
+      this.emitColumnsChange();
+
+      if (this.columnPreferencesKey()) {
+        this.store$.dispatch(preferredColumnsUpdated({
+          tableDisplayedColumns: [{
+            title: this.columnPreferencesKey(),
+            columns: this.columns().filter((col) => !col.hidden).map((col) => col.title),
+          }],
+        }));
+      }
+
+      this.cdr.markForCheck();
+    });
   }
 
   private emitColumnsChange(): void {

--- a/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
+++ b/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
@@ -73,7 +73,7 @@ export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges, 
     this.store$.pipe(
       waitForPreferences,
       map((config) => config.tableDisplayedColumns?.find((column) => column.title === this.columnPreferencesKey())),
-      filter((config) => !!config.columns?.length),
+      filter((config) => !!config?.columns?.length),
       untilDestroyed(this),
     ).subscribe((displayedColumns) => {
       this.columns().forEach((column) => {

--- a/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
+++ b/src/app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component.ts
@@ -61,7 +61,7 @@ export class IxTableColumnsSelectorComponent<T = unknown> implements OnChanges, 
   }
 
   ngOnChanges(changes: IxSimpleChanges<this>): void {
-    if (changes.columns.firstChange) {
+    if (changes.columns?.firstChange) {
       this.defaultColumns = changes.columns.currentValue;
     }
   }

--- a/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.html
+++ b/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.html
@@ -9,7 +9,11 @@
         {{ 'NFS Sessions' | translate }}
       </a>
 
-      <ix-table-columns-selector [columns]="columns" (columnsChange)="columnsChange($event)"></ix-table-columns-selector>
+      <ix-table-columns-selector
+        [columns]="columns"
+        [columnPreferencesKey]="'nfsList'"
+        (columnsChange)="columnsChange($event)"
+      ></ix-table-columns-selector>
 
       <button
         *ixRequiresRoles="requiredRoles"

--- a/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.spec.ts
+++ b/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.spec.ts
@@ -21,6 +21,7 @@ import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { NfsFormComponent } from 'app/pages/sharing/nfs/nfs-form/nfs-form.component';
 import { NfsListComponent } from 'app/pages/sharing/nfs/nfs-list/nfs-list.component';
+import { selectPreferences } from 'app/store/preferences/preferences.selectors';
 import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors';
 
 const shares: Partial<NfsShare>[] = [
@@ -72,6 +73,10 @@ describe('NfsListComponent', () => {
           {
             selector: selectIsEnterprise,
             value: true,
+          },
+          {
+            selector: selectPreferences,
+            value: {},
           },
         ],
       }),

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.html
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.html
@@ -13,7 +13,11 @@
         {{ 'SMB Sessions' | translate }}
       </a>
 
-      <ix-table-columns-selector [columns]="columns" (columnsChange)="columnsChange($event)"></ix-table-columns-selector>
+      <ix-table-columns-selector
+        [columns]="columns"
+        [columnPreferencesKey]="'smbList'"
+        (columnsChange)="columnsChange($event)"
+      ></ix-table-columns-selector>
 
       <button
         *ixRequiresRoles="requiredRoles"

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.spec.ts
@@ -29,6 +29,7 @@ import { ServiceStateButtonComponent } from 'app/pages/sharing/components/shares
 import { SmbAclComponent } from 'app/pages/sharing/smb/smb-acl/smb-acl.component';
 import { SmbFormComponent } from 'app/pages/sharing/smb/smb-form/smb-form.component';
 import { SmbListComponent } from 'app/pages/sharing/smb/smb-list/smb-list.component';
+import { selectPreferences } from 'app/store/preferences/preferences.selectors';
 import { selectServices } from 'app/store/services/services.selectors';
 
 const shares: Partial<SmbShare>[] = [
@@ -94,6 +95,10 @@ describe('SmbListComponent', () => {
               state: ServiceStatus.Stopped,
               enable: false,
             } as Service],
+          },
+          {
+            selector: selectPreferences,
+            value: {},
           },
         ],
       }),

--- a/src/app/store/preferences/preferences.actions.ts
+++ b/src/app/store/preferences/preferences.actions.ts
@@ -9,7 +9,7 @@ export const noPreferencesFound = createAction('[Preferences API] No Preferences
 export const themeNotFound = createAction('[Preferences] Theme Not Found');
 export const preferredColumnsUpdated = createAction(
   '[Preferences] Preferred Columns Updated',
-  props<{ columns: TableDisplayedColumns[] }>(),
+  props<{ tableDisplayedColumns: TableDisplayedColumns[] }>(),
 );
 export const shownNewIndicatorKeysUpdated = createAction(
   '[Preferences] Shown New Indicator Keys Updated',

--- a/src/app/store/preferences/preferences.reducer.ts
+++ b/src/app/store/preferences/preferences.reducer.ts
@@ -40,9 +40,19 @@ export const preferencesReducer = createReducer(
   on(preferencesLoaded, (state, { preferences }) => ({ ...state, preferences, areLoaded: true })),
   on(noPreferencesFound, (state) => ({ ...state, preferences: defaultPreferences, areLoaded: true })),
   on(sidenavUpdated, (state, sidenavStatus) => updatePreferences(state, { sidenavStatus })),
-  on(preferredColumnsUpdated, (state, { columns }) => updatePreferences(state, {
-    tableDisplayedColumns: columns,
-  })),
+  on(preferredColumnsUpdated, (state, { tableDisplayedColumns: newPreferences }) => {
+    const existingPreferences = state.preferences?.tableDisplayedColumns || [];
+    const combinedPreferences = [...existingPreferences, ...newPreferences];
+    const preferencesMap = combinedPreferences.reduce((map, preference) => {
+      map.set(preference.title, preference.columns?.filter(Boolean));
+      return map;
+    }, new Map<string, string[]>());
+    const mergedPreferences = Array.from(preferencesMap.entries()).map(([title, columns]) => ({ title, columns }));
+
+    return updatePreferences(state, {
+      tableDisplayedColumns: mergedPreferences,
+    });
+  }),
   on(shownNewIndicatorKeysUpdated, (state, { keys }) => updatePreferences(state, {
     shownNewFeatureIndicatorKeys: keys,
   })),


### PR DESCRIPTION
Testing: see ticket.
p.s _I don't see a reason for a separate service for these updates._

Current possible issue: We only know `title` or `propertyName`, but they are not always available.
maybe we can provide additional key for each column, especially to know how we save that column to the API.
Currently I use title. (so the selection changes when we change the language) 

Result:

https://github.com/user-attachments/assets/1dc7d022-4986-4fd2-b255-5a516273c9aa

