### PR TITLE
NAS-135261 / 25.04.1 / Don't allow editing AD users (by undsoft)

### DIFF
--- a/src/app/pages/credentials/groups/group-details-row/group-details-row.component.html
+++ b/src/app/pages/credentials/groups/group-details-row/group-details-row.component.html
@@ -5,7 +5,7 @@
       <span>{{ 'Members' | translate }}</span>
     </button>
 
-    @if (!group().builtin) {
+    @if (!group().builtin && group().local) {
       <button
         mat-button
         [ixTest]="[group().group, 'edit']"

--- a/src/app/pages/credentials/groups/group-details-row/group-details-row.component.spec.ts
+++ b/src/app/pages/credentials/groups/group-details-row/group-details-row.component.spec.ts
@@ -28,6 +28,7 @@ const dummyGroup = {
   id: 1,
   gid: 1000,
   group: 'dummy',
+  local: true,
   builtin: false,
   smb: true,
   users: [] as number[],
@@ -99,11 +100,27 @@ describe('GroupDetailsRowComponent', () => {
     expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/', 'credentials', 'groups', 1, 'members']);
   });
 
-  it('should open edit group form', async () => {
-    const editButton = await loader.getHarness(MatButtonHarness.with({ text: /Edit/ }));
-    await editButton.click();
+  describe('Edit button', () => {
+    it('should open edit group form', async () => {
+      const editButton = await loader.getHarness(MatButtonHarness.with({ text: /Edit/ }));
+      await editButton.click();
 
-    expect(spectator.inject(SlideIn).open).toHaveBeenCalledWith(GroupFormComponent, { data: dummyGroup });
+      expect(spectator.inject(SlideIn).open).toHaveBeenCalledWith(GroupFormComponent, { data: dummyGroup });
+    });
+
+    it('does not show Edit button for built-in groups', async () => {
+      spectator.setInput('group', { ...dummyGroup, builtin: true });
+
+      const editButton = await loader.getHarnessOrNull(MatButtonHarness.with({ text: 'Edit' }));
+      expect(editButton).toBeNull();
+    });
+
+    it('does not show Edit button for Active Directory groups', async () => {
+      spectator.setInput('group', { ...dummyGroup, local: false });
+
+      const editButton = await loader.getHarnessOrNull(MatButtonHarness.with({ text: 'Edit' }));
+      expect(editButton).toBeNull();
+    });
   });
 
   it('should open DeleteUserGroup when Delete button is pressed', async () => {

--- a/src/app/pages/credentials/users/user-details-row/user-details-row.component.html
+++ b/src/app/pages/credentials/users/user-details-row/user-details-row.component.html
@@ -1,12 +1,14 @@
 <ix-table-expandable-row [data]="getDetails(user())">
-  <button
-    mat-button
-    [ixTest]="['edit', user().username]"
-    (click)="doEdit(user())"
-  >
-    <ix-icon name="edit"></ix-icon>
-    <span>{{ 'Edit' | translate }}</span>
-  </button>
+  @if (user().local) {
+    <button
+      mat-button
+      [ixTest]="['edit', user().username]"
+      (click)="doEdit(user())"
+    >
+      <ix-icon name="edit"></ix-icon>
+      <span>{{ 'Edit' | translate }}</span>
+    </button>
+  }
 
   <ng-container *ixRequiresRoles="[Role.AccountWrite]">
     @if (!user().immutable && loggedInUser().pw_name !== user().username) {

--- a/src/app/pages/credentials/users/user-details-row/user-details-row.component.spec.ts
+++ b/src/app/pages/credentials/users/user-details-row/user-details-row.component.spec.ts
@@ -34,6 +34,7 @@ const dummyUser = {
   home: '/test-user',
   shell: '/usr/bin/zsh',
   full_name: 'test-user',
+  local: true,
   builtin: false,
   smb: false,
   password_disabled: false,


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x a609b90b1cbcccb8686e7b0115abef706a490acf

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 947189ec26fdec0b428eee9f0d4477973058acba

**Changes:**

AD users and groups won't be editable anymore.


Original PR: https://github.com/truenas/webui/pull/11876
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135261