### PR TITLE
NAS-137185 / 25.10-BETA.1 / add UI support for VNC to VM feature (by aervin)

### DIFF
--- a/src/app/enums/vm.enum.ts
+++ b/src/app/enums/vm.enum.ts
@@ -64,7 +64,13 @@ export const vmDiskModeLabels = new Map<VmDiskMode, string>([
 
 export enum VmDisplayType {
   Spice = 'SPICE',
+  Vnc = 'VNC',
 }
+
+export const vmDisplayTypeLabels = new Map<VmDisplayType, string>([
+  [VmDisplayType.Spice, T('SPICE')],
+  [VmDisplayType.Vnc, T('VNC')],
+]);
 
 export enum VmNicType {
   E1000 = 'E1000',

--- a/src/app/helptext/vm/devices/device-add-edit.ts
+++ b/src/app/helptext/vm/devices/device-add-edit.ts
@@ -42,15 +42,23 @@ export const helptextDevice = {
   rootpwd_tooltip: T('Enter a password for the <i>rancher</i> user. This\
  is used to log in to the VM from the serial shell.'),
 
-  port_tooltip: T('Can be set to <i>0</i>, left empty for TrueNAS to\
- assign a port when the VM is started, or set to a\
- fixed, preferred port number.'),
+  port_tooltip: T('Display server port for remote desktop client connections.'),
+
+  web_port_tooltip: T('Web console port for browser-based access to the VM display.'),
 
   wait_placeholder: T('Delay VM Boot Until SPICE Connects'),
   wait_tooltip: T('Wait to start VM until SPICE client connects.'),
 
-  resolution_tooltip: T('Select a screen resolution to use for SPICE sessions.'),
-  bind_tooltip: T('Select an IP address to use for SPICE sessions.'),
-  password_tooltip: T('Enter a SPICE password to automatically pass to the SPICE session.'),
+  enable_display_tooltip: T('Enable a SPICE display for web-based and client remote\
+ connections. Requires <i>UEFI</i> booting.'),
+  enable_vnc_tooltip: T('Enable a VNC display for client-only remote connections.\
+ Requires VNC client software. Cannot be accessed through web browser.'),
+  vnc_password_tooltip: T('VNC password (maximum 8 characters). Required for VNC connections.'),
+  vnc_bind_tooltip: T('Select an IP address for VNC connections. Leave as 0.0.0.0 to bind to all interfaces.'),
+  vnc_port_tooltip: T('Port for VNC connections. Leave empty to auto-assign an available port.'),
+  vnc_resolution_tooltip: T('Default screen resolution for VNC display.'),
+  resolution_tooltip: T('Select a screen resolution for the display.'),
+  bind_tooltip: T('Select an IP address to bind to for display connections.'),
+  password_tooltip: T('Enter a password for display authentication.'),
   web_tooltip: T('Set to enable connecting to the SPICE web interface.'),
 };

--- a/src/app/helptext/vm/vm-wizard/vm-wizard.ts
+++ b/src/app/helptext/vm/vm-wizard/vm-wizard.ts
@@ -4,7 +4,7 @@ import { helptextGlobal } from 'app/helptext/global-helptext';
 export const helptextVmWizard = {
   os_tooltip: T('Choose the VM operating system type.'),
   name_tooltip: T('Enter an alphanumeric name for the virtual machine.'),
-  password_tooltip: T('Enter a password for the SPICE display.'),
+  password_tooltip: T('Enter a password for the VNC display.'),
   description_tooltip: T('Description (optional).'),
   time_tooltip: T('VM system time. Default is <i>Local</i>.'),
   bootloader_tooltip: T('Select <i>UEFI</i> for newer operating systems or\
@@ -15,10 +15,12 @@ export const helptextVmWizard = {
   autostart_tooltip: T('Set to start this VM when the system boots.'),
   enableSecureBoot: T('Enabling secure boot may be a requirement for some operating systems like Windows 11.'),
   enableTrustedPlatformModule: T('Enable Trusted Platform Module (TPM) for enhanced security features. TPM provides hardware-based cryptographic security functions and may be required by some operating systems like Windows 11.'),
-  enable_display_tooltip: T('Enable a Display (Virtual Network Computing) remote\
- connection. Requires <i>UEFI</i> booting.'),
-  display_bind_tooltip: T('Select an IP address to use for remote SPICE sessions.\
- Note: this setting only applies if you are using a SPICE client other than the TrueNAS WebUI.'),
+  enable_vnc_tooltip: T('Enable a VNC display for client-only remote connections.\
+ Requires VNC client software. Cannot be accessed through web browser.'),
+  vnc_password_tooltip: T('VNC password (maximum 8 characters). Required for VNC connections.'),
+  vnc_bind_tooltip: T('Select an IP address for VNC connections. Leave as 0.0.0.0 to bind to all interfaces.'),
+  vnc_port_tooltip: T('Port for VNC connections. Leave empty to auto-assign an available port.'),
+  vnc_resolution_tooltip: T('Default screen resolution for VNC display.'),
   vcpus_warning: T('The product of vCPUs, cores and threads must not exceed {maxVcpus} on this system.'),
   vcpus_tooltip: T('Number of virtual CPUs to allocate to the virtual\
  machine. The VM operating system\

--- a/src/app/interfaces/vm-device.interface.ts
+++ b/src/app/interfaces/vm-device.interface.ts
@@ -108,6 +108,7 @@ interface VmDisplayAttributes {
   type: VmDisplayType;
   wait: boolean;
   web: boolean;
+  web_port: number | null;
   dtype: VmDeviceType.Display;
 }
 

--- a/src/app/pages/vm/devices/device-form/device-form.component.html
+++ b/src/app/pages/vm/devices/device-form/device-form.component.html
@@ -165,41 +165,80 @@
               }
             }
             @case (VmDeviceType.Display) {
-              <ix-input
-                formControlName="port"
-                type="number"
-                [label]="'Port' | translate"
-                [tooltip]="helptext.port_tooltip | translate"
-              ></ix-input>
+              @if (isNew) {
+                <ix-select
+                  formControlName="type"
+                  [label]="'Display Type' | translate"
+                  [options]="displayTypes$"
+                  [required]="true"
+                  [tooltip]="'Select the display protocol type.' | translate"
+                ></ix-select>
+              } @else {
+                <div class="display-type-info">
+                  <label>{{ 'Display Type' | translate }}</label>
+                  <p><strong>{{ getCurrentDisplayTypeLabel() }}</strong></p>
+                </div>
+              }
 
-              <ix-select
-                formControlName="resolution"
-                [label]="'Resolution' | translate"
-                [options]="resolutions$"
-                [tooltip]="helptext.resolution_tooltip | translate"
-                [required]="true"
-              ></ix-select>
+              @if (!isNew || getCurrentDisplayType()) {
+                <ix-select
+                  formControlName="bind"
+                  [label]="'Bind' | translate"
+                  [options]="bindOptions$"
+                  [required]="true"
+                  [tooltip]="helptext.bind_tooltip | translate"
+                ></ix-select>
 
-              <ix-select
-                formControlName="bind"
-                [label]="'Bind' | translate"
-                [options]="bindOptions$"
-                [tooltip]="helptext.bind_tooltip | translate"
-                [required]="true"
-              ></ix-select>
+                <ix-input
+                  formControlName="password"
+                  type="password"
+                  [label]="'Password' | translate"
+                  [required]="true"
+                  [tooltip]="helptext.password_tooltip | translate"
+                ></ix-input>
 
-              <ix-input
-                formControlName="password"
-                type="password"
-                [label]="'Password' | translate"
-                [tooltip]="helptext.password_tooltip | translate"
-              ></ix-input>
+                <ix-select
+                  formControlName="resolution"
+                  [label]="'Resolution' | translate"
+                  [options]="resolutions$"
+                  [required]="true"
+                  [tooltip]="helptext.resolution_tooltip | translate"
+                ></ix-select>
 
-              <ix-checkbox
-                formControlName="web"
-                [label]="'Web Interface' | translate"
-                [tooltip]="helptext.web_tooltip | translate"
-              ></ix-checkbox>
+                <ix-input
+                  formControlName="port"
+                  type="number"
+                  [label]="'Port (optional)' | translate"
+                  [tooltip]="helptext.port_tooltip | translate"
+                ></ix-input>
+
+                @if (getCurrentDisplayType() === VmDisplayType.Spice) {
+                  <ix-checkbox
+                    formControlName="web"
+                    [label]="'Web Interface' | translate"
+                    [tooltip]="helptext.web_tooltip | translate"
+                  ></ix-checkbox>
+
+                  @if (displayForm.controls.web.value) {
+                    <ix-input
+                      formControlName="web_port"
+                      type="number"
+                      [label]="'Web Port' | translate"
+                      [tooltip]="helptext.web_port_tooltip | translate"
+                    ></ix-input>
+                  }
+                }
+
+                @if (getCurrentDisplayType() === VmDisplayType.Vnc) {
+                  <div class="vnc-warning">
+                    <p><strong>{{ 'Note' | translate }}:</strong> {{ 'VNC requires a separate client application and cannot be accessed through the web browser. Password is limited to 8 characters.' | translate }}</p>
+                  </div>
+                }
+              } @else {
+                <div class="display-type-prompt">
+                  <p class="muted">{{ 'Select a display type above to configure display settings.' | translate }}</p>
+                </div>
+              }
             }
           }
         </ng-container>

--- a/src/app/pages/vm/devices/device-form/device-form.component.scss
+++ b/src/app/pages/vm/devices/device-form/device-form.component.scss
@@ -14,3 +14,37 @@
     margin-bottom: 8px;
   }
 }
+
+.display-type-info {
+  margin-bottom: 16px;
+  margin-top: 24px;
+
+  label {
+    display: block;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1;
+    margin-bottom: 6px;
+    opacity: 0.6;
+    text-transform: uppercase;
+  }
+
+  p {
+    font-size: 14px;
+    margin: 0;
+  }
+}
+
+.display-type-prompt {
+  background-color: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  margin: 24px 0;
+  padding: 16px;
+  text-align: center;
+
+  .muted {
+    font-style: italic;
+    margin: 0;
+    opacity: 0.6;
+  }
+}

--- a/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
@@ -677,6 +677,7 @@ describe('DeviceFormComponent', () => {
           'Port (optional)': '5900',
           Resolution: '1024x768',
           'Web Interface': true,
+          'Web Port': '',
         });
       });
     });

