### PR TITLE
NAS-134938 / 25.04.1 / Physical ports in Fibre Channel Ports do not display WWPNs unless target is mapped (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.spec.ts
+++ b/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.spec.ts
@@ -124,9 +124,9 @@ describe('FibreChannelPortsComponent', () => {
       ['Port', 'Target', 'WWPN', 'WWPN (B)', 'State', ''],
       ['fc0', 'target1', 'naa.220034800d75aec4', 'naa.220034800d75aec5', 'A: Online B: Offline', ''],
       ['– fc0/1 (virtual)', 'target2', 'naa.220034800d75aec8', 'naa.220034800d75aec9', 'A: – B: –', ''],
-      ['– fc0/2 (virtual)', '', '', '', 'A: – B: –', ''],
+      ['– fc0/2 (virtual)', '-', '-', '-', 'A: – B: –', ''],
       ['fc1', 'target2', 'naa.220034800d75aec6', 'naa.220034800d75aec7', 'A: Online B: Online', ''],
-      ['– fc1/1 (virtual)', '', '', '', 'A: – B: –', ''],
+      ['– fc1/1 (virtual)', '-', '-', '-', 'A: – B: –', ''],
     ]);
   });
 

--- a/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.ts
+++ b/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.ts
@@ -93,18 +93,20 @@ export class FibreChannelPortsComponent implements OnInit {
         title: this.translate.instant('Target'),
         propertyName: 'target',
         getValue: (row) => {
-          return row.target?.iscsi_target_name;
+          return row.target?.iscsi_target_name || '-';
         },
         disableSorting: true,
       }),
       textColumn({
         title: this.translate.instant('WWPN'),
         propertyName: 'wwpn',
+        getValue: (row) => this.resolveWwpn(row, 'wwpn'),
         disableSorting: true,
       }),
       textColumn({
         title: this.translate.instant('WWPN (B)'),
         propertyName: 'wwpn_b',
+        getValue: (row) => this.resolveWwpn(row, 'wwpn_b'),
         hidden: !this.isHa(),
         disableSorting: true,
       }),
@@ -181,5 +183,20 @@ export class FibreChannelPortsComponent implements OnInit {
         this.rows.set(buildPortsTableRow(hosts, ports, statuses));
         this.dataProvider.setRows(this.rows());
       });
+  }
+
+  private resolveWwpn(row: FibreChannelPortRow, key: 'wwpn' | 'wwpn_b'): string {
+    if (row?.[key]) {
+      return row[key];
+    }
+
+    const aliasPrefix = row?.host?.alias?.split?.('/')?.[0];
+    const isPhysical = row?.name === aliasPrefix;
+
+    if (isPhysical && row?.host?.[key]) {
+      return row.host[key];
+    }
+
+    return '-';
   }
 }


### PR DESCRIPTION
Testing: see ticket.

Before:
<img width="1469" alt="Screenshot 2025-04-08 at 16 37 55" src="https://github.com/user-attachments/assets/57234523-837d-473d-a8b1-40241c9f1cd0" />

After:
<img width="1471" alt="Screenshot 2025-04-08 at 16 37 58" src="https://github.com/user-attachments/assets/13a83cc8-3a1f-4427-af40-ec3e71f5faaf" />


Original PR: https://github.com/truenas/webui/pull/11863
Jira URL: https://ixsystems.atlassian.net/browse/NAS-134938