### PR TITLE
Update cloudsync-provider.enum.ts

### DIFF
--- a/src/app/enums/cloudsync-provider.enum.ts
+++ b/src/app/enums/cloudsync-provider.enum.ts
@@ -42,7 +42,7 @@ export const cloudSyncProviderNameMap = new Map<CloudSyncProviderName, string>([
   [CloudSyncProviderName.Mega, T('Mega')],
   [CloudSyncProviderName.MicrosoftAzure, T('Microsoft Azure')],
   [CloudSyncProviderName.MicrosoftOneDrive, T('Microsoft OneDrive')],
-  [CloudSyncProviderName.OpenstackSwift, T('OpenStack Swift')],
+  [CloudSyncProviderName.OpenstackSwift, T('OpenStack Swift (OVH, Oracle, Rackspace, etc)')],
   [CloudSyncProviderName.Pcloud, T('pCloud')],
   [CloudSyncProviderName.Sftp, T('SFTP')],
   [CloudSyncProviderName.Storj, T('Storj')],


### PR DESCRIPTION

**Changes:**

Request from the Sales team to make sure our Cloud Providers have the name OVH listed officially in the UI that they can point to for customers.

**Testing:**

No functional changes, label only. 

### Downstream

No downstream impacts. 
