### PR TITLE
NAS-135771 / 25.10 / Require checklist items to be resolved on PRs

### DIFF
--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -1,0 +1,13 @@
+name: Require Checklist Items To Be Resolved
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/require-checklist-action@v2
+        with:
+          requireChecklist: false # Does not fail if the checklist is not present at all.

--- a/.github/workflows/require-checklist.yml
+++ b/.github/workflows/require-checklist.yml
@@ -1,11 +1,12 @@
-name: Require Checklist Items To Be Resolved
+name: Checklist
 
 on:
   pull_request:
     types: [opened, edited, synchronize]
 
 jobs:
-  job1:
+  checklist:
+    name: Resolve all checklist items
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/require-checklist-action@v2


### PR DESCRIPTION
**Testing:**
One of the jobs should fails because this checklist item is not done:

- [x] Not done.

The intention is to allow developers to add checklist items to their PR so that they don't forget to do something before merging the PR.