### PR TITLE
Fixes units for apps table and apps widget for apps network stats

### DIFF
--- a/src/app/modules/pipes/network-speed/network-speed.pipe.ts
+++ b/src/app/modules/pipes/network-speed/network-speed.pipe.ts
@@ -6,9 +6,9 @@ import { buildNormalizedFileSize } from 'app/helpers/file-size.utils';
   name: 'ixNetworkSpeed',
 })
 export class NetworkSpeedPipe implements PipeTransform {
-  transform(value: number): string {
+  transform(value: number, unit: 'b' | 'B' = 'b'): string {
     return this.translate.instant('{bits}/s', {
-      bits: buildNormalizedFileSize(value, 'b', 10),
+      bits: buildNormalizedFileSize(value, unit, 10),
     });
   }
 

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.html
@@ -49,9 +49,9 @@
 <div class="cell cell-network" [matTooltip]="'Incoming / Outgoing network traffic' | translate">
   @if (hasStats() && stats()?.networks?.length) {
     <span>
-      {{ incomingTraffic() | ixNetworkSpeed }}
+      {{ incomingTraffic() | ixNetworkSpeed: 'B' }}
       -
-      {{ outgoingTraffic() | ixNetworkSpeed }}
+      {{ outgoingTraffic() | ixNetworkSpeed: 'B' }}
     </span>
   } @else {
     {{ 'N/A' | translate }}

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.spec.ts
@@ -89,7 +89,7 @@ describe('AppRowComponent', () => {
     expect(spectator.query('.cell-cpu')).toHaveText('90%');
     expect(spectator.query('.cell-ram')).toHaveText('80 MiB');
     expect(spectator.query('.cell-io')).toHaveText('1 KiB - 2 KiB');
-    expect(spectator.query('.cell-network')).toHaveText('768 b/s - 1.02 kb/s');
+    expect(spectator.query('.cell-network')).toHaveText('768 B/s - 1.02 kB/s');
   });
 
   describe('actions', () => {

--- a/src/app/pages/dashboard/widgets/apps/common/app-network-info/app-network-info.component.html
+++ b/src/app/pages/dashboard/widgets/apps/common/app-network-info/app-network-info.component.html
@@ -4,13 +4,13 @@
     <div class="in-out-row">
       <span>{{ 'In' | translate }}:</span>
       <span *ixWithLoadingState="stats() as stats">
-        {{ incomingTraffic() | ixNetworkSpeed }}
+        {{ incomingTraffic() | ixNetworkSpeed: 'B' }}
       </span>
     </div>
     <div class="in-out-row">
       <span>{{ 'Out' | translate }}:</span>
       <span *ixWithLoadingState="stats() as stats">
-        {{ outgoingTraffic() | ixNetworkSpeed }}
+        {{ outgoingTraffic() | ixNetworkSpeed: 'B' }}
       </span>
     </div>
   </div>

--- a/src/app/pages/dashboard/widgets/apps/common/app-network-info/app-network-info.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/common/app-network-info/app-network-info.component.spec.ts
@@ -47,8 +47,8 @@ describe('AppNetworkInfoComponent', () => {
 
   it('checks in-out rows', () => {
     const inOutRows = spectator.queryAll('.in-out-row');
-    expect(inOutRows[0]).toHaveText('In: 123 b/s');
-    expect(inOutRows[1]).toHaveText('Out: 456 b/s');
+    expect(inOutRows[0]).toHaveText('In: 123 B/s');
+    expect(inOutRows[1]).toHaveText('Out: 456 B/s');
   });
 
   it('should generate correct network chart data', () => {


### PR DESCRIPTION
**Changes:**

Fixes units for apps table and apps widget for apps network stats

**Testing:**

See that apps network traffic unit is Bytes ('B') and not bits ('b')

