### PR TITLE
NAS-135651 / 25.10 / Disable reconnect dialog on failover

### DIFF
--- a/src/app/pages/signin/signin.component.spec.ts
+++ b/src/app/pages/signin/signin.component.spec.ts
@@ -28,6 +28,7 @@ describe('SigninComponent', () => {
   const loginBanner$ = new BehaviorSubject<string>('');
   const isTokenWithinTimeline$ = new BehaviorSubject<boolean>(true);
   const isReconnectAllowed$ = new BehaviorSubject<boolean>(false);
+  const isFailoverRestart$ = new BehaviorSubject<boolean>(false);
 
   const createComponent = createComponentFactory({
     component: SigninComponent,
@@ -52,7 +53,7 @@ describe('SigninComponent', () => {
     ],
     providers: [
       mockProvider(DialogService, {
-        fullScreenDialog: jest.fn(),
+        fullScreenDialog: jest.fn(() => of()),
       }),
       mockProvider(AuthService, {
         hasAuthToken: true,
@@ -64,6 +65,8 @@ describe('SigninComponent', () => {
         isConnected$,
         isReconnectAllowed$,
         setReconnectAllowed: jest.fn(),
+        isFailoverRestart$,
+        setFailoverStatus: jest.fn(),
       }),
     ],
   });
@@ -144,6 +147,14 @@ describe('SigninComponent', () => {
       spectator.detectChanges();
 
       expect(spectator.inject(DialogService).fullScreenDialog).toHaveBeenCalled();
+    });
+
+    it('checks signin store is initialized when isFailoverStart$ is true', () => {
+      isFailoverRestart$.next(true);
+      spectator.detectChanges();
+
+      expect(spectator.inject(SigninStore, true).init).toHaveBeenCalled();
+      expect(spectator.inject(WebSocketStatusService).setFailoverStatus).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/src/app/pages/signin/signin.component.ts
+++ b/src/app/pages/signin/signin.component.ts
@@ -85,6 +85,16 @@ export class SigninComponent {
       this.wsStatus.setReconnectAllowed(true);
     });
 
+    this.wsStatus.isFailoverRestart$
+      .pipe(
+        filter(Boolean),
+        untilDestroyed(this),
+      )
+      .subscribe(() => {
+        this.signinStore.init();
+        this.wsStatus.setFailoverStatus(false);
+      });
+
     this.signinStore.loginBanner$.pipe(
       filter(Boolean),
       filter(() => this.window.sessionStorage.getItem('loginBannerDismissed') !== 'true'),

--- a/src/app/pages/system-tasks/failover/failover.component.ts
+++ b/src/app/pages/system-tasks/failover/failover.component.ts
@@ -62,6 +62,7 @@ export class FailoverComponent implements OnInit {
   ngOnInit(): void {
     // Replace URL so that we don't restart again if page is refreshed.
     this.location.replaceState('/signin');
+    this.wsStatus.setReconnectAllowed(false);
     this.matDialog.closeAll();
     this.api.call('failover.become_passive').pipe(untilDestroyed(this)).subscribe({
       error: (error: unknown) => { // error on restart

--- a/src/app/pages/system-tasks/failover/failover.component.ts
+++ b/src/app/pages/system-tasks/failover/failover.component.ts
@@ -63,6 +63,8 @@ export class FailoverComponent implements OnInit {
     // Replace URL so that we don't restart again if page is refreshed.
     this.location.replaceState('/signin');
     this.wsStatus.setReconnectAllowed(false);
+    this.wsStatus.setFailoverStatus(true);
+
     this.matDialog.closeAll();
     this.api.call('failover.become_passive').pipe(untilDestroyed(this)).subscribe({
       error: (error: unknown) => { // error on restart

--- a/src/app/services/websocket-status.service.spec.ts
+++ b/src/app/services/websocket-status.service.spec.ts
@@ -124,4 +124,16 @@ describe('WebSocketStatusSerice', () => {
       expectObservable(spectator.service.isActiveSession$).toBe('a', { a: true });
     });
   });
+
+  it('checks setFailoverStatus', () => {
+    spectator.service.setFailoverStatus(true);
+    testScheduler.run(({ expectObservable }) => {
+      expectObservable(spectator.service.isFailoverRestart$).toBe('a', { a: true });
+    });
+
+    spectator.service.setFailoverStatus(false);
+    testScheduler.run(({ expectObservable }) => {
+      expectObservable(spectator.service.isFailoverRestart$).toBe('a', { a: false });
+    });
+  });
 });

--- a/src/app/services/websocket-status.service.ts
+++ b/src/app/services/websocket-status.service.ts
@@ -19,6 +19,7 @@ export class WebSocketStatusService {
   }
 
   readonly isReconnectAllowed$ = new BehaviorSubject<boolean>(false);
+  readonly isFailoverRestart$ = new BehaviorSubject<boolean>(false);
   private readonly isLoggedIn$ = new BehaviorSubject<boolean>(false);
   private readonly authStatus$ = new BehaviorSubject<boolean>(false);
   readonly isAuthenticated$ = this.authStatus$.asObservable();
@@ -50,5 +51,9 @@ export class WebSocketStatusService {
 
   setReconnectAllowed(status: boolean): void {
     this.isReconnectAllowed$.next(status);
+  }
+
+  setFailoverStatus(status: boolean): void {
+    this.isFailoverRestart$.next(status);
   }
 }


### PR DESCRIPTION
**Changes:**

- Do not show reconnect dialog when system restart was initiated using the Failover button

**Testing:**

- Try to restart system using Initiate Failover button