### PR TITLE
NAS-135063 / 25.10 / Rsync Task - Auxiliary parameter goes off screen

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-chips/ix-chips.component.scss
+++ b/src/app/modules/forms/ix-forms/components/ix-chips/ix-chips.component.scss
@@ -1,5 +1,3 @@
-@import 'mixins/text';
-
 :host {
   color: var(--fg1);
   display: block;


### PR DESCRIPTION
Testing: see ticket.

Preview:
<img width="408" alt="NAS-135063" src="https://github.com/user-attachments/assets/3ad41efd-f857-485c-93bf-d42e27e750b7" />
