### PR TITLE
NAS-136761: Disable function not exposed in the UI in the NVMe Namespace widget.

### DIFF
--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.html
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.html
@@ -34,15 +34,6 @@
               <span class="namespace-actions">
                 <button
                   mat-icon-button
-                  [ixTest]="['edit-namespace', namespace.device_path]"
-                  [matTooltip]="'Edit namespace' | translate"
-                  (click)="onEditNamespace(namespace)"
-                >
-                  <ix-icon name="edit"></ix-icon>
-                </button>
-
-                <button
-                  mat-icon-button
                   [ixTest]="['delete-namespace', namespace.device_path]"
                   [matTooltip]="'Delete namespace' | translate"
                   (click)="onDeleteNamespace(namespace)"


### PR DESCRIPTION
Final decision: 
```lets remove Edit ability for namespaces for now. Only add/delete.```