### PR TITLE
NAS-136964 / 25.10-RC.1 / Directory Services summary for LDAP always shows BindDN (by AlexKarpov98)

### DIFF
--- a/src/app/helptext/directory-service/dashboard.ts
+++ b/src/app/helptext/directory-service/dashboard.ts
@@ -16,9 +16,9 @@ export const helptextDashboard = {
     title: T('LDAP'),
     status: T('Status'),
     statusMessage: T('Status Message'),
-    hostname: T('Hostname'),
+    serverUrls: T('Server URLs'),
     baseDN: T('Base DN'),
-    bindDN: T('Bind DN'),
+    credentialType: T('Credential Type'),
   },
   ipa: {
     title: T('IPA'),

--- a/src/app/pages/directory-service/directory-services.component.html
+++ b/src/app/pages/directory-service/directory-services.component.html
@@ -6,7 +6,7 @@
         *ixRequiresRoles="requiredRoles"
         mat-button
         ixTest="configure-active-directory"
-        [ixUiSearch]="searchableElements.elements.configureActiveDirectory"
+        [ixUiSearch]="searchableElements.elements.configureDirectoryServices"
         (click)="openDirectoryServicesForm()"
       >
         {{ 'Configure Directory Services' | translate }}

--- a/src/app/pages/directory-service/directory-services.component.html
+++ b/src/app/pages/directory-service/directory-services.component.html
@@ -56,6 +56,7 @@
           <button
             mat-button color="default"
             [ixTest]="[card.title, 'settings']"
+            [ixUiSearch]="searchableElements.elements.settings"
             (click)="card.onSettingsPressed()"
           >
             {{ 'Settings' | translate }}

--- a/src/app/pages/directory-service/directory-services.component.spec.ts
+++ b/src/app/pages/directory-service/directory-services.component.spec.ts
@@ -153,6 +153,369 @@ describe('DirectoryServicesComponent', () => {
     });
   });
 
