### PR TITLE
NAS-136903 / 25.10-RC.1 / Validation Inconsistency in Storage Disk Source Field of Container Form (by AlexKarpov98)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-explorer/explorer-create-dataset/explorer-create-dataset.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-explorer/explorer-create-dataset/explorer-create-dataset.component.ts
@@ -37,33 +37,24 @@ export class ExplorerCreateDatasetComponent implements AfterViewInit {
 
   protected readonly requiredRoles = [Role.DatasetWrite];
 
-  protected isButtonDisabled = computed(() => {
+  private isExplorerDisabled = computed(() => this.explorer.isDisabled());
+  private hasValidParent = computed(() => !!this.parent());
+  private isPathMatchingSelection = computed(() => {
     const currentValue = this.explorerValue();
     const selectedPath = Array.isArray(currentValue) ? currentValue[0] : currentValue;
-    const lastSelectedNode = this.explorer.lastSelectedNode();
-
-    // Check if explorer is disabled
-    if (this.explorer.isDisabled()) {
-      return true;
-    }
-
-    // Check if we have a valid parent path
-    if (!this.parent()) {
-      return true;
-    }
-
-    // Check if the current path matches the selected node path
-    // This ensures the button is disabled when path is manually changed to invalid value
-    const isPathMatchingSelection = lastSelectedNode?.data.path === selectedPath;
-    const isMountpointSelected = lastSelectedNode?.data.isMountpoint;
-
-    return !isPathMatchingSelection || !isMountpointSelected;
+    return this.explorer.lastSelectedNode()?.data.path === selectedPath;
   });
+
+  protected isButtonDisabled = computed(() => this.isExplorerDisabled()
+    || !this.hasValidParent()
+    || !this.isPathMatchingSelection()
+    || !this.explorer.lastSelectedNode()?.data.isMountpoint);
 
   protected explorerValue = signal<string | string[]>('');
 
   ngAfterViewInit(): void {
-    // TODO: Unclear why this is needed, but control in `ngControl` is empty for some reason in constructor.
+    // NgControl is not initialized at construction time — it's only available after view init.
+    // We listen to control value changes here to sync explorerValue for button logic.
     this.ngControl.control?.valueChanges?.pipe(untilDestroyed(this))?.subscribe((value: string | string[]) => {
       this.explorerValue.set(value);
     });

--- a/src/app/modules/forms/ix-forms/components/ix-explorer/explorer-create-dataset/explorer-create-dataset.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-explorer/explorer-create-dataset/explorer-create-dataset.component.ts
@@ -38,8 +38,26 @@ export class ExplorerCreateDatasetComponent implements AfterViewInit {
   protected readonly requiredRoles = [Role.DatasetWrite];
 
   protected isButtonDisabled = computed(() => {
-    const isMountpointSelected = this.explorer.lastSelectedNode()?.data.isMountpoint;
-    return this.explorer.isDisabled() || !isMountpointSelected || !this.parent();
+    const currentValue = this.explorerValue();
+    const selectedPath = Array.isArray(currentValue) ? currentValue[0] : currentValue;
+    const lastSelectedNode = this.explorer.lastSelectedNode();
+
+    // Check if explorer is disabled
+    if (this.explorer.isDisabled()) {
+      return true;
+    }
+
+    // Check if we have a valid parent path
+    if (!this.parent()) {
+      return true;
+    }
+
+    // Check if the current path matches the selected node path
+    // This ensures the button is disabled when path is manually changed to invalid value
+    const isPathMatchingSelection = lastSelectedNode?.data.path === selectedPath;
+    const isMountpointSelected = lastSelectedNode?.data.isMountpoint;
+
+    return !isPathMatchingSelection || !isMountpointSelected;
   });
 
   protected explorerValue = signal<string | string[]>('');


### PR DESCRIPTION
Testing: see ticket.
Now button is disabled when invalid path provided. 

Original PR: https://github.com/truenas/webui/pull/12382
