### PR TITLE
NAS-136726 / 25.10 / Fix WebSocket concurrent calls tracking not cleaning up on connection close

### DIFF
--- a/src/app/modules/websocket/websocket-handler.service.ts
+++ b/src/app/modules/websocket/websocket-handler.service.ts
@@ -180,6 +180,13 @@ export class WebSocketHandlerService {
   private onClose(event: CloseEvent): void {
     this.wsStatus.setConnectionStatus(false);
     this.isConnectionLive$.next(false);
+
+    // Clean up pending calls when connection closes
+    this.activeCalls = 0;
+    this.pendingCalls.clear();
+    this.callsInConcurrentCallsError.clear();
+    // Note: queuedCalls are kept so they can be processed when connection reopens
+
     if (this.reconnectTimerSubscription) {
       return;
     }


### PR DESCRIPTION

- Add cleanup of activeCalls, pendingCalls, and callsInConcurrentCallsError in onClose method
- Prevents "Max concurrent calls limit reached" error when connection closes unexpectedly
- Ensures call tracking is reset when WebSocket reconnects
- Keeps queuedCalls to allow processing when connection reopens