### PR TITLE
NAS-135398 / 25.04.1 / Allow root disk size to be specified when using zvols (by undsoft)

### DIFF
--- a/src/app/pages/instances/components/instance-wizard/instance-wizard.component.html
+++ b/src/app/pages/instances/components/instance-wizard/instance-wizard.component.html
@@ -147,14 +147,12 @@
           [options]="diskIoBusOptions$"
         ></ix-select>
 
-        @if (form.value.source_type !== VirtualizationSource.Zvol) {
-          <ix-input
-            formControlName="root_disk_size"
-            type="number"
-            [required]="true"
-            [label]="'Root Disk Size (in GiB)' | translate"
-          ></ix-input>
-        }
+        <ix-input
+          formControlName="root_disk_size"
+          type="number"
+          [required]="true"
+          [label]="'Root Disk Size (in GiB)' | translate"
+        ></ix-input>
       }
 
       <ix-list


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 0c9d537020b43bc73d58572c456789529dce0911

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 68b862bd417584446d82c139323e048a6ec410da

Previously root disk size was hidden when using an existing zvol. This appears to be unnecessary.

Original PR: https://github.com/truenas/webui/pull/11895
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135398