### PR TITLE
NAS-137170 / 25.10-RC.1 / Save buttons showing error dialog instead of being locked and inaccessible on Users (WIP) screen for Restricted admins (by AlexKarpov98)

### DIFF
--- a/src/app/pages/credentials/new-users/user-form/user-form.component.html
+++ b/src/app/pages/credentials/new-users/user-form/user-form.component.html
@@ -28,6 +28,7 @@
 
   <ix-form-actions>
     <button
+      *ixRequiresRoles="requiredRoles"
       mat-button
       type="submit"
       color="primary"

--- a/src/app/pages/credentials/new-users/user-form/user-form.component.ts
+++ b/src/app/pages/credentials/new-users/user-form/user-form.component.ts
@@ -10,6 +10,7 @@ import {
   startWith,
   switchMap,
 } from 'rxjs';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import {
   hasShellAccess, hasSshAccess, hasTrueNasAccess, isEmptyHomeDirectory,
@@ -53,6 +54,7 @@ import { AppState } from 'app/store';
     TestDirective,
     AuthSectionComponent,
     AdditionalDetailsSectionComponent,
+    RequiresRolesDirective,
   ],
   providers: [
     UserFormStore,
@@ -82,6 +84,7 @@ export class UserFormComponent implements OnInit {
   protected readonly tooltips = tooltips;
   protected readonly Role = Role;
   protected readonly fakeTooltip = '';
+  protected readonly requiredRoles = [Role.AccountWrite];
 
   protected form = this.formBuilder.group({
     username: ['', [

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.html
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.html
@@ -85,6 +85,7 @@
             ixTest="back"
           >{{ 'Back' | translate }}</button>
           <button
+            *ixRequiresRoles="requiredRoles"
             mat-button
             matStepperNext
             color="primary"

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.spec.ts
@@ -7,6 +7,7 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { MockComponents } from 'ng-mocks';
 import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { NvmeOfNamespaceType } from 'app/enums/nvme-of.enum';
 import { NvmeOfHost, NvmeOfPort, NvmeOfSubsystem } from 'app/interfaces/nvme-of.interface';
 import { DetailsTableHarness } from 'app/modules/details-table/details-table.harness';
@@ -48,6 +49,7 @@ describe('AddSubsystemComponent', () => {
         associatePorts: jest.fn(() => of(undefined)),
         associateHosts: jest.fn(() => of(undefined)),
       }),
+      mockAuth(),
       mockApi([
         mockCall('nvmet.subsys.create', newSubsystem),
         mockCall('nvmet.namespace.create'),

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.ts
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.ts
@@ -14,6 +14,8 @@ import {
   finalize, forkJoin, map, Observable, of, switchMap,
   tap,
 } from 'rxjs';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
+import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { helptextNvmeOf } from 'app/helptext/sharing/nvme-of/nvme-of';
 import {
@@ -72,6 +74,7 @@ import { checkIfServiceIsEnabled } from 'app/store/services/services.actions';
     IxCheckboxComponent,
     AddSubsystemHostsComponent,
     AddSubsystemNamespacesComponent,
+    RequiresRolesDirective,
     AddSubsystemPortsComponent,
     DetailsItemComponent,
     DetailsTableComponent,
@@ -90,6 +93,7 @@ export class AddSubsystemComponent {
   private matDialog = inject(MatDialog);
 
   protected isLoading = signal(false);
+  requiredRoles = [Role.SharingNvmeTargetWrite];
 
   protected form = this.formBuilder.group({
     name: ['', Validators.required],


### PR DESCRIPTION
Testing: see ticket.
Create `readonly` user and check the affected places.

Preview: 

https://github.com/user-attachments/assets/337c0610-c8d0-4784-a725-db5e0f19bed6



Original PR: https://github.com/truenas/webui/pull/12429
