### PR TITLE
NAS-135554 / 25.10 / Fix disabled `Compression` in replication tasks

### DIFF
--- a/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.spec.ts
+++ b/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.spec.ts
@@ -102,6 +102,16 @@ describe('TransportSectionComponent', () => {
         netcat_passive_side_connect_address: null,
       });
     });
+
+    it('sends compression: null in payload when it is disabled', async () => {
+      await form.fillForm({
+        'Stream Compression': 'Disabled',
+      });
+
+      expect(spectator.component.getPayload()).toMatchObject({
+        compression: null,
+      });
+    });
   });
 
   describe('SSH+NETCAT transport', () => {

--- a/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.ts
+++ b/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.ts
@@ -126,11 +126,11 @@ export class TransportSectionComponent implements OnChanges {
       return {
         ...omitBy({
           ssh_credentials: values.ssh_credentials,
-          compression: values.compression === CompressionType.Disabled ? null : values.compression,
           speed_limit: values.speed_limit,
           large_block: values.large_block,
           compressed: values.compressed,
         }, isNull),
+        compression: values.compression === CompressionType.Disabled ? null : values.compression,
         netcat_active_side: null,
         netcat_active_side_listen_address: null,
         netcat_active_side_port_min: null,


### PR DESCRIPTION
**Testing:**

1. Create a replication task that uses SSH connection. You can create an SSH connection to the same system.
2. Check that Compression field can be set to disabled.