### PR TITLE
NAS-135398 / 25.10 / Allow root disk size to be specified when using zvols

### DIFF
--- a/src/app/pages/instances/components/instance-wizard/instance-wizard.component.html
+++ b/src/app/pages/instances/components/instance-wizard/instance-wizard.component.html
@@ -153,14 +153,12 @@
           [options]="diskIoBusOptions$"
         ></ix-select>
 
-        @if (!isZvolSourceType) {
-          <ix-input
-            formControlName="root_disk_size"
-            type="number"
-            [required]="true"
-            [label]="'Root Disk Size (in GiB)' | translate"
-          ></ix-input>
-        }
+        <ix-input
+          formControlName="root_disk_size"
+          type="number"
+          [required]="true"
+          [label]="'Root Disk Size (in GiB)' | translate"
+        ></ix-input>
       }
 
       <ix-list


### PR DESCRIPTION
Previously root disk size was hidden when using an existing zvol. This appears to be unnecessary.