### PR TITLE
NAS-135953 / 25.04.2 / Input is not a valid integer in SSH form (by undsoft)

### DIFF
--- a/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.html
+++ b/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.html
@@ -130,6 +130,7 @@
       <ix-fieldset [title]="'More Options' | translate">
         <ix-input
           formControlName="connect_timeout"
+          type="number"
           [label]="'Connect Timeout' | translate"
           [tooltip]="helptext.connect_timeout_tooltip | translate"
         ></ix-input>

--- a/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.spec.ts
+++ b/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.spec.ts
@@ -163,7 +163,7 @@ describe('SshConnectionFormComponent', () => {
           existing_key_id: 2,
         },
         manual_setup: {
-          connect_timeout: '20',
+          connect_timeout: 20,
           host: 'truenas.com',
           port: 23,
           remote_host_key: 'ssh-rsaNew',
@@ -229,7 +229,7 @@ describe('SshConnectionFormComponent', () => {
       const values = await form.getValues();
       expect(values['Remote Host Key']).toBe('ssh-rsaAREMOTE');
       expect(api.call).toHaveBeenCalledWith('keychaincredential.remote_ssh_host_key_scan', [{
-        connect_timeout: '30',
+        connect_timeout: 30,
         host: 'remote.com',
         port: 24,
       }]);


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x e7c1876d477de6f8be605189a5bd023db8f2e1bd
    git cherry-pick -x ec847eca3da30120e8eef249991bebc63a16a140

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 449e0d5306e5f7cbba8d736214de4fe92e7fc492

**Testing:**

See ticket.


Original PR: https://github.com/truenas/webui/pull/12025
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135953