### PR TITLE
NAS-137291: VM list does not remember column state

### DIFF
--- a/src/app/pages/vm/vm-list.component.html
+++ b/src/app/pages/vm/vm-list.component.html
@@ -11,7 +11,11 @@
     </div>
 
     <ix-search-input1 [value]="filterString" (search)="onListFiltered($event)"></ix-search-input1>
-    <ix-table-columns-selector [columns]="columns" (columnsChange)="columnsChange($event)"></ix-table-columns-selector>
+    <ix-table-columns-selector
+      [columnPreferencesKey]="'vmList'"
+      [columns]="columns"
+      (columnsChange)="columnsChange($event)"
+    ></ix-table-columns-selector>
 
     <button
       *ixRequiresRoles="requiredRoles"


### PR DESCRIPTION
Testing: see ticket.

Now VM list remembers column state.


https://github.com/user-attachments/assets/70662903-996d-4830-a4e3-a5868dccac5a

