### PR TITLE
NAS-137150 / 25.10-RC.1 / Private Key and Passphrase Validation Errors when Importing CSR (by AlexKarpov98)

### DIFF
--- a/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-import/csr-import.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-import/csr-import.component.spec.ts
@@ -59,4 +59,66 @@ describe('CsrImportComponent', () => {
       },
     ]);
   });
+
+  it('converts empty strings to null in getPayload()', async () => {
+    await form.fillForm({
+      'Signing Request': csr,
+      'Private Key': '',
+      Passphrase: '',
+      'Confirm Passphrase': '',
+    });
+
+    expect(spectator.component.getPayload()).toEqual({
+      CSR: csr,
+      passphrase: null,
+      privatekey: null,
+    });
+  });
+
+  it('returns summary without passphrase when passphrase is empty', async () => {
+    await form.fillForm({
+      'Signing Request': csr,
+      'Private Key': 'ABHDDJJKEY',
+      Passphrase: '',
+      'Confirm Passphrase': '',
+    });
+
+    expect(spectator.component.getSummary()).toEqual([
+      {
+        label: 'Signing Request',
+        value: 'ABCDEF......654321',
+      },
+    ]);
+  });
+
+  it('handles whitespace-only strings by converting to null', async () => {
+    await form.fillForm({
+      'Signing Request': csr,
+      'Private Key': '   ',
+      Passphrase: ' \t ',
+      'Confirm Passphrase': ' \t ',
+    });
+
+    const payload = spectator.component.getPayload();
+    expect(payload.passphrase).toBeNull();
+    expect(payload.privatekey).toBeNull();
+  });
+
+  it('preserves non-empty values correctly', async () => {
+    const privateKey = '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----';
+    const passphrase = 'my-secure-passphrase';
+
+    await form.fillForm({
+      'Signing Request': csr,
+      'Private Key': privateKey,
+      Passphrase: passphrase,
+      'Confirm Passphrase': passphrase,
+    });
+
+    expect(spectator.component.getPayload()).toEqual({
+      CSR: csr,
+      passphrase,
+      privatekey: privateKey,
+    });
+  });
 });

--- a/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-import/csr-import.component.ts
+++ b/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-import/csr-import.component.ts
@@ -70,12 +70,12 @@ export class CsrImportComponent implements SummaryProvider {
     return summary;
   }
 
