### PR TITLE
NAS-136826 / 25.10 / Add TestDirective to directory services form

### DIFF
--- a/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
@@ -38,6 +38,7 @@ import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-sele
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
 import { ModalHeaderComponent } from 'app/modules/slide-ins/components/modal-header/modal-header.component';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
+import { TestDirective } from 'app/modules/test-id/test.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ActiveDirectoryConfigComponent } from './active-directory-config/active-directory-config.component';
 import { CredentialConfigComponent } from './credential-config/credential-config.component';
@@ -64,6 +65,7 @@ import { DirectoryServiceValidationService } from './services/directory-service-
     FormActionsComponent,
     MatButton,
     TranslateModule,
+    TestDirective,
     CredentialConfigComponent,
     ActiveDirectoryConfigComponent,
     LdapConfigComponent,


### PR DESCRIPTION
**Changes:**

Add missing TestDirective import to ensure ixTest attributes are properly converted to data-test attributes in the rendered DOM. This makes the save button render with data-test="button-save" attribute, matching the behavior of other forms like the SMB form.

**Testing:**

Inspect save element using developer tools and check data-test="save-button" is there.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
