### PR TITLE
NAS-12345: Update dataset details interface for new API

### DIFF
--- a/src/app/interfaces/dataset.interface.ts
+++ b/src/app/interfaces/dataset.interface.ts
@@ -170,7 +170,7 @@ export interface DatasetDetails {
   key_format: ZfsProperty<EncryptionKeyFormat>;
   key_loaded: boolean;
   locked: boolean;
-  readonly: boolean;
+  readonly: ZfsProperty<OnOff, boolean>;
   mountpoint: string;
   name: string;
   pool: string;
@@ -196,8 +196,8 @@ export interface DatasetDetails {
   children?: DatasetDetails[];
   volsize?: ZfsProperty<string, number>; // Present for type === DatasetType.Volume
   thick_provisioned?: boolean; // Present for type === DatasetType.Volume
-  atime: boolean;
-  casesensitive: boolean;
+  atime: ZfsProperty<OnOff, boolean>;
+  casesensitivity: ZfsProperty<DatasetCaseSensitivity, string>;
   origin: ZfsProperty<string>;
   sync: ZfsProperty<string>;
   compression: ZfsProperty<string>;

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
@@ -55,7 +55,7 @@
       <div class="details-item">
         <div class="label">{{ 'Enable Atime' | translate }}:</div>
         <div class="value">
-          {{ (dataset().atime ? OnOff.On : OnOff.Off) | translate }}
+        {{ (dataset().atime.parsed ? OnOff.On : OnOff.Off) | translate }}
         </div>
       </div>
     }
@@ -66,7 +66,7 @@
     <div class="details-item">
       <div class="label">{{ 'Case Sensitivity' | translate }}:</div>
       <div class="value">
-        {{ (dataset().casesensitive ? OnOff.On : OnOff.Off) | translate }}
+        {{ (dataset().casesensitivity.value === 'SENSITIVE' ? OnOff.On : OnOff.Off) | translate }}
       </div>
     </div>
     <div class="details-item">

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
@@ -8,7 +8,8 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { DatasetType } from 'app/enums/dataset.enum';
+import { DatasetType, DatasetCaseSensitivity } from 'app/enums/dataset.enum';
+import { OnOff } from 'app/enums/on-off.enum';
 import { ZfsPropertySource } from 'app/enums/zfs-property-source.enum';
 import { DatasetDetails } from 'app/interfaces/dataset.interface';
 import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button.component';
@@ -29,9 +30,9 @@ const dataset = {
   sync: { value: 'STANDARD' },
   compression: { source: ZfsPropertySource.Inherited, value: 'LZ4' },
   compressratio: { value: '3.81x' },
-  atime: true,
+  atime: { parsed: true, rawvalue: 'on', value: OnOff.On, source: ZfsPropertySource.Local },
   deduplication: { value: 'OFF' },
-  casesensitive: false,
+  casesensitivity: { parsed: 'insensitive', rawvalue: 'insensitive', value: DatasetCaseSensitivity.Insensitive, source: ZfsPropertySource.Local },
   comments: { value: 'Test comment', source: ZfsPropertySource.Local },
 } as DatasetDetails;
 


### PR DESCRIPTION
## Summary
- update DatasetDetails interface for ZFS property object fields
- adjust dataset details card to use updated atime and case sensitivity fields
- update dataset details card tests

## Testing
- `yarn lint src/app/interfaces/dataset.interface.ts` *(fails: JavaScript heap out of memory)*
- `yarn test src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts` *(fails: Cannot find module 'environments/environment')*

------
https://chatgpt.com/codex/tasks/task_e_685eb62a527c832d87602e754d5b8a8d