### PR TITLE
NAS-137234 / 26.04 / Apps - sorting arrow has incorrect color

### DIFF
--- a/src/assets/styles/other/_material-overrides.scss
+++ b/src/assets/styles/other/_material-overrides.scss
@@ -171,6 +171,8 @@ html .ix-dark {
   --mat-button-filled-label-text-tracking: normal;
   --mat-button-outlined-label-text-tracking: normal;
 
+  --mat-sort-arrow-color: var(--fg2);
+
   .mat-mdc-slide-toggle {
     --mat-switch-label-text-color: var(--fg2);
   }


### PR DESCRIPTION
Result:

<img width="312" height="165" alt="Screenshot 2025-08-20 at 13 39 04" src="https://github.com/user-attachments/assets/30ba9b1f-aecf-4b67-a962-f6756049160a" />
