### PR TITLE
NAS-136899 / 25.10 / Allow "ips" or "interface_ips" in checking for TNC configuration

### DIFF
--- a/src/app/interfaces/truenas-connect-config.interface.ts
+++ b/src/app/interfaces/truenas-connect-config.interface.ts
@@ -14,6 +14,7 @@ export interface TruenasConnectConfig extends TruenasConnectUpdate {
   status: TruenasConnectStatus;
   status_reason: string;
   certificate: number;
+  interfaces_ips: string[];
 }
 
 export interface TruenasConnectUpdate {

--- a/src/app/modules/layout/topbar/topbar.component.spec.ts
+++ b/src/app/modules/layout/topbar/topbar.component.spec.ts
@@ -1,6 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { EventEmitter } from '@angular/core';
+import { EventEmitter, signal } from '@angular/core';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialog } from '@angular/material/dialog';
 import {
@@ -12,6 +12,7 @@ import { of } from 'rxjs';
 import { mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { JobState } from 'app/enums/job-state.enum';
 import { Job } from 'app/interfaces/job.interface';
+import { TruenasConnectConfig } from 'app/interfaces/truenas-connect-config.interface';
 import { selectImportantUnreadAlertsCount } from 'app/modules/alerts/store/alert.selectors';
 import { UpdateDialog } from 'app/modules/dialog/components/update-dialog/update-dialog.component';
 import { UiSearchProvider } from 'app/modules/global-search/services/ui-search.service';
@@ -47,6 +48,7 @@ describe('TopbarComponent', () => {
   let spectator: Spectator<TopbarComponent>;
   let loader: HarnessLoader;
   const updateRunningStatus$ = new EventEmitter<'true' | 'false'>();
+  const mockConfigSignal = signal<TruenasConnectConfig | null>(null);
 
   const createComponent = createComponentFactory({
     component: TopbarComponent,
@@ -78,7 +80,7 @@ describe('TopbarComponent', () => {
       }),
       mockApi(),
       mockProvider(TruenasConnectService, {
-        config: () => ({}),
+        config: mockConfigSignal,
       }),
       provideMockStore({
         selectors: [
@@ -143,6 +145,75 @@ describe('TopbarComponent', () => {
         title: 'Update in Progress',
         message: 'A system update is in progress. It might have been launched in another window or by an external source like TrueCommand.',
       },
+    });
+  });
+
+  describe('hasTncConfig', () => {
+    const baseTncConfig: Partial<TruenasConnectConfig> = {
+      tnc_base_url: 'https://tnc.example.com',
+      account_service_base_url: 'https://account.example.com',
+      leca_service_base_url: 'https://leca.example.com',
+    };
+
+    it('returns falsy when config is null or undefined', () => {
+      mockConfigSignal.set(null);
+      expect(spectator.component.hasTncConfig()).toBeFalsy();
+    });
+
+    it('returns falsy when ips and interfaces_ips are both empty', () => {
+      mockConfigSignal.set({
+        ...baseTncConfig,
+        ips: [],
+        interfaces_ips: [],
+      } as TruenasConnectConfig);
+      expect(spectator.component.hasTncConfig()).toBeFalsy();
+    });
+
+    it('returns falsy when missing required URLs even with IPs', () => {
+      mockConfigSignal.set({
+        ips: ['192.168.1.1'],
+        interfaces_ips: [],
+        tnc_base_url: '',
+        account_service_base_url: '',
+        leca_service_base_url: '',
+      } as TruenasConnectConfig);
+      expect(spectator.component.hasTncConfig()).toBeFalsy();
+    });
+
+    it('returns truthy when ips array has values and all required URLs are present', () => {
+      mockConfigSignal.set({
+        ...baseTncConfig,
+        ips: ['192.168.1.1'],
+        interfaces_ips: [],
+      } as TruenasConnectConfig);
+      expect(spectator.component.hasTncConfig()).toBeTruthy();
+    });
+
+    it('returns truthy when interfaces_ips array has values and all required URLs are present', () => {
+      mockConfigSignal.set({
+        ...baseTncConfig,
+        ips: [],
+        interfaces_ips: ['10.0.0.1'],
+      } as TruenasConnectConfig);
+      expect(spectator.component.hasTncConfig()).toBeTruthy();
+    });
+
+    it('returns truthy when both ips and interfaces_ips arrays have values', () => {
+      mockConfigSignal.set({
+        ...baseTncConfig,
+        ips: ['192.168.1.1'],
+        interfaces_ips: ['10.0.0.1'],
+      } as TruenasConnectConfig);
+      expect(spectator.component.hasTncConfig()).toBeTruthy();
+    });
+
+    it('returns truthy when only interfaces_ips has values (backward compatibility)', () => {
+      mockConfigSignal.set({
+        ...baseTncConfig,
+        ips: [],
+        interfaces_ips: ['10.0.0.1', '10.0.0.2'],
+      } as TruenasConnectConfig);
+      expect(spectator.component.hasTncConfig()).toBeTruthy();
     });
   });
 });

--- a/src/app/modules/layout/topbar/topbar.component.ts
+++ b/src/app/modules/layout/topbar/topbar.component.ts
@@ -89,7 +89,7 @@ export class TopbarComponent implements OnInit {
   readonly shownDialog = signal(false);
   readonly hasTncConfig = computed(() => {
     const config = this.tnc.config();
-    return config?.ips?.length && config.tnc_base_url
+    return config && (config.ips.length || config.interfaces_ips.length) && config.tnc_base_url
       && config.account_service_base_url
       && config.leca_service_base_url;
   });

--- a/src/app/modules/truenas-connect/components/truenas-connect-status-modal/truenas-connect-status-modal.component.spec.ts
+++ b/src/app/modules/truenas-connect/components/truenas-connect-status-modal/truenas-connect-status-modal.component.spec.ts
@@ -23,6 +23,7 @@ describe('TruenasConnectStatusModalComponent', () => {
   const config = signal({
     enabled: true,
     ips: ['10.220.36.85'],
+    interfaces_ips: [],
     tnc_base_url: 'https://truenas.connect.dev.ixsystems.net/',
     account_service_base_url: 'https://account-service.dev.ixsystems.net/',
     leca_service_base_url: 'https://leca-server.dev.ixsystems.net/',

--- a/src/app/modules/truenas-connect/services/truenas-connect.service.spec.ts
+++ b/src/app/modules/truenas-connect/services/truenas-connect.service.spec.ts
@@ -17,6 +17,7 @@ describe('TruenasConnectService', () => {
   const config: TruenasConnectConfig = {
     id: 1,
     ips: [''],
+    interfaces_ips: [],
     enabled: true,
     tnc_base_url: 'https://tnc-test.ixsystems.com',
     account_service_base_url: 'https://account-service-test.ixsystems.com',

--- a/src/app/modules/truenas-connect/truenas-connect-button.component.spec.ts
+++ b/src/app/modules/truenas-connect/truenas-connect-button.component.spec.ts
@@ -16,6 +16,7 @@ describe('TruenasConnectButtonComponent', () => {
   const config = {
     enabled: true,
     ips: ['10.220.36.85'],
+    interfaces_ips: [],
     tnc_base_url: 'https://truenas.connect.dev.ixsystems.net/',
     account_service_base_url: 'https://account-service.dev.ixsystems.net/',
     leca_service_base_url: 'https://leca-server.dev.ixsystems.net/',


### PR DESCRIPTION
**Changes:**
 - Add `interfaces_ips` field to `TruenasConnectConfig` interface
  - Update `hasTncConfig` computed property to check both `ips` and
  `interfaces_ips` arrays
  - Ensures TrueNAS Connect configuration is considered valid when
  either IP source is available

**Testing:**
1. Run this in shell 
`
midclt call tn_connect.update '{"enabled": true, "ips": [IP_ADDRESS], "account_service_base_url": "https://account-service.dev.ixsystems.net/", "leca_service_base_url": "https://dns-service.dev.ixsystems.net/", "tnc_base_url": "https://truenas.connect.dev.ixsystems.net/", "heartbeat_url": "https://heartbeat-service.dev.ixsystems.net/"}'
`
2. TNC icon should appear in topbar
<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
