### PR TITLE
NAS-135778: remove alternative styling on TNC header button 

### DIFF
--- a/src/app/modules/truenas-connect/truenas-connect-button.component.html
+++ b/src/app/modules/truenas-connect/truenas-connect-button.component.html
@@ -1,15 +1,3 @@
-@if (tnc.config()?.status === TruenasConnectStatus.Configured) {
-<button
-  ixTest="tnc-show-status"
-  mat-icon-button
-  matBadge="&#8288;"
-  matBadgeSize="small"
-  [matTooltip]="tooltips.tncStatus | translate"
-  (click)="showStatus()"
->
-  <ix-icon name="ix-truenas-connect-logo"></ix-icon>
-</button>
-} @else {
 <button
   ixTest="tnc-show-status"
   mat-icon-button
@@ -18,4 +6,3 @@
 >
   <ix-icon name="ix-truenas-connect-logo"></ix-icon>
 </button>
-}

--- a/src/app/modules/truenas-connect/truenas-connect-button.component.ts
+++ b/src/app/modules/truenas-connect/truenas-connect-button.component.ts
@@ -5,7 +5,6 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatTooltip } from '@angular/material/tooltip';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
-import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
 import { helptextTopbar } from 'app/helptext/topbar';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
 import { TestDirective } from 'app/modules/test-id/test.directive';
@@ -32,7 +31,6 @@ export class TruenasConnectButtonComponent {
   private matDialog = inject(MatDialog);
   tnc = inject(TruenasConnectService);
 
-  readonly TruenasConnectStatus = TruenasConnectStatus;
   tooltips = helptextTopbar.tooltips;
 
   protected showStatus(): void {


### PR DESCRIPTION
Just a minor styling change requested by Patrick. No more "blue dot" when the TNC service is configured and healthy.
