### PR TITLE
NAS-136592 / 25.10 / Various fixes to new users form

### DIFF
--- a/src/app/pages/credentials/new-users/all-users/user-details/user-access-card/user-access-card.component.html
+++ b/src/app/pages/credentials/new-users/all-users/user-details/user-access-card/user-access-card.component.html
@@ -132,15 +132,27 @@
     </mat-card-content>
 
     <mat-card-actions>
-      <button
-        *ixRequiresRoles="[Role.AccountWrite]"
-        mat-button
-        [ixTest]="['toggle-lock-status', user.username]"
-        [ixUiSearch]="searchableElements.elements.toggleLock"
-        (click)="toggleLockStatus()"
-      >
-        {{ user.locked ? unlockUserText : lockUserText }}
-      </button>
+      @if (shouldShowLockButton()) {
+        <button
+          *ixRequiresRoles="[Role.AccountWrite]"
+          mat-button
+          [ixTest]="['lock-user', user.username]"
+          [ixUiSearch]="searchableElements.elements.toggleLock"
+          (click)="toggleLockStatus()"
+        >
+          {{ lockUserText }}
+        </button>
+      } @else if (user.locked) {
+        <button
+          *ixRequiresRoles="[Role.AccountWrite]"
+          mat-button
+          [ixTest]="['unlock-user', user.username]"
+          [ixUiSearch]="searchableElements.elements.toggleLock"
+          (click)="toggleLockStatus()"
+        >
+          {{ unlockUserText }}
+        </button>
+      }
     </mat-card-actions>
   }
 </mat-card>

--- a/src/app/pages/credentials/new-users/all-users/user-details/user-access-card/user-access-card.component.spec.ts
+++ b/src/app/pages/credentials/new-users/all-users/user-details/user-access-card/user-access-card.component.spec.ts
@@ -120,7 +120,7 @@ describe('UserAccessCardComponent', () => {
     expect(sshSection).toHaveText('SSH Key Set & Password Login Enabled');
   });
 
