### PR TITLE
NAS-135972 / 25.04.2 / Don't show option to set password for non-local users (by RehanY147)

### DIFF
--- a/src/app/modules/auth/auth.service.spec.ts
+++ b/src/app/modules/auth/auth.service.spec.ts
@@ -14,6 +14,7 @@ import { TestScheduler } from 'rxjs/testing';
 import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { AccountAttribute } from 'app/enums/account-attribute.enum';
 import { LoginResult } from 'app/enums/login-result.enum';
 import { Role } from 'app/enums/role.enum';
 import { WINDOW } from 'app/helpers/window.helper';
@@ -47,6 +48,10 @@ describe('AuthService', () => {
     privilege: {
       webui_access: true,
     },
+    account_attributes: [
+      AccountAttribute.Local,
+      AccountAttribute.PasswordChangeRequired,
+    ],
   } as LoggedInUser;
 
   const mockWsStatus = new WebSocketStatusService();
@@ -65,6 +70,10 @@ describe('AuthService', () => {
           response_type: LoginExResponseType.Success,
           user_info: {
             privilege: { webui_access: true },
+            account_attributes: [
+              AccountAttribute.Local,
+              AccountAttribute.PasswordChangeRequired,
+            ],
           },
         } as LoginExResponse),
       ]),
@@ -167,6 +176,24 @@ describe('AuthService', () => {
       );
       expect(spectator.inject(ApiService).call).not.toHaveBeenCalledWith('auth.me');
       expect(spectator.inject(ApiService).call).not.toHaveBeenCalledWith('auth.generate_token');
+    });
+
+    it('emits correct isLocalUser$', () => {
+      timer$.next(0);
+
+      const obs$ = spectator.service.login('dummy', 'dummy');
+      testScheduler.run(({ expectObservable }) => {
+        expectObservable(obs$).toBe(
+          '(a|)',
+          { a: LoginResult.Success },
+        );
+        expectObservable(spectator.service.isLocalUser$).toBe('a', {
+          a: true,
+        });
+        expectObservable(spectator.service.isPasswordChangeRequired$).toBe('a', {
+          a: true,
+        });
+      });
     });
   });
 

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -68,6 +68,11 @@ export class AuthService {
     map((user) => user.account_attributes.includes(AccountAttribute.Otpw)),
   );
 
+  isLocalUser$: Observable<boolean> = this.user$.pipe(
+    filter(Boolean),
+    map((user) => user.account_attributes.includes(AccountAttribute.Local)),
+  );
+
   isPasswordChangeRequired$: Observable<boolean> = this.user$.pipe(
     filter(Boolean),
     map((user) => user.account_attributes.includes(AccountAttribute.PasswordChangeRequired)),

--- a/src/app/pages/credentials/users/first-login-dialog/first-login-dialog.component.html
+++ b/src/app/pages/credentials/users/first-login-dialog/first-login-dialog.component.html
@@ -4,7 +4,7 @@
   </h2>
 
   <div class="container">
-    @if (isOtpwUser()) {
+    @if (isOtpwUser() && isLocalUser()) {
       <div class="left-side" [class.step-finished]="wasOneTimePasswordChanged()">
         <mat-card>
           <mat-toolbar-row>

--- a/src/app/pages/credentials/users/first-login-dialog/first-login-dialog.component.spec.ts
+++ b/src/app/pages/credentials/users/first-login-dialog/first-login-dialog.component.spec.ts
@@ -20,6 +20,7 @@ describe('FirstLoginDialogComponent', () => {
   const mockTwoFactorConfig$ = new BehaviorSubject({ secret_configured: false });
   const mockWasOneTimePasswordChanged$ = new BehaviorSubject(false);
   const mockIsOtpwUser$ = new BehaviorSubject(true);
+  const mockIsLocalUser$ = new BehaviorSubject(true);
 
   const createComponent = createComponentFactory({
     component: FirstLoginDialogComponent,
@@ -29,6 +30,7 @@ describe('FirstLoginDialogComponent', () => {
         wasOneTimePasswordChanged$: mockWasOneTimePasswordChanged$,
         isOtpwUser$: mockIsOtpwUser$.asObservable(),
         userTwoFactorConfig$: mockTwoFactorConfig$.asObservable(),
+        isLocalUser$: mockIsLocalUser$.asObservable(),
       }),
       provideMockStore(),
       mockProvider(MatDialogRef),
@@ -108,5 +110,14 @@ describe('FirstLoginDialogComponent', () => {
     spectator.component.passwordChanged();
 
     expect(passwordChangedSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('does not show password cahnge when non-local user', () => {
+    mockIsOtpwUser$.next(true);
+    spectator.detectChanges();
+    expect(spectator.query(ChangePasswordFormComponent)).toExist();
+    mockIsLocalUser$.next(false);
+    spectator.detectChanges();
+    expect(spectator.query(ChangePasswordFormComponent)).not.toExist();
   });
 });

--- a/src/app/pages/credentials/users/first-login-dialog/first-login-dialog.component.ts
+++ b/src/app/pages/credentials/users/first-login-dialog/first-login-dialog.component.ts
@@ -34,6 +34,7 @@ import { TwoFactorComponent } from 'app/pages/two-factor-auth/two-factor.compone
 })
 export class FirstLoginDialogComponent {
   isOtpwUser = toSignal(this.authService.isOtpwUser$);
+  isLocalUser = toSignal(this.authService.isLocalUser$);
   wasOneTimePasswordChanged = toSignal(this.authService.wasOneTimePasswordChanged$);
   userTwoFactorAuthConfigured = toSignal(this.authService.userTwoFactorConfig$.pipe(
     map((config) => config.secret_configured),


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 02b023091fdc3085a85443dc0ae7cdae263eefc9

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~3
    git cherry-pick -x cdb4bbeb0a7acd75ef9225c1005718799c3d51c1

**Changes:**

Don't show option to set password for non-local users right after login.

**Testing:**

See ticket


Original PR: https://github.com/truenas/webui/pull/12069
Jira URL: https://ixsystems.atlassian.net/browse/NAS-135972