### PR TITLE
NAS-137154 / 25.10-RC.1 / Sorting on Display Port not proper (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-table/classes/base-data-provider.ts
+++ b/src/app/modules/ix-table/classes/base-data-provider.ts
@@ -87,11 +87,16 @@ export function sort<T>(rows: T[], sorting: TableSort<T>): T[] {
   const direction = sorting.direction;
   const propertyName = sorting.propertyName;
 
-  if (direction === null || propertyName === null) {
+  if (direction === null) {
     return sorted;
   }
+
   if (sorting.sortBy) {
     return direction === SortDirection.Desc ? sortBy(sorted, sorting.sortBy).reverse() : sortBy(sorted, sorting.sortBy);
+  }
+
+  if (propertyName === null) {
+    return sorted;
   }
 
   return orderBy(sorted, propertyName, direction);


### PR DESCRIPTION
Testing: see ticket.
Fixed sorting for all VM fields.

Preview:

https://github.com/user-attachments/assets/9d40d83d-9c03-4dce-95bf-70289b12acea



Original PR: https://github.com/truenas/webui/pull/12454