-  getPayload(): Omit<CsrImportComponent['form']['value'], 'passphrase2'> {
+  getPayload(): { CSR: string; privatekey: string | null; passphrase: string | null } {
     const values = this.form.getRawValue();
 
     return {
       CSR: normalizeCertificateNewlines(values.CSR) || '',
-      privatekey: normalizeCertificateNewlines(values.privatekey),
+      privatekey: normalizeCertificateNewlines(values.privatekey) || null,
       passphrase: values.passphrase?.trim() || null,
     };
   }

--- a/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-import/csr-import.component.ts
+++ b/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-import/csr-import.component.ts
@@ -12,6 +12,7 @@ import { matchOthersFgValidator } from 'app/modules/forms/ix-forms/validators/pa
 import { SummaryProvider, SummarySection } from 'app/modules/summary/summary.interface';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { getCertificatePreview } from 'app/pages/credentials/certificates-dash/utils/get-certificate-preview.utils';
+import { normalizeCertificateNewlines } from 'app/pages/credentials/certificates-dash/utils/normalize-certificate.utils';
 
 @UntilDestroy()
 @Component({
@@ -73,8 +74,8 @@ export class CsrImportComponent implements SummaryProvider {
     const values = this.form.getRawValue();
 
     return {
-      CSR: values.CSR,
-      privatekey: values.privatekey?.trim() || null,
+      CSR: normalizeCertificateNewlines(values.CSR) || '',
+      privatekey: normalizeCertificateNewlines(values.privatekey),
       passphrase: values.passphrase?.trim() || null,
     };
   }

--- a/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-import/csr-import.component.ts
+++ b/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-import/csr-import.component.ts
@@ -4,7 +4,6 @@ import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { pick } from 'lodash-es';
 import { helptextSystemCertificates } from 'app/helptext/system/certificates';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
@@ -71,8 +70,12 @@ export class CsrImportComponent implements SummaryProvider {
   }
 
   getPayload(): Omit<CsrImportComponent['form']['value'], 'passphrase2'> {
-    const values = this.form.value;
+    const values = this.form.getRawValue();
 
-    return pick(values, ['CSR', 'privatekey', 'passphrase']);
+    return {
+      CSR: values.CSR,
+      privatekey: values.privatekey?.trim() || null,
+      passphrase: values.passphrase?.trim() || null,
+    };
   }
 }

--- a/src/app/pages/credentials/certificates-dash/import-certificate/import-certificate.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/import-certificate/import-certificate.component.spec.ts
@@ -103,7 +103,7 @@ describe('ImportCertificateComponent', () => {
       name: 'test-cert-no-private-key',
       add_to_trusted_store: false,
       certificate: '--BEING CERTIFICATE--',
-      privatekey: undefined,
+      privatekey: null,
       passphrase: null,
       create_type: CertificateCreateType.Import,
     }]);

--- a/src/app/pages/credentials/certificates-dash/import-certificate/import-certificate.component.ts
+++ b/src/app/pages/credentials/certificates-dash/import-certificate/import-certificate.component.ts
@@ -25,6 +25,7 @@ import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
+import { normalizeCertificateNewlines } from 'app/pages/credentials/certificates-dash/utils/normalize-certificate.utils';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 
 @UntilDestroy()
@@ -114,11 +115,14 @@ export class ImportCertificateComponent {
   }
 
   private getPayload(): CertificateCreate {
+    const values = this.form.getRawValue();
+
     return {
-      ...omit(this.form.getRawValue(), ['passphrase2']),
+      ...omit(values, ['passphrase2']),
       create_type: CertificateCreateType.Import,
-      passphrase: this.form.controls.passphrase.value || null,
-      privatekey: this.form.controls.privatekey.value || undefined,
+      certificate: normalizeCertificateNewlines(values.certificate) || '',
+      privatekey: normalizeCertificateNewlines(values.privatekey) || undefined,
+      passphrase: values.passphrase || null,
     };
   }
 }

--- a/src/app/pages/credentials/certificates-dash/import-certificate/import-certificate.component.ts
+++ b/src/app/pages/credentials/certificates-dash/import-certificate/import-certificate.component.ts
@@ -121,7 +121,7 @@ export class ImportCertificateComponent {
       ...omit(values, ['passphrase2']),
       create_type: CertificateCreateType.Import,
       certificate: normalizeCertificateNewlines(values.certificate) || '',
-      privatekey: normalizeCertificateNewlines(values.privatekey) || undefined,
+      privatekey: normalizeCertificateNewlines(values.privatekey) || null,
       passphrase: values.passphrase || null,
     };
   }

