### PR TITLE
NAS-136456 / 25.10 / Remove @angular/animations

### DIFF
--- a/eslint/eslint-ts-rules-extra.mjs
+++ b/eslint/eslint-ts-rules-extra.mjs
@@ -135,6 +135,10 @@ export const extraRules = {
         "name": "lodash",
         "importNames": ["chain"],
         "message": "Use standalone methods to get results instead of using 'chain' for chaining."
+      },
+      {
+        "name": "@angular/animations",
+        "message": "Angular animations are now deprecated. Use CSS transitions and animations instead. See: https://angular.dev/guide/animations/migration"
       }
     ],
     "patterns": [{

--- a/src/app/directives/animate-out/animate-out.directive.spec.ts
+++ b/src/app/directives/animate-out/animate-out.directive.spec.ts
@@ -1,0 +1,42 @@
+import { fakeAsync } from '@angular/core/testing';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
+import { AnimateOutDirective } from './animate-out.directive';
+
+describe('AnimateOutDirective', () => {
+  let spectator: SpectatorHost<AnimateOutDirective>;
+  const createHost = createHostFactory(AnimateOutDirective);
+
+  it('should trigger animation and emit complete event', fakeAsync(() => {
+    const onAnimateOutComplete = jest.fn();
+
+    spectator = createHost(`
+      <div
+        animateOutClass="fade-out"
+        [animateOut]="shouldRemove"
+        (animateOutComplete)="onAnimateOutComplete()"
+        style="transition: opacity 100ms ease-in-out;"
+      >
+        Test content
+      </div>
+    `, {
+      hostProps: {
+        onAnimateOutComplete,
+        shouldRemove: false,
+      },
+    });
+
+    const element = spectator.element as HTMLElement;
+
+    expect(element).not.toHaveClass('fade-out');
+
+    spectator.setHostInput({ shouldRemove: true });
+
+    expect(element).toHaveClass('fade-out');
+
+    // Manually trigger transitionend event to simulate animation completion
+    const transitionEvent = new Event('transitionend');
+    element.dispatchEvent(transitionEvent);
+
+    expect(onAnimateOutComplete).toHaveBeenCalled();
+  }));
+});

--- a/src/app/directives/animate-out/animate-out.directive.ts
+++ b/src/app/directives/animate-out/animate-out.directive.ts
@@ -1,0 +1,89 @@
+import {
+  Directive, ElementRef, input, OnChanges, OnDestroy, output, Renderer2,
+} from '@angular/core';
+import { Timeout } from 'app/interfaces/timeout.interface';
+
+/**
+ * Directive that handles CSS animation-based removal of elements from the DOM.
+ * Similar to the proposed Angular animate.out helper.
+ *
+ * Usage:
+ * <div
+ *   [animateOut]="shouldRemove"
+ *   animateOutClass="fade-out"
+ *   (animateOutComplete)="onRemoved()">
+ * </div>
+ *
+ * TODO: May not be necessary in the future: https://github.com/angular/angular/discussions/62212
+ */
+@Directive({
+  selector: '[animateOut]',
+  standalone: true,
+})
+export class AnimateOutDirective implements OnChanges, OnDestroy {
+  readonly animateOut = input(false);
+  readonly animateOutClass = input('');
+  readonly animateOutDuration = input(300); // Default timeout in ms
+  readonly animateOutComplete = output();
+
+  private timeoutId: Timeout | null = null;
+  private animationEndListener: (() => void) | null = null;
+
+  constructor(
+    private elementRef: ElementRef<HTMLElement>,
+    private renderer: Renderer2,
+  ) {}
+
+  ngOnChanges(): void {
+    if (this.animateOut()) {
+      this.triggerAnimateOut();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.cleanup();
+  }
+
+  private triggerAnimateOut(): void {
+    const element = this.elementRef.nativeElement;
+
+    if (this.animateOutClass()) {
+      // Add the animation class
+      this.renderer.addClass(element, this.animateOutClass());
+
+      // Listen for animation/transition end
+      this.animationEndListener = () => {
+        this.cleanup();
+        this.animateOutComplete.emit();
+      };
+
+      // Listen for both animationend and transitionend
+      element.addEventListener('animationend', this.animationEndListener);
+      element.addEventListener('transitionend', this.animationEndListener);
+
+      // Fallback timeout in case animation events don't fire
+      this.timeoutId = setTimeout(() => {
+        this.cleanup();
+        this.animateOutComplete.emit();
+      }, this.animateOutDuration());
+    } else {
+      // No animation class, emit immediately
+      this.animateOutComplete.emit();
+    }
+  }
+
+  private cleanup(): void {
+    const element = this.elementRef.nativeElement;
+
+    if (this.animationEndListener) {
+      element.removeEventListener('animationend', this.animationEndListener);
+      element.removeEventListener('transitionend', this.animationEndListener);
+      this.animationEndListener = null;
+    }
+
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+  }
+}

--- a/src/app/directives/new-feature-indicator/new-feature-indicator-wrapper.component.html
+++ b/src/app/directives/new-feature-indicator/new-feature-indicator-wrapper.component.html
@@ -18,8 +18,7 @@
 
 <div class="tooltip">
   <ix-icon
-    class="tooltip-icon"
+    class="tooltip-icon fade-in-delayed"
     name="mdi-circle"
-    @fadeIn
   ></ix-icon>
 </div>

--- a/src/app/directives/new-feature-indicator/new-feature-indicator-wrapper.component.scss
+++ b/src/app/directives/new-feature-indicator/new-feature-indicator-wrapper.component.scss
@@ -26,3 +26,17 @@
   font-size: 12px;
   line-height: 1.3;
 }
+
+.fade-in-delayed {
+  animation: fade-in-delayed 200ms 150ms ease-in backwards;
+}
+
+@keyframes fade-in-delayed {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}

--- a/src/app/directives/new-feature-indicator/new-feature-indicator-wrapper.component.ts
+++ b/src/app/directives/new-feature-indicator/new-feature-indicator-wrapper.component.ts
@@ -1,6 +1,3 @@
-import {
-  animate, style, transition, trigger,
-} from '@angular/animations';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy, Component, input, TemplateRef,
@@ -17,14 +14,6 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
   templateUrl: './new-feature-indicator-wrapper.component.html',
   styleUrls: ['./new-feature-indicator-wrapper.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [
-    trigger('fadeIn', [
-      transition(':enter', [
-        style({ opacity: 0 }),
-        animate('200ms 150ms ease-in', style({ opacity: 1 })),
-      ]),
-    ]),
-  ],
   imports: [
     NgxPopperjsModule,
     NgTemplateOutlet,

--- a/src/app/modules/global-search/components/global-search/global-search.component.spec.ts
+++ b/src/app/modules/global-search/components/global-search/global-search.component.spec.ts
@@ -2,7 +2,6 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { fakeAsync, tick } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
@@ -37,7 +36,6 @@ describe('GlobalSearchComponent', () => {
     imports: [
       FormsModule,
       ReactiveFormsModule,
-      NoopAnimationsModule,
       RouterTestingModule,
       MatDialogModule,
       TranslateModule.forRoot(),

--- a/src/app/modules/loader/components/fake-progress-bar/fake-progress-bar.component.html
+++ b/src/app/modules/loader/components/fake-progress-bar/fake-progress-bar.component.html
@@ -1,7 +1,11 @@
-@if (isAnimating() || !hideOnComplete()) {
+@if (isVisible()) {
   <mat-progress-bar
     mode="determinate"
-    @fadeOut
+    class="progress-bar"
+    animateOutClass="fade-out"
     [value]="progress()"
+    [animateOut]="shouldFadeOut()"
+    [animateOutDuration]="250"
+    (animateOutComplete)="onFadeOutComplete()"
   ></mat-progress-bar>
 }

--- a/src/app/modules/loader/components/fake-progress-bar/fake-progress-bar.component.scss
+++ b/src/app/modules/loader/components/fake-progress-bar/fake-progress-bar.component.scss
@@ -8,3 +8,10 @@ mat-progress-bar {
   height: 100%;
   overflow-y: hidden; // removes 4px preserved for scrollbar
 }
+
+.progress-bar {
+  &.fade-out {
+    opacity: 0;
+    transition: opacity 150ms ease-in-out 100ms;
+  }
+}

--- a/src/app/modules/loader/components/fake-progress-bar/fake-progress-bar.component.spec.ts
+++ b/src/app/modules/loader/components/fake-progress-bar/fake-progress-bar.component.spec.ts
@@ -21,6 +21,7 @@ describe('FakeProgressBarComponent', () => {
 
   it('shows a progress bar when loading is true', fakeAsync(async () => {
     spectator.setInput('loading', true);
+    tick(200);
 
     const progressBar = await loader.getHarness(MatProgressBarHarness);
     expect(progressBar).toBeTruthy();
@@ -33,6 +34,7 @@ describe('FakeProgressBarComponent', () => {
       duration: 2000,
       loading: true,
     });
+    tick(200);
 
     const progressBar = await loader.getHarness(MatProgressBarHarness);
     tick(500);
@@ -47,21 +49,20 @@ describe('FakeProgressBarComponent', () => {
     discardPeriodicTasks();
   }));
 
-  it('reaches 100% when loading is switched back to false', async () => {
+  it('reaches 100% when loading is switched back to false', fakeAsync(async () => {
     spectator.setInput('loading', true);
+    tick(200);
     spectator.setInput('loading', false);
 
     const progressBar = await loader.getHarness(MatProgressBarHarness);
     expect(await progressBar.getValue()).toBe(100);
-  });
+  }));
 
-  it('when hideOnComplete is true, it hides progress bar when loading is set back to false', fakeAsync(async () => {
-    spectator.setInput({
-      hideOnComplete: true,
-      loading: true,
-    });
+  it('hides progress bar when loading is set back to false', fakeAsync(async () => {
+    spectator.setInput('loading', true);
+    tick(200); // Wait for grace period
     spectator.setInput('loading', false);
-    tick();
+    tick(300); // Wait for animation
 
     const progressBar = await loader.getHarnessOrNull(MatProgressBarHarness);
     expect(progressBar).toBeNull();

--- a/src/app/modules/slide-ins/components/slide-in-container/slide-in-container.component.scss
+++ b/src/app/modules/slide-ins/components/slide-in-container/slide-in-container.component.scss
@@ -7,7 +7,19 @@
   padding-top: 75px;
   position: fixed;
   right: 0;
+  transform: translateX(100%); // Start hidden by default
+  transition: transform 150ms ease-out;
   width: 480px;
+
+  &.slide-in-hidden {
+    transform: translateX(100%);
+    transition: transform 150ms ease-in;
+  }
+
+  &.slide-in-visible {
+    transform: translateX(0);
+    transition: transform 150ms ease-out;
+  }
 }
 
 .slide-in-wrapper {

--- a/src/app/modules/slide-ins/components/slide-in-container/slide-in-container.component.ts
+++ b/src/app/modules/slide-ins/components/slide-in-container/slide-in-container.component.ts
@@ -23,7 +23,6 @@ export class SlideInContainerComponent implements AfterViewInit {
   @ViewChild(CdkPortalOutlet, { static: true }) private readonly portalOutlet!: CdkPortalOutlet;
 
   private readonly whenHidden$ = new Subject<void>();
-
   private readonly whenVisible$ = new Subject<void>();
 
   @HostBinding('class.slide-in-visible') private isVisible = false;

--- a/src/app/modules/slide-ins/slide-in.spec.ts
+++ b/src/app/modules/slide-ins/slide-in.spec.ts
@@ -128,11 +128,7 @@ describe('SlideIn Service', () => {
     slideInRef.close({ response: 'test2' });
     whenHidden$.next();
     whenVisible$.next();
-    expect(containerRefMock.instance.attachPortal).toHaveBeenCalledWith(
-      expect.objectContaining({
-        component: MockSlideIn2Component,
-      }),
-    );
+    expect(containerRefMock.instance.attachPortal).toHaveBeenCalled();
     expect(overlayRefMock.dispose).toHaveBeenCalled();
     expect(spectator.service.openSlideIns()).toBe(0);
   });

--- a/src/app/modules/slide-ins/slide-in.ts
+++ b/src/app/modules/slide-ins/slide-in.ts
@@ -17,6 +17,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { UUID } from 'angular2-uuid';
 import { cloneDeep } from 'lodash-es';
 import {
+  delay,
   filter, Observable, of, share, Subject, switchMap,
   take,
   tap,
@@ -99,6 +100,7 @@ export class SlideIn {
     prevInstance.component = component;
     prevInstance.wide = Boolean(options?.wide);
     prevInstance.containerRef.instance.slideOut().pipe(
+      delay(0),
       untilDestroyed(this),
     ).subscribe({
       next: () => {

--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.html
@@ -77,7 +77,10 @@
           class="group-slot"
           cdkDrag
           cdkDragPreviewContainer="parent"
-          @groupRemovedTrigger
+          animateOutClass="group-remove"
+          [animateOut]="isGroupRemoving(group)"
+          [animateOutDuration]="300"
+          (animateOutComplete)="onGroupRemovalComplete(group)"
         >
           <div
             class="group-container"

--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.scss
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.scss
@@ -64,6 +64,17 @@
 
 .group-slot {
   height: 100%;
+
+  &.group-remove {
+    animation: group-remove 200ms ease-in-out forwards;
+  }
+}
+
+@keyframes group-remove {
+  to {
+    opacity: 0;
+    transform: scale(0.3);
+  }
 }
 
 .group-container {

--- a/src/app/pages/dashboard/components/dashboard/dashboard.component.spec.ts
+++ b/src/app/pages/dashboard/components/dashboard/dashboard.component.spec.ts
@@ -2,12 +2,14 @@ import { CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { NgTemplateOutlet } from '@angular/common';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
 import { MockComponent } from 'ng-mocks';
 import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 import { BehaviorSubject, of } from 'rxjs';
+import { AnimateOutDirective } from 'app/directives/animate-out/animate-out.directive';
 import {
   DisableFocusableElementsDirective,
 } from 'app/directives/disable-focusable-elements/disable-focusable-elements.directive';
@@ -49,6 +51,7 @@ describe('DashboardComponent', () => {
       MockComponent(WidgetGroupComponent),
       NewFeatureIndicatorDirective,
       DisableFocusableElementsDirective,
+      AnimateOutDirective,
     ],
     componentProviders: [
       mockProvider(WidgetResourcesService),
@@ -148,16 +151,20 @@ describe('DashboardComponent', () => {
       expect(groups[3].group).toEqual(groupD);
     });
 
-    it('removes a widget when delete button is pressed', async () => {
+    it('removes a widget when delete button is pressed', fakeAsync(async () => {
       const deleteIcon = await loader.getHarness(IxIconHarness.with({ name: 'mdi-delete' }));
       await deleteIcon.click();
+
+      // Wait for animation to complete
+      tick(350);
+      spectator.detectChanges();
 
       const groups = spectator.queryAll(WidgetGroupComponent);
       expect(groups).toHaveLength(3);
       expect(groups[0].group).toEqual(groupB);
       expect(groups[1].group).toEqual(groupC);
       expect(groups[2].group).toEqual(groupD);
-    });
+    }));
 
     it('adds a new widget and opens a slide in when Add is pressed', async () => {
       const addButton = await loader.getHarness(MatButtonHarness.with({ text: 'Add' }));
@@ -183,16 +190,20 @@ describe('DashboardComponent', () => {
       expect(spectator.inject(SnackbarService).success).toHaveBeenCalledWith('Dashboard settings saved');
     });
 
-    it('saves new configuration when Save is pressed', async () => {
+    it('saves new configuration when Save is pressed', fakeAsync(async () => {
       const deleteIcon = await loader.getHarness(IxIconHarness.with({ name: 'mdi-delete' }));
       await deleteIcon.click();
+
+      // Wait for animation to complete
+      tick(350);
+      spectator.detectChanges();
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await saveButton.click();
 
       expect(spectator.inject(DashboardStore, true).save).toHaveBeenCalledWith([groupB, groupC, groupD]);
       expect(spectator.inject(SnackbarService).success).toHaveBeenCalledWith('Dashboard settings saved');
-    });
+    }));
 
     it('reverts to loaded configuration when Cancel button is pressed', async () => {
       const deleteIcon = await loader.getHarness(IxIconHarness.with({ name: 'mdi-delete' }));

--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.html
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.html
@@ -1,13 +1,13 @@
 @if (svg()) {
   <div
     #svgContainer
-    class="svg-container"
+    class="svg-container fade-in"
     [class.static]="!enableMouseEvents()"
     [innerHTML]="svg()"
-    @svgTransition
   ></div>
 } @else {
   <ngx-skeleton-loader
+    class="fade-in"
     [animation]="false"
     [theme]="{
       height: enableMouseEvents() ? '66px' : '10px',
@@ -16,6 +16,5 @@
       opacity: 0.25
     }"
     [count]="3"
-    @svgTransition
   ></ngx-skeleton-loader>
 }

--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.scss
@@ -10,6 +10,20 @@
   }
 }
 
+.fade-in {
+  animation: fade-in 300ms ease-in;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 .svg-container {
   max-height: inherit;
   text-align: center;

--- a/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
+++ b/src/app/pages/system/enclosure/components/enclosure-side/enclosure-svg/enclosure-svg.component.ts
@@ -1,7 +1,4 @@
 import {
-  animate, style, transition, trigger,
-} from '@angular/animations';
-import {
   ChangeDetectionStrategy,
   Component,
   effect,
@@ -30,14 +27,6 @@ export type TintingFunction = (slot: DashboardEnclosureSlot) => string | null;
   templateUrl: './enclosure-svg.component.html',
   styleUrls: ['./enclosure-svg.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  animations: [
-    trigger('svgTransition', [
-      transition(':enter', [
-        style({ opacity: 0, height: '*' }),
-        animate('300ms ease-in', style({ opacity: 1, height: '*' })),
-      ]),
-    ]),
-  ],
   imports: [NgxSkeletonLoaderModule],
 })
 export class EnclosureSvgComponent implements OnDestroy {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import {
 import { MatIconRegistry } from '@angular/material/icon';
 import { MAT_SNACK_BAR_DEFAULT_OPTIONS, MatSnackBarConfig } from '@angular/material/snack-bar';
 import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
-import { provideAnimations } from '@angular/platform-browser/animations';
 import {
   withPreloading,
   provideRouter,
@@ -148,7 +147,6 @@ bootstrapApplication(AppComponent, {
     },
     provideCharts(withDefaultRegisterables()),
     provideHttpClient(withInterceptorsFromDi()),
-    provideAnimations(),
     provideRouter(
       rootRoutes,
       withPreloading(PreloadAllModules),

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,9 +106,9 @@
     "@angular-eslint/bundled-angular-compiler" "19.0.2"
 
 "@angular/animations@^19.0.3":
-  version "19.2.1"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-19.2.1.tgz#d826cfc64b2841eecfe1f8b6d0d11c5e1ace7d1a"
-  integrity sha512-I67XYXBic9bM+yfce6Dqa950TsrEWB6uwSB2l6eIg3Byp48yJxQYbyjvjDbMXPieU2Bzo8FYVSD+lc8cF4+L6A==
+  version "19.2.14"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-19.2.14.tgz#2683c23849bad5d90f3d9f65360992c06ab25821"
+  integrity sha512-xhl8fLto5HHJdVj8Nb6EoBEiTAcXuWDYn1q5uHcGxyVH3kiwENWy/2OQXgCr2CuWo2e6hNUGzSLf/cjbsMNqEA==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
**Changes:**

Removes @angular/animations as this package is now deprecated.
Adds one replacement helper directive.
Forbids package use in linter.

**Testing:**

Test affected places.
