### PR TITLE
NAS-136521: Return asterisk to required selects

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.html
+++ b/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.html
@@ -3,6 +3,7 @@
     <ix-label
       [label]="label()"
       [tooltip]="tooltip()"
+      [required]="required()"
       [ixTestOverride]="controlDirective.name || ''"
     ></ix-label>
   }
@@ -77,7 +78,7 @@
                 class="option-tooltip"
                 [header]="option.label | translate"
                 [message]="option.tooltip | translate"
-                (click)="onOptionTooltipClicked($event)"
+                (click)="$event.stopPropagation()"
               ></ix-tooltip>
             }
           </mat-option>

--- a/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.spec.ts
@@ -81,9 +81,7 @@ describe('IxSelectComponent', () => {
       const label = spectator.query(IxLabelComponent)!;
       expect(label).toExist();
       expect(label.label()).toBe('Select Group');
-      // Required selects are always rendered without an asterisk,
-      // because there is no way to select an empty value anyway.
-      expect(label.required()).toBe(false);
+      expect(label.required()).toBe(true);
       expect(label.tooltip()).toBe('Select group to use.');
     });
 
@@ -263,6 +261,26 @@ describe('IxSelectComponent', () => {
       spectator.setHostInput('options$', options2$);
       // Unchanged
       expect(options1$.subscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it('automatically selects first option when select is empty and required', async () => {
+      spectator = createHost(
+        '<ix-select [formControl]="control" [required]="true" [options]="options$"></ix-select>',
+        {
+          hostProps: {
+            control,
+            options$: of([
+              { label: 'Great Britain', value: 'GBR' },
+              { label: 'Greenland', value: 'GRL' },
+            ]),
+          },
+        },
+      );
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+
+      const select = await loader.getHarness(IxSelectHarness);
+      expect(await select.getValue()).toBe('Great Britain');
+      expect(control.value).toBe('GBR');
     });
   });
 });

--- a/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.ts
@@ -178,15 +178,17 @@ export class IxSelectComponent implements ControlValueAccessor, OnInit, OnChange
       this.optsSubscription?.unsubscribe();
       this.optsSubscription = this.opts$.pipe(untilDestroyed(this)).subscribe((opts) => {
         this.opts = opts;
+
+        // Auto-select the first option for empty required selects
+        if (!this.value && this.required && this.opts.length > 0 && !this.multiple()) {
+          this.value = opts[0].value;
+          this.onChange(this.value);
+        }
       });
     }
   }
 
-  onOptionTooltipClicked(event: MouseEvent): void {
-    event.stopPropagation();
-  }
-
-  selectAll(): void {
+  private selectAll(): void {
     if (this.multiple()) {
       this.value = this.opts.map((opt) => opt.value) as SelectOptionValueType;
       this.onChange(this.value);
@@ -198,7 +200,7 @@ export class IxSelectComponent implements ControlValueAccessor, OnInit, OnChange
     this.onChange(this.value);
   }
 
-  toggleSelectAll(checked: boolean): void {
+  protected toggleSelectAll(checked: boolean): void {
     if (checked) {
       this.selectAll();
     } else {


### PR DESCRIPTION
**Changes:**

I had previously removed asterisk from selects with `[required]="true"` because it seemed redundant.
While this still may be true, having a required select without an asterisk is confusing for `[multiple]="true"`, hence I'm bringing it back.

Also adds functionality where empty required singular select with auto-select first loaded option.

**Testing**
Check if auto-selection of first option breaks something.