### PR TITLE
Enable Claude review workflow to run on new commits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,7 @@
 name: Claude Review
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
     branches:
       - master
     paths-ignore:


### PR DESCRIPTION
## Summary
- Add 'synchronize' event type to claude.yml workflow so it runs when new commits are pushed to PR branches
- Currently the workflow only runs when PRs are initially opened
- This change allows Claude to provide reviews on updated code in PRs

## Test plan
- [x] Verify workflow file syntax is correct
- [x] Test by pushing commits to a PR and confirming Claude workflow runs

🤖 Generated with [Claude Code](https://claude.ai/code)