### PR TITLE
NAS-134152 / 25.10 / use the default value from the schema for hidden fields

### DIFF
--- a/eslint/eslint-ts-rules-overrides.mjs
+++ b/eslint/eslint-ts-rules-overrides.mjs
@@ -49,6 +49,7 @@ export const ruleOverrides = {
   "sonarjs/no-redundant-assignments": ["off"],
   "sonarjs/pseudo-random": ["off"],
   "sonarjs/todo-tag": ["off"],
+  "sonarjs/unused-import": ["off"],
   "sonarjs/xml-parser-xxe": ["off"],
 
   "@smarttools/rxjs/no-ignored-takewhile-value": ["off"],

--- a/src/app/pages/apps/components/app-wizard/app-wizard.component.ts
+++ b/src/app/pages/apps/components/app-wizard/app-wizard.component.ts
@@ -259,6 +259,7 @@ export class AppWizardComponent implements OnInit, OnDestroy {
 
   onSubmit(): void {
     const data = this.appSchemaService.serializeFormValue(this.form.getRawValue(), this.chartSchema) as ChartFormValues;
+
     const deleteField$ = new Subject<string>();
     deleteField$.pipe(untilDestroyed(this)).subscribe({
       next: (fieldToBeDeleted) => {

--- a/src/app/services/schema/app-schema.service.ts
+++ b/src/app/services/schema/app-schema.service.ts
@@ -431,7 +431,10 @@ export class AppSchemaService {
       altDefault = false;
     }
 
-    const defaultValue = isNew && schema.default !== undefined ? schema.default : altDefault;
+    // For hidden fields with default values, always use the default value from schema
+    // For new apps, use schema default if available
+    const shouldUseSchemaDefault = (schema.hidden || isNew) && schema.default !== undefined;
+    const defaultValue = shouldUseSchemaDefault ? schema.default : altDefault;
     const newFormControl = new CustomUntypedFormControl(
       defaultValue,
       this.buildSchemaControlValidator(defaultValue, schema),


### PR DESCRIPTION
**Changes:**

Make UUID for GPUs work when editing apps.

**Testing:**

Edit apps and select nvidia GPU.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
