### PR TITLE
NAS-137291 / 25.10-RC.1 / VM list does not remember column state (by AlexKarpov98)

### DIFF
--- a/src/app/pages/vm/vm-list.component.html
+++ b/src/app/pages/vm/vm-list.component.html
@@ -11,7 +11,11 @@
     </div>
 
     <ix-search-input1 [value]="filterString" (search)="onListFiltered($event)"></ix-search-input1>
-    <ix-table-columns-selector [columns]="columns" (columnsChange)="columnsChange($event)"></ix-table-columns-selector>
+    <ix-table-columns-selector
+      [columnPreferencesKey]="'vmList'"
+      [columns]="columns"
+      (columnsChange)="columnsChange($event)"
+    ></ix-table-columns-selector>
 
     <button
       *ixRequiresRoles="requiredRoles"

--- a/src/app/pages/vm/vm-list.component.spec.ts
+++ b/src/app/pages/vm/vm-list.component.spec.ts
@@ -3,6 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
+import { provideMockStore } from '@ngrx/store/testing';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
@@ -66,6 +67,15 @@ describe('VmListComponent', () => {
       mockApi([
         mockCall('vm.query', virtualMachines),
       ]),
+      provideMockStore({
+        initialState: {
+          preferences: {
+            preferences: {
+              vmList: {},
+            },
+          },
+        },
+      }),
       mockProvider(SystemGeneralService, {
         isEnterprise: () => false,
       }),


### PR DESCRIPTION
Testing: see ticket.

Now VM list remembers column state.


https://github.com/user-attachments/assets/70662903-996d-4830-a4e3-a5868dccac5a



Original PR: https://github.com/truenas/webui/pull/12455
