### PR TITLE
NAS-136973 / 25.10-RC.1 / Virtual Machines page doesnt refresh properly (by AlexKarpov98)

### DIFF
--- a/src/app/enums/vm.enum.ts
+++ b/src/app/enums/vm.enum.ts
@@ -93,5 +93,6 @@ export enum VmState {
   Stopped = 'STOPPED',
   // Below statuses been seen in ApiEvent<VirtualMachine>. Perhaps we could handle them.
   Shutoff = 'SHUTOFF',
+  Suspended = 'SUSPENDED',
   UpdatingConfiguration = 'UPDATING CONFIGURATION',
 }

--- a/src/app/pages/vm/utils/vm-gpu.service.ts
+++ b/src/app/pages/vm/utils/vm-gpu.service.ts
@@ -28,9 +28,9 @@ export class VmGpuService {
   updateVmGpus(vm: VirtualMachine, newGpuIds: string[]): Observable<unknown> {
     return this.gpuService.getAllGpus().pipe(
       switchMap((allGpus) => {
-        const previousVmPciDevices = vm.devices.filter((device) => {
+        const previousVmPciDevices = (vm.devices?.filter((device) => {
           return device.attributes.dtype === VmDeviceType.Pci;
-        }) as VmPciPassthroughDevice[];
+        }) || []) as VmPciPassthroughDevice[];
         const previousSlots = previousVmPciDevices.map((device) => device.attributes.pptdev);
         const previousGpus = allGpus.filter(byVmPciSlots(previousSlots));
 

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
@@ -196,8 +196,8 @@ export class VmEditFormComponent implements OnInit {
 
   private setupGpuControl(vm: VirtualMachine): void {
     const vmPciSlots = vm.devices
-      .filter((device) => device.attributes.dtype === VmDeviceType.Pci)
-      .map((pciDevice: VmPciPassthroughDevice) => pciDevice.attributes.pptdev);
+      ?.filter((device) => device.attributes.dtype === VmDeviceType.Pci)
+      ?.map((pciDevice: VmPciPassthroughDevice) => pciDevice.attributes.pptdev);
 
     this.gpuService.getAllGpus().pipe(untilDestroyed(this)).subscribe((allGpus) => {
       const vmGpus = allGpus.filter(byVmPciSlots(vmPciSlots));

--- a/src/app/pages/vm/vm-list.component.spec.ts
+++ b/src/app/pages/vm/vm-list.component.spec.ts
@@ -4,7 +4,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
-import { Subject, of } from 'rxjs';
+import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { VmState } from 'app/enums/vm.enum';
@@ -70,7 +70,6 @@ describe('VmListComponent', () => {
         isEnterprise: () => false,
       }),
       mockProvider(VmService, {
-        refreshVmList$: new Subject(),
         getAvailableMemory: jest.fn(() => of(4096)),
         hasVirtualizationSupport$: of(true),
       }),

--- a/src/app/pages/vm/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list.component.ts
@@ -1,14 +1,17 @@
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject,
+} from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { MatTooltip } from '@angular/material/tooltip';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { filter, tap } from 'rxjs';
+import { filter, take, tap } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
+import { CollectionChangeType } from 'app/enums/api.enum';
 import { Role } from 'app/enums/role.enum';
 import {
   VmBootloader, VmDeviceType, VmState, vmTimeNames,
@@ -120,13 +123,13 @@ export class VmListComponent implements OnInit {
       title: this.translate.instant('Running'),
       requiredRoles: this.requiredRoles,
       getValue: (row) => row.status.state === VmState.Running,
-      onRowToggle: (row) => this.vmService.toggleVmStatus(row),
+      onRowToggle: (row, checked, toggle) => this.handleVmStatusToggle(row, checked, toggle),
     }),
     toggleColumn({
       title: this.translate.instant('Start on Boot'),
       requiredRoles: this.requiredRoles,
       propertyName: 'autostart',
-      onRowToggle: (row) => this.vmService.toggleVmAutostart(row),
+      onRowToggle: (row, checked, toggle) => this.handleAutostartToggle(row, checked, toggle),
     }),
     textColumn({
       title: this.translate.instant('Virtual CPUs'),
@@ -187,7 +190,7 @@ export class VmListComponent implements OnInit {
 
   ngOnInit(): void {
     this.createDataProvider();
-    this.listenForVmUpdates();
+    this.subscribeToVmEvents();
     this.dataProvider.emptyType$.pipe(untilDestroyed(this)).subscribe(() => {
       this.onListFiltered(this.filterString);
     });
@@ -202,11 +205,30 @@ export class VmListComponent implements OnInit {
     this.refresh();
   }
 
-  listenForVmUpdates(): void {
-    this.vmService.refreshVmList$
+  subscribeToVmEvents(): void {
+    this.api.subscribe('vm.query')
       .pipe(untilDestroyed(this))
-      .subscribe(() => {
-        this.refresh();
+      .subscribe((event) => {
+        // Update the local VM data to reflect real-time changes
+        const updatedVm = event.fields;
+        const vmIndex = this.vmMachines.findIndex((vm) => vm?.id === updatedVm?.id);
+
+        if (vmIndex !== -1) {
+          // Update existing VM
+          this.vmMachines[vmIndex] = { ...this.vmMachines[vmIndex], ...updatedVm };
+          this.dataProvider.setRows([...this.vmMachines]);
+        } else if (event.msg === CollectionChangeType.Added) {
+          // Add new VM
+          this.vmMachines.push(updatedVm);
+          this.dataProvider.setRows([...this.vmMachines]);
+        } else if (event.msg === CollectionChangeType.Removed) {
+          // Remove deleted VM
+          this.vmMachines = this.vmMachines.filter((vm) => vm?.id !== updatedVm?.id);
+          this.dataProvider.setRows([...this.vmMachines]);
+        }
+
+        // Trigger change detection
+        this.cdr.detectChanges();
       });
   }
 
@@ -254,5 +276,43 @@ export class VmListComponent implements OnInit {
 
   private refresh(): void {
     this.dataProvider.load();
+  }
+
+  private handleVmStatusToggle(vm: VirtualMachine, checked: boolean, toggle: { toggle(): void }): void {
+    if (vm.status.state === VmState.Running && !checked) {
+      // User wants to stop a running VM - show stop dialog
+      this.vmService.doStop(vm).pipe(
+        take(1),
+        untilDestroyed(this),
+      ).subscribe((confirmed: boolean) => {
+        if (!confirmed) {
+          // User cancelled - revert toggle state
+          setTimeout(() => toggle.toggle(), 0);
+        }
+      });
+    } else if (vm.status.state !== VmState.Running && checked) {
+      // User wants to start a stopped VM - start directly
+      this.vmService.doStart(vm).pipe(
+        take(1),
+        untilDestroyed(this),
+      ).subscribe((success: boolean) => {
+        if (!success) {
+          // Start failed - revert toggle state
+          setTimeout(() => toggle.toggle(), 0);
+        }
+      });
+    }
+  }
+
+  private handleAutostartToggle(vm: VirtualMachine, _checked: boolean, toggle: { toggle(): void }): void {
+    this.vmService.toggleVmAutostart(vm).pipe(
+      take(1),
+      untilDestroyed(this),
+    ).subscribe((success: boolean) => {
+      if (!success) {
+        // Operation failed - revert toggle state
+        setTimeout(() => toggle.toggle(), 0);
+      }
+    });
   }
 }

--- a/src/app/pages/vm/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list.component.ts
@@ -209,25 +209,20 @@ export class VmListComponent implements OnInit {
     this.api.subscribe('vm.query')
       .pipe(untilDestroyed(this))
       .subscribe((event) => {
-        // Update the local VM data to reflect real-time changes
         const updatedVm = event.fields;
         const vmIndex = this.vmMachines.findIndex((vm) => vm?.id === updatedVm?.id);
 
         if (vmIndex !== -1) {
-          // Update existing VM
           this.vmMachines[vmIndex] = { ...this.vmMachines[vmIndex], ...updatedVm };
           this.dataProvider.setRows([...this.vmMachines]);
         } else if (event.msg === CollectionChangeType.Added) {
-          // Add new VM
           this.vmMachines.push(updatedVm);
           this.dataProvider.setRows([...this.vmMachines]);
         } else if (event.msg === CollectionChangeType.Removed) {
-          // Remove deleted VM
           this.vmMachines = this.vmMachines.filter((vm) => vm?.id !== updatedVm?.id);
           this.dataProvider.setRows([...this.vmMachines]);
         }
 
-        // Trigger change detection
         this.cdr.detectChanges();
       });
   }

--- a/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.html
+++ b/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.html
@@ -1,7 +1,8 @@
-@if (isRunning()) {
+@if (vmStateInfo().isRunning) {
   <button
     *ixRequiresRoles="requiredRoles"
     mat-button
+    [attr.aria-label]="'Stop' | translate"
     [ixTest]="['stop', vm().id]"
     (click)="doStop()"
   >
@@ -12,6 +13,7 @@
   <button
     *ixRequiresRoles="requiredRoles"
     mat-button
+    [attr.aria-label]="'Restart' | translate"
     [ixTest]="['restart', vm().id]"
     (click)="doRestart()"
   >
@@ -22,16 +24,18 @@
   <button
     *ixRequiresRoles="requiredRoles"
     mat-button
+    [attr.aria-label]="'Power Off' | translate"
     [ixTest]="['power_off', vm().id]"
     (click)="doPowerOff()"
   >
     <ix-icon name="power_settings_new"></ix-icon>
     <span>{{ 'Power Off' | translate }}</span>
   </button>
-} @else if (isSuspended()) {
+} @else if (vmStateInfo().isSuspended) {
   <button
     *ixRequiresRoles="requiredRoles"
     mat-button
+    [attr.aria-label]="'Resume' | translate"
     [ixTest]="['resume', vm().id]"
     (click)="doStart()"
   >
@@ -42,6 +46,7 @@
   <button
     *ixRequiresRoles="requiredRoles"
     mat-button
+    [attr.aria-label]="'Power Off' | translate"
     [ixTest]="['power_off', vm().id]"
     (click)="doPowerOff()"
   >
@@ -53,6 +58,7 @@
     *ixRequiresRoles="requiredRoles"
     mat-button
     [ixTest]="['start', vm().id]"
+    [attr.aria-label]="'Start' | translate"
     (click)="doStart()"
   >
     <ix-icon name="mdi-play-circle"></ix-icon>
@@ -63,6 +69,7 @@
 <button
   mat-button
   [ixTest]="['edit', vm().id]"
+  [attr.aria-label]="'Edit' | translate"
   (click)="doEdit()"
 >
   <ix-icon name="edit"></ix-icon>
@@ -72,6 +79,7 @@
 <button
   *ixRequiresRoles="requiredRoles"
   mat-button
+  [attr.aria-label]="'Delete' | translate"
   [ixTest]="['delete', vm().id]"
   (click)="doDelete()"
 >
@@ -81,6 +89,7 @@
 
 <button
   mat-button
+  [attr.aria-label]="'Devices' | translate"
   [ixTest]="['devices', vm().id]"
   (click)="openDevices()"
 >
@@ -91,6 +100,7 @@
 <button
   *ixRequiresRoles="requiredRoles"
   mat-button
+  [attr.aria-label]="'Clone' | translate"
   [ixTest]="['clone', vm().id]"
   (click)="doClone()"
 >
@@ -101,6 +111,7 @@
 @if (showDisplayButton()) {
   <button
     mat-button
+    [attr.aria-label]="'Display' | translate"
     [ixTest]="['open_display', vm().id]"
     (click)="openDisplay()"
   >
@@ -109,10 +120,11 @@
   </button>
 }
 
-@if (isRunning()) {
+@if (vmStateInfo().isRunning) {
   <button
     mat-button
     [ixTest]="['open_serial_shell', vm().id]"
+    [attr.aria-label]="'Serial Shell' | translate"
     (click)="openSerialShell()"
   >
     <ix-icon name="keyboard_arrow_right"></ix-icon>
@@ -124,6 +136,7 @@
   *ixRequiresRoles="requiredReadRoles"
   mat-button
   [ixTest]="['download_logs', vm().id]"
+  [attr.aria-label]="'Download Logs' | translate"
   (click)="downloadLogs()"
 >
   <ix-icon name="content_paste"></ix-icon>

--- a/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.html
+++ b/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.html
@@ -28,6 +28,26 @@
     <ix-icon name="power_settings_new"></ix-icon>
     <span>{{ 'Power Off' | translate }}</span>
   </button>
+} @else if (isSuspended()) {
+  <button
+    *ixRequiresRoles="requiredRoles"
+    mat-button
+    [ixTest]="['resume', vm().id]"
+    (click)="doStart()"
+  >
+    <ix-icon name="mdi-play-circle"></ix-icon>
+    <span>{{ 'Resume' | translate }}</span>
+  </button>
+
+  <button
+    *ixRequiresRoles="requiredRoles"
+    mat-button
+    [ixTest]="['power_off', vm().id]"
+    (click)="doPowerOff()"
+  >
+    <ix-icon name="power_settings_new"></ix-icon>
+    <span>{{ 'Power Off' | translate }}</span>
+  </button>
 } @else {
   <button
     *ixRequiresRoles="requiredRoles"

--- a/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.spec.ts
+++ b/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.spec.ts
@@ -5,7 +5,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
-import { Subject, of } from 'rxjs';
+import { of } from 'rxjs';
 import { fakeFile } from 'app/core/testing/utils/fake-file.uitls';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { VmState } from 'app/enums/vm.enum';
@@ -45,11 +45,10 @@ describe('VirtualMachineDetailsRowComponent', () => {
     providers: [
       mockAuth(),
       mockProvider(VmService, {
-        refreshVmList$: new Subject(),
         hasVirtualizationSupport$: of(true),
         downloadLogs: jest.fn(() => of(fakeFile('test.log'))),
-        doStart: jest.fn(),
-        doStop: jest.fn(),
+        doStart: jest.fn(() => of()),
+        doStop: jest.fn(() => of()),
         doRestart: jest.fn(() => of()),
       }),
       mockProvider(SlideIn, {

--- a/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.ts
+++ b/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.ts
@@ -92,26 +92,15 @@ export class VirtualMachineDetailsRowComponent {
   }
 
   protected doEdit(): void {
-    this.slideIn
-      .open(VmEditFormComponent, { data: this.vm() })
-      .pipe(untilDestroyed(this))
-      .subscribe();
+    this.slideIn.open(VmEditFormComponent, { data: this.vm() });
   }
 
   protected doDelete(): void {
-    this.matDialog
-      .open(DeleteVmDialogComponent, { data: this.vm() })
-      .afterClosed()
-      .pipe(untilDestroyed(this))
-      .subscribe();
+    this.matDialog.open(DeleteVmDialogComponent, { data: this.vm() });
   }
 
   protected doClone(): void {
-    this.matDialog
-      .open(CloneVmDialogComponent, { data: this.vm() })
-      .afterClosed()
-      .pipe(untilDestroyed(this))
-      .subscribe();
+    this.matDialog.open(CloneVmDialogComponent, { data: this.vm() });
   }
 
   protected downloadLogs(): void {

--- a/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.ts
+++ b/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.ts
@@ -1,10 +1,11 @@
-import { Component, ChangeDetectionStrategy, input, computed, inject } from '@angular/core';
+import {
+  Component, ChangeDetectionStrategy, input, computed, inject,
+} from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
-import { filter } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { VmState } from 'app/enums/vm.enum';
@@ -48,15 +49,20 @@ export class VirtualMachineDetailsRowComponent {
   protected readonly requiredRoles = [Role.VmWrite];
 
   readonly isRunning = computed(() => this.vm().status.state === VmState.Running);
+  readonly isSuspended = computed(() => this.vm().status.state === VmState.Suspended);
 
   readonly showDisplayButton = computed(() => this.isRunning() && this.vm().display_available);
 
   protected doStart(): void {
-    this.vmService.doStart(this.vm());
+    this.vmService.doStart(this.vm()).pipe(
+      untilDestroyed(this),
+    ).subscribe();
   }
 
   protected doStop(): void {
-    this.vmService.doStop(this.vm());
+    this.vmService.doStop(this.vm()).pipe(
+      untilDestroyed(this),
+    ).subscribe();
   }
 
   protected doRestart(): void {
@@ -88,24 +94,24 @@ export class VirtualMachineDetailsRowComponent {
   protected doEdit(): void {
     this.slideIn
       .open(VmEditFormComponent, { data: this.vm() })
-      .pipe(filter((response) => !!response.response), untilDestroyed(this))
-      .subscribe(() => this.vmService.refreshVmList$.next());
+      .pipe(untilDestroyed(this))
+      .subscribe();
   }
 
   protected doDelete(): void {
     this.matDialog
       .open(DeleteVmDialogComponent, { data: this.vm() })
       .afterClosed()
-      .pipe(filter(Boolean), untilDestroyed(this))
-      .subscribe(() => this.vmService.refreshVmList$.next());
+      .pipe(untilDestroyed(this))
+      .subscribe();
   }
 
   protected doClone(): void {
     this.matDialog
       .open(CloneVmDialogComponent, { data: this.vm() })
       .afterClosed()
-      .pipe(filter(Boolean), untilDestroyed(this))
-      .subscribe(() => this.vmService.refreshVmList$.next());
+      .pipe(untilDestroyed(this))
+      .subscribe();
   }
 
   protected downloadLogs(): void {

--- a/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.ts
+++ b/src/app/pages/vm/vm-list/vm-details-row/vm-details-row.component.ts
@@ -48,10 +48,15 @@ export class VirtualMachineDetailsRowComponent {
   protected readonly requiredReadRoles = [Role.VmRead];
   protected readonly requiredRoles = [Role.VmWrite];
 
-  readonly isRunning = computed(() => this.vm().status.state === VmState.Running);
-  readonly isSuspended = computed(() => this.vm().status.state === VmState.Suspended);
+  readonly vmStateInfo = computed(() => {
+    const state = this.vm().status.state;
+    return {
+      isRunning: state === VmState.Running,
+      isSuspended: state === VmState.Suspended,
+    };
+  });
 
-  readonly showDisplayButton = computed(() => this.isRunning() && this.vm().display_available);
+  readonly showDisplayButton = computed(() => this.vmStateInfo().isRunning && this.vm().display_available);
 
   protected doStart(): void {
     this.vmService.doStart(this.vm()).pipe(

--- a/src/app/services/vm.service.ts
+++ b/src/app/services/vm.service.ts
@@ -99,6 +99,10 @@ export class VmService {
           }
           return of(false);
         }),
+        catchError((error: unknown) => {
+          this.errorHandler.showErrorModal(error);
+          return of(false);
+        }),
       );
   }
 


### PR DESCRIPTION
**Changes:**
- Fixed slide in buttons state, previously it showed incorrect status if I haven't submitted an action
- Added `Suspended` state support. `Power Off & Resume` buttons are the only ones available for `Suspended` state as described.
- Refactored refresh state logic to depend on the `vm.query` subscription - to get all updates.

 
<!-- Briefly describe what changed. -->

**Testing:**
See ticket.
<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Suspended state support added


Original PR: https://github.com/truenas/webui/pull/12381