-  it('should open lock/unlock dialog when button is clicked', async () => {
+  it('should open lock user when button Lock User is clicked', async () => {
     const lockButton = await loader.getHarness(MatButtonHarness.with({ text: 'Lock User' }));
     await lockButton.click();
 
@@ -129,6 +129,31 @@ describe('UserAccessCardComponent', () => {
       locked: true,
     }]);
     expect(spectator.inject(SnackbarService).success).toHaveBeenCalled();
+  });
+
+  it('should unlock user when Unlock is clicked', async () => {
+    spectator.setInput('user', { ...mockUser, locked: true });
+
+    const unlockButton = await loader.getHarness(MatButtonHarness.with({ text: 'Unlock User' }));
+    await unlockButton.click();
+
+    expect(spectator.inject(DialogService).confirm).toHaveBeenCalled();
+    expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('user.update', [mockUser.id, {
+      locked: false,
+    }]);
+    expect(spectator.inject(SnackbarService).success).toHaveBeenCalled();
+  });
+
+  it('should not show Lock User button if this is a built-in user (other than root)', async () => {
+    spectator.setInput('user', { ...mockUser, builtin: true, username: 'testuser' });
+
+    const lockButton = await loader.getHarnessOrNull(MatButtonHarness.with({ text: 'Lock User' }));
+    expect(lockButton).toBeNull();
+
+    // Check root
+    spectator.setInput('user', { ...mockUser, builtin: true, username: 'root' });
+    const rootLockButton = await loader.getHarness(MatButtonHarness.with({ text: 'Lock User' }));
+    expect(rootLockButton).toBeTruthy();
   });
 
   describe('API Keys', () => {

--- a/src/app/pages/credentials/new-users/all-users/user-details/user-access-card/user-access-card.component.ts
+++ b/src/app/pages/credentials/new-users/all-users/user-details/user-access-card/user-access-card.component.ts
@@ -91,6 +91,11 @@ export class UserAccessCardComponent {
     return this.user().roles.length && this.user().local;
   });
 
+  protected shouldShowLockButton = computed(() => {
+    const user = this.user();
+    return !user.locked && (!user.builtin || user.username === 'root');
+  });
+
   constructor(
     private translate: TranslateService,
     private api: ApiService,
@@ -122,7 +127,6 @@ export class UserAccessCardComponent {
     this.dialogService.confirm({
       message,
       buttonText,
-      title: this.translate.instant('Confirmation'),
       hideCheckbox: true,
     }).pipe(
       filter(Boolean),

--- a/src/app/pages/credentials/new-users/user-form/additional-details-section/additional-details-section.component.html
+++ b/src/app/pages/credentials/new-users/user-form/additional-details-section/additional-details-section.component.html
@@ -87,20 +87,23 @@
         </ix-editable>
       </ix-details-item>
 
-      <ix-details-item [label]="'UID' | translate">
-        <ix-editable [emptyValue]="editingUser() ? (editingUser()?.uid.toString() | translate) : ('Next Available' | translate)">
-          <div view>
-            {{ form.controls.uid.value }}
-          </div>
+      @if (!editingUser()) {
+        <ix-details-item [label]="'UID' | translate">
+          <ix-editable [emptyValue]="'Next Available' | translate">
+            <div view>
+              {{ form.controls.uid.value }}
+            </div>
 
-          <div edit>
-            <ix-input
-              formControlName="uid"
-              [attr.aria-label]="'UID' | translate"
-            ></ix-input>
-          </div>
-        </ix-editable>
-      </ix-details-item>
+            <div edit>
+              <ix-input
+                type="number"
+                formControlName="uid"
+                [attr.aria-label]="'UID' | translate"
+              ></ix-input>
+            </div>
+          </ix-editable>
+        </ix-details-item>
+      }
 
       <ix-details-item [label]="'Home Directory' | translate">
         <ix-editable [emptyValue]="homeDirectoryEmptyValue() | translate">

--- a/src/app/pages/credentials/new-users/user-form/additional-details-section/additional-details-section.component.spec.ts
+++ b/src/app/pages/credentials/new-users/user-form/additional-details-section/additional-details-section.component.spec.ts
@@ -17,7 +17,6 @@ import { DetailsTableHarness } from 'app/modules/details-table/details-table.har
 import { EditableHarness } from 'app/modules/forms/editable/editable.harness';
 import { IxCheckboxHarness } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.harness';
 import { IxExplorerHarness } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.harness';
-import { IxInputHarness } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.harness';
 import { IxPermissionsHarness } from 'app/modules/forms/ix-forms/components/ix-permissions/ix-permissions.harness';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { AdditionalDetailsSectionComponent } from 'app/pages/credentials/new-users/user-form/additional-details-section/additional-details-section.component';
@@ -187,7 +186,6 @@ describe('AdditionalDetailsSectionComponent', () => {
         Email: 'Not Set',
         Groups: 'Primary Group: test-group  Auxiliary Groups: test-group-2, test-group-3',
         'Home Directory': '/home/test',
-        UID: '1004',
         Shell: '/usr/bin/bash',
       });
 
@@ -196,30 +194,16 @@ describe('AdditionalDetailsSectionComponent', () => {
       });
     });
 
+    it('does not show UID on edit', async () => {
+      const values = await (await loader.getHarness(DetailsTableHarness)).getValues();
+
+      expect(Object.keys(values)).not.toContain('UID');
+    });
+
     it('loads home share path and puts it in home field', async () => {
       const homeInput = await loader.getHarness(DetailsItemHarness.with({ label: 'Home Directory' }));
       expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('sharing.smb.query', [[['enabled', '=', true], ['options.home', '=', true]]]);
       expect(await homeInput.getValueText()).toBe('/home/test');
-    });
-
-    it('check uid field is disabled', async () => {
-      const editables = await loader.getHarness(DetailsTableHarness);
-
-      expect(await editables.getValues()).toEqual({
-        'Full Name': 'test',
-        Email: 'Not Set',
-        Groups: 'Primary Group: test-group  Auxiliary Groups: test-group-2, test-group-3',
-        'Home Directory': '/home/test',
-        UID: '1004',
-      });
-
-      const uidField = await editables.getHarnessForItem('UID', EditableHarness);
-      await uidField.open();
-
-      spectator.detectChanges();
-
-      const uidInput = await loader.getHarness(IxInputHarness.with({ selector: '[aria-label="UID"]' }));
-      expect(await uidInput.isDisabled()).toBeTruthy();
     });
   });
 

--- a/src/app/pages/credentials/new-users/user-form/additional-details-section/additional-details-section.component.spec.ts
+++ b/src/app/pages/credentials/new-users/user-form/additional-details-section/additional-details-section.component.spec.ts
@@ -151,7 +151,7 @@ describe('AdditionalDetailsSectionComponent', () => {
         home: '/var/empty',
         home_mode: '700',
         home_create: false,
-        uid: '1234',
+        uid: 1234,
       });
     });
 

