### PR TITLE
NAS-135923 / 25.10-RC.1 / Instance shell: the "Reconnect" button does not work after an instance reboot (by AlexKarpov98)

### DIFF
--- a/src/app/modules/terminal/components/terminal/terminal.component.html
+++ b/src/app/modules/terminal/components/terminal/terminal.component.html
@@ -15,7 +15,7 @@
             <ng-container *ngTemplateOutlet="terminalLoading"></ng-container>
           } @else {
             <p>{{ 'Connection lost. Click Reconnect to restore the session.' | translate }}</p>
-            <button mat-raised-button color="primary" [disabled]="isReconnecting()" (click)="reconnect()">
+            <button mat-button color="primary" [disabled]="isReconnecting()" (click)="reconnect()">
               {{ 'Reconnect' | translate }}
             </button>
           }

--- a/src/app/modules/terminal/components/terminal/terminal.component.html
+++ b/src/app/modules/terminal/components/terminal/terminal.component.html
@@ -14,9 +14,9 @@
           @if (!hasAttemptedAutoReconnect) {
             <ng-container *ngTemplateOutlet="terminalLoading"></ng-container>
           } @else {
-            <p>{{ 'Connection lost. Click Connect to restore the session.' | translate }}</p>
+            <p>{{ 'Connection lost. Click Reconnect to restore the session.' | translate }}</p>
             <button mat-raised-button color="primary" [disabled]="isReconnecting()" (click)="reconnect()">
-              {{ 'Connect' | translate }}
+              {{ 'Reconnect' | translate }}
             </button>
           }
         }

--- a/src/app/modules/terminal/components/terminal/terminal.component.html
+++ b/src/app/modules/terminal/components/terminal/terminal.component.html
@@ -1,15 +1,15 @@
 <ix-page-header>
-  @if (shellConnected) {
+  @if (shellConnected()) {
     <ix-terminal-font-size (fontSizeChanged)="onFontSizeChanged($event)"></ix-terminal-font-size>
   } @else {
     <button
       mat-button
       color="primary"
       ixTest="reconnect"
-      [disabled]="isReconnecting"
+      [disabled]="isReconnecting()"
       (click)="reconnect()"
     >
-      @if (isReconnecting) {
+      @if (isReconnecting()) {
         {{ 'Reconnecting...' | translate }}
       } @else {
         {{ 'Reconnect' | translate }}

--- a/src/app/modules/terminal/components/terminal/terminal.component.html
+++ b/src/app/modules/terminal/components/terminal/terminal.component.html
@@ -1,28 +1,42 @@
 <ix-page-header>
   @if (shellConnected()) {
     <ix-terminal-font-size (fontSizeChanged)="onFontSizeChanged($event)"></ix-terminal-font-size>
-  } @else {
-    <button
-      mat-button
-      color="primary"
-      ixTest="reconnect"
-      [disabled]="isReconnecting()"
-      (click)="reconnect()"
-    >
-      @if (isReconnecting()) {
-        {{ 'Reconnecting...' | translate }}
-      } @else {
-        {{ 'Reconnect' | translate }}
-      }
-    </button>
   }
 </ix-page-header>
 
 <div class="terminal-wrapper">
+  @if (!shellConnected()) {
+    <div class="terminal-busy-overlay">
+      <div class="busy-content">
+        @if (isReconnecting()) {
+          <ng-container *ngTemplateOutlet="terminalLoading"></ng-container>
+        } @else {
+          @if (!hasAttemptedAutoReconnect) {
+            <ng-container *ngTemplateOutlet="terminalLoading"></ng-container>
+          } @else {
+            <p>{{ 'Connection lost. Click Connect to restore the session.' | translate }}</p>
+            <button mat-raised-button color="primary" [disabled]="isReconnecting()" (click)="reconnect()">
+              {{ 'Connect' | translate }}
+            </button>
+          }
+        }
+      </div>
+    </div>
+  }
   <div
     #terminal
     id="terminal"
     [ngStyle]="{ 'font-size': fontSize + 'px' }"
+    [class.terminal-dimmed]="!shellConnected()"
     (window:resize)="onResize()"
   ></div>
 </div>
+
+<ng-template #terminalLoading>
+  <mat-progress-spinner diameter="48" mode="indeterminate"></mat-progress-spinner>
+  @if (isInstanceShell()) {
+    <p>{{ 'Connecting to instance shell...' | translate }}</p>
+  } @else {
+    <p>{{ 'Connecting...' | translate }}</p>
+  }
+</ng-template>

--- a/src/app/modules/terminal/components/terminal/terminal.component.html
+++ b/src/app/modules/terminal/components/terminal/terminal.component.html
@@ -2,8 +2,18 @@
   @if (shellConnected) {
     <ix-terminal-font-size (fontSizeChanged)="onFontSizeChanged($event)"></ix-terminal-font-size>
   } @else {
-    <button mat-button color="primary" ixTest="reconnect" (click)="reconnect()">
-      {{ 'Reconnect' | translate }}
+    <button
+      mat-button
+      color="primary"
+      ixTest="reconnect"
+      [disabled]="isReconnecting"
+      (click)="reconnect()"
+    >
+      @if (isReconnecting) {
+        {{ 'Reconnecting...' | translate }}
+      } @else {
+        {{ 'Reconnect' | translate }}
+      }
     </button>
   }
 </ix-page-header>

--- a/src/app/modules/terminal/components/terminal/terminal.component.scss
+++ b/src/app/modules/terminal/components/terminal/terminal.component.scss
@@ -8,10 +8,45 @@
   margin-left: 8px;
   margin-right: 8px;
   padding: 10px 0 10px 10px;
+  position: relative;
 }
 
 #terminal {
   height: 100%;
+  
+  &.terminal-dimmed {
+    opacity: 0.3;
+    pointer-events: none;
+  }
+}
+
+.terminal-busy-overlay {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.7);
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 10;
+
+  .busy-content {
+    align-items: center;
+    color: white;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    text-align: center;
+
+    p {
+      font-size: 14px;
+      line-height: 1.4;
+      margin: 0;
+      max-width: 300px;
+    }
+  }
 }
 
 .font-size-controls {
@@ -27,3 +62,4 @@
     }
   }
 }
