### PR TITLE
NAS-136842 / 25.10 / The Shares > iSCSI screen tabs for Targets, Extents, etc Cannot be seen in iXDark theme

### DIFF
--- a/src/assets/styles/other/_material-overrides.scss
+++ b/src/assets/styles/other/_material-overrides.scss
@@ -40,6 +40,7 @@ html .ix-dark {
   --mat-button-filled-container-color: var(--bg2);
   --mat-button-filled-label-text-color: var(--fg2);
   --mat-icon-button-disabled-icon-color: var(--alt-fg1);
+  --mat-list-list-item-disabled-label-text-color: var(--fg2);
   --mat-snack-bar-container-color: var(--bg2);
   --mat-slide-toggle-selected-hover-handle-color: var(--primary);
   --mdc-switch-selected-handle-color: var(--primary);

--- a/src/assets/styles/other/_material-overrides.scss
+++ b/src/assets/styles/other/_material-overrides.scss
@@ -38,6 +38,8 @@ html .ix-dark {
   --mat-slide-toggle-selected-pressed-handle-color: var(--primary);
   --mat-button-outlined-label-text-color: var(--fg2);
   --mat-button-filled-container-color: var(--bg2);
+  --mat-button-filled-label-text-color: var(--fg2);
+  --mat-icon-button-disabled-icon-color: var(--alt-fg1);
   --mat-snack-bar-container-color: var(--bg2);
   --mat-slide-toggle-selected-hover-handle-color: var(--primary);
   --mdc-switch-selected-handle-color: var(--primary);
@@ -429,7 +431,7 @@ html .ix-dark {
 .mat-mdc-snack-bar-container.ix-snackbar-high-priority {
   // Force the parent overlay wrapper to have higher z-index
   position: relative;
-  
+
   // Use a pseudo-element to push the z-index up
   &::before {
     bottom: 0;


### PR DESCRIPTION
Testing: see ticket.

Preview:

<img width="1728" height="891" alt="Screenshot 2025-07-30 at 12 39 14" src="https://github.com/user-attachments/assets/852eadfd-2bd6-475d-8bc0-e6b22580530b" />
