### PR TITLE
NAS-135539 / 25.10 / Incorrect endpoint is used to check for updates

### DIFF
--- a/src/app/pages/dashboard/services/widget-resources.service.spec.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.spec.ts
@@ -10,6 +10,7 @@ import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { App } from 'app/interfaces/app.interface';
 import { Pool } from 'app/interfaces/pool.interface';
 import { SystemInfo } from 'app/interfaces/system-info.interface';
+import { SystemUpdateChange } from 'app/interfaces/system-update.interface';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
 import { selectSystemInfo } from 'app/store/system-info/system-info.selectors';
 
@@ -50,7 +51,9 @@ describe('WidgetResourcesService', () => {
         mockCall('cloudsync.query'),
         mockCall('webui.main.dashboard.sys_info'),
         mockCall('interface.query'),
-        mockCall('update.check_available'),
+        mockCall('update.get_pending', [
+          {} as SystemUpdateChange,
+        ]),
         mockCall('reporting.netdata_get_data', [interfaceEth0]),
       ]),
       mockProvider(Store, {
@@ -79,6 +82,12 @@ describe('WidgetResourcesService', () => {
 
   it('returns apps', async () => {
     expect(await firstValueFrom(spectator.service.installedApps$)).toEqual(apps);
+  });
+
+  describe('updateAvailable$', () => {
+    it('returns true when api knows about available updates', async () => {
+      expect(await firstValueFrom(spectator.service.updateAvailable$)).toBe(true);
+    });
   });
 
   describe('networkInterfaceLastHourStats', () => {

--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -6,7 +6,6 @@ import {
   filter,
   forkJoin, map, of, repeat, shareReplay, startWith, throttleTime, timer,
 } from 'rxjs';
-import { SystemUpdateStatus } from 'app/enums/system-update.enum';
 import { LoadingState, toLoadingState } from 'app/helpers/operators/to-loading-state.helper';
 import { ApiEvent } from 'app/interfaces/api-message.interface';
 import { App, AppStartQueryParams, AppStats } from 'app/interfaces/app.interface';
@@ -72,8 +71,8 @@ export class WidgetResourcesService {
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 
-  readonly updateAvailable$ = this.api.call('update.check_available').pipe(
-    map((update) => update.status === SystemUpdateStatus.Available),
+  readonly updateAvailable$ = this.api.call('update.get_pending').pipe(
+    map((updates) => Boolean(updates.length)),
     catchError(() => of(false)),
     shareReplay({ refCount: false, bufferSize: 1 }),
   );


### PR DESCRIPTION
**Changes:**

`update.check_available` is to reach out to update servers and check if there is an update, so it doesn't make sense to call it on main dashboard.

