### PR TITLE
NAS-136988 / 26.04 / Fix and improve External Share for Goldeye

### DIFF
--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.ts
@@ -1,5 +1,7 @@
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy, Component, OnInit, inject,
+} from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatCard } from '@angular/material/card';
 import { MatToolbarRow } from '@angular/material/toolbar';
@@ -15,7 +17,9 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { LoadingMap, accumulateLoadingState } from 'app/helpers/operators/accumulate-loading-state.helper';
-import { LegacySmbShareOptions, SmbShare, SmbSharesec } from 'app/interfaces/smb-share.interface';
+import {
+  ExternalSmbShareOptions, LegacySmbShareOptions, SmbShare, SmbSharesec,
+} from 'app/interfaces/smb-share.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EmptyComponent } from 'app/modules/empty/empty.component';
 import { EmptyService } from 'app/modules/empty/empty.service';
@@ -98,7 +102,7 @@ export class SmbCardComponent implements OnInit {
     }),
     textColumn({
       title: this.translate.instant('Path'),
-      propertyName: 'path',
+      getValue: (row) => (row.options as ExternalSmbShareOptions)?.remote_path?.join(', ') || row.path,
     }),
     textColumn({
       title: this.translate.instant('Description'),

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.html
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.html
@@ -10,25 +10,6 @@
       <ix-smb-users-warning></ix-smb-users-warning>
 
       <ix-fieldset [title]="'Basic' | translate">
-        @if (form.controls.purpose.value !== SmbPresetType.ExternalShare) {
-          <ix-explorer
-            formControlName="path"
-            [required]="true"
-            [tooltip]="helptextSharingSmb.pathTooltip | translate"
-            [label]="helptextSharingSmb.pathLabel | translate"
-            [nodeProvider]="treeNodeProvider"
-            [rootNodes]="rootNodes()"
-          >
-            <ix-explorer-create-dataset [datasetProperties]="createDatasetProps"></ix-explorer-create-dataset>
-          </ix-explorer>
-        }
-
-        <ix-input
-          formControlName="name"
-          [label]="helptextSharingSmb.nameLabel | translate"
-          [required]="true"
-        ></ix-input>
-
         <ix-select
           formControlName="purpose"
           emptyValue=""
@@ -47,6 +28,25 @@
             (extensionsEnabled)="extensionsEnabled()"
           ></ix-smb-extensions-warning>
         }
+
+        @if (form.controls.purpose.value !== SmbPresetType.ExternalShare) {
+          <ix-explorer
+            formControlName="path"
+            [required]="true"
+            [tooltip]="helptextSharingSmb.pathTooltip | translate"
+            [label]="helptextSharingSmb.pathLabel | translate"
+            [nodeProvider]="treeNodeProvider"
+            [rootNodes]="rootNodes()"
+          >
+            <ix-explorer-create-dataset [datasetProperties]="createDatasetProps"></ix-explorer-create-dataset>
+          </ix-explorer>
+        }
+
+        <ix-input
+          formControlName="name"
+          [label]="helptextSharingSmb.nameLabel | translate"
+          [required]="true"
+        ></ix-input>
 
         @if (form.controls.remote_path.enabled) {
           <ix-chips

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.html
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.html
@@ -51,7 +51,7 @@
         @if (form.controls.remote_path.enabled) {
           <ix-chips
             formControlName="remote_path"
-            [label]="'Remote Path' | translate"
+            [label]="'Remote Paths' | translate"
             [tooltip]="'This is the path to the external server and share. Each server entry must include a full domain name or IP address and share name. Separate the server and share with the `\\` character. \n\n Example: 192.168.0.200\\SHARE' | translate"
             [required]="true"
           ></ix-chips>

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
@@ -1,5 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialog } from '@angular/material/dialog';
@@ -498,9 +499,9 @@ describe('SmbFormComponent', () => {
     it('toggle between Basic/Advanced fields when corresponding buttons are pressed', async () => {
       // Start with advanced options visible because we opened it in beforeEach
       expect(await form.getLabels()).toEqual([
+        'Purpose',
         'Path',
         'Name',
-        'Purpose',
         'Description',
         'Enabled',
         'Export Read Only',
@@ -514,9 +515,9 @@ describe('SmbFormComponent', () => {
       await basicOptions.click();
 
       expect(await form.getLabels()).toEqual([
+        'Purpose',
         'Path',
         'Name',
-        'Purpose',
         'Description',
         'Enabled',
       ]);
@@ -557,6 +558,48 @@ describe('SmbFormComponent', () => {
       await submitForm(commonValues);
 
       expect(store$.dispatch).toHaveBeenCalledWith(checkIfServiceIsEnabled({ serviceName: ServiceName.Cifs }));
+    });
+
+    it('should change purpose to External when path contains IP address/share format', fakeAsync(async () => {
+      const pathControl = await loader.getHarness(IxExplorerHarness.with({ label: 'Path' }));
+      const purposeControl = await loader.getHarness(IxSelectHarness.with({ label: 'Purpose' }));
+
+      // Initially should be Default Share
+      expect(await purposeControl.getValue()).toBe('Default Share');
+
+      // Set IP address path format
+      await pathControl.setValue('192.168.0.200\\SHARE');
+
+      // Wait for debounced changes to trigger
+      tick(100);
+      spectator.detectChanges();
+
+      // Purpose should now be External Share
+      expect(await purposeControl.getValue()).toBe('External Share');
+    }));
+
+    it('should change purpose to External when path starts with EXTERNAL prefix', async () => {
+      const pathControl = await loader.getHarness(IxExplorerHarness.with({ label: 'Path' }));
+      const purposeControl = await loader.getHarness(IxSelectHarness.with({ label: 'Purpose' }));
+
+      expect(await purposeControl.getValue()).toBe('Default Share');
+
+      await pathControl.setValue('EXTERNAL:192.168.0.200\\SHARE');
+      spectator.detectChanges();
+
+      expect(await purposeControl.getValue()).toBe('External Share');
+    });
+
+    it('should change purpose to External when path starts with EXTERNAL only', async () => {
+      const pathControl = await loader.getHarness(IxExplorerHarness.with({ label: 'Path' }));
+      const purposeControl = await loader.getHarness(IxSelectHarness.with({ label: 'Purpose' }));
+
+      expect(await purposeControl.getValue()).toBe('Default Share');
+
+      await pathControl.setValue('external:');
+      spectator.detectChanges();
+
+      expect(await purposeControl.getValue()).toBe('External Share');
     });
   });
 

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
@@ -397,7 +397,7 @@ describe('SmbFormComponent', () => {
       await submitForm({
         ...commonValues,
         Purpose: 'External Share',
-        'Remote Path': ['192.168.0.1\\SHARE'],
+        'Remote Paths': ['192.168.0.1\\SHARE'],
       });
 
       expect(api.call).toHaveBeenLastCalledWith('sharing.smb.create', [

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -1,4 +1,6 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, OnInit, signal, inject } from '@angular/core';
+import {
+  AfterViewInit, ChangeDetectionStrategy, Component, OnInit, signal, inject,
+} from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
@@ -381,12 +383,34 @@ export class SmbFormComponent implements OnInit, AfterViewInit {
   private setupPathControl(): void {
     this.form.controls.path.valueChanges.pipe(
       debounceTime(50),
-      tap(() => this.setNameFromPath()),
+      tap(() => {
+        const pathValue = this.form.controls.path.value?.toUpperCase() || '';
+
+        // Check if path is external (starts with EXTERNAL or matches IP\SHARE pattern)
+        if (this.isExternalPath(pathValue)) {
+          this.form.controls.purpose.setValue(SmbSharePurpose.ExternalShare);
+        }
+
+        this.setNameFromPath();
+      }),
       untilDestroyed(this),
     )
       .subscribe((path) => {
         this.checkAndShowStripAclWarning(path, this.form.controls.acl.value);
       });
+  }
+
+  private isExternalPath(path: string): boolean {
+    if (!path) return false;
+
+    // Check if path starts with EXTERNAL (case insensitive)
+    if (path.toUpperCase().startsWith(externalSmbSharePath.toUpperCase())) {
+      return true;
+    }
+
+    // Check if path matches IP\SHARE pattern (e.g., 192.168.0.200\SHARE)
+    const ipSharePattern = /^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\\[^\\]+$/;
+    return ipSharePattern.test(path);
   }
 
   private setupAfpWarning(): void {
@@ -422,7 +446,7 @@ export class SmbFormComponent implements OnInit, AfterViewInit {
         return;
       }
 
-      nameControl.setValue(name);
+      nameControl.setValue(name.toLowerCase());
       nameControl.markAsTouched();
     }
   }
@@ -433,7 +457,7 @@ export class SmbFormComponent implements OnInit, AfterViewInit {
       || !path
       || aclValue
       || this.form.controls.purpose.value === SmbSharePurpose.ExternalShare
-      || path.startsWith(externalSmbSharePath)
+      || this.isExternalPath(path)
     ) {
       return;
     }
@@ -686,7 +710,7 @@ export class SmbFormComponent implements OnInit, AfterViewInit {
 
     if (
       this.form.controls.purpose.value === SmbSharePurpose.ExternalShare
-      || sharePath.startsWith(externalSmbSharePath)
+      || this.isExternalPath(sharePath)
     ) {
       return of(false);
     }

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -353,7 +353,18 @@ export class SmbFormComponent implements OnInit, AfterViewInit {
   private setupMangleWarning(): void {
     this.form.controls.aapl_name_mangling.valueChanges.pipe(
       filter((value) => {
-        return value !== (this.existingSmbShare?.options as LegacySmbShareOptions)?.aapl_name_mangling && !this.isNew;
+        if (this.isNew) {
+          return false;
+        }
+
+        // Check if the original share purpose supported aapl_name_mangling
+        const originalPurpose = this.existingSmbShare?.purpose;
+        const originalSupportedFields = originalPurpose ? presetEnabledFields[originalPurpose] : [];
+        const wasFieldSupported = originalSupportedFields?.includes('aapl_name_mangling') ?? false;
+
+        // Only show warning if the field was supported in the original purpose and the value actually changed
+        return wasFieldSupported
+          && value !== (this.existingSmbShare?.options as LegacySmbShareOptions)?.aapl_name_mangling;
       }),
       take(1),
       switchMap(() => this.dialogService.confirm({

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -1,5 +1,7 @@
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject,
+} from '@angular/core';
 import { MatAnchor, MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { MatToolbarRow } from '@angular/material/toolbar';
@@ -17,7 +19,7 @@ import { EmptyType } from 'app/enums/empty-type.enum';
 import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { shared } from 'app/helptext/sharing';
-import { SmbSharePurpose, SmbShare } from 'app/interfaces/smb-share.interface';
+import { SmbSharePurpose, SmbShare, ExternalSmbShareOptions } from 'app/interfaces/smb-share.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EmptyComponent } from 'app/modules/empty/empty.component';
 import { EmptyService } from 'app/modules/empty/empty.service';
@@ -112,7 +114,7 @@ export class SmbListComponent implements OnInit {
     }),
     textColumn({
       title: this.translate.instant('Path'),
-      propertyName: 'path',
+      getValue: (row) => (row.options as ExternalSmbShareOptions)?.remote_path?.join(', ') || row.path,
     }),
     textColumn({
       title: this.translate.instant('Description'),


### PR DESCRIPTION
Testing: see ticket.

We show purpose first.
But still if user types some external path - we switch to `External` Purpose.

Preview:

https://github.com/user-attachments/assets/a1f0800b-89b4-43ce-8b74-eb7be586cd1a


