### PR TITLE
NAS-137241 / 26.04 / warn users about adding special/dedup VDEVs with no redundancy

### DIFF
--- a/src/app/helptext/storage/volumes/pool-creation/pool-creation.ts
+++ b/src/app/helptext/storage/volumes/pool-creation/pool-creation.ts
@@ -37,4 +37,7 @@ export const helptextPoolCreation = {
   raidz3Tooltip: T('Uses three disks for parity while all other disks store data. RAIDZ3 requires at least five disks. RAIDZ is a traditional ZFS data protection scheme. \nChoose RAIDZ over dRAID when managing a smaller set of drives, where simplicity of setup and predictable disk usage are primary considerations.'),
 
   dRaidChildrenExplanation: T('The number of children must at the minimum accomodate the total number of disks required for the previous configuration options including parity drives.'),
+
+  addVdevStripeSpecialWarning: T('Adding a stripe metadata VDEV introduces a single point of failure to your pool.'),
+  addVdevStripeDedupWarning: T('Adding a stripe dedup VDEV introduces a single point of failure to your pool.'),
 };


### PR DESCRIPTION
**Changes:**
During add VDEV workflow, adds warnings about special and dedup VDEVs lacking redundancy.

**Testing:**
* Create a pool
* Navigate to that pool's "Add VDEV" workflow.
* Verify that adding special or dedup VDEVs without redundancy results in a red warning message.
