### PR TITLE
Fix Claude Code configuration syntax errors

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,12 +8,12 @@
       "Bash(mv:*)",
       "Bash(npx tsc:*)",
       "Bash(ls:*)",
-      "Bash(find *)",
-      "Bash(sed *)",
+      "Bash(find:*)",
+      "Bash(sed:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
-      "Bash(open \"https://github.com/truenas/webui/:*)",
-      "Fetch(https://github.com:*",
+      "Bash(open \"https://github.com/truenas/webui/*\")",
+      "Fetch(https://github.com:*)",
       "Bash(curl:*)",
       "mcp__playwright__browser_navigate",
       "mcp__playwright__browser_wait_for",
@@ -22,15 +22,5 @@
     "deny": []
   },
   "includeCoAuthoredBy": false,
-  "enableAllProjectMcpServers": false,
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": [
-        "@playwright/mcp@latest",
-        "--browser-arg=--lang=en-US",
-        "--browser-arg=--accept-lang=en-US,en;q=0.9"
-      ]
-    }
-  }
+  "enableAllProjectMcpServers": false
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--browser-arg=--lang=en-US",
+        "--browser-arg=--accept-lang=en-US,en;q=0.9"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed syntax errors in `.claude/settings.json` permissions
- Moved MCP server configuration to proper `.mcp.json` file
- Corrected missing colons and parentheses in permission patterns

## Test plan
- [x] Run `/doctor` command in Claude Code to verify no configuration errors
- [x] Verify Playwright MCP server can be loaded from `.mcp.json`

🤖 Generated with [Claude Code](https://claude.ai/code)