### PR TITLE
NAS-134499 / 25.10 / Update messaging for admin on STIG

### DIFF
--- a/src/app/core/testing/classes/mock-auth.service.ts
+++ b/src/app/core/testing/classes/mock-auth.service.ts
@@ -24,4 +24,8 @@ export class MockAuthService extends AuthService {
   }
 
   override refreshUser = jest.fn(() => of(undefined));
+
+  override clearAuthToken(): void {
+    // Mock implementation to avoid ngx-webstorage issues in tests
+  }
 }

--- a/src/app/core/testing/utils/mock-auth.utils.ts
+++ b/src/app/core/testing/utils/mock-auth.utils.ts
@@ -49,7 +49,11 @@ export function mockAuth(
             isAuthenticated$: of(false),
           }),
           createSpyObject(ErrorHandlerService),
-          createSpyObject(Window),
+          createSpyObject(Window, {
+            sessionStorage: {
+              removeItem: jest.fn(),
+            },
+          }),
         );
 
         mockService.setUser(user as LoggedInUser);

--- a/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.html
+++ b/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.html
@@ -19,9 +19,8 @@
         [label]="'Enable General Purpose OS STIG compatibility mode' | translate"
         [tooltip]="'Enable this mode to enhance system security to meet US federal government security requirements. Note that enabling STIG mode will restrict some functionality.' | translate"
       ></ix-slide-toggle>
-
-      @if (form.controls.enable_gpos_stig.value) {
-        <mat-hint>{{ 'Global Two-Factor Authentication must be enabled to activate this feature.' | translate }}</mat-hint>
+      @if (form.controls.enable_gpos_stig.hasError('globalTwoFactorRequired')) {
+        <mat-error>{{ stigValidationError() | translate }}<span class="link-button" (click)="navigateToGlobal2Fa()">{{ 'Enable it here.' | translate }}</span></mat-error>
       }
       <mat-hint>{{ 'Restart is required after changing these settings.' | translate }}</mat-hint>
       @if (isStigEnabled()) {

--- a/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.scss
+++ b/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.scss
@@ -5,16 +5,32 @@
 }
 
 mat-hint {
-  display: flex;
   font-size: 12px;
-
-  &.stig-error {
-    color: var(--red);
-    font-weight: 500;
-  }
 
   &.stig-info {
     color: var(--orange);
     font-weight: 500;
+  }
+}
+
+mat-error {
+  display: block;
+  font-size: 12px;
+  margin-top: 5px;
+  
+  .link-button {
+    display: inline;
+  }
+}
+
+.link-button {
+  color: var(--primary);
+  cursor: pointer;
+  display: inline;
+  margin-left: 5px;
+  text-decoration: underline;
+
+  &:hover {
+    color: var(--primary-dark);
   }
 }

--- a/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.spec.ts
+++ b/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.spec.ts
@@ -8,7 +8,6 @@ import { of } from 'rxjs';
 import { stigPasswordRequirements } from 'app/constants/stig-password-requirements.constants';
 import { MockAuthService } from 'app/core/testing/classes/mock-auth.service';
 import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
-import { mockJob, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { PasswordComplexityRuleset } from 'app/enums/password-complexity-ruleset.enum';
 import { ProductType } from 'app/enums/product-type.enum';
@@ -49,7 +48,7 @@ describe('SystemSecurityFormComponent', () => {
         ],
       }),
       mockProvider(DialogService, {
-        confirm: jest.fn(() => of()),
+        confirm: jest.fn(() => of(true)),
         jobDialog: jest.fn(() => ({ afterClosed: () => of(undefined) })),
       }),
       mockProvider(SnackbarService),
@@ -62,9 +61,18 @@ describe('SystemSecurityFormComponent', () => {
         requireConfirmationWhen: jest.fn(),
       }),
       mockAuth(),
-      mockApi([
-        mockJob('system.security.update', fakeSuccessfulJob()),
-      ]),
+      mockProvider(ApiService, {
+        call: jest.fn((method: string) => {
+          if (method === 'user.query') {
+            return of([]);
+          }
+          if (method === 'auth.twofactor.config') {
+            return of({ enabled: false });
+          }
+          return of(null);
+        }),
+        job: jest.fn(() => fakeSuccessfulJob()),
+      }),
     ],
   });
 

