### PR TITLE
NAS-136597: generates TNC claim token when `Get Connected` is clicked

### DIFF
--- a/src/app/modules/truenas-connect/truenas-connect-button.component.ts
+++ b/src/app/modules/truenas-connect/truenas-connect-button.component.ts
@@ -1,9 +1,9 @@
-import { ChangeDetectionStrategy, Component, effect } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule, MatIconButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTooltip } from '@angular/material/tooltip';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
 import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
 import { helptextTopbar } from 'app/helptext/topbar';
@@ -33,13 +33,6 @@ export class TruenasConnectButtonComponent {
   tooltips = helptextTopbar.tooltips;
 
   constructor(private matDialog: MatDialog, public tnc: TruenasConnectService) {
-    effect(() => {
-      if (this.tnc.config()?.status === TruenasConnectStatus.ClaimTokenMissing) {
-        this.tnc.generateToken()
-          .pipe(untilDestroyed(this))
-          .subscribe();
-      }
-    });
   }
 
   protected showStatus(): void {


### PR DESCRIPTION

**Changes:**
'tn_connect.generate_claim_token' will only be called when the token does not exist and `Get Connected` is clicked.

**Testing:**
1. enable the TNC service
2. click TNC service icon in the toolbar
3. Click `Get Connected` and it will open a new tab that navigates to the TNC system registration page

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
