### PR TITLE
NAS-135539 / 25.04.1 / Incorrect endpoint is used to check for updates (by undsoft)

### DIFF
--- a/src/app/pages/dashboard/services/widget-resources.service.spec.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.spec.ts
@@ -16,6 +16,7 @@ import { App } from 'app/interfaces/app.interface';
 import { CloudSyncTask } from 'app/interfaces/cloud-sync-task.interface';
 import { NetworkInterface } from 'app/interfaces/network-interface.interface';
 import { Pool } from 'app/interfaces/pool.interface';
+import { SystemUpdateChange } from 'app/interfaces/system-update.interface';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
 
 const pools = [
@@ -214,7 +215,9 @@ describe('WidgetResourcesService', () => {
         mockCall('webui.main.dashboard.sys_info'),
         mockCall('app.query', apps),
         mockCall('pool.query', pools),
-        mockCall('update.check_available'),
+        mockCall('update.get_pending', [
+          {} as SystemUpdateChange,
+        ]),
         mockCall('reporting.netdata_get_data', [interfaceEth0]),
       ]),
     ],
@@ -250,6 +253,12 @@ describe('WidgetResourcesService', () => {
 
   it('returns apps', async () => {
     expect(await firstValueFrom(spectator.service.installedApps$)).toEqual(apps);
+  });
+
+  describe('updateAvailable$', () => {
+    it('returns true when api knows about available updates', async () => {
+      expect(await firstValueFrom(spectator.service.updateAvailable$)).toBe(true);
+    });
   });
 
   describe('networkInterfaceLastHourStats', () => {

--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -7,7 +7,6 @@ import {
   filter,
   forkJoin, map, of, repeat, shareReplay, startWith, switchMap, throttleTime, timer,
 } from 'rxjs';
-import { SystemUpdateStatus } from 'app/enums/system-update.enum';
 import { LoadingState, toLoadingState } from 'app/helpers/operators/to-loading-state.helper';
 import { ApiEvent } from 'app/interfaces/api-message.interface';
 import { App, AppStartQueryParams, AppStats } from 'app/interfaces/app.interface';
@@ -100,8 +99,8 @@ export class WidgetResourcesService {
     map((datasets) => this.parseVolumeData(datasets)),
   );
 
-  readonly updateAvailable$ = this.api.call('update.check_available').pipe(
-    map((update) => update.status === SystemUpdateStatus.Available),
+  readonly updateAvailable$ = this.api.call('update.get_pending').pipe(
+    map((updates) => Boolean(updates.length)),
     catchError(() => of(false)),
     shareReplay({ refCount: false, bufferSize: 1 }),
   );


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 9157b9ba77972d5b00179562aa5686be34b64e7c

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x bce424849f3487c7a1a9a8b0fbb3788e72ed55c1

**Changes:**

`update.check_available` is to reach out to update servers and check if there is an update, so it doesn't make sense to call it on main dashboard.



Original PR: https://github.com/truenas/webui/pull/11932
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135539