### PR TITLE
NAS-135762 / 25.04.2 / Bring back B2 `chunk_size` option (by AlexKarpov98)

### DIFF
--- a/src/app/helptext/data-protection/cloudsync/cloudsync.ts
+++ b/src/app/helptext/data-protection/cloudsync/cloudsync.ts
@@ -35,6 +35,11 @@ export const helptextCloudSync = {
   encryption_placeholder: T('Server Side Encryption'),
   encryption_tooltip: T('Choose <i>AES-256</i> or <i>None</i>.'),
 
+  chunkSizeLabel: T('Upload Chunk Size (MiB)'),
+  chunkSizeTooltip: T('Files are split into chunks of this size before upload.\
+ Up to «--transfers» chunks can be in progress at one time. The single largest file\
+ being transferred must fit into no more than 10,000 chunks.'),
+
   storage_class_placeholder: T('Storage Class'),
   storage_class_tooltip: T('Classification for each S3 object. Choose a\
  class based on the specific use case or performance requirements.\

--- a/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.html
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-form/cloudsync-form.component.html
@@ -204,6 +204,14 @@
               [options]="encryptionOptions$"
             ></ix-select>
           }
+          @if (form.controls.chunk_size.enabled) {
+            <ix-input
+              formControlName="chunk_size"
+              type="number"
+              [label]="helptext.chunkSizeLabel | translate"
+              [tooltip]="helptext.chunkSizeTooltip | translate"
+            ></ix-input>
+          }
           <div class="advanced-title">
             {{ helptext.advanced_remote_options | translate }}
           </div>

--- a/src/assets/i18n/af.json
+++ b/src/assets/i18n/af.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ast.json
+++ b/src/assets/i18n/ast.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/az.json
+++ b/src/assets/i18n/az.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/be.json
+++ b/src/assets/i18n/be.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/bn.json
+++ b/src/assets/i18n/bn.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/br.json
+++ b/src/assets/i18n/br.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/bs.json
+++ b/src/assets/i18n/bs.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -1471,6 +1471,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",
   "Filesystem Attrs Write": "",

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/da.json
+++ b/src/assets/i18n/da.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1442,6 +1442,7 @@
   "File size is limited to {n} MiB.": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesystem Attrs Read": "",
   "Filesystem Attrs Write": "",
   "Filesystem Data Read": "",

--- a/src/assets/i18n/dsb.json
+++ b/src/assets/i18n/dsb.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/el.json
+++ b/src/assets/i18n/el.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/en-au.json
+++ b/src/assets/i18n/en-au.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/en-gb.json
+++ b/src/assets/i18n/en-gb.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/eo.json
+++ b/src/assets/i18n/eo.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/es-ar.json
+++ b/src/assets/i18n/es-ar.json
@@ -135,6 +135,7 @@
   "Estimated total raw data capacity": "",
   "Export/Disconnect Pool": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Finding Pools": "",
   "Finding pools to import...": "",
   "Following container images are available to update:\n": "",

--- a/src/assets/i18n/es-co.json
+++ b/src/assets/i18n/es-co.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/es-mx.json
+++ b/src/assets/i18n/es-mx.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/es-ni.json
+++ b/src/assets/i18n/es-ni.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/es-ve.json
+++ b/src/assets/i18n/es-ve.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1756,6 +1756,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/et.json
+++ b/src/assets/i18n/et.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/eu.json
+++ b/src/assets/i18n/eu.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/fa.json
+++ b/src/assets/i18n/fa.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -381,6 +381,7 @@
   "Fibre Channel Ports": "",
   "File ID": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesystem Attrs Read": "",
   "Filesystem Attrs Write": "",
   "Filesystem Data Read": "",

--- a/src/assets/i18n/fy.json
+++ b/src/assets/i18n/fy.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ga.json
+++ b/src/assets/i18n/ga.json
@@ -352,6 +352,7 @@
   "Fibre Channel Ports": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Finding Pools": "",
   "Finding pools to import...": "",
   "Finish": "",

--- a/src/assets/i18n/gd.json
+++ b/src/assets/i18n/gd.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/he.json
+++ b/src/assets/i18n/he.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/hi.json
+++ b/src/assets/i18n/hi.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/hr.json
+++ b/src/assets/i18n/hr.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/hsb.json
+++ b/src/assets/i18n/hsb.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/hu.json
+++ b/src/assets/i18n/hu.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ia.json
+++ b/src/assets/i18n/ia.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/id.json
+++ b/src/assets/i18n/id.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/io.json
+++ b/src/assets/i18n/io.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/is.json
+++ b/src/assets/i18n/is.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -142,6 +142,7 @@
   "FTP Port number. Leave blank to use the default port <i>21</i>.": "",
   "FTP Service": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Finding Pools": "",
   "Finding pools to import...": "",
   "Following container images are available to update:\n": "",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -1689,6 +1689,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ka.json
+++ b/src/assets/i18n/ka.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/kk.json
+++ b/src/assets/i18n/kk.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/km.json
+++ b/src/assets/i18n/km.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/kn.json
+++ b/src/assets/i18n/kn.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -136,6 +136,7 @@
   "Estimated total raw data capacity": "",
   "Export/Disconnect Pool": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Finding Pools": "",
   "Finding pools to import...": "",
   "Following container images are available to update:\n": "",

--- a/src/assets/i18n/lb.json
+++ b/src/assets/i18n/lb.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/lt.json
+++ b/src/assets/i18n/lt.json
@@ -1932,6 +1932,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/lv.json
+++ b/src/assets/i18n/lv.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/mk.json
+++ b/src/assets/i18n/mk.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ml.json
+++ b/src/assets/i18n/ml.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/mn.json
+++ b/src/assets/i18n/mn.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/mr.json
+++ b/src/assets/i18n/mr.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/my.json
+++ b/src/assets/i18n/my.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/nb.json
+++ b/src/assets/i18n/nb.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ne.json
+++ b/src/assets/i18n/ne.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -187,6 +187,7 @@
   "FC Target": "",
   "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Finding Pools": "",
   "Finding pools to import...": "",
   "Finish": "",

--- a/src/assets/i18n/nn.json
+++ b/src/assets/i18n/nn.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/os.json
+++ b/src/assets/i18n/os.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/pa.json
+++ b/src/assets/i18n/pa.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/pl.json
+++ b/src/assets/i18n/pl.json
@@ -164,6 +164,7 @@
   "Export/Disconnect Pool": "",
   "FC Target": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Finding Pools": "",
   "Finding pools to import...": "",
   "Following container images are available to update:\n": "",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -1886,6 +1886,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1124,6 +1124,7 @@
   "File Permissions": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Finding Pools": "",
   "Finding pools to import...": "",
   "Finish": "",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -1299,6 +1299,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",
   "Filesystem Attrs Write": "",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/sq.json
+++ b/src/assets/i18n/sq.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/sr-latn.json
+++ b/src/assets/i18n/sr-latn.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/sr.json
+++ b/src/assets/i18n/sr.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/strings.json
+++ b/src/assets/i18n/strings.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/sw.json
+++ b/src/assets/i18n/sw.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/ta.json
+++ b/src/assets/i18n/ta.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/te.json
+++ b/src/assets/i18n/te.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/th.json
+++ b/src/assets/i18n/th.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/tt.json
+++ b/src/assets/i18n/tt.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/udm.json
+++ b/src/assets/i18n/udm.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/uk.json
+++ b/src/assets/i18n/uk.json
@@ -943,6 +943,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesystem": "",
   "Finding Pools": "",
   "Finding pools to import...": "",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -1938,6 +1938,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesize": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",

--- a/src/assets/i18n/zh-hans.json
+++ b/src/assets/i18n/zh-hans.json
@@ -193,6 +193,7 @@
   "Failed to renew certificate": "",
   "Failover is unhealthy. Rebooting now will cause a production outage.": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Finding Pools": "",
   "Finding pools to import...": "",
   "Finish": "",

--- a/src/assets/i18n/zh-hant.json
+++ b/src/assets/i18n/zh-hant.json
@@ -1253,6 +1253,7 @@
   "Filename": "",
   "Filename Encryption (not recommended)": "",
   "Files are split into chunks of this size  before upload. The number of chunks that can be simultaneously  transferred is set by the <b>Transfers</b> number. The single  largest file being transferred must fit into no more than 10,000  chunks.": "",
+  "Files are split into chunks of this size before upload. Up to «--transfers» chunks can be in progress at one time. The single largest file being transferred must fit into no more than 10,000 chunks.": "",
   "Filesystem": "",
   "Filesystem Attrs Read": "",
   "Filesystem Attrs Write": "",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 135b398cab570d313d3e4c74da9f1dcdc31e1dfe
    git cherry-pick -x dcb556c9cdf3d0eec6fa503981c0831ff42f95a0

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 2f3c0d7273b334d28adfc7a8c446aa4d2a9dc5b1

Testing: see ticket.

`chunk_size` is now available for `B2` provider.

Original PR: https://github.com/truenas/webui/pull/12067
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135762