### PR TITLE
NAS-136993 / 26.04 / Add method name filter to WebSocket debug panel

### DIFF
--- a/src/app/modules/websocket-debug-panel/components/message-list/message-list.component.html
+++ b/src/app/modules/websocket-debug-panel/components/message-list/message-list.component.html
@@ -1,6 +1,13 @@
 <div class="message-list-container">
   <div class="message-list-header">
     <div class="header-controls">
+      <ix-input
+        class="filter-field"
+        ixTest="websocket-debug-filter"
+        [placeholder]="'Filter by method' | translate"
+        [(ngModel)]="filterText"
+        (ngModelChange)="applyFilter()">
+      </ix-input>
       <mat-checkbox
         ixTest="websocket-debug-auto-scroll"
         matTooltip="Auto-scroll to latest message"
@@ -24,7 +31,7 @@
     </div>
   } @else {
     <div #messageViewport class="message-viewport">
-      @for (message of formattedMessagesArray; track message.id) {
+      @for (message of filteredMessagesArray; track message.id) {
         <div class="message-item"
              [class.outgoing]="message.direction === 'out'"
              [class.incoming]="message.direction === 'in'"

--- a/src/app/modules/websocket-debug-panel/components/message-list/message-list.component.scss
+++ b/src/app/modules/websocket-debug-panel/components/message-list/message-list.component.scss
@@ -18,16 +18,60 @@
   background-color: var(--bg2);
   border-bottom: 1px solid var(--lines);
   display: flex;
-  justify-content: flex-end;
   padding: 4px 12px;
 
   .header-controls {
     align-items: center;
     display: flex;
+    flex: 1;
     gap: 12px;
+    justify-content: space-between;
     
     mat-checkbox {
       font-size: 12px;
+      margin-left: auto;
+    }
+
+    ix-input.filter-field {
+      display: block;
+      flex: 0 1 200px;
+      margin: 0 !important;
+      min-width: 150px;
+      padding: 0 !important;
+
+      ::ng-deep {
+        // Override all possible margins and paddings
+        * {
+          margin-bottom: 0 !important;
+          margin-top: 0 !important;
+        }
+
+        // Hide label completely
+        ix-label {
+          display: none !important;
+        }
+
+        .input-container {
+          margin: 0 !important;
+          padding: 0 !important;
+        }
+
+        input {
+          font-size: 12px;
+          height: 28px;
+          margin: 0;
+          padding: 4px 8px;
+        }
+
+        // Remove any mat-form-field related spacing
+        .mat-mdc-form-field-wrapper,
+        .mat-mdc-text-field-wrapper,
+        .mat-mdc-form-field-flex,
+        .mat-mdc-form-field-infix {
+          margin: 0 !important;
+          padding: 0 !important;
+        }
+      }
     }
   }
 

--- a/src/app/modules/websocket-debug-panel/components/message-list/message-list.component.spec.ts
+++ b/src/app/modules/websocket-debug-panel/components/message-list/message-list.component.spec.ts
@@ -280,5 +280,81 @@ describe('MessageListComponent', () => {
     });
   });
 
+  describe('filter functionality', () => {
+    beforeEach(() => {
+      // Initialize component with messages
+      spectator.component.ngAfterViewInit();
+      spectator.detectChanges();
+    });
+
+    it('should initialize with empty filter text', () => {
+      expect(spectator.component['filterText']).toBe('');
+    });
+
+    it('should show all messages when filter is empty', () => {
+      spectator.component['filterText'] = '';
+      spectator.component['applyFilter']();
+      expect(spectator.component['filteredMessagesArray']).toHaveLength(2);
+      expect(spectator.component['hasMessages']).toBe(true);
+    });
+
+    it('should filter messages by method name (case-insensitive)', () => {
+      // Test filtering for "system"
+      spectator.component['filterText'] = 'system';
+      spectator.component['applyFilter']();
+      expect(spectator.component['filteredMessagesArray']).toHaveLength(1);
+      expect(spectator.component['filteredMessagesArray'][0].methodName).toBe('system.info');
+
+      // Test case-insensitive filtering
+      spectator.component['filterText'] = 'SYSTEM';
+      spectator.component['applyFilter']();
+      expect(spectator.component['filteredMessagesArray']).toHaveLength(1);
+
+      // Test partial match
+      spectator.component['filterText'] = 'info';
+      spectator.component['applyFilter']();
+      expect(spectator.component['filteredMessagesArray']).toHaveLength(1);
+      expect(spectator.component['filteredMessagesArray'][0].methodName).toBe('system.info');
+    });
+
+    it('should show no messages when filter matches nothing', () => {
+      spectator.component['filterText'] = 'nonexistent';
+      spectator.component['applyFilter']();
+      expect(spectator.component['filteredMessagesArray']).toHaveLength(0);
+      expect(spectator.component['hasMessages']).toBe(false);
+    });
+
+    it('should update hasMessages based on filtered results', () => {
+      // With matching filter
+      spectator.component['filterText'] = 'system';
+      spectator.component['applyFilter']();
+      expect(spectator.component['hasMessages']).toBe(true);
+
+      // With non-matching filter
+      spectator.component['filterText'] = 'xyz';
+      spectator.component['applyFilter']();
+      expect(spectator.component['hasMessages']).toBe(false);
+
+      // Clear filter
+      spectator.component['filterText'] = '';
+      spectator.component['applyFilter']();
+      expect(spectator.component['hasMessages']).toBe(true);
+    });
+
+    it('should trim whitespace in filter text', () => {
+      spectator.component['filterText'] = '  system  ';
+      spectator.component['applyFilter']();
+      expect(spectator.component['filteredMessagesArray']).toHaveLength(1);
+      expect(spectator.component['filteredMessagesArray'][0].methodName).toBe('system.info');
+    });
+
+    it('should handle filter for messages with Unknown method name', () => {
+      spectator.component['filterText'] = 'unknown';
+      spectator.component['applyFilter']();
+      expect(spectator.component['filteredMessagesArray']).toHaveLength(1);
+      expect(spectator.component['filteredMessagesArray'][0].methodName).toBe('Unknown');
+    });
+  });
+
   // trackBy function was removed from the component
 });


### PR DESCRIPTION
- Add filter input field in message list header using ix-input component
- Implement real-time filtering of messages by method name (case-insensitive)
- Position filter on the left, auto-scroll and clear button on the right
- Remove label and minimize padding on filter input for compact design
- Update component to use filtered messages array for display

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

Type in a filter and make sure only method names that includes the input are shown

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
