### PR TITLE
NAS-136784 / 25.10 / Always show all GPUs but forbid selection of critical ones

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -123,6 +123,7 @@ import {
 import { FileRecord, ListdirQueryParams } from 'app/interfaces/file-record.interface';
 import { FileSystemStat, Statfs } from 'app/interfaces/filesystem-stat.interface';
 import { FtpConfig, FtpConfigUpdate } from 'app/interfaces/ftp-config.interface';
+import { GpuPciChoices } from 'app/interfaces/gpu-pci-choice.interface';
 import {
   CreateGroup, DeleteGroupParams, Group, UpdateGroup,
 } from 'app/interfaces/group.interface';
@@ -939,7 +940,7 @@ export interface ApiCallDirectory {
   'vm.device.create': { params: [VmDeviceUpdate]; response: VmDevice };
   'vm.device.delete': { params: [number, VmDeviceDelete?]; response: boolean };
   'vm.device.disk_choices': { params: void; response: Choices };
-  'system.advanced.get_gpu_pci_choices': { params: void; response: Choices };
+  'system.advanced.get_gpu_pci_choices': { params: void; response: GpuPciChoices };
   'vm.device.nic_attach_choices': { params: void; response: Choices };
   'vm.device.passthrough_device_choices': { params: void; response: Record<string, VmPassthroughDeviceChoice> };
   'vm.device.query': { params: QueryParams<VmDevice>; response: VmDevice[] };

--- a/src/app/interfaces/gpu-pci-choice.interface.ts
+++ b/src/app/interfaces/gpu-pci-choice.interface.ts
@@ -1,0 +1,7 @@
+export interface GpuPciChoice {
+  pci_slot: string;
+  uses_system_critical_devices: boolean;
+  critical_reason: string;
+}
+
+export type GpuPciChoices = Record<string, GpuPciChoice>;

--- a/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.spec.ts
+++ b/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.spec.ts
@@ -44,8 +44,21 @@ describe('IsolatedGpuPcisFormComponent', () => {
       mockApi([
         mockCall('system.advanced.update_gpu_pci_ids'),
         mockCall('system.advanced.get_gpu_pci_choices', {
-          'Fake HD Graphics [0000:00:01.0]': '0000:00:01.0',
-          'Intel Corporation HD Graphics 510 [0000:00:02.0]': '0000:00:02.0',
+          'Fake HD Graphics [0000:00:01.0]': {
+            pci_slot: '0000:00:01.0',
+            uses_system_critical_devices: false,
+            critical_reason: '',
+          },
+          'Intel Corporation HD Graphics 510 [0000:00:02.0]': {
+            pci_slot: '0000:00:02.0',
+            uses_system_critical_devices: false,
+            critical_reason: '',
+          },
+          'Critical GPU [0000:00:03.0]': {
+            pci_slot: '0000:00:03.0',
+            uses_system_critical_devices: true,
+            critical_reason: 'Critical devices found: 0000:00:01.0, 0000:00:00.0',
+          },
         }),
       ]),
       mockProvider(SystemGeneralService),
@@ -56,8 +69,13 @@ describe('IsolatedGpuPcisFormComponent', () => {
       mockProvider(DialogService),
       mockProvider(GpuService, {
         getGpuOptions: () => of([
-          { label: 'Fake HD Graphics', value: '0000:00:01.0' },
-          { label: 'Intel Corporation HD Graphics 510', value: '0000:00:02.0' },
+          { label: 'Fake HD Graphics [0000:00:01.0]', value: '0000:00:01.0', disabled: false },
+          { label: 'Intel Corporation HD Graphics 510 [0000:00:02.0]', value: '0000:00:02.0', disabled: false },
+          {
+            label: 'Critical GPU [0000:00:03.0] (System Critical)',
+            value: '0000:00:03.0',
+            disabled: false,
+          },
         ]),
       }),
       mockProvider(IsolatedGpuValidatorService, {

--- a/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
+++ b/src/app/pages/system/advanced/isolated-gpus/isolated-gpus-form/isolated-gpus-form.component.ts
@@ -7,9 +7,12 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { map, of, take } from 'rxjs';
+import {
+  of, take,
+} from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
+import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
@@ -19,6 +22,8 @@ import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
+import { CriticalGpuPreventionService } from 'app/services/gpu/critical-gpu-prevention.service';
+import { GpuService } from 'app/services/gpu/gpu.service';
 import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-validator.service';
 import { AppState } from 'app/store';
 import { advancedConfigUpdated } from 'app/store/system-config/system-config.actions';
@@ -55,11 +60,9 @@ export class IsolatedGpusFormComponent implements OnInit {
     }),
   });
 
-  readonly options$ = this.api.call('system.advanced.get_gpu_pci_choices').pipe(map((choices) => {
-    return Object.entries(choices).map(
-      ([value, label]) => ({ value: label, label: value }),
-    );
-  }));
+  criticalGpus = new Map<string, string>(); // Maps pci_slot to critical_reason
+
+  readonly options$ = this.gpuService.getGpuOptions();
 
   constructor(
     protected api: ApiService,
@@ -68,7 +71,10 @@ export class IsolatedGpusFormComponent implements OnInit {
     private cdr: ChangeDetectorRef,
     private store$: Store<AppState>,
     private gpuValidator: IsolatedGpuValidatorService,
+    private gpuService: GpuService,
     private snackbar: SnackbarService,
+    private dialog: DialogService,
+    private criticalGpuPrevention: CriticalGpuPreventionService,
     public slideInRef: SlideInRef<undefined, boolean>,
   ) {
     this.slideInRef.requireConfirmationWhen(() => {
@@ -85,6 +91,14 @@ export class IsolatedGpusFormComponent implements OnInit {
       this.formGroup.setValue({ isolated_gpu_pci_ids: config.isolated_gpu_pci_ids });
       this.cdr.markForCheck();
     });
+
+    // Setup critical GPU prevention
+    this.criticalGpus = this.criticalGpuPrevention.setupCriticalGpuPrevention(
+      this.formGroup.controls.isolated_gpu_pci_ids,
+      this,
+      this.translate.instant('Cannot Isolate GPU'),
+      this.translate.instant('System critical GPUs cannot be isolated'),
+    );
   }
 
   onSubmit(): void {

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.spec.ts
@@ -84,8 +84,16 @@ describe('VmEditFormComponent', () => {
         mockCall('vm.update'),
         mockCall('system.advanced.update_gpu_pci_ids'),
         mockCall('system.advanced.get_gpu_pci_choices', {
-          'GeForce [0000:02:00.0]': '0000:02:00.0',
-          'Intel Arc [0000:03:00.0]': '0000:03:00.0',
+          'GeForce [0000:02:00.0]': {
+            pci_slot: '0000:02:00.0',
+            uses_system_critical_devices: false,
+            critical_reason: '',
+          },
+          'Intel Arc [0000:03:00.0]': {
+            pci_slot: '0000:03:00.0',
+            uses_system_critical_devices: false,
+            critical_reason: '',
+          },
         }),
       ]),
       mockAuth(),

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.spec.ts
@@ -29,8 +29,16 @@ describe('GpuStepComponent', () => {
       }),
       mockApi([
         mockCall('system.advanced.get_gpu_pci_choices', {
-          'GeForce GTX 1080 [0000:03:00.0]': '0000:03:00.0',
-          'GeForce GTX 1080 Ti [0000:04:00.0]': '0000:04:00.0',
+          'GeForce GTX 1080 [0000:03:00.0]': {
+            pci_slot: '0000:03:00.0',
+            uses_system_critical_devices: false,
+            critical_reason: '',
+          },
+          'GeForce GTX 1080 Ti [0000:04:00.0]': {
+            pci_slot: '0000:04:00.0',
+            uses_system_critical_devices: false,
+            critical_reason: '',
+          },
         }),
       ]),
     ],

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
@@ -1,19 +1,24 @@
 import {
-  ChangeDetectionStrategy, Component,
+  ChangeDetectionStrategy, Component, OnInit,
 } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
+import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
+import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import { SummaryProvider, SummarySection } from 'app/modules/summary/summary.interface';
 import { TestDirective } from 'app/modules/test-id/test.directive';
+import { ApiService } from 'app/modules/websocket/api.service';
+import { CriticalGpuPreventionService } from 'app/services/gpu/critical-gpu-prevention.service';
 import { GpuService } from 'app/services/gpu/gpu.service';
 import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-validator.service';
 
+@UntilDestroy()
 @Component({
   selector: 'ix-gpu-step',
   templateUrl: './gpu-step.component.html',
@@ -31,24 +36,36 @@ import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-valid
     TranslateModule,
   ],
 })
-export class GpuStepComponent implements SummaryProvider {
+export class GpuStepComponent implements SummaryProvider, OnInit {
   form = this.formBuilder.nonNullable.group({
     hide_from_msr: [false],
     ensure_display_device: [true],
-    gpus: [[] as string[], {
-      asyncValidators: [this.gpuValidator.validateGpu],
-    }],
+    gpus: [[] as string[], [], [this.gpuValidator.validateGpu]],
   });
 
   readonly helptext = helptextVmWizard;
   readonly gpuOptions$ = this.gpuService.getGpuOptions();
+  criticalGpus = new Map<string, string>(); // Maps pci_slot to critical_reason
 
   constructor(
     private formBuilder: FormBuilder,
     private gpuValidator: IsolatedGpuValidatorService,
     private translate: TranslateService,
     private gpuService: GpuService,
+    private dialog: DialogService,
+    private api: ApiService,
+    private criticalGpuPrevention: CriticalGpuPreventionService,
   ) {}
+
+  ngOnInit(): void {
+    // Setup critical GPU prevention
+    this.criticalGpus = this.criticalGpuPrevention.setupCriticalGpuPrevention(
+      this.form.controls.gpus,
+      this,
+      this.translate.instant('Cannot Select GPU'),
+      this.translate.instant('System critical GPUs cannot be used for VMs'),
+    );
+  }
 
   getSummary(): SummarySection {
     const gpusSelected = this.form.getRawValue().gpus.length;

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
@@ -100,8 +100,16 @@ describe('VmWizardComponent', () => {
         }),
         mockCall('system.advanced.update_gpu_pci_ids'),
         mockCall('system.advanced.get_gpu_pci_choices', {
-          'GeForce GTX 1080 [0000:03:00.0]': '0000:03:00.0',
-          'GeForce GTX 1070 [0000:02:00.0]': '0000:02:00.0',
+          'GeForce GTX 1080 [0000:03:00.0]': {
+            pci_slot: '0000:03:00.0',
+            uses_system_critical_devices: false,
+            critical_reason: '',
+          },
+          'GeForce GTX 1070 [0000:02:00.0]': {
+            pci_slot: '0000:02:00.0',
+            uses_system_critical_devices: false,
+            critical_reason: '',
+          },
         }),
       ]),
       mockProvider(GpuService, {

--- a/src/app/services/gpu/critical-gpu-prevention.service.ts
+++ b/src/app/services/gpu/critical-gpu-prevention.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@angular/core';
+import { AbstractControl } from '@angular/forms';
+import { untilDestroyed } from '@ngneat/until-destroy';
+import { TranslateService } from '@ngx-translate/core';
+import { DialogService } from 'app/modules/dialog/dialog.service';
+import { ApiService } from 'app/modules/websocket/api.service';
+
+@Injectable({ providedIn: 'root' })
+export class CriticalGpuPreventionService {
+  constructor(
+    private api: ApiService,
+    private dialog: DialogService,
+    private translate: TranslateService,
+  ) {}
+
+  setupCriticalGpuPrevention(
+    control: AbstractControl<string[]>,
+    component: object, // Component with untilDestroyed
+    dialogTitle: string,
+    defaultMessage: string,
+  ): Map<string, string> {
+    const criticalGpus = new Map<string, string>();
+
+    // Load critical GPUs information
+    this.api.call('system.advanced.get_gpu_pci_choices').pipe(
+      untilDestroyed(component),
+    ).subscribe((choices) => {
+      criticalGpus.clear();
+      Object.entries(choices).forEach(([, choice]) => {
+        if (choice.uses_system_critical_devices) {
+          criticalGpus.set(choice.pci_slot, choice.critical_reason);
+        }
+      });
+    });
+
+    // Prevent selection of critical GPUs
+    control.valueChanges
+      .pipe(untilDestroyed(component))
+      .subscribe((selectedIds) => {
+        if (!selectedIds || selectedIds.length === 0) {
+          return;
+        }
+
+        const criticalSelectedIds = selectedIds.filter((id) => criticalGpus.has(id));
+
+        if (criticalSelectedIds.length > 0) {
+          // Remove critical GPUs from selection
+          const filteredIds = selectedIds.filter((id) => !criticalGpus.has(id));
+          control.setValue(filteredIds, { emitEvent: false });
+
+          // Show error with the critical reason
+          const criticalReason = criticalGpus.get(criticalSelectedIds[0]);
+          const infoBlurb = this.translate.instant('In order to isolate GPU the device cannot share memory management with other devices.');
+          const message = criticalReason || this.translate.instant(defaultMessage);
+          this.dialog.error({
+            title: this.translate.instant(dialogTitle),
+            message: `${message}<br><br><i>${infoBlurb}</i>`,
+          });
+        }
+      });
+
+    return criticalGpus;
+  }
+}

--- a/src/app/services/gpu/gpu.service.ts
+++ b/src/app/services/gpu/gpu.service.ts
@@ -10,7 +10,7 @@ import {
 } from 'rxjs/operators';
 import { DeviceType } from 'app/enums/device-type.enum';
 import { Device } from 'app/interfaces/device.interface';
-import { Option } from 'app/interfaces/option.interface';
+import { SelectOption } from 'app/interfaces/option.interface';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { AppState } from 'app/store';
 import { advancedConfigUpdated } from 'app/store/system-config/system-config.actions';
@@ -43,11 +43,15 @@ export class GpuService {
     return this.allGpus$;
   }
 
-  getGpuOptions(): Observable<Option[]> {
+  getGpuOptions(): Observable<SelectOption[]> {
     return this.api.call('system.advanced.get_gpu_pci_choices').pipe(
       map((choices) => {
         return Object.entries(choices).map(
-          ([value, label]) => ({ value: label, label: value }),
+          ([label, choice]): SelectOption => ({
+            value: choice.pci_slot,
+            label: choice.uses_system_critical_devices ? `${label} (System Critical)` : label,
+            disabled: false,
+          }),
         );
       }),
     );


### PR DESCRIPTION
**Changes:**

Make GPUs screen show all available but show a error dialog when selection a system critical one, forbidding selection.

**Testing:**

Have two GPUs in the system, once that cannot be isolated and one that can.
Try select system critical and verify error shows up.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
