### PR TITLE
NAS-137176 / 26.04 / renamed dark and blue theme labels

### DIFF
--- a/src/app/modules/theme/theme.constants.ts
+++ b/src/app/modules/theme/theme.constants.ts
@@ -2,7 +2,7 @@ import { Theme } from 'app/interfaces/theme.interface';
 
 export const defaultTheme: Theme = {
   name: 'ix-dark',
-  label: 'iX Dark',
+  label: 'Dark',
   labelSwatch: 'blue',
   description: 'TrueNAS default theme',
   accentColors: ['blue', 'magenta', 'orange', 'cyan', 'yellow', 'violet', 'red', 'green', 'pink', 'aqua', 'tomato', 'teal', 'slategray', 'salmon'],
@@ -38,7 +38,7 @@ export const allThemes: Theme[] = [
   defaultTheme,
   {
     name: 'ix-blue',
-    label: 'iX Blue',
+    label: 'Blue',
     labelSwatch: 'blue',
     description: 'Official iX System Colors on light',
     accentColors: ['blue', 'orange', 'cyan', 'violet', 'yellow', 'magenta', 'red', 'green', 'pink', 'aqua', 'tomato', 'teal', 'slategray', 'salmon'],

--- a/src/app/pages/system/general-settings/gui/gui-card/gui-card.component.html
+++ b/src/app/pages/system/general-settings/gui/gui-card/gui-card.component.html
@@ -20,7 +20,7 @@
       <mat-list-item [ixUiSearch]="searchableElements.elements.theme">
         <span class="label">{{ 'Theme' | translate }}:</span>
         <span *ixWithLoadingState="preferences$ as preferences" class="value">
-          {{ preferences.userTheme }}
+          {{ themeLabel() }}
         </span>
       </mat-list-item>
       <mat-list-item [ixUiSearch]="searchableElements.elements.sslCertificate">

--- a/src/app/pages/system/general-settings/gui/gui-card/gui-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/gui/gui-card/gui-card.component.spec.ts
@@ -61,7 +61,7 @@ describe('GuiCardComponent', () => {
     const itemTexts = await parallel(() => items.map((item) => item.getFullText()));
 
     expect(itemTexts).toEqual([
-      'Theme: ix-dark',
+      'Theme: Dark',
       'GUI SSL Certificate: truenas_default',
       'Web Interface IPv4 Address: 0.0.0.0',
       'Web Interface IPv6 Address: 0.0.0.0',

--- a/src/app/pages/system/general-settings/gui/gui-card/gui-card.component.ts
+++ b/src/app/pages/system/general-settings/gui/gui-card/gui-card.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { MatList, MatListItem } from '@angular/material/list';
@@ -15,6 +16,7 @@ import { helptextSystemGeneral as helptext } from 'app/helptext/system/general';
 import { WithLoadingStateDirective } from 'app/modules/loader/directives/with-loading-state/with-loading-state.directive';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { TestDirective } from 'app/modules/test-id/test.directive';
+import { allThemes } from 'app/modules/theme/theme.constants';
 import { guiCardElements } from 'app/pages/system/general-settings/gui/gui-card/gui-card.elements';
 import { GuiFormComponent } from 'app/pages/system/general-settings/gui/gui-form/gui-form.component';
 import { AppState } from 'app/store';
@@ -58,6 +60,14 @@ export class GuiCardComponent {
     waitForPreferences,
     toLoadingState(),
   );
+
+  private preferencesSignal = toSignal(this.preferences$);
+
+  protected themeLabel = computed(() => {
+    const preferences = this.preferencesSignal();
+    const theme = preferences?.value?.userTheme;
+    return allThemes.find((themeItem) => themeItem.name === theme)?.label;
+  });
 
   readonly helptext = helptext;
 

--- a/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.spec.ts
+++ b/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.spec.ts
@@ -145,7 +145,7 @@ describe('GuiFormComponent', () => {
           'GUI SSL Certificate': 'freenas_default',
           'HTTPS Protocols': ['TLSv1.2', 'TLSv1.3'],
           'Show Console Messages': false,
-          Theme: 'iX Dark',
+          Theme: 'Dark',
           'Usage collection & UI error reporting': false,
           'Web Interface HTTP -> HTTPS Redirect': false,
           'Web Interface HTTP Port': '80',


### PR DESCRIPTION
**Changes:**
- removed `iX` in the theme labels
<img width="702" height="164" alt="image" src="https://github.com/user-attachments/assets/bdbbda01-f9e0-4617-bab6-ed0663bbd37b" />

**Testing:**

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
