### PR TITLE
NAS-137088 / 25.10-RC.1 / Handle network activity disabled status in update page (by william-gr)

### DIFF
--- a/src/app/enums/api.enum.ts
+++ b/src/app/enums/api.enum.ts
@@ -2,8 +2,10 @@ export enum ApiErrorName {
   NotAuthenticated = 'ENOTAUTHENTICATED',
   NoAccess = 'EACCES',
   NoMemory = 'ENOMEM',
+  NoNetwork = 'ENONET',
   AlreadyExists = 'EEXIST',
   Again = 'EAGAIN',
+  Fault = 'EFAULT',
   Validation = 'EINVAL',
 }
 

--- a/src/app/enums/system-update.enum.ts
+++ b/src/app/enums/system-update.enum.ts
@@ -3,6 +3,7 @@ export enum UpdateCode {
   Error = 'ERROR',
   RebootRequired = 'REBOOT_REQUIRED',
   HaUnavailable = 'HA_UNAVAILABLE',
+  NetworkActivityDisabled = 'NETWORK_ACTIVITY_DISABLED',
 }
 
 export enum SystemUpdateOperationType {

--- a/src/app/pages/system/update/update.component.html
+++ b/src/app/pages/system/update/update.component.html
@@ -39,7 +39,7 @@
           </h4>
         }
 
-        @if (status()?.error) {
+        @if (status()?.error && !isNetworkActivityDisabled()) {
           <h4>
             {{ status()?.error }}
           </h4>
@@ -80,6 +80,10 @@
 
     @if (isRebootRequired()) {
       <h4 class="hint">{{ 'An update is already applied. Please restart the system.' | translate }}</h4>
+    }
+
+    @if (isNetworkActivityDisabled()) {
+      <h4 class="hint">{{ 'Network activity has been administratively disabled for update operation. Please use Manual Update.' | translate }}</h4>
     }
 
     @if (changelog() || newVersion()?.release_notes_url) {


### PR DESCRIPTION
- Add NetworkActivityDisabled to UpdateCode enum for identifying disabled network status
- Add NoNetwork (ENONET) and Fault (EFAULT) to ApiErrorName enum
- Implement handleApiError method to silently handle ENONET errors without showing error dialogs
- Display user-friendly message "Network activity has been administratively disabled for update operation. Please use Manual Update." when network is disabled
- Hide error field when status code is NETWORK_ACTIVITY_DISABLED
- Add comprehensive test coverage for network disabled status and error handling scenarios

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

Disable network activity for update in Network global settings and navigate to update page.
You will need middleware changes committed today.
Websocket debug panel wont work because it cant mock error messages yet.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/12463
