### PR TITLE
NAS-136863 / 25.04.2 / handle sign in case when failover status is SINGLE (by william-gr)

### DIFF
--- a/src/app/services/failover-validation.service.spec.ts
+++ b/src/app/services/failover-validation.service.spec.ts
@@ -69,6 +69,18 @@ describe('FailoverValidationService', () => {
       });
     });
 
+    it('returns success when status is SINGLE', () => {
+      api.mockCall('failover.licensed', true);
+      api.mockCall('failover.status', FailoverStatus.Single);
+
+      spectator.service.validateFailover().subscribe((result) => {
+        expect(result).toEqual({ success: true });
+        expect(api.call).toHaveBeenCalledWith('failover.licensed');
+        expect(api.call).toHaveBeenCalledWith('failover.status');
+        expect(api.call).not.toHaveBeenCalledWith('failover.disabled.reasons');
+      });
+    });
+
     it('returns error when status is not MASTER', () => {
       api.mockCall('failover.licensed', true);
       api.mockCall('failover.status', FailoverStatus.Backup);

--- a/src/app/services/failover-validation.service.ts
+++ b/src/app/services/failover-validation.service.ts
@@ -87,6 +87,11 @@ export class FailoverValidationService {
   protected checkFailoverStatus(): Observable<FailoverValidationResult> {
     return this.api.call('failover.status').pipe(
       switchMap((status) => {
+        // SINGLE status means no failover is configured, proceed as normal
+        if (status === FailoverStatus.Single) {
+          return of({ success: true });
+        }
+
         if (status !== FailoverStatus.Master) {
           return of({
             success: false,


### PR DESCRIPTION
**Changes:**

Handle sign in after license is applied for HA.

**Testing:**

failover.licensed is True and failover.status is SINGLE
Happens on fresh install and after license is applied.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |


Original PR: https://github.com/truenas/webui/pull/12314
