### PR TITLE
NAS-136458 / 25.10 / Update dataset details interface for new API (by denysbutenko)

### DIFF
--- a/src/app/interfaces/dataset.interface.ts
+++ b/src/app/interfaces/dataset.interface.ts
@@ -170,7 +170,7 @@ export interface DatasetDetails {
   key_format: ZfsProperty<EncryptionKeyFormat>;
   key_loaded: boolean;
   locked: boolean;
-  readonly: boolean;
+  readonly: ZfsProperty<OnOff, boolean>;
   mountpoint: string;
   name: string;
   pool: string;
@@ -196,8 +196,8 @@ export interface DatasetDetails {
   children?: DatasetDetails[];
   volsize?: ZfsProperty<string, number>; // Present for type === DatasetType.Volume
   thick_provisioned?: boolean; // Present for type === DatasetType.Volume
-  atime: boolean;
-  casesensitive: boolean;
+  atime: ZfsProperty<OnOff, boolean>;
+  casesensitivity: ZfsProperty<DatasetCaseSensitivity, string>;
   origin: ZfsProperty<string>;
   sync: ZfsProperty<string>;
   compression: ZfsProperty<string>;

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.spec.ts
@@ -8,6 +8,8 @@ import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { DatasetType } from 'app/enums/dataset.enum';
+import { OnOff } from 'app/enums/on-off.enum';
+import { ZfsPropertySource } from 'app/enums/zfs-property-source.enum';
 import { DatasetQuota } from 'app/interfaces/dataset-quota.interface';
 import { DatasetDetails } from 'app/interfaces/dataset.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -27,6 +29,12 @@ const datasetQuotas = {
   },
   quota: {
     parsed: 8388608,
+  },
+  readonly: {
+    parsed: false,
+    rawvalue: 'off',
+    value: OnOff.Off,
+    source: ZfsPropertySource.Local,
   },
 } as DatasetDetails;
 

