### PR TITLE
NAS-137014 / 25.10-RC.1 / Add web_port field to VM Display device configuration (by william-gr)

### DIFF
--- a/src/app/helptext/vm/devices/device-add-edit.ts
+++ b/src/app/helptext/vm/devices/device-add-edit.ts
@@ -44,6 +44,8 @@ export const helptextDevice = {
 
   port_tooltip: T('SPICE server port for direct remote desktop client connections (e.g., virt-viewer).'),
 
+  web_port_tooltip: T('Web console port for browser-based access to the VM display.'),
+
   wait_placeholder: T('Delay VM Boot Until SPICE Connects'),
   wait_tooltip: T('Wait to start VM until SPICE client connects.'),
 

--- a/src/app/helptext/vm/devices/device-add-edit.ts
+++ b/src/app/helptext/vm/devices/device-add-edit.ts
@@ -42,9 +42,7 @@ export const helptextDevice = {
   rootpwd_tooltip: T('Enter a password for the <i>rancher</i> user. This\
  is used to log in to the VM from the serial shell.'),
 
-  port_tooltip: T('Can be set to <i>0</i>, left empty for TrueNAS to\
- assign a port when the VM is started, or set to a\
- fixed, preferred port number.'),
+  port_tooltip: T('SPICE server port for direct remote desktop client connections (e.g., virt-viewer).'),
 
   wait_placeholder: T('Delay VM Boot Until SPICE Connects'),
   wait_tooltip: T('Wait to start VM until SPICE client connects.'),

--- a/src/app/interfaces/vm-device.interface.ts
+++ b/src/app/interfaces/vm-device.interface.ts
@@ -108,6 +108,7 @@ interface VmDisplayAttributes {
   type: VmDisplayType;
   wait: boolean;
   web: boolean;
+  web_port: number | null;
   dtype: VmDeviceType.Display;
 }
 

--- a/src/app/pages/vm/devices/device-form/device-form.component.html
+++ b/src/app/pages/vm/devices/device-form/device-form.component.html
@@ -200,6 +200,15 @@
                 [label]="'Web Interface' | translate"
                 [tooltip]="helptext.web_tooltip | translate"
               ></ix-checkbox>
+
+              @if (displayForm.controls.web.value) {
+                <ix-input
+                  formControlName="web_port"
+                  type="number"
+                  [label]="'Web Port' | translate"
+                  [tooltip]="'Web console port for browser-based access to the VM display.' | translate"
+                ></ix-input>
+              }
             }
           }
         </ng-container>

--- a/src/app/pages/vm/devices/device-form/device-form.component.html
+++ b/src/app/pages/vm/devices/device-form/device-form.component.html
@@ -206,7 +206,7 @@
                   formControlName="web_port"
                   type="number"
                   [label]="'Web Port' | translate"
-                  [tooltip]="'Web console port for browser-based access to the VM display.' | translate"
+                  [tooltip]="helptext.web_port_tooltip | translate"
                 ></ix-input>
               }
             }

--- a/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
@@ -662,6 +662,28 @@ describe('DeviceFormComponent', () => {
           'Web Port': '5901',
         });
       });
+
+      it('shows web_port field only when Web Interface is enabled', async () => {
+        // Initially web is true, so web_port should be visible
+        let values = await form.getValues();
+        expect(values).toHaveProperty('Web Port', '5901');
+
+        // Disable Web Interface
+        await form.fillForm({ 'Web Interface': false });
+        spectator.detectChanges();
+
+        // Web Port field should no longer be in the form values
+        values = await form.getValues();
+        expect(values).not.toHaveProperty('Web Port');
+
+        // Re-enable Web Interface
+        await form.fillForm({ 'Web Interface': true });
+        spectator.detectChanges();
+
+        // Web Port field should be visible again (though value may be cleared)
+        values = await form.getValues();
+        expect(values).toHaveProperty('Web Port');
+      });
     });
 
     describe('edits display to 46', () => {

--- a/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
@@ -625,6 +625,7 @@ describe('DeviceFormComponent', () => {
         bind: '0.0.0.0',
         password: '12345678910',
         web: true,
+        web_port: 5901,
         type: VmDisplayType.Spice,
         resolution: '1024x768',
         port: 5900,
@@ -658,6 +659,7 @@ describe('DeviceFormComponent', () => {
           Port: '5900',
           Resolution: '1024x768',
           'Web Interface': true,
+          'Web Port': '5901',
         });
       });
     });

--- a/src/app/pages/vm/devices/device-form/device-form.component.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.ts
@@ -140,6 +140,7 @@ export class DeviceFormComponent implements OnInit {
     bind: [''],
     password: [''],
     web: [true],
+    web_port: [null as number | null, [Validators.min(5900), Validators.max(65535)]],
   });
 
   usbForm = this.formBuilder.group({


### PR DESCRIPTION
- Add web_port input to Display device form with validation
- Show web_port field only when Web Interface checkbox is enabled
- Update Port field tooltip to clarify SPICE server usage
- Update tests to include web_port field in Display device tests

**Changes:**

Ad web_port to Display devices

**Testing:**

Edit Display device and change web port.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | New Web Port field to VM 
|Testing         | Make sure changing Web Port changes the port when accessing it


Original PR: https://github.com/truenas/webui/pull/12374
