### PR TITLE
NAS-133829 / 25.10 / Remove Generate Claim Token step for TrueNAS Connect update

### DIFF
--- a/src/app/modules/truenas-connect/components/truenas-connect-modal/truenas-connect-modal.component.html
+++ b/src/app/modules/truenas-connect/components/truenas-connect-modal/truenas-connect-modal.component.html
@@ -54,11 +54,6 @@
   </div>
 
   <div>
-    @if(tnc.config()?.status === TruenasConnectStatus.ClaimTokenMissing) {
-    <button ixTest="tnc-generate-token" mat-button (click)="generateToken()">
-      {{ 'Generate Token' | translate }}
-    </button>
-    }
     <button mat-button ixTest="tnc-form-cancel" (click)="cancel()">
       {{ 'Cancel' | translate }}
     </button>

--- a/src/app/modules/truenas-connect/components/truenas-connect-modal/truenas-connect-modal.component.spec.ts
+++ b/src/app/modules/truenas-connect/components/truenas-connect-modal/truenas-connect-modal.component.spec.ts
@@ -80,21 +80,6 @@ describe('TruenasConnectModalComponent', () => {
     });
   });
 
-  it('should generate a tokken', async () => {
-    configSignal.set({
-      ...config,
-      status: TruenasConnectStatus.ClaimTokenMissing,
-    });
-    const generateSpy = jest.spyOn(spectator.inject(TruenasConnectService), 'generateToken');
-    const generateBtn = await loader.getHarness(
-      MatButtonHarness.with({
-        text: 'Generate Token',
-      }),
-    );
-    await generateBtn.click();
-    expect(generateSpy).toHaveBeenCalled();
-  });
-
   it('should save the form', async () => {
     const tncInput = await loader.getHarness(
       IxInputHarness.with({

--- a/src/app/modules/truenas-connect/components/truenas-connect-modal/truenas-connect-modal.component.ts
+++ b/src/app/modules/truenas-connect/components/truenas-connect-modal/truenas-connect-modal.component.ts
@@ -100,12 +100,6 @@ export class TruenasConnectModalComponent {
       .subscribe();
   }
 
-  protected generateToken(): void {
-    this.tnc.generateToken()
-      .pipe(untilDestroyed(this))
-      .subscribe();
-  }
-
   protected connect(): void {
     this.tnc.connect()
       .pipe(untilDestroyed(this))

--- a/src/app/modules/truenas-connect/truenas-connect-button.component.ts
+++ b/src/app/modules/truenas-connect/truenas-connect-button.component.ts
@@ -3,6 +3,7 @@ import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule, MatIconButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTooltip } from '@angular/material/tooltip';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
 import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
 import { helptextTopbar } from 'app/helptext/topbar';
@@ -11,6 +12,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { TruenasConnectStatusModalComponent } from 'app/modules/truenas-connect/components/truenas-connect-status-modal/truenas-connect-status-modal.component';
 import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
 
+@UntilDestroy()
 @Component({
   selector: 'ix-truenas-connect-button',
   standalone: true,
@@ -34,7 +36,9 @@ export class TruenasConnectButtonComponent {
   constructor(private matDialog: MatDialog, public tnc: TruenasConnectService) {
     effect(() => {
       if (this.tnc.config()?.status === TruenasConnectStatus.ClaimTokenMissing) {
-        this.tnc.generateToken();
+        this.tnc.generateToken()
+          .pipe(untilDestroyed(this))
+          .subscribe();
       }
     });
   }

--- a/src/app/modules/truenas-connect/truenas-connect-button.component.ts
+++ b/src/app/modules/truenas-connect/truenas-connect-button.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect } from '@angular/core';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule, MatIconButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
@@ -6,7 +6,6 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
 import { helptextTopbar } from 'app/helptext/topbar';
-import { TruenasConnectConfig } from 'app/interfaces/truenas-connect-config.interface';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { TruenasConnectStatusModalComponent } from 'app/modules/truenas-connect/components/truenas-connect-status-modal/truenas-connect-status-modal.component';
@@ -30,10 +29,15 @@ import { TruenasConnectService } from 'app/modules/truenas-connect/services/true
 })
 export class TruenasConnectButtonComponent {
   readonly TruenasConnectStatus = TruenasConnectStatus;
-  config: TruenasConnectConfig;
   tooltips = helptextTopbar.mat_tooltips;
 
-  constructor(private matDialog: MatDialog, public tnc: TruenasConnectService) {}
+  constructor(private matDialog: MatDialog, public tnc: TruenasConnectService) {
+    effect(() => {
+      if (this.tnc.config()?.status === TruenasConnectStatus.ClaimTokenMissing) {
+        this.tnc.generateToken();
+      }
+    });
+  }
 
   protected showStatus(): void {
     this.matDialog.open(TruenasConnectStatusModalComponent, {

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1516,7 +1516,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1488,7 +1488,6 @@
   "Generate Key": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -2057,7 +2057,6 @@
   "Generate New": "Generar nuevo",
   "Generate One-Time Password": "Generar contraseña de un solo uso",
   "Generate Temporary One-Time Password": "Generar contraseña temporal de un solo uso",
-  "Generate Token": "Generar token",
   "Generic": "Genérico",
   "Generic dataset suitable for any share type.": "Conjunto de datos genérico adecuado para cualquier tipo de compartición",
   "Get Support": "Conseguir ayuda",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1810,7 +1810,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -349,7 +349,6 @@
   "FTP": "",
   "FTP Service": "",
   "Full Admin": "",
-  "Generate Token": "",
   "Global 2FA": "",
   "Global 2FA Enable": "",
   "Global Settings": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -2019,7 +2019,6 @@
   "Generate New": "Gin Nua",
   "Generate One-Time Password": "Cruthaigh Pasfhocal Aonair",
   "Generate Temporary One-Time Password": "Cruthaigh Pasfhocal Aon-uaire Se",
-  "Generate Token": "Cruthaigh Comhartha",
   "Generic": "Cineálach",
   "Generic dataset suitable for any share type.": "Tacar sonraí cineálach atá oiriúnach d’aon chineál scaireanna.",
   "Get Support": "Faigh Tacaíocht",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -2024,7 +2024,6 @@
   "Generate New": "Genera nuovo",
   "Generate One-Time Password": "Genera password monouso",
   "Generate Temporary One-Time Password": "Genera password monouso temporanea",
-  "Generate Token": "Genera token",
   "Generic": "Generico",
   "Generic dataset suitable for any share type.": "Dataset generico adatto a qualsiasi tipo di condivisione.",
   "Get Support": "Ottieni supporto",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1744,7 +1744,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -2012,7 +2012,6 @@
   "Generate New": "새로 생성",
   "Generate One-Time Password": "일회용 비밀번호 생성",
   "Generate Temporary One-Time Password": "임시 일회용 비밀번호 생성",
-  "Generate Token": "토큰 생성",
   "Generic": "일반",
   "Generic dataset suitable for any share type.": "일반 데이터 세트는 모든 공유 유형에 적합합니다.",
   "Get Support": "지원 받기",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1993,7 +1993,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -2173,7 +2173,6 @@
   "Generate Key": "Sleutel genereren",
   "Generate Keypair": "Sleutelpaar genereren",
   "Generate New": "Nieuwe genereren",
-  "Generate Token": "Genereer token",
   "Generic": "Algemeen",
   "Generic dataset suitable for any share type.": "Generieke sataset geschikt voor elk share-type.",
   "Get Support": "Krijg ondersteuning",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -2095,7 +2095,6 @@
   "Generate New": "Generuj nowy",
   "Generate One-Time Password": "Generuj jednorazowe hasło",
   "Generate Temporary One-Time Password": "Generuj tymczasowe jednorazowe hasło",
-  "Generate Token": "Generuj token",
   "Generic": "Ogólne",
   "Generic dataset suitable for any share type.": "Ogólny zestaw danych odpowiedni dla dowolnego typu udziału.",
   "Get Support": "Uzyskaj wsparcie",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1947,7 +1947,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1124,7 +1124,6 @@
   "Generate idmap low range based on same algorithm that SSSD uses by default.": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",
   "GID": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1330,7 +1330,6 @@
   "Generate Encryption Key": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -924,7 +924,6 @@
   "Generate CSR": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",
   "Give your exporter configuration a name": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1999,7 +1999,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -128,7 +128,6 @@
   "Force shutdown now": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Global Two-Factor Authentication must be enabled to activate this feature.": "",
   "Go to API keys": "",
   "Go to App Settings": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1295,7 +1295,6 @@
   "Generate New": "",
   "Generate One-Time Password": "",
   "Generate Temporary One-Time Password": "",
-  "Generate Token": "",
   "Generic": "",
   "Generic dataset suitable for any share type.": "",
   "Get Support": "",


### PR DESCRIPTION
**Changes:**
- removed `Generate Token` button in TNC Config dialog

**Testing:**
1. Setup the initial configuration of TNC by running
`midclt call tn_connect.update '{"enabled": true, "ips": ["NAS_STATIC_IP"], "account_service_base_url": "https://account-service.dev.ixsystems.net/", "leca_service_base_url": "https://dns-service.dev.ixsystems.net/", "tnc_base_url": "https://truenas.connect.dev.ixsystems.net/", "heartbeat_url": "https://heartbeat-service.dev.ixsystems.net/"}'`
2. If the status is `CLAIM_TOKEN_MISSING`, it will automatically send a ws call `tn_connect.generate_claim_token` to generate claim token.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