--- a/src/app/pages/credentials/new-users/user-form/additional-details-section/additional-details-section.component.ts
+++ b/src/app/pages/credentials/new-users/user-form/additional-details-section/additional-details-section.component.ts
@@ -203,7 +203,6 @@ export class AdditionalDetailsSectionComponent implements OnInit {
     if (!this.editingUser()) {
       this.setFirstShellOption();
     }
-    this.detectFullNameChanges();
     this.detectHomeDirectoryChanges();
     this.setHomeSharePath();
     this.listenValueChanges();
@@ -370,31 +369,6 @@ export class AdditionalDetailsSectionComponent implements OnInit {
         this.form.patchValue({ shell: defaultShell });
       }
     });
-  }
-
-  private detectFullNameChanges(): void {
-    this.form.controls.full_name.valueChanges.pipe(
-      map((fullName) => this.getUserName(fullName)),
-      filter((username) => !!username),
-      untilDestroyed(this),
-    ).subscribe((username) => {
-      this.userFormStore.updateUserConfig({ username });
-    });
-  }
-
-  private getUserName(fullName: string): string {
-    let username: string;
-    const formatted = fullName.trim().split(/[\s,]+/);
-    if (formatted.length === 1) {
-      username = formatted[0];
-    } else {
-      username = formatted[0][0] + formatted.pop();
-    }
-    if (username.length >= 8) {
-      username = username.substring(0, 8);
-    }
-
-    return username.toLocaleLowerCase();
   }
 
   private detectHomeDirectoryChanges(): void {

--- a/src/assets/ui-searchable-elements.json
+++ b/src/assets/ui-searchable-elements.json
@@ -912,6 +912,28 @@
     "hierarchy": [
       "Credentials",
       "Users (WIP)",
+      "Toggle Lock Status"
+    ],
+    "synonyms": [
+      "Lock User",
+      "Unlock User"
+    ],
+    "requiredRoles": [
+      "ACCOUNT_WRITE"
+    ],
+    "visibleTokens": [],
+    "anchorRouterLink": [
+      "/credentials/users-new"
+    ],
+    "routerLink": null,
+    "anchor": "toggle-lock-status",
+    "triggerAnchor": null,
+    "section": "ui"
+  },
+  {
+    "hierarchy": [
+      "Credentials",
+      "Users (WIP)",
       "Profile"
     ],
     "synonyms": [],


### PR DESCRIPTION
**Changes:**

- Since UID cannot be edited, don't show it on the form on edit.
- Remove functionality that updates username when Full Name is changed.
- Fix error: user_create.uid: Input should be a valid integer when specifying UID manually
- Prevent builtin users from being locked, except for root.