--- a/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
+++ b/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
@@ -17,7 +17,7 @@ import { MatHint } from '@angular/material/form-field';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  filter, forkJoin, map, of,
+  filter, map, of,
 } from 'rxjs';
 import { stigPasswordRequirements } from 'app/constants/stig-password-requirements.constants';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
@@ -201,19 +201,16 @@ export class SystemSecurityFormComponent implements OnInit {
   }
 
   private checkUsersWithoutTwoFactorAuth(callback: () => void): void {
-    forkJoin({
-      users: this.api.call('user.query', [[
-        ['OR', [['builtin', '=', false], ['username', '=', 'root']]],
-        ['twofactor_auth_configured', '=', false],
-        ['locked', '=', false],
-        ['password_disabled', '=', false],
-        ['roles', '!=', []],
-      ]] as QueryParams<User>),
-      globalTwoFactorConfig: this.api.call('auth.twofactor.config'),
-    }).pipe(
+    this.api.call('user.query', [[
+      ['OR', [['builtin', '=', false], ['username', '=', 'root']]],
+      ['twofactor_auth_configured', '=', false],
+      ['locked', '=', false],
+      ['password_disabled', '=', false],
+      ['roles', '!=', []],
+    ]] as QueryParams<User>).pipe(
       untilDestroyed(this),
     ).subscribe({
-      next: ({ users }) => {
+      next: (users) => {
         if (users.length > 0) {
           this.showStigWarningDialog(users, callback);
         } else {
@@ -242,7 +239,7 @@ export class SystemSecurityFormComponent implements OnInit {
       cancelText: this.translate.instant('Cancel'),
       hideCheckbox: true,
     }).pipe(
-      filter(Boolean),
+      filter((result) => !!result),
       untilDestroyed(this),
     ).subscribe(() => {
       callback();

--- a/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
+++ b/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
@@ -13,11 +13,12 @@ import {
 } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
-import { MatHint } from '@angular/material/form-field';
+import { MatError, MatHint } from '@angular/material/form-field';
+import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  filter, map, of,
+  filter, map, of, switchMap,
 } from 'rxjs';
 import { stigPasswordRequirements } from 'app/constants/stig-password-requirements.constants';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
@@ -55,6 +56,7 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
     MatButton,
     TestDirective,
     TranslateModule,
+    MatError,
     MatHint,
     IxInputComponent,
     IxSelectComponent,
@@ -97,6 +99,8 @@ export class SystemSecurityFormComponent implements OnInit {
 
   private systemSecurityConfig = signal<SystemSecurityConfig>(this.slideInRef.getData());
   protected isStigEnabled = signal<boolean>(false);
+  protected globalTwoFactorEnabled = signal<boolean>(false);
+  protected stigValidationError = signal<string | null>(null);
 
   constructor(
     private formBuilder: FormBuilder,
@@ -106,6 +110,7 @@ export class SystemSecurityFormComponent implements OnInit {
     private api: ApiService,
     private authService: AuthService,
     private errorHandler: ErrorHandlerService,
+    private router: Router,
     public slideInRef: SlideInRef<SystemSecurityConfig, boolean>,
   ) {
     this.slideInRef.requireConfirmationWhen(() => {
@@ -116,6 +121,19 @@ export class SystemSecurityFormComponent implements OnInit {
   ngOnInit(): void {
     if (this.systemSecurityConfig()) {
       this.initSystemSecurityForm();
+      // Check global 2FA status if STIG is already enabled
+      if (this.systemSecurityConfig().enable_gpos_stig) {
+        this.api.call('auth.twofactor.config').pipe(
+          untilDestroyed(this),
+        ).subscribe((twoFactorConfig) => {
+          const enabled = twoFactorConfig?.enabled || false;
+          this.globalTwoFactorEnabled.set(enabled);
+          if (!enabled) {
+            this.stigValidationError.set('Global Two-Factor Authentication must be enabled to activate this feature.');
+            this.form.controls.enable_gpos_stig.setErrors({ globalTwoFactorRequired: true });
+          }
+        });
+      }
     }
   }
 
@@ -284,11 +302,35 @@ export class SystemSecurityFormComponent implements OnInit {
     });
 
     this.form.controls.enable_gpos_stig.valueChanges
-      .pipe(untilDestroyed(this))
-      .subscribe((value) => {
-        this.isStigEnabled.set(value);
-
-        if (value) {
+      .pipe(
+        switchMap((value) => {
+          this.isStigEnabled.set(value);
+          if (value) {
+            // Check if global 2FA is enabled
+            return this.api.call('auth.twofactor.config').pipe(
+              map((twoFactorConfig) => ({ stigEnabled: value, twoFactorEnabled: twoFactorConfig?.enabled || false })),
+            );
+          }
+          return of({ stigEnabled: value, twoFactorEnabled: false });
+        }),
+        untilDestroyed(this),
+      )
+      .subscribe(({ stigEnabled, twoFactorEnabled }) => {
+        if (stigEnabled) {
+          this.globalTwoFactorEnabled.set(twoFactorEnabled);
+          if (!twoFactorEnabled) {
+            this.stigValidationError.set('Global Two-Factor Authentication must be enabled to activate this feature.');
+            this.form.controls.enable_gpos_stig.setErrors({ globalTwoFactorRequired: true });
+          } else {
+            this.stigValidationError.set(null);
+            // Remove only the globalTwoFactorRequired error
+            const errors = this.form.controls.enable_gpos_stig.errors;
+            if (errors?.['globalTwoFactorRequired']) {
+              delete errors['globalTwoFactorRequired'];
+              const hasErrors = Object.keys(errors).length > 0;
+              this.form.controls.enable_gpos_stig.setErrors(hasErrors ? errors : null);
+            }
+          }
           const currentValues = this.form.value;
           const updates: Partial<typeof currentValues> = {
             enable_fips: true,
@@ -331,6 +373,16 @@ export class SystemSecurityFormComponent implements OnInit {
           }
 
           this.form.patchValue(updates);
+        } else {
+          // Reset validation error when STIG is disabled
+          this.stigValidationError.set(null);
+          this.globalTwoFactorEnabled.set(false);
+          const errors = this.form.controls.enable_gpos_stig.errors;
+          if (errors?.['globalTwoFactorRequired']) {
+            delete errors['globalTwoFactorRequired'];
+            const hasErrors = Object.keys(errors).length > 0;
+            this.form.controls.enable_gpos_stig.setErrors(hasErrors ? errors : null);
+          }
         }
 
         Object.keys(this.form.controls).forEach((key) => {
@@ -340,5 +392,12 @@ export class SystemSecurityFormComponent implements OnInit {
           }
         });
       });
+  }
+
+  navigateToGlobal2Fa(): void {
+    // Mark form as pristine to avoid unsaved changes dialog
+    this.form.markAsPristine();
+    this.slideInRef.close({ response: false });
+    this.router.navigate(['/credentials/two-factor']);
   }
 }

--- a/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
+++ b/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
@@ -220,7 +220,7 @@ export class SystemSecurityFormComponent implements OnInit {
 
   private checkUsersWithoutTwoFactorAuth(callback: () => void): void {
     this.api.call('user.query', [[
-      ['OR', [['builtin', '=', false], ['username', '=', 'root']]],
+      ['builtin', '=', false],
       ['twofactor_auth_configured', '=', false],
       ['locked', '=', false],
       ['password_disabled', '=', false],


### PR DESCRIPTION
**Changes:**

Add a warning if there are users without 2FA configured when enabling STIG.

**Testing:**

Have admin users without 2FA and enable STIG.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |Warn if there are users with roles and without 2FA
|Testing         |Enabling STIG has new potential dialog