--- a/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
@@ -53,7 +53,10 @@ describe('DeviceFormComponent', () => {
       mockApi([
         mockCall('vm.device.create'),
         mockCall('vm.device.update'),
-        mockCall('vm.get_display_devices', [{}, {}] as VmDisplayDevice[]),
+        mockCall('vm.get_display_devices', [
+          { attributes: { dtype: VmDeviceType.Display, type: VmDisplayType.Spice } },
+          { attributes: { dtype: VmDeviceType.Display, type: VmDisplayType.Vnc } },
+        ] as VmDisplayDevice[]),
         mockCall('vm.device.bind_choices', {
           '0.0.0.0': '0.0.0.0',
           '::': '::',
@@ -618,7 +621,7 @@ describe('DeviceFormComponent', () => {
   });
 
   describe('Display', () => {
-    const existingDisplay = {
+    const existingSpiceDisplay = {
       id: 1,
       attributes: {
         dtype: VmDeviceType.Display,
@@ -633,13 +636,29 @@ describe('DeviceFormComponent', () => {
       vm: 45,
     } as VmDisplayDevice;
 
-    describe('edits display', () => {
+    const existingVncDisplay = {
+      id: 2,
+      attributes: {
+        dtype: VmDeviceType.Display,
+        bind: '192.168.1.100',
+        password: 'vncpass',
+        web: false,
+        web_port: null,
+        type: VmDisplayType.Vnc,
+        resolution: '1920x1080',
+        port: 5901,
+      },
+      order: 1003,
+      vm: 45,
+    } as VmDisplayDevice;
+
+    describe('edits SPICE display', () => {
       beforeEach(async () => {
         spectator = createComponent({
           providers: [
             mockProvider(SlideInRef, {
               ...slideInRef,
-              getData: jest.fn(() => ({ virtualMachineId: 45, device: existingDisplay })),
+              getData: jest.fn(() => ({ virtualMachineId: 45, device: existingSpiceDisplay })),
             }),
           ],
         });
@@ -655,7 +674,7 @@ describe('DeviceFormComponent', () => {
           Bind: '0.0.0.0',
           'Device Order': '1002',
           Password: '12345678910',
-          Port: '5900',
+          'Port (optional)': '5900',
           Resolution: '1024x768',
           'Web Interface': true,
         });
@@ -676,10 +695,271 @@ describe('DeviceFormComponent', () => {
       });
 
       it('hides Display type option when VM already has 2 or more displays (proxy for having 1 display of each type)', async () => {
-        spectator.inject(MockApiService).mockCall('vm.get_display_devices', [{}, {}] as VmDisplayDevice[]);
+        spectator.inject(MockApiService).mockCall('vm.get_display_devices', [
+          { attributes: { dtype: VmDeviceType.Display, type: VmDisplayType.Spice } },
+          { attributes: { dtype: VmDeviceType.Display, type: VmDisplayType.Vnc } },
+        ] as VmDisplayDevice[]);
         const typeSelect = await loader.getHarness(IxSelectHarness.with({ label: 'Type' }));
         expect(api.call).toHaveBeenCalledWith('vm.get_display_devices', [46]);
         expect(await typeSelect.getOptionLabels()).not.toContain('Display');
+      });
+    });
+
+    describe('edits VNC display', () => {
+      beforeEach(async () => {
+        spectator = createComponent({
+          providers: [
+            mockProvider(SlideInRef, {
+              ...slideInRef,
+              getData: jest.fn(() => ({ virtualMachineId: 45, device: existingVncDisplay })),
+            }),
+          ],
+        });
+        loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+        form = await loader.getHarness(IxFormHarness);
+        saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+        api = spectator.inject(ApiService);
+      });
+
+      it('shows values for an existing VNC display device', async () => {
+        const values = await form.getValues();
+        expect(values).toMatchObject({
+          'Device Order': '1003',
+          Password: 'vncpass',
+          'Port (optional)': '5901',
+        });
+
+        // Verify Web Interface is disabled for VNC
+        expect(values).not.toHaveProperty('Web Interface');
+        expect(values).not.toHaveProperty('Web Port');
+      });
+
+      it('updates an existing VNC display device', async () => {
+        await form.fillForm({
+          Bind: '0.0.0.0',
+          Password: 'newpass',
+        });
+
+        await saveButton.click();
+
+        expect(api.call).toHaveBeenLastCalledWith('vm.device.update', [2, {
+          attributes: {
+            dtype: VmDeviceType.Display,
+            type: VmDisplayType.Vnc,
+            bind: '0.0.0.0',
+            password: 'newpass',
+            resolution: '1920x1080',
+            port: 5901,
+            web: false,
+            web_port: null,
+          },
+          order: 1003,
+          vm: 45,
+        }]);
+      });
+
+      it('validates VNC password length (8 character limit)', async () => {
+        await form.fillForm({
+          Password: '123456789', // 9 characters - should be invalid for VNC
+        });
+
+        expect(spectator.component.displayForm.controls.password.invalid).toBe(true);
+        expect(spectator.component.displayForm.controls.password.hasError('maxlength')).toBe(true);
+      });
+    });
+
+    describe('adds new display devices', () => {
+      const createComponentForAdding = createComponentFactory({
+        component: DeviceFormComponent,
+        imports: [
+          ReactiveFormsModule,
+        ],
+        providers: [
+          mockApi([
+            mockCall('vm.device.create'),
+            mockCall('vm.device.update'),
+            mockCall('vm.get_display_devices', []), // No existing display devices
+            mockCall('vm.device.bind_choices', {
+              '0.0.0.0': '0.0.0.0',
+              '::': '::',
+            }),
+            mockCall('vm.resolution_choices', {
+              '640x480': '640x480',
+              '800x600': '800x600',
+              '1024x768': '1024x768',
+              '1920x1080': '1920x1080',
+            }),
+            mockCall('vm.device.usb_passthrough_choices', {}),
+            mockCall('vm.device.passthrough_device_choices', {}),
+            mockCall('vm.random_mac', '00:a0:98:30:09:90'),
+            mockCall('vm.device.nic_attach_choices', {}),
+            mockCall('vm.device.disk_choices', {}),
+            mockCall('vm.device.usb_controller_choices', {}),
+            mockCall('system.advanced.config', {} as AdvancedConfig),
+          ]),
+          mockAuth(),
+          mockProvider(DialogService),
+          mockProvider(SlideIn),
+          mockProvider(FilesystemService),
+          mockProvider(SlideInRef, {
+            ...slideInRef,
+            getData: jest.fn(() => ({ virtualMachineId: 45 })),
+          }),
+          mockProvider(VmService, {
+            hasVirtualizationSupport$: of(true),
+          }),
+        ],
+      });
+
+      beforeEach(async () => {
+        spectator = createComponentForAdding();
+        loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+        form = await loader.getHarness(IxFormHarness);
+        saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+        api = spectator.inject(ApiService);
+      });
+
+      it('adds a new SPICE display device', async () => {
+        await form.fillForm({
+          Type: 'Display',
+          'Display Type': 'SPICE',
+          Bind: '0.0.0.0',
+          Password: 'spicepass',
+          Resolution: '1024x768',
+          'Web Interface': true,
+          'Device Order': 1004,
+        });
+
+        await saveButton.click();
+
+        expect(api.call).toHaveBeenLastCalledWith('vm.device.create', [{
+          attributes: {
+            dtype: VmDeviceType.Display,
+            type: VmDisplayType.Spice,
+            bind: '0.0.0.0',
+            password: 'spicepass',
+            resolution: '1024x768',
+            port: null,
+            web: true,
+            web_port: null,
+          },
+          order: 1004,
+          vm: 45,
+        }]);
+      });
+
+      it('adds a new VNC display device', async () => {
+        await form.fillForm({
+          Type: 'Display',
+          'Display Type': 'VNC',
+          Bind: '0.0.0.0',
+          Password: 'vncpass',
+          Resolution: '1920x1080',
+          'Device Order': 1005,
+        });
+
+        await saveButton.click();
+
+        expect(api.call).toHaveBeenLastCalledWith('vm.device.create', [{
+          attributes: {
+            dtype: VmDeviceType.Display,
+            type: VmDisplayType.Vnc,
+            bind: '0.0.0.0',
+            password: 'vncpass',
+            resolution: '1920x1080',
+            port: null,
+            web: false,
+            web_port: null,
+          },
+          order: 1005,
+          vm: 45,
+        }]);
+      });
+    });
+
+    describe('display type switching', () => {
+      const createComponentForSwitching = createComponentFactory({
+        component: DeviceFormComponent,
+        imports: [
+          ReactiveFormsModule,
+        ],
+        providers: [
+          mockApi([
+            mockCall('vm.device.create'),
+            mockCall('vm.device.update'),
+            mockCall('vm.get_display_devices', []), // No existing display devices
+            mockCall('vm.device.bind_choices', {
+              '0.0.0.0': '0.0.0.0',
+              '::': '::',
+            }),
+            mockCall('vm.resolution_choices', {
+              '640x480': '640x480',
+              '800x600': '800x600',
+              '1024x768': '1024x768',
+              '1920x1080': '1920x1080',
+            }),
+            mockCall('vm.device.usb_passthrough_choices', {}),
+            mockCall('vm.device.passthrough_device_choices', {}),
+            mockCall('vm.random_mac', '00:a0:98:30:09:90'),
+            mockCall('vm.device.nic_attach_choices', {}),
+            mockCall('vm.device.disk_choices', {}),
+            mockCall('vm.device.usb_controller_choices', {}),
+            mockCall('system.advanced.config', {} as AdvancedConfig),
+          ]),
+          mockAuth(),
+          mockProvider(DialogService),
+          mockProvider(SlideIn),
+          mockProvider(FilesystemService),
+          mockProvider(SlideInRef, {
+            ...slideInRef,
+            getData: jest.fn(() => ({ virtualMachineId: 45 })),
+          }),
+          mockProvider(VmService, {
+            hasVirtualizationSupport$: of(true),
+          }),
+        ],
+      });
+
+      beforeEach(async () => {
+        spectator = createComponentForSwitching();
+        loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+        form = await loader.getHarness(IxFormHarness);
+      });
+
+      it('disables web interface when switching from SPICE to VNC', async () => {
+        await form.fillForm({
+          Type: 'Display',
+          'Display Type': 'SPICE',
+          'Web Interface': true,
+        });
+
+        // Switch to VNC
+        await form.fillForm({ 'Display Type': 'VNC' });
+        spectator.detectChanges();
+
+        // Web Interface should be disabled and hidden
+        expect(spectator.component.displayForm.controls.web.value).toBe(false);
+        expect(spectator.component.displayForm.controls.web.disabled).toBe(true);
+
+        const values = await form.getValues();
+        expect(values).not.toHaveProperty('Web Interface');
+      });
+
+      it('enables web interface when switching from VNC to SPICE', async () => {
+        await form.fillForm({
+          Type: 'Display',
+          'Display Type': 'VNC',
+        });
+
+        // Switch to SPICE
+        await form.fillForm({ 'Display Type': 'SPICE' });
+        spectator.detectChanges();
+
+        // Web Interface should be enabled and visible
+        expect(spectator.component.displayForm.controls.web.enabled).toBe(true);
+
+        const values = await form.getValues();
+        expect(values).toHaveProperty('Web Interface');
       });
     });
   });

--- a/src/app/pages/vm/devices/device-form/device-form.component.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.ts
@@ -14,6 +14,7 @@ import { mntPath } from 'app/enums/mnt-path.enum';
 import { Role } from 'app/enums/role.enum';
 import {
   VmDeviceType, vmDeviceTypeLabels, VmDiskMode, vmDiskModeLabels, VmNicType, vmNicTypeLabels,
+  VmDisplayType,
 } from 'app/enums/vm.enum';
 import { assertUnreachable } from 'app/helpers/assert-unreachable.utils';
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
@@ -100,6 +101,48 @@ export class DeviceFormComponent implements OnInit {
     return !this.existingDevice;
   }
 
+  getCurrentDisplayType(): VmDisplayType | null {
+    if (!this.isNew && this.existingDevice?.attributes?.dtype === VmDeviceType.Display) {
+      return this.existingDevice.attributes.type;
+    }
+    return this.displayForm.value.type || null;
+  }
+
+  getCurrentDisplayTypeLabel(): string {
+    const displayType = this.getCurrentDisplayType();
+    if (displayType === VmDisplayType.Spice) {
+      return 'SPICE';
+    }
+    if (displayType === VmDisplayType.Vnc) {
+      return 'VNC';
+    }
+    return 'Unknown';
+  }
+
+  private updateDisplayFormForType(displayType: VmDisplayType | null): void {
+    if (displayType === VmDisplayType.Vnc) {
+      // VNC-specific: disable web interface, set maxLength for password
+      this.displayForm.controls.web.patchValue(false);
+      this.displayForm.controls.web.disable();
+      this.displayForm.controls.web_port.disable();
+      this.displayForm.controls.bind.setValidators([Validators.required]);
+      this.displayForm.controls.password.setValidators([Validators.required, Validators.maxLength(8)]);
+    } else if (displayType === VmDisplayType.Spice) {
+      // SPICE: enable web interface, remove maxLength restriction
+      this.displayForm.controls.web.enable();
+      this.displayForm.controls.bind.setValidators([Validators.required]);
+      this.displayForm.controls.password.setValidators([Validators.required]);
+    } else {
+      // No display type selected: clear validators for bind and password
+      this.displayForm.controls.bind.clearValidators();
+      this.displayForm.controls.password.clearValidators();
+    }
+
+    // Update validation state
+    this.displayForm.controls.bind.updateValueAndValidity();
+    this.displayForm.controls.password.updateValueAndValidity();
+  }
+
   existingDevice: VmDevice;
   protected slideInData: { virtualMachineId?: number; device?: VmDevice } | undefined;
 
@@ -135,10 +178,11 @@ export class DeviceFormComponent implements OnInit {
   });
 
   displayForm = this.formBuilder.group({
-    port: [null as number | null],
-    resolution: [''],
+    type: [null as VmDisplayType | null, Validators.required],
     bind: [''],
     password: [''],
+    resolution: ['1920x1080'],
+    port: [null as number | null],
     web: [true],
   });
 
@@ -153,6 +197,7 @@ export class DeviceFormComponent implements OnInit {
 
   readonly helptext = helptextDevice;
   readonly VmDeviceType = VmDeviceType;
+  readonly VmDisplayType = VmDisplayType;
   readonly usbDeviceOptions$ = this.api.call('vm.device.usb_passthrough_choices').pipe(
     map((usbDevices) => {
       const options = Object.entries(usbDevices).map(([id, device]) => {
@@ -184,6 +229,7 @@ export class DeviceFormComponent implements OnInit {
   readonly resolutions$ = this.api.call('vm.resolution_choices').pipe(choicesToOptions());
   readonly nicOptions$ = this.api.call('vm.device.nic_attach_choices').pipe(choicesToOptions());
   readonly nicTypes$ = of(mapToOptions(vmNicTypeLabels, this.translate));
+  readonly displayTypes$ = new BehaviorSubject<{ label: string; value: VmDisplayType }[]>([]);
 
   readonly passthroughProvider = new SimpleAsyncComboboxProvider(
     this.api.call('vm.device.passthrough_device_choices').pipe(
@@ -263,6 +309,16 @@ export class DeviceFormComponent implements OnInit {
       }
     });
 
+    // Handle display type changes for new devices
+    if (this.isNew) {
+      this.displayForm.controls.type.valueChanges.pipe(untilDestroyed(this)).subscribe((displayType) => {
+        this.updateDisplayFormForType(displayType);
+      });
+
+      // Initialize display form with no validators since no type is selected
+      this.updateDisplayFormForType(null);
+    }
+
     if (this.slideInData?.virtualMachineId) {
       this.virtualMachineId = this.slideInData.virtualMachineId;
       this.setVirtualMachineId();
@@ -299,7 +355,17 @@ export class DeviceFormComponent implements OnInit {
         this.nicForm.patchValue(this.existingDevice.attributes);
         break;
       case VmDeviceType.Display:
-        this.displayForm.patchValue(this.existingDevice.attributes);
+        this.displayForm.patchValue({
+          type: this.existingDevice.attributes.type,
+          bind: this.existingDevice.attributes.bind,
+          password: this.existingDevice.attributes.password,
+          resolution: this.existingDevice.attributes.resolution,
+          port: this.existingDevice.attributes.port,
+          web: this.existingDevice.attributes.web,
+          web_port: this.existingDevice.attributes.web_port,
+        });
+        // Configure form for the specific display type
+        this.updateDisplayFormForType(this.existingDevice.attributes.type);
         break;
       case VmDeviceType.Disk:
         this.diskForm.patchValue({
@@ -420,6 +486,21 @@ export class DeviceFormComponent implements OnInit {
       } as VmDeviceUpdate['attributes'];
     }
 
+    // Handle display device attributes
+    if (this.typeControl.value === VmDeviceType.Display) {
+      const displayValues = this.displayForm.value;
+      return {
+        dtype: VmDeviceType.Display,
+        type: displayValues.type,
+        bind: displayValues.bind,
+        password: displayValues.password,
+        resolution: displayValues.resolution,
+        port: displayValues.port,
+        web: displayValues.type === VmDisplayType.Spice ? displayValues.web : false,
+        web_port: displayValues.type === VmDisplayType.Spice ? displayValues.web_port : null,
+      } as VmDeviceUpdate['attributes'];
+    }
+
     return values as VmDeviceUpdate['attributes'];
   }
 
@@ -430,12 +511,50 @@ export class DeviceFormComponent implements OnInit {
     this.api.call('vm.get_display_devices', [this.virtualMachineId])
       .pipe(untilDestroyed(this))
       .subscribe((devices) => {
-        if (devices.length < 2) {
+        const spiceDevices = devices.filter((device) => device.attributes.type === VmDisplayType.Spice);
+        const vncDevices = devices.filter((device) => device.attributes.type === VmDisplayType.Vnc);
+
+        // If editing an existing device, allow the current device type
+        if (this.existingDevice && this.existingDevice.attributes.dtype === VmDeviceType.Display) {
+          const currentType = this.existingDevice.attributes.type;
+          const availableTypes = [
+            { label: 'SPICE', value: VmDisplayType.Spice },
+            { label: 'VNC', value: VmDisplayType.Vnc },
+          ].filter((type) => type.value === currentType
+            || (type.value === VmDisplayType.Spice && spiceDevices.length === 0)
+            || (type.value === VmDisplayType.Vnc && vncDevices.length === 0));
+          this.displayTypes$.next(availableTypes);
           return;
         }
 
-        const optionsWithoutDisplay = this.deviceTypeOptions.filter((option) => option.value !== VmDeviceType.Display);
-        this.deviceTypes$.next(optionsWithoutDisplay);
+        // For new devices, show available display types
+        const availableTypes = [
+          { label: 'SPICE', value: VmDisplayType.Spice },
+          { label: 'VNC', value: VmDisplayType.Vnc },
+        ].filter((type) => (type.value === VmDisplayType.Spice && spiceDevices.length === 0)
+          || (type.value === VmDisplayType.Vnc && vncDevices.length === 0));
+
+        this.displayTypes$.next(availableTypes);
+
+        // Auto-select display type if only one is available
+        if (availableTypes.length === 1 && this.isNew) {
+          const singleAvailableType = availableTypes[0].value;
+          this.displayForm.patchValue({ type: singleAvailableType });
+          this.displayForm.controls.type.markAsTouched();
+          this.displayForm.controls.type.updateValueAndValidity();
+          this.updateDisplayFormForType(singleAvailableType);
+        }
+
+        // Hide display option from device type dropdown if no display types are available
+        if (availableTypes.length === 0) {
+          const optionsWithoutDisplay = this.deviceTypeOptions.filter(
+            (option) => option.value !== VmDeviceType.Display,
+          );
+          this.deviceTypes$.next(optionsWithoutDisplay);
+        } else {
+          // Ensure display option is available in device type dropdown
+          this.deviceTypes$.next(this.deviceTypeOptions);
+        }
       });
   }
 }

--- a/src/app/pages/vm/devices/device-form/device-form.component.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.ts
@@ -184,6 +184,7 @@ export class DeviceFormComponent implements OnInit {
     resolution: ['1920x1080'],
     port: [null as number | null],
     web: [true],
+    web_port: [null as number | null],
   });
 
   usbForm = this.formBuilder.group({

--- a/src/app/pages/vm/devices/device-list/device-delete-modal/device-delete-modal.component.html
+++ b/src/app/pages/vm/devices/device-list/device-delete-modal/device-delete-modal.component.html
@@ -6,7 +6,7 @@
     class="device-delete-modal-content"
   >
     <p
-      [innerHTML]="'Delete <b>{deviceType} {device}</b>' | translate: { device: device.id, deviceType: device.dtype }"
+      [innerHTML]="'Delete <b>{deviceType} {device}</b>' | translate: { device: device.id, deviceType: getDeviceTypeLabel() }"
     ></p>
 
     @if (device.attributes.dtype === VmDeviceType.Disk) {

--- a/src/app/pages/vm/devices/device-list/device-delete-modal/device-delete-modal.component.spec.ts
+++ b/src/app/pages/vm/devices/device-list/device-delete-modal/device-delete-modal.component.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@ngneat/spectator/jest';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { VmDeviceType } from 'app/enums/vm.enum';
+import { VmDeviceType, VmDisplayType } from 'app/enums/vm.enum';
 import { VmDevice, VmDiskDevice, VmRawFileDevice } from 'app/interfaces/vm-device.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
@@ -178,14 +178,14 @@ describe('DeviceDeleteModalComponent', () => {
   });
 
   describe('for other device', () => {
-    const fakeRawFile = {
+    const fakeOtherDevice = {
       id: 6,
       attributes: {
-        dtype: undefined,
+        dtype: VmDeviceType.Nic,
       },
-    } as unknown as VmRawFileDevice;
+    } as VmDevice;
 
-    const createComponent = createComponentWithData(fakeRawFile);
+    const createComponent = createComponentWithData(fakeOtherDevice);
 
     beforeEach(() => {
       spectator = createComponent();
@@ -223,10 +223,119 @@ describe('DeviceDeleteModalComponent', () => {
           await submitButton.click();
 
           expect(api.call).toHaveBeenCalledWith('vm.device.delete', [
-            fakeRawFile.id,
+            fakeOtherDevice.id,
             expectedValues,
           ]);
         });
+      });
+    });
+  });
+
+  describe('display device type labels', () => {
+    const spiceDisplayDevice = {
+      id: 10,
+      attributes: {
+        dtype: VmDeviceType.Display,
+        type: VmDisplayType.Spice,
+      },
+    } as VmDevice;
+
+    const vncDisplayDevice = {
+      id: 11,
+      attributes: {
+        dtype: VmDeviceType.Display,
+        type: VmDisplayType.Vnc,
+      },
+    } as VmDevice;
+
+    const nicDevice = {
+      id: 12,
+      attributes: {
+        dtype: VmDeviceType.Nic,
+      },
+    } as VmDevice;
+
+    const displayDeviceWithoutType = {
+      id: 13,
+      attributes: {
+        dtype: VmDeviceType.Display,
+        type: undefined,
+      },
+    } as VmDevice;
+
+    describe('for SPICE display device', () => {
+      const createComponent = createComponentWithData(spiceDisplayDevice);
+
+      beforeEach(() => {
+        spectator = createComponent();
+      });
+
+      afterEach(() => {
+        spectator.fixture.destroy();
+      });
+
+      it('shows correct label for SPICE display device', () => {
+        const component = spectator.component;
+        const label = component.getDeviceTypeLabel();
+
+        expect(label).toBe('Display (SPICE)');
+      });
+    });
+
+    describe('for VNC display device', () => {
+      const createComponent = createComponentWithData(vncDisplayDevice);
+
+      beforeEach(() => {
+        spectator = createComponent();
+      });
+
+      afterEach(() => {
+        spectator.fixture.destroy();
+      });
+
+      it('shows correct label for VNC display device', () => {
+        const component = spectator.component;
+        const label = component.getDeviceTypeLabel();
+
+        expect(label).toBe('Display (VNC)');
+      });
+    });
+
+    describe('for non-display device', () => {
+      const createComponent = createComponentWithData(nicDevice);
+
+      beforeEach(() => {
+        spectator = createComponent();
+      });
+
+      afterEach(() => {
+        spectator.fixture.destroy();
+      });
+
+      it('shows correct label for non-display device', () => {
+        const component = spectator.component;
+        const label = component.getDeviceTypeLabel();
+
+        expect(label).toBe('NIC');
+      });
+    });
+
+    describe('for display device without type', () => {
+      const createComponent = createComponentWithData(displayDeviceWithoutType);
+
+      beforeEach(() => {
+        spectator = createComponent();
+      });
+
+      afterEach(() => {
+        spectator.fixture.destroy();
+      });
+
+      it('shows fallback label for display device without type', () => {
+        const component = spectator.component;
+        const label = component.getDeviceTypeLabel();
+
+        expect(label).toBe('Display');
       });
     });
   });

--- a/src/app/pages/vm/devices/device-list/device-delete-modal/device-delete-modal.component.ts
+++ b/src/app/pages/vm/devices/device-list/device-delete-modal/device-delete-modal.component.ts
@@ -10,7 +10,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
-import { VmDeviceType } from 'app/enums/vm.enum';
+import { VmDeviceType, vmDeviceTypeLabels } from 'app/enums/vm.enum';
 import { VmDevice, VmDeviceDelete, VmDiskDevice } from 'app/interfaces/vm-device.interface';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
@@ -138,5 +138,19 @@ export class DeviceDeleteModalComponent implements OnInit {
 
   private getZvolName(disk: VmDiskDevice): string {
     return disk.attributes.path.split('/').pop() || '';
+  }
+
+  getDeviceTypeLabel(): string {
+    if (this.device.attributes.dtype === VmDeviceType.Display) {
+      // For display devices, include the protocol type (SPICE/VNC)
+      const displayType = this.device.attributes.type;
+      if (displayType) {
+        const baseLabel = vmDeviceTypeLabels.get(this.device.attributes.dtype) ?? this.device.attributes.dtype;
+        return this.translate.instant(baseLabel) + ` (${displayType})`;
+      }
+    }
+
+    const deviceLabel = vmDeviceTypeLabels.get(this.device.attributes.dtype) ?? this.device.attributes.dtype;
+    return this.translate.instant(deviceLabel);
   }
 }

--- a/src/app/pages/vm/devices/device-list/device-list/device-list.component.ts
+++ b/src/app/pages/vm/devices/device-list/device-list/device-list.component.ts
@@ -194,6 +194,15 @@ export class DeviceListComponent implements OnInit {
   }
 
   private getDeviceTypeLabel(device: VmDevice): string {
+    if (device.attributes.dtype === VmDeviceType.Display) {
+      // For display devices, include the protocol type (SPICE/VNC)
+      const displayType = device.attributes.type;
+      if (displayType) {
+        const baseLabel = vmDeviceTypeLabels.get(device.attributes.dtype) ?? device.attributes.dtype;
+        return this.translate.instant(baseLabel) + ` (${displayType})`;
+      }
+    }
+
     const deviceLabel = vmDeviceTypeLabels.get(device.attributes.dtype) ?? device.attributes.dtype;
     return this.translate.instant(deviceLabel);
   }

--- a/src/app/pages/vm/vm-list.component.ts
+++ b/src/app/pages/vm/vm-list.component.ts
@@ -11,7 +11,7 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { Role } from 'app/enums/role.enum';
 import {
-  VmBootloader, VmDeviceType, VmState, vmTimeNames,
+  VmBootloader, VmDeviceType, VmDisplayType, VmState, vmTimeNames,
 } from 'app/enums/vm.enum';
 import { toLoadingState } from 'app/helpers/operators/to-loading-state.helper';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
@@ -232,13 +232,19 @@ export class VmListComponent implements OnInit {
     if (this.systemGeneralService.isEnterprise && ([VmBootloader.Grub, VmBootloader.UefiCsm].includes(vm.bootloader))) {
       return false;
     }
-    for (const device of devices) {
-      if (devices && device.attributes.dtype === VmDeviceType.Display) {
-        return device.attributes.port;
-      }
+
+    const displayDevices = devices.filter((device) => device.attributes.dtype === VmDeviceType.Display);
+    if (displayDevices.length === 0) {
+      return false;
     }
 
-    return false;
+    // Show ports for all display devices (SPICE and VNC)
+    const ports = displayDevices.map((device) => {
+      const type = device.attributes.type === VmDisplayType.Spice ? 'SPICE' : 'VNC';
+      return `${type}:${device.attributes.port}`;
+    });
+
+    return ports.join(', ');
   }
 
   protected columnsChange(columns: typeof this.columns): void {

--- a/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.html
+++ b/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.html
@@ -70,27 +70,31 @@
   ></ix-checkbox>
 
   <ix-checkbox
-    formControlName="enable_display"
-    [label]="'Enable Display' | translate"
-    [tooltip]="helptext.enable_display_tooltip | translate"
+    formControlName="enable_vnc"
+    [label]="'Enable Display (VNC)' | translate"
+    [tooltip]="helptext.enable_vnc_tooltip | translate"
   ></ix-checkbox>
 
-  @if (form.value.enable_display) {
+  @if (form.value.enable_vnc) {
     <ix-select
-      formControlName="bind"
+      formControlName="vnc_bind"
       [label]="'Bind' | translate"
       [options]="bindOptions$"
       [required]="true"
-      [tooltip]="helptext.display_bind_tooltip | translate"
+      [tooltip]="helptext.vnc_bind_tooltip | translate"
     ></ix-select>
 
     <ix-input
-      formControlName="password"
+      formControlName="vnc_password"
       type="password"
       [label]="'Password' | translate"
       [required]="true"
-      [tooltip]="helptext.password_tooltip | translate"
+      [tooltip]="helptext.vnc_password_tooltip | translate"
     ></ix-input>
+
+    <div class="vnc-warning">
+      <p><strong>{{ 'Note' | translate }}:</strong> {{ 'VNC requires a separate client application and cannot be accessed through the web browser. Password is limited to 8 characters.' | translate }}</p>
+    </div>
   }
 
   <ix-form-actions>

--- a/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.spec.ts
@@ -5,7 +5,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import {
-  VmBootloader, VmDisplayType, VmOs, VmTime,
+  VmBootloader, VmOs, VmTime,
 } from 'app/enums/vm.enum';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { OsStepComponent } from 'app/pages/vm/vm-wizard/steps/1-os-step/os-step.component';
@@ -51,8 +51,8 @@ describe('OsStepComponent', () => {
       'Boot Method': 'UEFI',
       'Shutdown Timeout': 90,
       'Start on Boot': true,
-      'Enable Display': true,
-      Password: '12345678910',
+      'Enable Display (VNC)': true,
+      Password: '12345678',
       Bind: '10.10.16.82',
     });
   }
@@ -68,10 +68,9 @@ describe('OsStepComponent', () => {
       bootloader: VmBootloader.Uefi,
       shutdown_timeout: 90,
       autostart: true,
-      enable_display: true,
-      display_type: VmDisplayType.Spice,
-      bind: '10.10.16.82',
-      password: '12345678910',
+      enable_vnc: true,
+      vnc_bind: '10.10.16.82',
+      vnc_password: '12345678',
       hyperv_enlightenments: false,
       enable_secure_boot: true,
       trusted_platform_module: false,
@@ -107,5 +106,99 @@ describe('OsStepComponent', () => {
         value: 'Linux',
       },
     ]);
+  });
+
+  describe('VNC Display', () => {
+    it('enables VNC fields when Enable Display (VNC) is checked', async () => {
+      await form.fillForm({
+        'Enable Display (VNC)': true,
+      });
+
+      const formValues = await form.getValues();
+      expect(formValues).toMatchObject({
+        'Enable Display (VNC)': true,
+      });
+
+      // VNC fields should be accessible
+      expect(spectator.component.form.controls.vnc_bind.enabled).toBe(true);
+      expect(spectator.component.form.controls.vnc_password.enabled).toBe(true);
+    });
+
+    it('disables VNC fields when Enable Display (VNC) is unchecked', async () => {
+      await form.fillForm({
+        'Enable Display (VNC)': true,
+        Bind: '10.10.16.82',
+        Password: 'vncpass',
+      });
+
+      await form.fillForm({
+        'Enable Display (VNC)': false,
+      });
+
+      // VNC fields should be disabled
+      expect(spectator.component.form.controls.vnc_bind.disabled).toBe(true);
+      expect(spectator.component.form.controls.vnc_password.disabled).toBe(true);
+    });
+
+    it('validates VNC password with 8-character limit', async () => {
+      await form.fillForm({
+        'Enable Display (VNC)': true,
+        Password: '123456789', // 9 characters - should be invalid
+      });
+
+      expect(spectator.component.form.controls.vnc_password.invalid).toBe(true);
+      expect(spectator.component.form.controls.vnc_password.hasError('maxlength')).toBe(true);
+    });
+
+    it('accepts VNC password with 8 characters or less', async () => {
+      await form.fillForm({
+        'Enable Display (VNC)': true,
+        Password: '12345678', // 8 characters - should be valid
+      });
+
+      expect(spectator.component.form.controls.vnc_password.valid).toBe(true);
+    });
+
+    it('requires VNC password when VNC is enabled', async () => {
+      await form.fillForm({
+        'Enable Display (VNC)': true,
+        Password: '', // Empty password - should be invalid
+      });
+
+      expect(spectator.component.form.controls.vnc_password.invalid).toBe(true);
+      expect(spectator.component.form.controls.vnc_password.hasError('required')).toBe(true);
+    });
+
+    it('shows VNC form values when enabled', async () => {
+      await form.fillForm({
+        'Enable Display (VNC)': true,
+        Password: 'vncpass',
+        Bind: '10.10.16.82',
+      });
+
+      expect(spectator.component.form.value).toMatchObject({
+        enable_vnc: true,
+        vnc_password: 'vncpass',
+        vnc_bind: '10.10.16.82',
+      });
+    });
+
+    it('shows complete form values with VNC enabled', async () => {
+      await form.fillForm({
+        'Guest Operating System': 'Linux',
+        Name: 'vnc-test-vm',
+        'Enable Display (VNC)': true,
+        Password: 'vncpass',
+        Bind: '10.10.16.82',
+      });
+
+      expect(spectator.component.form.value).toMatchObject({
+        os: VmOs.Linux,
+        name: 'vnc-test-vm',
+        enable_vnc: true,
+        vnc_password: 'vncpass',
+        vnc_bind: '10.10.16.82',
+      });
+    });
   });
 });

--- a/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.ts
@@ -8,7 +8,6 @@ import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {
   VmBootloader,
-  VmDisplayType,
   VmOs,
   vmOsLabels,
   VmTime,
@@ -70,10 +69,9 @@ export class OsStepComponent implements SummaryProvider {
     trusted_platform_module: [false],
     shutdown_timeout: [90, [Validators.min(0)]],
     autostart: [true],
-    enable_display: [true],
-    display_type: [VmDisplayType.Spice],
-    bind: ['0.0.0.0', [Validators.required]],
-    password: ['', Validators.required],
+    enable_vnc: [true],
+    vnc_bind: ['0.0.0.0', [Validators.required]],
+    vnc_password: ['', [Validators.required, Validators.maxLength(8)]],
   });
 
   readonly helptext = helptextVmWizard;
@@ -85,16 +83,21 @@ export class OsStepComponent implements SummaryProvider {
   readonly bindOptions$ = this.api.call('vm.device.bind_choices').pipe(choicesToOptions());
 
   constructor() {
-    this.form.controls.enable_display.valueChanges.pipe(untilDestroyed(this)).subscribe((isEnabled) => {
+    // Handle VNC display controls
+    this.form.controls.enable_vnc.valueChanges.pipe(untilDestroyed(this)).subscribe((isEnabled) => {
       if (isEnabled) {
-        this.form.controls.password.enable();
-        this.form.controls.bind.enable();
-        this.form.controls.display_type.enable();
+        this.form.controls.vnc_password.setValidators([Validators.required, Validators.maxLength(8)]);
+        this.form.controls.vnc_bind.setValidators([Validators.required]);
+        this.form.controls.vnc_bind.enable();
+        this.form.controls.vnc_password.enable();
       } else {
-        this.form.controls.password.disable();
-        this.form.controls.bind.disable();
-        this.form.controls.display_type.disable();
+        this.form.controls.vnc_password.clearValidators();
+        this.form.controls.vnc_bind.clearValidators();
+        this.form.controls.vnc_bind.disable();
+        this.form.controls.vnc_password.disable();
       }
+      this.form.controls.vnc_password.updateValueAndValidity();
+      this.form.controls.vnc_bind.updateValueAndValidity();
     });
   }
 

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
@@ -82,6 +82,7 @@ describe('VmWizardComponent', () => {
           UEFI: 'UEFI',
         }),
         mockCall('vm.device.bind_choices', {
+          '0.0.0.0': '0.0.0.0',
           '10.10.16.82': '10.10.16.82',
         }),
         mockCall('vm.cpu_model_choices', {
@@ -157,6 +158,7 @@ describe('VmWizardComponent', () => {
     await form.fillForm({
       'Guest Operating System': 'Windows',
       Name: 'test',
+      'Enable Display (VNC)': true,
       Password: '12345678',
     });
     await nextButton.click();
@@ -339,8 +341,9 @@ describe('VmWizardComponent', () => {
         bind: '0.0.0.0',
         password: '12345678',
         port: 13669,
-        type: VmDisplayType.Spice,
-        web: true,
+        resolution: '1920x1080',
+        type: VmDisplayType.Vnc,
+        web: false,
       },
     }]);
     expect(spectator.inject(GpuService).addIsolatedGpuPciIds).toHaveBeenCalledWith(

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -14,7 +14,7 @@ import { catchError, defaultIfEmpty } from 'rxjs/operators';
 import { GiB, MiB } from 'app/constants/bytes.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
-import { VmDeviceType, VmNicType, VmOs } from 'app/enums/vm.enum';
+import { VmDeviceType, VmDisplayType, VmNicType, VmOs } from 'app/enums/vm.enum';
 import { VirtualMachine, VirtualMachineUpdate } from 'app/interfaces/virtual-machine.interface';
 import { VmDevice, VmDeviceUpdate } from 'app/interfaces/vm-device.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -238,8 +238,8 @@ export class VmWizardComponent implements OnInit {
       requests.push(this.getCdromRequest(vm));
     }
 
-    if (this.osForm.enable_display) {
-      requests.push(this.getDisplayRequest(vm));
+    if (this.osForm.enable_vnc) {
+      requests.push(this.getVncDisplayRequest(vm));
     }
 
     if (this.gpuForm.gpus.length) {
@@ -308,17 +308,18 @@ export class VmWizardComponent implements OnInit {
     );
   }
 
-  private getDisplayRequest(vm: VirtualMachine): Observable<VmDevice | null> {
+  private getVncDisplayRequest(vm: VirtualMachine): Observable<VmDevice | null> {
     return this.api.call('vm.port_wizard').pipe(
       switchMap((port) => {
         return this.makeDeviceRequest(vm.id, {
           attributes: {
             dtype: VmDeviceType.Display,
             port: port.port,
-            bind: this.osForm.bind,
-            password: this.osForm.password,
-            web: true,
-            type: this.osForm.display_type,
+            bind: this.osForm.vnc_bind,
+            password: this.osForm.vnc_password,
+            resolution: '1920x1080',
+            web: false,
+            type: VmDisplayType.Vnc,
           },
         });
       }),

--- a/src/app/services/vm.service.ts
+++ b/src/app/services/vm.service.ts
@@ -1,12 +1,12 @@
 import { Injectable, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { untilDestroyed } from '@ngneat/until-destroy';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateService } from '@ngx-translate/core';
 import {
   BehaviorSubject, filter, Observable, repeat, Subject, switchMap, take,
 } from 'rxjs';
 import { ApiErrorName } from 'app/enums/api.enum';
-import { VmState } from 'app/enums/vm.enum';
+import { VmDisplayType, VmState } from 'app/enums/vm.enum';
 import { extractApiErrorDetails } from 'app/helpers/api.helper';
 import { WINDOW } from 'app/helpers/window.helper';
 import { helptextVmList } from 'app/helptext/vm/vm-list';
@@ -18,6 +18,7 @@ import {
   VmDisplayWebUriParams,
   VmDisplayWebUriParamsOptions,
 } from 'app/interfaces/virtual-machine.interface';
+import { VmDisplayDevice } from 'app/interfaces/vm-device.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -25,6 +26,7 @@ import { StopVmDialogComponent, StopVmDialogData } from 'app/pages/vm/vm-list/st
 import { DownloadService } from 'app/services/download.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 
+@UntilDestroy()
 @Injectable({ providedIn: 'root' })
 export class VmService {
   private api = inject(ApiService);
@@ -102,7 +104,35 @@ export class VmService {
     this.api.call('vm.get_display_devices', [vm.id])
       .pipe(this.loader.withLoader(), take(1))
       .subscribe({
-        next: () => this.openDisplayWebUri(vm.id),
+        next: (devices: VmDisplayDevice[]) => {
+          const spiceDevice = devices.find((device) => device.attributes.type === VmDisplayType.Spice);
+          const vncDevices = devices.filter((device) => device.attributes.type === VmDisplayType.Vnc);
+
+          if (spiceDevice?.attributes.web) {
+            this.openDisplayWebUri(vm.id);
+          } else if (vncDevices.length > 0) {
+            const vncConnections = vncDevices.map((device) => `${device.attributes.bind}:${device.attributes.port}`).join(', ');
+            this.dialogService.info(
+              this.translate.instant('VNC Display Available'),
+              this.translate.instant('Connect using a VNC client to: {connections}', { connections: vncConnections }),
+              true,
+            );
+          } else if (spiceDevice && !spiceDevice.attributes.web) {
+            this.dialogService.info(
+              this.translate.instant('SPICE Display Available'),
+              this.translate.instant(
+                'Web access is disabled. Connect using a SPICE client to: {connection}',
+                { connection: `${spiceDevice.attributes.bind}:${spiceDevice.attributes.port}` },
+              ),
+              true,
+            );
+          } else {
+            this.dialogService.warn(
+              this.translate.instant('No Display Available'),
+              this.translate.instant('No display devices are configured for this VM.'),
+            );
+          }
+        },
         error: (error: unknown) => this.errorHandler.showErrorModal(error),
       });
   }


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 0cfbcea3120fb66d52e84bc0748269a527c3753d
    git cherry-pick -x 9d233ee78eda48a6d7425f9e5ed40929d1d136c1

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 0041bdfaeffbf89306fd5f1a591ba0fa25ad7b6f

**Changes:**
* VNC display configuration now available in the VM wizard as well as "Add Device" form.
* SPICE display configuration has been removed from the VM wizard (still available via Add Device form).
* One SPICE display and one VNC display can be configured simultaneously.

**Testing:**
* Create a VM and configure a VNC display. Use your preferred VNC client to connect.
* After VM creation, verify that an additional SPICE display can also be configured.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | SPICE display config has been removed from the VM wizard in favor of VNC. SPICE displays can only be configured after VM creation via the Add Device form.
|Testing         | Configure a VNC display for a VM and connect via your preferred VNC client application.


Original PR: https://github.com/truenas/webui/pull/12427
