### PR TITLE
NAS-137215 / 25.10-RC.1 / Clean up Containers screen areas that are specific to the disabled VMs area (by AlexKarpov98)

### DIFF
--- a/src/app/enums/virtualization.enum.ts
+++ b/src/app/enums/virtualization.enum.ts
@@ -1,5 +1,4 @@
 import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
-import { iconMarker } from 'app/modules/ix-icon/icon-marker.util';
 
 export enum ImageOs {
   Linux = 'Linux',
@@ -36,21 +35,6 @@ export const diskIoBusLabels = new Map<DiskIoBus, string>([
   [DiskIoBus.VirtioBlk, 'Virtio-BLK'],
   [DiskIoBus.VirtioScsi, 'Virtio-SCSI'],
 ]);
-
-export const virtualizationTypeIcons = [
-  {
-    value: VirtualizationType.Container,
-    icon: iconMarker('mdi-linux'),
-    label: T('Container'),
-    description: T('Linux Only'),
-  },
-  {
-    value: VirtualizationType.Vm,
-    icon: iconMarker('mdi-laptop'),
-    label: T('VM'),
-    description: T('Any OS'),
-  },
-];
 
 export enum VirtualizationStatus {
   Running = 'RUNNING',

--- a/src/app/pages/instances/components/all-instances/all-instances-header/all-instances-header.component.spec.ts
+++ b/src/app/pages/instances/components/all-instances/all-instances-header/all-instances-header.component.spec.ts
@@ -40,6 +40,7 @@ describe('AllInstancesHeaderComponent', () => {
     providers: [
       mockProvider(VirtualizationInstancesStore, {
         initialize: jest.fn(),
+        instances: signal([]),
       }),
       mockProvider(VirtualizationConfigStore, storeMock),
       mockProvider(SlideIn, {

--- a/src/app/pages/instances/components/all-instances/all-instances-header/all-instances-header.component.ts
+++ b/src/app/pages/instances/components/all-instances/all-instances-header/all-instances-header.component.ts
@@ -6,7 +6,8 @@ import { RouterLink } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
-import { VirtualizationGlobalState } from 'app/enums/virtualization.enum';
+import { VirtualizationGlobalState, VirtualizationType } from 'app/enums/virtualization.enum';
+import { VirtualizationVolume } from 'app/interfaces/virtualization.interface';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { TestDirective } from 'app/modules/test-id/test.directive';
@@ -22,6 +23,7 @@ import {
 } from 'app/pages/instances/components/all-instances/all-instances-header/virtualization-state/virtualization-state.component';
 import {
   VolumesDialog,
+  VolumesDialogOptions,
 } from 'app/pages/instances/components/common/volumes-dialog/volumes-dialog.component';
 import {
   VirtualizationConfigStore,
@@ -82,8 +84,15 @@ export class AllInstancesHeaderComponent {
   }
 
   protected onManageVolumes(): void {
-    this.matDialog.open(VolumesDialog, {
+    this.matDialog.open<VolumesDialog, VolumesDialogOptions, VirtualizationVolume>(VolumesDialog, {
       minWidth: '80vw',
+      data: {
+        selectionMode: false,
+        config: this.config(),
+        showIsoManagement: this.instanceStore?.instances()?.filter(
+          (instance) => instance.type === VirtualizationType.Vm,
+        ).length > 0,
+      },
     });
   }
 

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disk-form/instance-disk-form.component.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-disks/instance-disk-form/instance-disk-form.component.ts
@@ -139,6 +139,7 @@ export class InstanceDiskFormComponent implements OnInit {
         data: {
           selectionMode: true,
           config: null,
+          showIsoManagement: this.instance.type === VirtualizationType.Vm,
         },
       })
       .afterClosed()

--- a/src/app/pages/instances/components/common/volumes-dialog/volumes-dialog.component.html
+++ b/src/app/pages/instances/components/common/volumes-dialog/volumes-dialog.component.html
@@ -53,16 +53,19 @@
         {{ 'Import Zvols' | translate }}
       </button>
     </div>
-    <div>
-      <ix-upload-iso (uploaded)="onImageUploaded()"></ix-upload-iso>
-      <button
-        mat-button
-        [ixTest]="['import-iso']"
-        (click)="importIso()"
-      >
-        <ix-icon name="mdi-database"></ix-icon>
-        {{ 'Import ISO' | translate }}
-      </button>
-    </div>
+
+    @if (options().showIsoManagement) {
+      <div>
+        <ix-upload-iso (uploaded)="onImageUploaded()"></ix-upload-iso>
+        <button
+          mat-button
+          [ixTest]="['import-iso']"
+          (click)="importIso()"
+        >
+          <ix-icon name="mdi-database"></ix-icon>
+          {{ 'Import ISO' | translate }}
+        </button>
+      </div>
+    }
   </div>
 </mat-dialog-content>

--- a/src/app/pages/instances/components/common/volumes-dialog/volumes-dialog.component.ts
+++ b/src/app/pages/instances/components/common/volumes-dialog/volumes-dialog.component.ts
@@ -51,6 +51,7 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 export interface VolumesDialogOptions {
   selectionMode: boolean;
   config: VirtualizationGlobalConfig | null;
+  showIsoManagement: boolean | null;
 }
 
 @UntilDestroy()
@@ -87,7 +88,11 @@ export class VolumesDialog implements OnInit {
   protected emptyService = inject(EmptyService);
   protected dialogRef = inject<MatDialogRef<VolumesDialog, VirtualizationVolume | null>>(MatDialogRef);
 
-  private options = signal<VolumesDialogOptions>({ selectionMode: false, config: null });
+  protected options = signal<VolumesDialogOptions>({
+    selectionMode: false,
+    config: null,
+    showIsoManagement: false,
+  });
 
   protected requiredRoles = [Role.VirtImageWrite];
 
@@ -160,7 +165,7 @@ export class VolumesDialog implements OnInit {
   constructor() {
     const options = inject<VolumesDialogOptions>(MAT_DIALOG_DATA);
 
-    this.options.set(options || { selectionMode: false, config: null });
+    this.options.set(options || { selectionMode: false, config: null, showIsoManagement: false });
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
**Changes:**
- Removed logic related to VM in Volumes dialog if no VMs provided

<!-- Briefly describe what changed. -->

https://github.com/user-attachments/assets/5261ffd3-316e-40d2-b144-b4ab0a4bc1e9


**Testing:**
Containers -> Manage Volumes should not show the buttons related to ISO management if no VM provided: Upload and Import.
<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Removed logic related to VM in Volumes dialog if no VMs provided
|Testing         |


Original PR: https://github.com/truenas/webui/pull/12471