+  describe('LDAP data card', () => {
+    beforeEach(() => {
+      mockServicesStatus.type = DirectoryServiceType.Ldap;
+      mockServicesStatus.status = DirectoryServiceStatus.Healthy;
+      mockDirectoryServicesConfig.service_type = DirectoryServiceType.Ldap;
+      mockDirectoryServicesConfig.configuration = {
+        basedn: 'dc=test,dc=com',
+        server_urls: ['ldap://server1.test.com', 'ldap://server2.test.com'],
+      } as LdapConfig;
+      mockDirectoryServicesConfig.credential = {
+        credential_type: DirectoryServiceCredentialType.LdapPlain,
+        binddn: 'cn=admin,dc=test,dc=com',
+        bindpw: 'password',
+      } as LdapCredentialPlain;
+    });
+
+    it('should display Server URLs in LDAP data card', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Server URLs');
+      expect(cardText).toContain('ldap://server1.test.com, ldap://server2.test.com');
+    });
+
+    it('should display Credential Type in LDAP data card', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Credential Type');
+      expect(cardText).toContain('Plain');
+    });
+
+    it('should display "None" when Server URLs is empty', async () => {
+      (mockDirectoryServicesConfig.configuration as LdapConfig).server_urls = [];
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Server URLs');
+      expect(cardText).toContain('None');
+    });
+
+    it('should display "None" when credential is not provided', async () => {
+      mockDirectoryServicesConfig.credential = null;
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Credential Type');
+      expect(cardText).toContain('None');
+    });
+  });
+
+  describe('Active Directory data card', () => {
+    beforeEach(() => {
+      mockServicesStatus.type = DirectoryServiceType.ActiveDirectory;
+      mockServicesStatus.status = DirectoryServiceStatus.Healthy;
+      mockServicesStatus.status_msg = 'Connected to domain';
+      mockDirectoryServicesConfig.service_type = DirectoryServiceType.ActiveDirectory;
+      mockDirectoryServicesConfig.configuration = {
+        domain: 'test.domain.com',
+      } as ActiveDirectoryConfig;
+      mockDirectoryServicesConfig.enable_account_cache = true;
+    });
+
+    it('should display Active Directory card title', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardTitle = spectator.query('mat-toolbar-row h3');
+      expect(cardTitle).toBeTruthy();
+      expect(cardTitle.textContent).toContain('Active Directory');
+    });
+
+    it('should display Status in Active Directory data card', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Status');
+      expect(cardText).toContain('HEALTHY');
+    });
+
+    it('should display Status Message when provided', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Status Message');
+      expect(cardText).toContain('Connected to domain');
+    });
+
+    it('should display Domain Name in Active Directory data card', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Domain Name');
+      expect(cardText).toContain('test.domain.com');
+    });
+
+    it('should display Account Cache as Enabled when enabled', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Account Cache');
+      expect(cardText).toContain('Enabled');
+    });
+
+    it('should display Account Cache as Disabled when disabled', async () => {
+      mockDirectoryServicesConfig.enable_account_cache = false;
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Account Cache');
+      expect(cardText).toContain('Disabled');
+    });
+
+    it('should not display Status Message when not provided', async () => {
+      mockServicesStatus.status_msg = null;
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).not.toContain('Status Message');
+    });
+  });
+
+  describe('IPA data card', () => {
+    beforeEach(() => {
+      mockServicesStatus.type = DirectoryServiceType.Ipa;
+      mockServicesStatus.status = DirectoryServiceStatus.Healthy;
+      mockServicesStatus.status_msg = 'IPA connection established';
+      mockDirectoryServicesConfig.service_type = DirectoryServiceType.Ipa;
+      mockDirectoryServicesConfig.configuration = {
+        domain: 'ipa.test.com',
+        target_server: 'ipa-server.test.com',
+        hostname: 'testhost',
+        basedn: 'dc=ipa,dc=test,dc=com',
+      } as IpaConfig;
+    });
+
+    it('should display IPA card title', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardTitle = spectator.query('mat-toolbar-row h3');
+      expect(cardTitle).toBeTruthy();
+      expect(cardTitle.textContent).toContain('IPA');
+    });
+
+    it('should display Status in IPA data card', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Status');
+      expect(cardText).toContain('HEALTHY');
+    });
+
+    it('should display Status Message when provided', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Status Message');
+      expect(cardText).toContain('IPA connection established');
+    });
+
+    it('should display Target Server in IPA data card', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Target Server');
+      expect(cardText).toContain('ipa-server.test.com');
+    });
+
+    it('should display Domain in IPA data card', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Domain');
+      expect(cardText).toContain('ipa.test.com');
+    });
+
+    it('should display Base DN in IPA data card', async () => {
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Base DN');
+      expect(cardText).toContain('dc=ipa,dc=test,dc=com');
+    });
+
+    it('should not display Status Message when not provided', async () => {
+      mockServicesStatus.status_msg = null;
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).not.toContain('Status Message');
+    });
+  });
+
+  describe('Card display logic', () => {
+    it('should display LDAP card when LDAP service is active', async () => {
+      mockServicesStatus.type = DirectoryServiceType.Ldap;
+      mockServicesStatus.status = DirectoryServiceStatus.Healthy;
+      mockDirectoryServicesConfig.service_type = DirectoryServiceType.Ldap;
+      mockDirectoryServicesConfig.configuration = {
+        basedn: 'dc=test,dc=com',
+        server_urls: ['ldap://test.com'],
+      } as LdapConfig;
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardTitle = spectator.query('mat-toolbar-row h3');
+      expect(cardTitle).toBeTruthy();
+      expect(cardTitle.textContent).toContain('LDAP');
+    });
+
+    it('should display Active Directory card when AD service is active', async () => {
+      mockServicesStatus.type = DirectoryServiceType.ActiveDirectory;
+      mockServicesStatus.status = DirectoryServiceStatus.Healthy;
+      mockDirectoryServicesConfig.service_type = DirectoryServiceType.ActiveDirectory;
+      mockDirectoryServicesConfig.configuration = {
+        domain: 'test.domain.com',
+      } as ActiveDirectoryConfig;
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardTitle = spectator.query('mat-toolbar-row h3');
+      expect(cardTitle).toBeTruthy();
+      expect(cardTitle.textContent).toContain('Active Directory');
+    });
+
+    it('should display IPA card when IPA service is active', async () => {
+      mockServicesStatus.type = DirectoryServiceType.Ipa;
+      mockServicesStatus.status = DirectoryServiceStatus.Healthy;
+      mockDirectoryServicesConfig.service_type = DirectoryServiceType.Ipa;
+      mockDirectoryServicesConfig.configuration = {
+        domain: 'ipa.test.com',
+        target_server: 'ipa-server.test.com',
+        basedn: 'dc=ipa,dc=test,dc=com',
+      } as IpaConfig;
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardTitle = spectator.query('mat-toolbar-row h3');
+      expect(cardTitle).toBeTruthy();
+      expect(cardTitle.textContent).toContain('IPA');
+    });
+  });
+
+  describe('Data card edge cases', () => {
+    it('should display "None" for null values in Active Directory card', async () => {
+      mockServicesStatus.type = DirectoryServiceType.ActiveDirectory;
+      mockServicesStatus.status = DirectoryServiceStatus.Healthy;
+      mockDirectoryServicesConfig.service_type = DirectoryServiceType.ActiveDirectory;
+      mockDirectoryServicesConfig.configuration = {
+        domain: null,
+      } as ActiveDirectoryConfig;
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Domain Name');
+      expect(cardText).toContain('None');
+    });
+
+    it('should display "None" for null values in LDAP card', async () => {
+      mockServicesStatus.type = DirectoryServiceType.Ldap;
+      mockServicesStatus.status = DirectoryServiceStatus.Healthy;
+      mockDirectoryServicesConfig.service_type = DirectoryServiceType.Ldap;
+      mockDirectoryServicesConfig.configuration = {
+        basedn: null,
+        server_urls: null,
+      } as LdapConfig;
+      mockDirectoryServicesConfig.credential = null;
+
+      spectator = createComponent();
+      await spectator.fixture.whenStable();
+
+      const cardContent = spectator.query('mat-card-content');
+      expect(cardContent).toBeTruthy();
+
+      const cardText = cardContent.textContent;
+      expect(cardText).toContain('Base DN');
+      expect(cardText).toContain('Server URLs');
+      expect(cardText).toContain('Credential Type');
+      // Should contain multiple "None" entries
+      const noneMatches = cardText.match(/None/g);
+      expect(noneMatches).toBeTruthy();
+      expect(noneMatches.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
   describe('Leave button interaction', () => {
     beforeEach(() => {
       spectator = createComponent();

--- a/src/app/pages/directory-service/directory-services.component.ts
+++ b/src/app/pages/directory-service/directory-services.component.ts
@@ -1,6 +1,8 @@
 import { CdkAccordionItem } from '@angular/cdk/accordion';
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, OnInit, signal, viewChild, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, OnInit, signal, viewChild, inject,
+} from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
@@ -18,7 +20,7 @@ import { DirectoryServiceStatus, DirectoryServiceType } from 'app/enums/director
 import { Role } from 'app/enums/role.enum';
 import { helptextDashboard } from 'app/helptext/directory-service/dashboard';
 import { ActiveDirectoryConfig } from 'app/interfaces/active-directory-config.interface';
-import { isLdapCredentialPlain } from 'app/interfaces/directoryservice-credentials.interface';
+import { credentialTypeLabels } from 'app/interfaces/directoryservice-credentials.interface';
 import { DirectoryServicesConfig } from 'app/interfaces/directoryservices-config.interface';
 import { DirectoryServicesStatus } from 'app/interfaces/directoryservices-status.interface';
 import { EmptyConfig } from 'app/interfaces/empty-config.interface';
@@ -211,13 +213,19 @@ export class DirectoryServicesComponent implements OnInit {
 
           items.push(
             {
+              label: this.translate.instant(helptextDashboard.ldap.serverUrls),
+              value: ldapConfig.server_urls?.join(', ') || null,
+            },
+            {
               label: this.translate.instant(helptextDashboard.ldap.baseDN),
               value: ldapConfig.basedn || null,
             },
             {
-              label: this.translate.instant(helptextDashboard.ldap.bindDN),
-              value: isLdapCredentialPlain(directoryServicesConfig?.credential)
-                ? directoryServicesConfig.credential.binddn
+              label: this.translate.instant(helptextDashboard.ldap.credentialType),
+              value: directoryServicesConfig?.credential
+                ? this.translate.instant(
+                  credentialTypeLabels[directoryServicesConfig.credential.credential_type],
+                )
                 : null,
             },
           );

--- a/src/app/pages/directory-service/directory-services.component.ts
+++ b/src/app/pages/directory-service/directory-services.component.ts
@@ -29,10 +29,11 @@ import { LdapConfig } from 'app/interfaces/ldap-config.interface';
 import { Option } from 'app/interfaces/option.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EmptyComponent } from 'app/modules/empty/empty.component';
+import { searchDelayConst } from 'app/modules/global-search/constants/delay.const';
+import { UiSearchDirectivesService } from 'app/modules/global-search/services/ui-search-directives.service';
 import { iconMarker } from 'app/modules/ix-icon/icon-marker.util';
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
-import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { TranslatedString } from 'app/modules/translate/translate.helper';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -84,7 +85,7 @@ export class DirectoryServicesComponent implements OnInit {
   private translate = inject(TranslateService);
   private cdr = inject(ChangeDetectorRef);
   private errorHandler = inject(ErrorHandlerService);
-  private snackbar = inject(SnackbarService);
+  private searchDirectives = inject(UiSearchDirectivesService);
 
   protected readonly requiredRoles = [Role.DirectoryServiceWrite];
   protected readonly searchableElements = directoryServicesElements;
@@ -109,6 +110,10 @@ export class DirectoryServicesComponent implements OnInit {
     large: true,
     icon: iconMarker('mdi-account-box'),
   };
+
+  constructor() {
+    setTimeout(() => this.handlePendingGlobalSearchElement(), searchDelayConst * 5);
+  }
 
   ngOnInit(): void {
     this.refreshCards();
@@ -363,5 +368,13 @@ export class DirectoryServicesComponent implements OnInit {
       .subscribe(() => {
         this.refreshCards();
       });
+  }
+
+  private handlePendingGlobalSearchElement(): void {
+    const pendingHighlightElement = this.searchDirectives.pendingUiHighlightElement;
+
+    if (pendingHighlightElement) {
+      this.searchDirectives.get(pendingHighlightElement)?.highlight(pendingHighlightElement);
+    }
   }
 }

--- a/src/app/pages/directory-service/directory-services.elements.ts
+++ b/src/app/pages/directory-service/directory-services.elements.ts
@@ -13,9 +13,5 @@ export const directoryServicesElements = {
       synonyms: [T('Active Directory')],
       anchor: 'configure-active-directory',
     },
-    configureLdap: {
-      hierarchy: [T('Configure LDAP')],
-      anchor: 'configure-ldap',
-    },
   },
 } satisfies UiSearchableElement;

--- a/src/app/pages/directory-service/directory-services.elements.ts
+++ b/src/app/pages/directory-service/directory-services.elements.ts
@@ -8,7 +8,7 @@ export const directoryServicesElements = {
     directoryServices: {
       anchor: 'directory-services',
     },
-    configureActiveDirectory: {
+    configureDirectoryServices: {
       hierarchy: [T('Configure Directory Services')],
       synonyms: [T('Active Directory'), 'AD', 'LDAP', 'OpenLDAP', 'IPA', 'FreeIPA', 'DS'],
       anchor: 'configure-active-directory',

--- a/src/app/pages/directory-service/directory-services.elements.ts
+++ b/src/app/pages/directory-service/directory-services.elements.ts
@@ -10,8 +10,12 @@ export const directoryServicesElements = {
     },
     configureDirectoryServices: {
       hierarchy: [T('Configure Directory Services')],
-      synonyms: [T('Active Directory'), 'AD', 'LDAP', 'OpenLDAP', 'IPA', 'FreeIPA', 'DS'],
+      synonyms: ['DS'],
       anchor: 'configure-active-directory',
+    },
+    settings: {
+      synonyms: [T('Active Directory'), 'AD', 'LDAP', 'OpenLDAP', 'IPA', 'FreeIPA', 'DS'],
+      anchor: 'settings',
     },
   },
 } satisfies UiSearchableElement;

--- a/src/app/pages/directory-service/directory-services.elements.ts
+++ b/src/app/pages/directory-service/directory-services.elements.ts
@@ -9,8 +9,8 @@ export const directoryServicesElements = {
       anchor: 'directory-services',
     },
     configureActiveDirectory: {
-      hierarchy: [T('Configure Active Directory')],
-      synonyms: [T('Active Directory')],
+      hierarchy: [T('Configure Directory Services')],
+      synonyms: [T('Active Directory'), 'AD', 'LDAP', 'OpenLDAP', 'IPA', 'FreeIPA', 'DS'],
       anchor: 'configure-active-directory',
     },
   },

--- a/src/assets/ui-searchable-elements.json
+++ b/src/assets/ui-searchable-elements.json
@@ -1823,10 +1823,16 @@
     "hierarchy": [
       "Credentials",
       "Directory Services",
-      "Configure Active Directory"
+      "Configure Directory Services"
     ],
     "synonyms": [
-      "Active Directory"
+      "Active Directory",
+      "AD",
+      "LDAP",
+      "OpenLDAP",
+      "IPA",
+      "FreeIPA",
+      "DS"
     ],
     "requiredRoles": [
       "DIRECTORY_SERVICE_WRITE"

--- a/src/assets/ui-searchable-elements.json
+++ b/src/assets/ui-searchable-elements.json
@@ -1826,12 +1826,6 @@
       "Configure Directory Services"
     ],
     "synonyms": [
-      "Active Directory",
-      "AD",
-      "LDAP",
-      "OpenLDAP",
-      "IPA",
-      "FreeIPA",
       "DS"
     ],
     "requiredRoles": [
@@ -1861,6 +1855,31 @@
     ],
     "routerLink": null,
     "anchor": "directory-services",
+    "triggerAnchor": null,
+    "section": "ui"
+  },
+  {
+    "hierarchy": [
+      "Credentials",
+      "Directory Services"
+    ],
+    "synonyms": [
+      "Active Directory",
+      "AD",
+      "LDAP",
+      "OpenLDAP",
+      "IPA",
+      "FreeIPA",
+      "DS"
+    ],
+    "requiredRoles": [],
+    "visibleTokens": [],
+    "anchorRouterLink": [
+      "/credentials",
+      "directory-services"
+    ],
+    "routerLink": null,
+    "anchor": "settings",
     "triggerAnchor": null,
     "section": "ui"
   },


### PR DESCRIPTION
**Changes:**
Added tests for each card.
Updated LDAP Card content.
Cleanup.

**Testing:**
See ticket.

Preview:
<img width="751" height="307" alt="Screenshot 2025-08-05 at 11 07 57" src="https://github.com/user-attachments/assets/8d69fbd1-ba19-4efb-836f-1a307ac35165" />


### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | LDAP Card changes
|Testing         |


Original PR: https://github.com/truenas/webui/pull/12369