+

--- a/src/app/modules/terminal/components/terminal/terminal.component.spec.ts
+++ b/src/app/modules/terminal/components/terminal/terminal.component.spec.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef } from '@angular/core';
+import { signal } from '@angular/core';
 import { of, Subject, throwError } from 'rxjs';
 import { take, tap } from 'rxjs/operators';
 import { ShellConnectedEvent } from 'app/interfaces/shell.interface';
@@ -10,14 +10,13 @@ import { ShellService } from 'app/services/shell.service';
 describe('TerminalComponent Reconnect Logic', () => {
   let authService: jest.Mocked<AuthService>;
   let shellService: jest.Mocked<ShellService>;
-  let cdr: jest.Mocked<ChangeDetectorRef>;
   let shellConnected$: Subject<ShellConnectedEvent>;
 
   // Mock the reconnect method from TerminalComponent
   class TestTerminalReconnectLogic {
-    shellConnected = false;
-    connectionId: string;
-    isReconnecting = false;
+    shellConnected = signal(false);
+    connectionId = signal<string>(undefined);
+    isReconnecting = signal(false);
     token: string;
     authService: AuthService;
     shellService: ShellService;
@@ -27,25 +26,21 @@ describe('TerminalComponent Reconnect Logic', () => {
     });
 
     constructor(
-      private authServiceParam: AuthService,
-      private shellServiceParam: ShellService,
-      private changeDetectorRef: ChangeDetectorRef,
+      authServiceParam: AuthService,
+      shellServiceParam: ShellService,
     ) {
       this.authService = authServiceParam;
       this.shellService = shellServiceParam;
 
       this.shellService.shellConnected$.subscribe((event: ShellConnectedEvent) => {
-        this.shellConnected = event.connected;
-        this.connectionId = event.id;
-
-        this.isReconnecting = false;
-        this.changeDetectorRef.markForCheck();
+        this.shellConnected.set(event.connected);
+        this.connectionId.set(event.id);
+        this.isReconnecting.set(false);
       });
     }
 
     reconnect(): void {
-      this.isReconnecting = true;
-      this.changeDetectorRef.markForCheck();
+      this.isReconnecting.set(true);
 
       this.authService.getOneTimeToken().pipe(
         take(1),
@@ -55,8 +50,7 @@ describe('TerminalComponent Reconnect Logic', () => {
         }),
       ).subscribe({
         error: () => {
-          this.isReconnecting = false;
-          this.changeDetectorRef.markForCheck();
+          this.isReconnecting.set(false);
         },
       });
     }
@@ -74,10 +68,6 @@ describe('TerminalComponent Reconnect Logic', () => {
       disconnectIfSessionActive: jest.fn(),
       shellConnected$: shellConnected$.asObservable(),
     } as unknown as jest.Mocked<ShellService>;
-
-    cdr = {
-      markForCheck: jest.fn(),
-    } as unknown as jest.Mocked<ChangeDetectorRef>;
   });
 
   afterEach(() => {
@@ -86,12 +76,11 @@ describe('TerminalComponent Reconnect Logic', () => {
 
   describe('reconnect functionality', () => {
     it('should get fresh token and attempt reconnection', () => {
-      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
 
       logic.reconnect();
 
-      expect(logic.isReconnecting).toBe(true);
-      expect(cdr.markForCheck).toHaveBeenCalled();
+      expect(logic.isReconnecting()).toBe(true);
       expect(authService.getOneTimeToken).toHaveBeenCalled();
       expect(shellService.connect).toHaveBeenCalledWith('fresh-token', {
         virt_instance_id: 'test-instance',
@@ -101,39 +90,36 @@ describe('TerminalComponent Reconnect Logic', () => {
 
     it('should handle token retrieval errors', () => {
       authService.getOneTimeToken.mockReturnValue(throwError(() => new Error('Token failed')));
-      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
 
       logic.reconnect();
 
-      expect(logic.isReconnecting).toBe(false);
-      expect(cdr.markForCheck).toHaveBeenCalledTimes(2); // Once for start, once for error
+      expect(logic.isReconnecting()).toBe(false);
     });
 
     it('should reset loading state on successful connection', () => {
-      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
-      logic.isReconnecting = true;
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+      logic.isReconnecting.set(true);
 
       shellConnected$.next({ connected: true, id: 'test-connection' });
 
-      expect(logic.shellConnected).toBe(true);
-      expect(logic.connectionId).toBe('test-connection');
-      expect(logic.isReconnecting).toBe(false);
-      expect(cdr.markForCheck).toHaveBeenCalled();
+      expect(logic.shellConnected()).toBe(true);
+      expect(logic.connectionId()).toBe('test-connection');
+      expect(logic.isReconnecting()).toBe(false);
     });
 
     it('should reset loading state on connection failure', () => {
-      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
-      logic.isReconnecting = true;
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+      logic.isReconnecting.set(true);
 
       shellConnected$.next({ connected: false });
 
-      expect(logic.shellConnected).toBe(false);
-      expect(logic.isReconnecting).toBe(false);
-      expect(cdr.markForCheck).toHaveBeenCalled();
+      expect(logic.shellConnected()).toBe(false);
+      expect(logic.isReconnecting()).toBe(false);
     });
 
     it('should update token when reconnecting', () => {
-      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
       logic.token = 'old-token';
 
       logic.reconnect();
@@ -144,29 +130,29 @@ describe('TerminalComponent Reconnect Logic', () => {
 
   describe('shell connection state management', () => {
     it('should handle connection events properly', () => {
-      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
 
       // Test connection
       shellConnected$.next({ connected: true, id: 'conn-123' });
-      expect(logic.shellConnected).toBe(true);
-      expect(logic.connectionId).toBe('conn-123');
+      expect(logic.shellConnected()).toBe(true);
+      expect(logic.connectionId()).toBe('conn-123');
 
       // Test disconnection
       shellConnected$.next({ connected: false });
-      expect(logic.shellConnected).toBe(false);
+      expect(logic.shellConnected()).toBe(false);
     });
 
     it('should reset reconnecting state on any connection event', () => {
-      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
-      logic.isReconnecting = true;
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+      logic.isReconnecting.set(true);
 
       // Both successful and failed connections should reset the loading state
       shellConnected$.next({ connected: true, id: 'test' });
-      expect(logic.isReconnecting).toBe(false);
+      expect(logic.isReconnecting()).toBe(false);
 
-      logic.isReconnecting = true;
+      logic.isReconnecting.set(true);
       shellConnected$.next({ connected: false });
-      expect(logic.isReconnecting).toBe(false);
+      expect(logic.isReconnecting()).toBe(false);
     });
   });
 });

--- a/src/app/modules/terminal/components/terminal/terminal.component.spec.ts
+++ b/src/app/modules/terminal/components/terminal/terminal.component.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { signal } from '@angular/core';
 import { of, Subject, throwError } from 'rxjs';
 import { take, tap } from 'rxjs/operators';
@@ -6,55 +7,94 @@ import { TerminalConfiguration } from 'app/interfaces/terminal.interface';
 import { AuthService } from 'app/modules/auth/auth.service';
 import { ShellService } from 'app/services/shell.service';
 
+// Mock the terminal logic from TerminalComponent
+class TestTerminalReconnectLogic {
+  shellConnected = signal(false);
+  connectionId = signal<string>(undefined);
+  isReconnecting = signal(false);
+  hasAttemptedAutoReconnect = false;
+  private autoReconnectEnabled = true;
+  token: string;
+  authService: AuthService;
+  shellService: ShellService;
+
+  conf = (): TerminalConfiguration => ({
+    connectionData: { virt_instance_id: 'test-instance', use_console: false },
+  });
+
+  constructor(
+    authServiceParam: AuthService,
+    shellServiceParam: ShellService,
+  ) {
+    this.authService = authServiceParam;
+    this.shellService = shellServiceParam;
+
+    this.shellService.shellConnected$.subscribe((event: ShellConnectedEvent) => {
+      this.shellConnected.set(event.connected);
+      this.connectionId.set(event.id);
+
+      if (event.connected) {
+        this.isReconnecting.set(false);
+        this.hasAttemptedAutoReconnect = false;
+      } else {
+        // Connection lost or failed
+        this.isReconnecting.set(false);
+
+        // Start immediate automatic reconnection for all shells (only once)
+        if (this.autoReconnectEnabled && !this.hasAttemptedAutoReconnect) {
+          this.hasAttemptedAutoReconnect = true;
+          this.performAutoReconnect();
+        }
+      }
+    });
+  }
+
+  reconnect(): void {
+    this.isReconnecting.set(true);
+
+    this.authService.getOneTimeToken().pipe(
+      take(1),
+      tap((token) => {
+        this.token = token;
+        this.shellService.connect(this.token, this.conf().connectionData);
+      }),
+    ).subscribe({
+      error: () => {
+        this.isReconnecting.set(false);
+      },
+    });
+  }
+
+  private performAutoReconnect(): void {
+    if (!this.autoReconnectEnabled || this.shellConnected() || this.isReconnecting()) {
+      return;
+    }
+
+    this.isReconnecting.set(true);
+
+    this.authService.getOneTimeToken().pipe(
+      take(1),
+      tap((token) => {
+        this.token = token;
+        this.shellService.connect(this.token, this.conf().connectionData);
+      }),
+    ).subscribe({
+      error: () => {
+        this.isReconnecting.set(false);
+      },
+    });
+  }
+
+  isInstanceShell(): boolean {
+    return 'virt_instance_id' in this.conf().connectionData;
+  }
+}
+
 // Create a simplified test for the reconnect functionality without the DOM dependencies
 describe('TerminalComponent Reconnect Logic', () => {
   let authService: jest.Mocked<AuthService>;
   let shellService: jest.Mocked<ShellService>;
   let shellConnected$: Subject<ShellConnectedEvent>;
-
-  // Mock the reconnect method from TerminalComponent
-  class TestTerminalReconnectLogic {
-    shellConnected = signal(false);
-    connectionId = signal<string>(undefined);
-    isReconnecting = signal(false);
-    token: string;
-    authService: AuthService;
-    shellService: ShellService;
-
-    conf = (): TerminalConfiguration => ({
-      connectionData: { virt_instance_id: 'test-instance', use_console: false },
-    });
-
-    constructor(
-      authServiceParam: AuthService,
-      shellServiceParam: ShellService,
-    ) {
-      this.authService = authServiceParam;
-      this.shellService = shellServiceParam;
-
-      this.shellService.shellConnected$.subscribe((event: ShellConnectedEvent) => {
-        this.shellConnected.set(event.connected);
-        this.connectionId.set(event.id);
-        this.isReconnecting.set(false);
-      });
-    }
-
-    reconnect(): void {
-      this.isReconnecting.set(true);
-
-      this.authService.getOneTimeToken().pipe(
-        take(1),
-        tap((token) => {
-          this.token = token;
-          this.shellService.connect(this.token, this.conf().connectionData);
-        }),
-      ).subscribe({
-        error: () => {
-          this.isReconnecting.set(false);
-        },
-      });
-    }
-  }
 
   beforeEach(() => {
     shellConnected$ = new Subject<ShellConnectedEvent>();
@@ -106,16 +146,18 @@ describe('TerminalComponent Reconnect Logic', () => {
       expect(logic.shellConnected()).toBe(true);
       expect(logic.connectionId()).toBe('test-connection');
       expect(logic.isReconnecting()).toBe(false);
+      expect(logic.hasAttemptedAutoReconnect).toBe(false);
     });
 
-    it('should reset loading state on connection failure', () => {
+    it('should trigger auto-reconnection on connection failure', () => {
       const logic = new TestTerminalReconnectLogic(authService, shellService);
-      logic.isReconnecting.set(true);
 
       shellConnected$.next({ connected: false });
 
       expect(logic.shellConnected()).toBe(false);
-      expect(logic.isReconnecting()).toBe(false);
+      expect(logic.isReconnecting()).toBe(true); // Auto-reconnection started
+      expect(logic.hasAttemptedAutoReconnect).toBe(true);
+      expect(authService.getOneTimeToken).toHaveBeenCalled();
     });
 
     it('should update token when reconnecting', () => {
@@ -125,6 +167,82 @@ describe('TerminalComponent Reconnect Logic', () => {
       logic.reconnect();
 
       expect(logic.token).toBe('fresh-token');
+    });
+  });
+
+  describe('auto-reconnection functionality', () => {
+    it('should automatically attempt reconnection when connection is lost', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+
+      // Simulate connection loss
+      shellConnected$.next({ connected: false });
+
+      expect(logic.hasAttemptedAutoReconnect).toBe(true);
+      expect(logic.isReconnecting()).toBe(true);
+      expect(authService.getOneTimeToken).toHaveBeenCalledTimes(1);
+      expect(shellService.connect).toHaveBeenCalledWith('fresh-token', {
+        virt_instance_id: 'test-instance',
+        use_console: false,
+      });
+    });
+
+    it('should only attempt auto-reconnection once per connection loss', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+
+      // First connection loss
+      shellConnected$.next({ connected: false });
+      expect(authService.getOneTimeToken).toHaveBeenCalledTimes(1);
+
+      // Second connection loss event (should not trigger another auto-reconnect)
+      shellConnected$.next({ connected: false });
+      expect(authService.getOneTimeToken).toHaveBeenCalledTimes(1); // Still only called once
+      expect(logic.hasAttemptedAutoReconnect).toBe(true);
+    });
+
+    it('should handle auto-reconnection failure gracefully', () => {
+      authService.getOneTimeToken.mockReturnValue(throwError(() => new Error('Auto-reconnect failed')));
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+
+      // Simulate connection loss
+      shellConnected$.next({ connected: false });
+
+      expect(logic.isReconnecting()).toBe(false);
+      expect(logic.hasAttemptedAutoReconnect).toBe(true);
+    });
+
+    it('should reset auto-reconnection flag on successful connection', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+      logic.hasAttemptedAutoReconnect = true;
+
+      // Simulate successful reconnection
+      shellConnected$.next({ connected: true, id: 'test-connection' });
+
+      expect(logic.hasAttemptedAutoReconnect).toBe(false);
+    });
+
+    it('should work for instance shells', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+
+      expect(logic.isInstanceShell()).toBe(true);
+
+      // Auto-reconnection should work regardless of shell type
+      shellConnected$.next({ connected: false });
+      expect(logic.isReconnecting()).toBe(true);
+    });
+
+    it('should work for non-instance shells', () => {
+      // Create logic with non-instance shell configuration
+      const nonInstanceLogic = new class extends TestTerminalReconnectLogic {
+        override conf = (): TerminalConfiguration => ({
+          connectionData: {},
+        });
+      }(authService, shellService);
+
+      expect(nonInstanceLogic.isInstanceShell()).toBe(false);
+
+      // Auto-reconnection should work for all shell types
+      shellConnected$.next({ connected: false });
+      expect(nonInstanceLogic.isReconnecting()).toBe(true);
     });
   });
 
@@ -142,17 +260,53 @@ describe('TerminalComponent Reconnect Logic', () => {
       expect(logic.shellConnected()).toBe(false);
     });
 
-    it('should reset reconnecting state on any connection event', () => {
+    it('should reset reconnecting state on successful connection', () => {
       const logic = new TestTerminalReconnectLogic(authService, shellService);
       logic.isReconnecting.set(true);
 
-      // Both successful and failed connections should reset the loading state
+      // Successful connection should reset the loading state
       shellConnected$.next({ connected: true, id: 'test' });
       expect(logic.isReconnecting()).toBe(false);
+    });
 
-      logic.isReconnecting.set(true);
+    it('should start auto-reconnection on connection loss', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+      logic.isReconnecting.set(false);
+
+      // Connection loss should start auto-reconnection
       shellConnected$.next({ connected: false });
-      expect(logic.isReconnecting()).toBe(false);
+      expect(logic.isReconnecting()).toBe(true); // Auto-reconnection started
+    });
+  });
+
+  describe('connection state management', () => {
+    it('should show overlay when shell is not connected', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+
+      // Shell starts as not connected
+      expect(logic.shellConnected()).toBe(false);
+      // Template will show overlay when !shellConnected()
+    });
+
+    it('should hide overlay when shell is connected', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+
+      shellConnected$.next({ connected: true, id: 'test-connection' });
+
+      expect(logic.shellConnected()).toBe(true);
+      // Template will hide overlay when shellConnected() is true
+    });
+
+    it('should maintain connection state properly', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService);
+
+      // Connect
+      shellConnected$.next({ connected: true, id: 'test-connection' });
+      expect(logic.shellConnected()).toBe(true);
+
+      // Disconnect
+      shellConnected$.next({ connected: false });
+      expect(logic.shellConnected()).toBe(false);
     });
   });
 });

--- a/src/app/modules/terminal/components/terminal/terminal.component.spec.ts
+++ b/src/app/modules/terminal/components/terminal/terminal.component.spec.ts
@@ -1,0 +1,172 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { of, Subject, throwError } from 'rxjs';
+import { take, tap } from 'rxjs/operators';
+import { ShellConnectedEvent } from 'app/interfaces/shell.interface';
+import { TerminalConfiguration } from 'app/interfaces/terminal.interface';
+import { AuthService } from 'app/modules/auth/auth.service';
+import { ShellService } from 'app/services/shell.service';
+
+// Create a simplified test for the reconnect functionality without the DOM dependencies
+describe('TerminalComponent Reconnect Logic', () => {
+  let authService: jest.Mocked<AuthService>;
+  let shellService: jest.Mocked<ShellService>;
+  let cdr: jest.Mocked<ChangeDetectorRef>;
+  let shellConnected$: Subject<ShellConnectedEvent>;
+
+  // Mock the reconnect method from TerminalComponent
+  class TestTerminalReconnectLogic {
+    shellConnected = false;
+    connectionId: string;
+    isReconnecting = false;
+    token: string;
+    authService: AuthService;
+    shellService: ShellService;
+
+    conf = (): TerminalConfiguration => ({
+      connectionData: { virt_instance_id: 'test-instance', use_console: false },
+    });
+
+    constructor(
+      private authServiceParam: AuthService,
+      private shellServiceParam: ShellService,
+      private changeDetectorRef: ChangeDetectorRef,
+    ) {
+      this.authService = authServiceParam;
+      this.shellService = shellServiceParam;
+
+      this.shellService.shellConnected$.subscribe((event: ShellConnectedEvent) => {
+        this.shellConnected = event.connected;
+        this.connectionId = event.id;
+
+        this.isReconnecting = false;
+        this.changeDetectorRef.markForCheck();
+      });
+    }
+
+    reconnect(): void {
+      this.isReconnecting = true;
+      this.changeDetectorRef.markForCheck();
+
+      this.authService.getOneTimeToken().pipe(
+        take(1),
+        tap((token) => {
+          this.token = token;
+          this.shellService.connect(this.token, this.conf().connectionData);
+        }),
+      ).subscribe({
+        error: () => {
+          this.isReconnecting = false;
+          this.changeDetectorRef.markForCheck();
+        },
+      });
+    }
+  }
+
+  beforeEach(() => {
+    shellConnected$ = new Subject<ShellConnectedEvent>();
+
+    authService = {
+      getOneTimeToken: jest.fn(() => of('fresh-token')),
+    } as unknown as jest.Mocked<AuthService>;
+
+    shellService = {
+      connect: jest.fn(),
+      disconnectIfSessionActive: jest.fn(),
+      shellConnected$: shellConnected$.asObservable(),
+    } as unknown as jest.Mocked<ShellService>;
+
+    cdr = {
+      markForCheck: jest.fn(),
+    } as unknown as jest.Mocked<ChangeDetectorRef>;
+  });
+
+  afterEach(() => {
+    shellConnected$.complete();
+  });
+
+  describe('reconnect functionality', () => {
+    it('should get fresh token and attempt reconnection', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+
+      logic.reconnect();
+
+      expect(logic.isReconnecting).toBe(true);
+      expect(cdr.markForCheck).toHaveBeenCalled();
+      expect(authService.getOneTimeToken).toHaveBeenCalled();
+      expect(shellService.connect).toHaveBeenCalledWith('fresh-token', {
+        virt_instance_id: 'test-instance',
+        use_console: false,
+      });
+    });
+
+    it('should handle token retrieval errors', () => {
+      authService.getOneTimeToken.mockReturnValue(throwError(() => new Error('Token failed')));
+      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+
+      logic.reconnect();
+
+      expect(logic.isReconnecting).toBe(false);
+      expect(cdr.markForCheck).toHaveBeenCalledTimes(2); // Once for start, once for error
+    });
+
+    it('should reset loading state on successful connection', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+      logic.isReconnecting = true;
+
+      shellConnected$.next({ connected: true, id: 'test-connection' });
+
+      expect(logic.shellConnected).toBe(true);
+      expect(logic.connectionId).toBe('test-connection');
+      expect(logic.isReconnecting).toBe(false);
+      expect(cdr.markForCheck).toHaveBeenCalled();
+    });
+
+    it('should reset loading state on connection failure', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+      logic.isReconnecting = true;
+
+      shellConnected$.next({ connected: false });
+
+      expect(logic.shellConnected).toBe(false);
+      expect(logic.isReconnecting).toBe(false);
+      expect(cdr.markForCheck).toHaveBeenCalled();
+    });
+
+    it('should update token when reconnecting', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+      logic.token = 'old-token';
+
+      logic.reconnect();
+
+      expect(logic.token).toBe('fresh-token');
+    });
+  });
+
+  describe('shell connection state management', () => {
+    it('should handle connection events properly', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+
+      // Test connection
+      shellConnected$.next({ connected: true, id: 'conn-123' });
+      expect(logic.shellConnected).toBe(true);
+      expect(logic.connectionId).toBe('conn-123');
+
+      // Test disconnection
+      shellConnected$.next({ connected: false });
+      expect(logic.shellConnected).toBe(false);
+    });
+
+    it('should reset reconnecting state on any connection event', () => {
+      const logic = new TestTerminalReconnectLogic(authService, shellService, cdr);
+      logic.isReconnecting = true;
+
+      // Both successful and failed connections should reset the loading state
+      shellConnected$.next({ connected: true, id: 'test' });
+      expect(logic.isReconnecting).toBe(false);
+
+      logic.isReconnecting = true;
+      shellConnected$.next({ connected: false });
+      expect(logic.isReconnecting).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
**Changes:**
- Fixed Reconnect logic.
- Added tests.
- Added loading indication for reconnect action.

<!-- Briefly describe what changed. -->

**Testing:**
See ticket.

Before:

https://github.com/user-attachments/assets/239cf4af-2899-4ac6-bc92-0dec9459ce65

After:


https://github.com/user-attachments/assets/5d8b6ff4-72bb-4957-a48b-eb689b82d4e0



Original PR: https://github.com/truenas/webui/pull/12393
