### PR TITLE
NAS-135326 / 25.10 / Nextcloud App Install Wizard Tooltip text exceeds size of tooltip pop-up for several settings

### DIFF
--- a/src/app/modules/tooltip/tooltip.component.scss
+++ b/src/app/modules/tooltip/tooltip.component.scss
@@ -38,6 +38,8 @@
   font-family: var(--font-family-body);
   font-size: 12px;
   line-height: 1.3;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 
   ::ng-deep a {
     color: inherit !important;


### PR DESCRIPTION
Testing: see ticket.