### PR TITLE
NAS-136928 / 25.10 / Use `ix-code-editor` instead of `ix-textarea` for mockconfig form

### DIFF
--- a/src/app/modules/websocket-debug-panel/components/mock-config/mock-config-form/mock-config-form.component.html
+++ b/src/app/modules/websocket-debug-panel/components/mock-config/mock-config-form/mock-config-form.component.html
@@ -16,14 +16,13 @@
         [hint]="'Regex pattern to match against message content' | translate"
       ></ix-input>
       
-      <ix-textarea
+      <ix-code-editor
         ixTest="response-data-textarea"
         formControlName="responseResult"
+        [language]="CodeEditorLanguage.Json"
         [label]="'Response Data' | translate"
-        [placeholder]="'{ &quot;result&quot;: &quot;success&quot; }' | translate"
         [hint]="'JSON format expected' | translate"
-        [rows]="8"
-      ></ix-textarea>
+      ></ix-code-editor>
 
       <ix-input
         ixTest="response-delay-input"

--- a/src/app/modules/websocket-debug-panel/components/mock-config/mock-config-form/mock-config-form.component.ts
+++ b/src/app/modules/websocket-debug-panel/components/mock-config/mock-config-form/mock-config-form.component.ts
@@ -7,8 +7,9 @@ import {
 import { MatButton } from '@angular/material/button';
 import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
+import { CodeEditorLanguage } from 'app/enums/code-editor-language.enum';
+import { IxCodeEditorComponent } from 'app/modules/forms/ix-forms/components/ix-code-editor/ix-code-editor.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
-import { IxTextareaComponent } from 'app/modules/forms/ix-forms/components/ix-textarea/ix-textarea.component';
 import { JobEventBuilderComponent } from 'app/modules/websocket-debug-panel/components/mock-config/job-event-builder/job-event-builder.component';
 import {
   MockConfig, MockEvent,
@@ -23,7 +24,7 @@ import { updateMockConfig } from 'app/modules/websocket-debug-panel/store/websoc
     MatButton,
     TranslateModule,
     IxInputComponent,
-    IxTextareaComponent,
+    IxCodeEditorComponent,
     JobEventBuilderComponent,
   ],
   templateUrl: './mock-config-form.component.html',
@@ -37,6 +38,8 @@ export class MockConfigFormComponent implements OnInit {
 
   private readonly fb = inject(FormBuilder);
   private readonly store = inject(Store);
+
+  protected readonly CodeEditorLanguage = CodeEditorLanguage;
 
   protected readonly form = this.fb.group({
     methodName: ['', Validators.required],


### PR DESCRIPTION
Testing: see ticket.

Preview:

<img width="1110" height="1766" alt="image" src="https://github.com/user-attachments/assets/a82539ea-cbdc-44b9-b5d1-7c1fc4ec5e60" />