--- a/src/app/pages/credentials/certificates-dash/utils/normalize-certificate.utils.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/utils/normalize-certificate.utils.spec.ts
@@ -1,0 +1,79 @@
+import { normalizeCertificateNewlines } from './normalize-certificate.utils';
+
+describe('normalizeCertificateNewlines', () => {
+  it('converts escaped newlines to proper newlines', () => {
+    const input = 'line1\\nline2\\nline3';
+    const expected = 'line1\nline2\nline3';
+
+    expect(normalizeCertificateNewlines(input)).toBe(expected);
+  });
+
+  it('handles certificate data with escaped newlines', () => {
+    const certificateData = '-----BEGIN CERTIFICATE-----\\nMIIDrTCCApWgAwIBAgIENFgbaDANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMC\\n-----END CERTIFICATE-----';
+    const expected = '-----BEGIN CERTIFICATE-----\nMIIDrTCCApWgAwIBAgIENFgbaDANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMC\n-----END CERTIFICATE-----';
+
+    expect(normalizeCertificateNewlines(certificateData)).toBe(expected);
+  });
+
+  it('trims whitespace from the result', () => {
+    const input = '  line1\\nline2\\nline3  ';
+    const expected = 'line1\nline2\nline3';
+
+    expect(normalizeCertificateNewlines(input)).toBe(expected);
+  });
+
+  it('returns null for empty string', () => {
+    expect(normalizeCertificateNewlines('')).toBeNull();
+  });
+
+  it('returns null for null input', () => {
+    expect(normalizeCertificateNewlines(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(normalizeCertificateNewlines(undefined)).toBeNull();
+  });
+
+  it('returns null for whitespace-only string', () => {
+    expect(normalizeCertificateNewlines('   ')).toBeNull();
+  });
+
+  it('returns null for whitespace-only string with escaped newlines', () => {
+    expect(normalizeCertificateNewlines('\\n\\n\\n')).toBeNull();
+  });
+
+  it('handles mixed real and escaped newlines', () => {
+    const input = 'line1\nline2\\nline3';
+    const expected = 'line1\nline2\nline3';
+
+    expect(normalizeCertificateNewlines(input)).toBe(expected);
+  });
+
+  it('preserves already normalized certificate data', () => {
+    const certificateData = '-----BEGIN CERTIFICATE-----\nMIIDrTCCApWgAwIBAgIENFgbaDANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMC\n-----END CERTIFICATE-----';
+
+    expect(normalizeCertificateNewlines(certificateData)).toBe(certificateData);
+  });
+
+  describe('usage patterns with explicit null handling', () => {
+    it('handles required field pattern: normalizeCertificateNewlines(data) || ""', () => {
+      // Required fields should use || '' to ensure non-null string
+      expect(normalizeCertificateNewlines('cert\\ndata') || '').toBe('cert\ndata');
+      expect(normalizeCertificateNewlines('') || '').toBe('');
+      expect(normalizeCertificateNewlines('   ') || '').toBe('');
+    });
+
+    it('handles optional field pattern: normalizeCertificateNewlines(data)', () => {
+      // Optional fields can be null
+      expect(normalizeCertificateNewlines('key\\ndata')).toBe('key\ndata');
+      expect(normalizeCertificateNewlines('')).toBeNull();
+      expect(normalizeCertificateNewlines('   ')).toBeNull();
+    });
+
+    it('handles undefined fallback pattern: normalizeCertificateNewlines(data) || undefined', () => {
+      // Some optional fields use undefined instead of null
+      expect(normalizeCertificateNewlines('key\\ndata') || undefined).toBe('key\ndata');
+      expect(normalizeCertificateNewlines('') || undefined).toBeUndefined();
+    });
+  });
+});

--- a/src/app/pages/credentials/certificates-dash/utils/normalize-certificate.utils.ts
+++ b/src/app/pages/credentials/certificates-dash/utils/normalize-certificate.utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Normalizes certificate data by converting escaped newlines to proper newlines
+ * and handling empty/whitespace-only strings.
+ *
+ * This utility is commonly needed when handling certificate data from form inputs
+ * where newlines may be escaped as \\n instead of proper \n characters.
+ *
+ * @param certData - The certificate data string to normalize
+ * @returns Normalized certificate data with proper newlines, or null if empty/whitespace-only
+ */
+export function normalizeCertificateNewlines(certData: string): string | null {
+  if (!certData) return null;
+  const normalized = certData.replace(/\\n/g, '\n').trim();
+  return normalized || null;
+}


### PR DESCRIPTION
**Testing:** 
see ticket and use CSR and Private key from the Comment here -> https://ixsystems.atlassian.net/browse/NAS-137150?focusedCommentId=317319

The form should be submitted successfully now.

Added more tests + util method.

Original PR: https://github.com/truenas/webui/pull/12423
