### PR TITLE
NAS-137230 / 25.10-RC.1 / Fix misleading help text for Show Text Console without Password Prompt (by AlexKarpov98)

### DIFF
--- a/src/app/helptext/system/advanced.ts
+++ b/src/app/helptext/system/advanced.ts
@@ -13,8 +13,9 @@ export const helptextSystemAdvanced = {
   systemDatasetTooltip: T('Store system logs on the system dataset. Unset to store system logs in <i>/var/</i> on the operating system device.'),
   syslogAuditTooltip: T('Check to enable Audit Logs'),
 
-  consoleMenuTooltip: T('Unset to add a login prompt to the system before\
- the console menu is shown.'),
+  consoleMenuTooltip: T('Select to display the TrueNAS console menu without authentication.\n\n\
+When unset, you must log in before accessing the console.\n\n\
+Note: If the administrative account Shell is not set to TrueNAS Console, you enter the Linux shell. Enter <code>cli --menu</code> to access the console menu.'),
 
   serialConsoleTooltip: T('Do not set this if the Serial Port is disabled.'),
 


### PR DESCRIPTION
Code review is enough.

Preview:

<img width="445" height="194" alt="Screenshot 2025-08-27 at 10 29 47" src="https://github.com/user-attachments/assets/e91695fa-400b-42af-b66a-fcbb8ccb1119" />


Original PR: https://github.com/truenas/webui/pull/12462
