### PR TITLE
NAS-135063 / 25.04.3 / Rsync Task - Auxiliary parameter goes off screen (by AlexKarpov98)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-chips/ix-chips.component.scss
+++ b/src/app/modules/forms/ix-forms/components/ix-chips/ix-chips.component.scss
@@ -1,5 +1,3 @@
-@import 'mixins/text';
-
 :host {
   color: var(--fg1);
   display: block;

--- a/src/app/modules/forms/ix-forms/components/ix-chips/ix-chips.component.scss
+++ b/src/app/modules/forms/ix-forms/components/ix-chips/ix-chips.component.scss
@@ -1,3 +1,5 @@
+@import 'mixins/text';
+
 :host {
   color: var(--fg1);
   display: block;
@@ -19,6 +21,7 @@
   border-radius: 2px;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   font-size: 12px;
   padding: 2px 8px;
   position: relative;
@@ -40,6 +43,17 @@
 .chip {
   display: flex;
   font-size: 11px;
+  height: inherit;
+  word-break: break-word;
+
+  &::ng-deep {
+    span {
+      overflow: hidden;
+      padding: 1px 0;
+      white-space: normal;
+      word-break: break-word;
+    }
+  }
 }
 
 .mat-standard-chip {


### PR DESCRIPTION
Testing: see ticket.

Preview:
<img width="408" alt="NAS-135063" src="https://github.com/user-attachments/assets/3ad41efd-f857-485c-93bf-d42e27e750b7" />


Original PR: https://github.com/truenas/webui/pull/12179