--- a/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.ts
+++ b/src/app/pages/datasets/components/dataset-capacity-management-card/dataset-capacity-management-card.component.ts
@@ -75,7 +75,7 @@ export class DatasetCapacityManagementCardComponent implements OnChanges, OnInit
   });
 
   protected checkQuotas = computed(() => {
-    return !this.dataset().locked && this.isFilesystem() && !this.dataset().readonly;
+    return !this.dataset().locked && this.isFilesystem() && !this.dataset().readonly.parsed;
   });
 
   protected hasQuota = computed(() => {

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
@@ -66,7 +66,11 @@
     <div class="details-item">
       <div class="label">{{ 'Case Sensitivity' | translate }}:</div>
       <div class="value">
-        {{ (dataset().casesensitivity.value === 'SENSITIVE' ? OnOff.On : OnOff.Off) | translate }}
+        {{ (
+            dataset().casesensitivity.value === DatasetCaseSensitivity.Sensitive
+              ? OnOff.On
+              : OnOff.Off
+          ) | translate }}
       </div>
     </div>
     <div class="details-item">

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.html
@@ -55,7 +55,7 @@
       <div class="details-item">
         <div class="label">{{ 'Enable Atime' | translate }}:</div>
         <div class="value">
-          {{ (dataset().atime ? OnOff.On : OnOff.Off) | translate }}
+        {{ (dataset().atime.parsed ? OnOff.On : OnOff.Off) | translate }}
         </div>
       </div>
     }
@@ -66,7 +66,7 @@
     <div class="details-item">
       <div class="label">{{ 'Case Sensitivity' | translate }}:</div>
       <div class="value">
-        {{ (dataset().casesensitive ? OnOff.On : OnOff.Off) | translate }}
+        {{ (dataset().casesensitivity.value === 'SENSITIVE' ? OnOff.On : OnOff.Off) | translate }}
       </div>
     </div>
     <div class="details-item">

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
@@ -28,12 +28,28 @@ const dataset = {
   pool: 'pool',
   type: DatasetType.Filesystem,
   sync: { value: 'STANDARD' },
-  compression: { source: ZfsPropertySource.Inherited, value: 'LZ4' },
+  compression: {
+    source: ZfsPropertySource.Inherited,
+    value: 'LZ4',
+  },
   compressratio: { value: '3.81x' },
-  atime: { parsed: true, rawvalue: 'on', value: OnOff.On, source: ZfsPropertySource.Local },
+  atime: {
+    parsed: true,
+    rawvalue: 'on',
+    value: OnOff.On,
+    source: ZfsPropertySource.Local,
+  },
   deduplication: { value: 'OFF' },
-  casesensitivity: { parsed: 'insensitive', rawvalue: 'insensitive', value: DatasetCaseSensitivity.Insensitive, source: ZfsPropertySource.Local },
-  comments: { value: 'Test comment', source: ZfsPropertySource.Local },
+  casesensitivity: {
+    parsed: 'insensitive',
+    rawvalue: 'insensitive',
+    value: DatasetCaseSensitivity.Insensitive,
+    source: ZfsPropertySource.Local,
+  },
+  comments: {
+    value: 'Test comment',
+    source: ZfsPropertySource.Local,
+  },
 } as DatasetDetails;
 
 const zvol = {

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts
@@ -8,7 +8,8 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { DatasetType } from 'app/enums/dataset.enum';
+import { DatasetType, DatasetCaseSensitivity } from 'app/enums/dataset.enum';
+import { OnOff } from 'app/enums/on-off.enum';
 import { ZfsPropertySource } from 'app/enums/zfs-property-source.enum';
 import { DatasetDetails } from 'app/interfaces/dataset.interface';
 import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button.component';
@@ -29,9 +30,9 @@ const dataset = {
   sync: { value: 'STANDARD' },
   compression: { source: ZfsPropertySource.Inherited, value: 'LZ4' },
   compressratio: { value: '3.81x' },
-  atime: true,
+  atime: { parsed: true, rawvalue: 'on', value: OnOff.On, source: ZfsPropertySource.Local },
   deduplication: { value: 'OFF' },
-  casesensitive: false,
+  casesensitivity: { parsed: 'insensitive', rawvalue: 'insensitive', value: DatasetCaseSensitivity.Insensitive, source: ZfsPropertySource.Local },
   comments: { value: 'Test comment', source: ZfsPropertySource.Local },
 } as DatasetDetails;
 

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.ts
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.ts
@@ -12,7 +12,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { filter, first, switchMap } from 'rxjs/operators';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
-import { DatasetType } from 'app/enums/dataset.enum';
+import { DatasetType, DatasetCaseSensitivity } from 'app/enums/dataset.enum';
 import { OnOff } from 'app/enums/on-off.enum';
 import { Role } from 'app/enums/role.enum';
 import { ZfsPropertySource } from 'app/enums/zfs-property-source.enum';
@@ -59,6 +59,7 @@ export class DatasetDetailsCardComponent {
 
   protected readonly Role = Role;
   readonly OnOff = OnOff;
+  readonly DatasetCaseSensitivity = DatasetCaseSensitivity;
 
   constructor(
     private translate: TranslateService,

--- a/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.spec.ts
+++ b/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.spec.ts
@@ -9,6 +9,8 @@ import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { AclType } from 'app/enums/acl-type.enum';
+import { OnOff } from 'app/enums/on-off.enum';
+import { ZfsPropertySource } from 'app/enums/zfs-property-source.enum';
 import { Acl, NfsAcl, PosixAcl } from 'app/interfaces/acl.interface';
 import { DatasetDetails } from 'app/interfaces/dataset.interface';
 import { FileSystemStat } from 'app/interfaces/filesystem-stat.interface';
@@ -41,6 +43,12 @@ describe('PermissionsCardComponent', () => {
     name: 'testpool/dataset',
     mountpoint: '/mnt/testpool/dataset',
     pool: 'testpool',
+    readonly: {
+      parsed: false,
+      rawvalue: 'off',
+      value: OnOff.Off,
+      source: ZfsPropertySource.Local,
+    },
   } as DatasetDetails;
 
   let spectator: Spectator<PermissionsCardComponent>;
@@ -176,7 +184,12 @@ describe('PermissionsCardComponent', () => {
     it('does not show edit button when dataset is readonly', async () => {
       spectator.setInput('dataset', {
         ...dataset,
-        readonly: true,
+        readonly: {
+          parsed: true,
+          rawvalue: 'on',
+          value: OnOff.On,
+          source: ZfsPropertySource.Local,
+        },
       } as DatasetDetails);
 
       const editButton = await loader.getHarness(MatButtonHarness.with({ text: 'Edit' }));

--- a/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.ts
+++ b/src/app/pages/datasets/modules/permissions/containers/permissions-card/permissions-card.component.ts
@@ -111,7 +111,7 @@ export class PermissionsCardComponent implements OnInit, OnChanges {
   });
 
   readonly canEditPermissions = computed(() => {
-    return this.acl() && !isRootDataset(this.dataset()) && !this.dataset().locked && !this.dataset().readonly;
+    return this.acl() && !isRootDataset(this.dataset()) && !this.dataset().locked && !this.dataset().readonly.parsed;
   });
 
   readonly isLocked = computed(() => {
@@ -131,7 +131,7 @@ export class PermissionsCardComponent implements OnInit, OnChanges {
       return this.translate.instant(helptextPermissions.editDisabled.locked);
     }
 
-    if (this.dataset().readonly) {
+    if (this.dataset().readonly.parsed) {
       return this.translate.instant(helptextPermissions.editDisabled.readonly);
     }
 


### PR DESCRIPTION
## Summary
- update DatasetDetails interface for ZFS property object fields
- adjust dataset details card to use updated atime and case sensitivity fields
- update dataset details card tests

## Testing
- `yarn lint src/app/interfaces/dataset.interface.ts` *(fails: JavaScript heap out of memory)*
- `yarn test src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.spec.ts` *(fails: Cannot find module 'environments/environment')*

------
https://chatgpt.com/codex/tasks/task_e_685eb62a527c832d87602e754d5b8a8d

Original PR: https://github.com/truenas/webui/pull/12188
