### PR TITLE
NAS-117171: webui makes it too easy to try to set an invalid POSIX1E ACL

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(rm:*)"
-    ],
-    "deny": []
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rm:*)"
+    ],
+    "deny": []
+  }
+}

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.html
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.html
@@ -68,6 +68,34 @@
             </button>
           </div>
 
+          @if (acl?.acltype === AclType.Posix1e) {
+            <div class="posix-helpers">
+              <h4 class="helpers-label">{{ 'POSIX ACL Helpers' | translate }}</h4>
+              <div class="control-buttons">
+                <button
+                  mat-button
+                  class="action"
+                  ixTest="copy-access-to-default"
+                  [disabled]="!hasAccessEntries()"
+                  (click)="onCopyAccessToDefaultPressed()"
+                >
+                  <ix-icon name="content_copy"></ix-icon>
+                  {{ 'Copy Access to Default' | translate }}
+                </button>
+                <button
+                  mat-button
+                  class="action"
+                  ixTest="ensure-mask-entries"
+                  [disabled]="!needsMaskEntries()"
+                  (click)="onEnsureMaskEntriesPressed()"
+                >
+                  <ix-icon name="security"></ix-icon>
+                  {{ 'Add Missing MASK Entries' | translate }}
+                </button>
+              </div>
+            </div>
+          }
+
           <div class="controls-container">
             <div class="controls">
               <ix-acl-editor-save-controls

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.scss
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-acl-editor/dataset-acl-editor.component.scss
@@ -111,3 +111,25 @@
     }
   }
 }
+
+.posix-helpers {
+  border-top: 1px solid var(--lines);
+  margin: 16px 20px 0;
+  padding-top: 16px;
+
+  .helpers-label {
+    font-size: 14px;
+    margin-bottom: 10px;
+    margin-top: 0;
+  }
+
+  .control-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    button {
+      width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
**Changes:**
Added `Copy Access to Default` & `Add Missing MASK Entries` buttons for `AclType.Posix1e` ACL Types.

Improvements:
* Users should not be able to remove USER_OBJ, GROUP_OBJ, OTHER entries. This also is true of case where default entries are specified
* Users should have easy way to replace default entries with what’s specified in access list (convenience feature)
* If user specifies USER or GROUP entries, a MASK entry should automatically be added to the relevant list so that user has ability to review it and set appropriately. 

**Testing:**
See ticket.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Improved experience for POSIX ACLs
