### PR TITLE
NAS-135388 / 25.10 / A banner for STIG disappeared if the system rebooted

### DIFF
--- a/src/app/pages/signin/signin.component.ts
+++ b/src/app/pages/signin/signin.component.ts
@@ -88,11 +88,13 @@ export class SigninComponent implements OnInit {
     this.signinStore.loginBanner$.pipe(
       filter(Boolean),
       filter(() => this.window.sessionStorage.getItem('loginBannerDismissed') !== 'true'),
-      switchMap((text) => this.dialog.fullScreenDialog({
-        message: text as TranslatedString,
-        showClose: true,
-        pre: true,
-      }).pipe(take(1))),
+      switchMap((text) => {
+        return this.dialog.fullScreenDialog({
+          message: text as TranslatedString,
+          showClose: true,
+          pre: true,
+        }).pipe(take(1));
+      }),
       filter(Boolean),
       untilDestroyed(this),
     ).subscribe(() => {

--- a/src/app/pages/signin/store/signin.store.ts
+++ b/src/app/pages/signin/store/signin.store.ts
@@ -75,7 +75,10 @@ export class SigninStore extends ComponentStore<SigninState> {
   setLoadingState = this.updater((state, isLoading: boolean) => ({ ...state, isLoading }));
 
   init = this.effect((trigger$: Observable<void>) => trigger$.pipe(
-    tap(() => this.setLoadingState(true)),
+    tap(() => {
+      this.setState(initialState);
+      this.setLoadingState(true);
+    }),
     switchMap(() => this.updateService.hardRefreshIfNeeded()),
     switchMap(() => forkJoin([
       this.checkIfAdminPasswordSet(),


### PR DESCRIPTION
**Testing:**

Original issue was reproducible by setting login banner in Advanced Settings, logging out and breaking websocket connection.
The expectation is that login banner is still shown after WS connection reestablishes.

For connection to break you can just wait for bit on login page.
