### PR TITLE
NAS-136335 / 25.10 / Disable material autocomplete in sign-in form fields

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-input/ix-input.component.html
+++ b/src/app/modules/forms/ix-forms/components/ix-input/ix-input.component.html
@@ -70,7 +70,7 @@
     </button>
   }
 
-  <mat-autocomplete #auto="matAutocomplete" (optionSelected)="optionSelected($event.option.value)">
+  <mat-autocomplete #auto="matAutocomplete" (optionSelected)="optionSelected($event.option.value)" [matAutocompleteDisabled]="disableMatAutocomplete()">
     @if (filteredOptions?.length) {
       @for (option of filteredOptions; track trackByIdentity(option)) {
         <mat-option

--- a/src/app/modules/forms/ix-forms/components/ix-input/ix-input.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-input/ix-input.component.ts
@@ -72,6 +72,7 @@ export class IxInputComponent implements ControlValueAccessor, OnInit, OnChanges
   readonly type = input<string>('text');
   readonly autocomplete = input('off');
   readonly autocompleteOptions = input<Option[]>();
+  readonly disableMatAutocomplete = input<boolean>(false);
   readonly maxLength = input(524288);
 
   /** If formatted value returned by parseAndFormatInput has non-numeric letters

--- a/src/app/pages/signin/signin-form/signin-form.component.html
+++ b/src/app/pages/signin/signin-form/signin-form.component.html
@@ -6,6 +6,7 @@
       class="username-input"
       [prefixIcon]="iconMarker('person')"
       [label]="'Username' | translate"
+      [disableMatAutocomplete]="true"
     ></ix-input>
 
     <ix-input
@@ -14,6 +15,7 @@
       autocomplete="current-password"
       [prefixIcon]="iconMarker('mdi-lock')"
       [label]="'Password' | translate"
+      [disableMatAutocomplete]="true"
     ></ix-input>
 
     @if (showSecurityWarning) {
@@ -48,6 +50,7 @@
       [prefixIcon]="iconMarker('phonelink')"
       [label]="'Two-Factor Authentication Code' | translate"
       [required]="true"
+      [disableMatAutocomplete]="true"
     ></ix-input>
 
     @if (showSecurityWarning) {


### PR DESCRIPTION
## Summary
- Added `disableMatAutocomplete` input to `ix-input` component
- Disabled Material autocomplete for all sign-in form fields (username, password, 2FA code)

## Test plan
- [ ] Verify signin page loads without browser autocomplete suggestions
- [ ] Test username field doesn't show autocomplete dropdown
- [ ] Test password field doesn't show autocomplete dropdown
- [ ] Test 2FA code field doesn't show autocomplete dropdown
- [ ] Verify signin functionality still works correctly
