### PR TITLE
Add markdown highlight syntax for warnings and errors in release notes

### DIFF
--- a/src/app/pages/system/update/components/dynamic-markdown/dynamic-markdown.component.scss
+++ b/src/app/pages/system/update/components/dynamic-markdown/dynamic-markdown.component.scss
@@ -26,4 +26,36 @@
       padding: 0;
     }
   }
+
+  .highlight-warning {
+    background-color: rgba(var(--color-warning-rgb), 0.15);
+    border-radius: 4px;
+    color: var(--orange);
+    display: inline-block;
+    font-weight: 500;
+    padding: 2px 8px;
+    position: relative;
+
+    &::before {
+      content: '⚠ ';
+      font-size: 1.1em;
+      margin-right: 4px;
+    }
+  }
+
+  .highlight-error {
+    background-color: rgba(var(--color-error-rgb), 0.15);
+    border-radius: 4px;
+    color: var(--red);
+    display: inline-block;
+    font-weight: 500;
+    padding: 2px 8px;
+    position: relative;
+
+    &::before {
+      content: '✖ ';
+      font-size: 1.1em;
+      margin-right: 4px;
+    }
+  }
 }

--- a/src/app/pages/system/update/components/dynamic-markdown/dynamic-markdown.component.ts
+++ b/src/app/pages/system/update/components/dynamic-markdown/dynamic-markdown.component.ts
@@ -66,6 +66,9 @@ export class DynamicMarkdownComponent {
       },
     );
 
+    // Process highlight syntax and convert to warnings
+    processed = this.processHighlightSyntax(processed);
+
     return processed;
   }
 
@@ -194,5 +197,25 @@ export class DynamicMarkdownComponent {
     }
 
     return tabs;
+  }
+
+  private processHighlightSyntax(content: string): string {
+    let processed = content;
+
+    // Match ===text=== for warning highlights
+    // Must have exactly 3 equals on each side
+    processed = processed.replace(
+      /(?<![=])===([^=]+?)===(?![=])/gu,
+      '<span class="highlight-warning">$1</span>',
+    );
+
+    // Match ==text== for error highlights
+    // Must have exactly 2 equals on each side
+    processed = processed.replace(
+      /(?<![=])==([^=]+?)==(?![=])/gu,
+      '<span class="highlight-error">$1</span>',
+    );
+
+    return processed;
   }
 }


### PR DESCRIPTION
- Add support for ==text== syntax to display as error highlights (red)
- Add support for ===text=== syntax to display as warning highlights (orange)
- Both highlights include appropriate icons and background colors
- Add comprehensive test coverage for both highlight types
- Ensure proper handling of edge cases with multiple equals signs

**Changes:**

Support for breaking changes and warnings in release notes.

**Testing:**

Have a release notes file with:
==breaking change==
and
===warning message===

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
