### PR TITLE
NAS-137064 / 26.04 / implement page reload after enabling/disabling TNC

### DIFF
--- a/src/app/modules/truenas-connect/services/truenas-connect.service.ts
+++ b/src/app/modules/truenas-connect/services/truenas-connect.service.ts
@@ -8,6 +8,7 @@ import { WINDOW } from 'app/helpers/window.helper';
 import { TruenasConnectConfig } from 'app/interfaces/truenas-connect-config.interface';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+import { WebSocketStatusService } from 'app/services/websocket-status.service';
 
 @Injectable({
   providedIn: 'root',
@@ -16,6 +17,7 @@ export class TruenasConnectService {
   private window = inject<Window>(WINDOW);
   private api = inject(ApiService);
   private errorHandler = inject(ErrorHandlerService);
+  private wsStatus = inject(WebSocketStatusService);
 
   config = signal<TruenasConnectConfig | null>(null);
   config$ = toObservable(this.config);
@@ -32,6 +34,17 @@ export class TruenasConnectService {
       ),
     )
       .subscribe((config) => {
+        if (
+          this.config()
+          && (
+            (this.config().status === TruenasConnectStatus.CertGenerationSuccess
+              && config.status === TruenasConnectStatus.Configured)
+              || (this.config().status === TruenasConnectStatus.Configured
+                && config.status === TruenasConnectStatus.Disabled)
+          )
+        ) {
+          this.wsStatus.setPageReload(true);
+        }
         this.config.set(config);
       });
   }

--- a/src/app/pages/signin/signin.component.ts
+++ b/src/app/pages/signin/signin.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject, effect } from '@angular/core';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { MatProgressBar } from '@angular/material/progress-bar';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -110,6 +110,13 @@ export class SigninComponent implements OnInit {
       .subscribe(() => {
         this.focusFirstInput();
       });
+
+    effect(() => {
+      if (this.wsStatus.pageReloadRequired()) {
+        this.wsStatus.setPageReload(false);
+        this.window.location.reload();
+      }
+    });
   }
 
   ngOnInit(): void {

--- a/src/app/services/websocket-status.service.spec.ts
+++ b/src/app/services/websocket-status.service.spec.ts
@@ -136,4 +136,16 @@ describe('WebSocketStatusSerice', () => {
       expectObservable(spectator.service.isFailoverRestart$).toBe('a', { a: false });
     });
   });
+
+  it('initializes pageReloadRequired signal with false', () => {
+    expect(spectator.service.pageReloadRequired()).toBe(false);
+  });
+
+  it('allows setting pageReloadRequired via setPageReload method', () => {
+    spectator.service.setPageReload(true);
+    expect(spectator.service.pageReloadRequired()).toBe(true);
+
+    spectator.service.setPageReload(false);
+    expect(spectator.service.pageReloadRequired()).toBe(false);
+  });
 });

--- a/src/app/services/websocket-status.service.ts
+++ b/src/app/services/websocket-status.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import {
   BehaviorSubject, combineLatest,
@@ -23,6 +23,8 @@ export class WebSocketStatusService {
   private readonly isLoggedIn$ = new BehaviorSubject<boolean>(false);
   private readonly authStatus$ = new BehaviorSubject<boolean>(false);
   readonly isAuthenticated$ = this.authStatus$.asObservable();
+  readonly pageReloadRequired = signal(false);
+
   get isAuthenticated(): boolean {
     return this.authStatus$.getValue();
   }
@@ -55,5 +57,9 @@ export class WebSocketStatusService {
 
   setFailoverStatus(status: boolean): void {
     this.isFailoverRestart$.next(status);
+  }
+
+  setPageReload(status: boolean): void {
+    this.pageReloadRequired.set(status);
   }
 }


### PR DESCRIPTION
**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**
1. Update TNC Config
`midclt call tn_connect.update_environment '{"account_service_base_url": "https://account-service.dev.ixsystems.net/", "leca_service_base_url": "https://dns-service.dev.ixsystems.net/", "tnc_base_url": "https://truenas.connect.dev.ixsystems.net/", "heartbeat_url": "https://heartbeat-service.dev.ixsystems.net/"}'`
in case TNC icon doesn't appear in the header: `midclt call tn_connect.update '{"enabled": true}'`
2. Test the functionality of enabling and disabling the TNC service thru the UI.
3. After enabling or disabling, it will redirect to the login page, where a page reload will occur.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
