### PR TITLE
NAS-137315 / 26.04 / Refactor syslog configuration to support multiple servers

### DIFF
--- a/src/app/interfaces/advanced-config.interface.ts
+++ b/src/app/interfaces/advanced-config.interface.ts
@@ -1,6 +1,12 @@
 import { SedUser } from 'app/enums/sed-user.enum';
 import { SyslogLevel, SyslogTransport } from 'app/enums/syslog.enum';
 
+export interface SyslogServer {
+  host: string;
+  transport?: SyslogTransport;
+  tls_certificate?: number | null;
+}
+
 export interface AdvancedConfig {
   advancedmode: boolean;
   anonstats: boolean;
@@ -22,15 +28,12 @@ export interface AdvancedConfig {
   serialconsole: boolean;
   serialport: string;
   serialspeed: string;
-  syslog_tls_certificate: number;
-  syslog_transport: SyslogTransport;
   syslog_audit: boolean;
   sysloglevel: SyslogLevel;
-  syslogserver: string;
+  syslogservers: SyslogServer[];
   traceback: boolean;
   uploadcrash: boolean;
   sed_passwd: string;
-  syslog_tls_certificate_authority: number;
   kernel_extra_options: string;
   legacy_ui?: boolean;
 }

--- a/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.html
+++ b/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.html
@@ -29,15 +29,9 @@
         </span>
       </mat-list-item>
       <mat-list-item [ixUiSearch]="searchableElements.elements.server">
-        <span class="label">{{ 'Syslog Server' | translate }}:</span>
+        <span class="label">{{ 'Syslog Servers' | translate }}:</span>
         <span *ixWithLoadingState="advancedConfig$ as advancedConfig" class="value">
-          {{ advancedConfig.syslogserver }}
-        </span>
-      </mat-list-item>
-      <mat-list-item [ixUiSearch]="searchableElements.elements.transport">
-        <span class="label">{{ 'Syslog Transport' | translate }}:</span>
-        <span *ixWithLoadingState="advancedConfig$ as advancedConfig" class="value">
-          {{ advancedConfig.syslog_transport }}
+          {{ formatSyslogServers(advancedConfig) }}
         </span>
       </mat-list-item>
       <mat-list-item [ixUiSearch]="searchableElements.elements.includeAuditLogs">

--- a/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.spec.ts
+++ b/src/app/pages/system/advanced/syslog/syslog-card/syslog-card.component.spec.ts
@@ -19,6 +19,7 @@ import { selectAdvancedConfig } from 'app/store/system-config/system-config.sele
 describe('SyslogCardComponent', () => {
   let spectator: Spectator<SyslogCardComponent>;
   let loader: HarnessLoader;
+
   const createComponent = createComponentFactory({
     component: SyslogCardComponent,
     imports: [
@@ -33,10 +34,14 @@ describe('SyslogCardComponent', () => {
             selector: selectAdvancedConfig,
             value: {
               fqdn_syslog: true,
-              syslogserver: '127.1.2.3',
               sysloglevel: SyslogLevel.Alert,
-              syslog_transport: SyslogTransport.Tcp,
               syslog_audit: false,
+              syslogservers: [
+                {
+                  host: '127.1.2.3',
+                  transport: SyslogTransport.Tcp,
+                },
+              ],
             } as AdvancedConfig,
           },
         ],
@@ -62,11 +67,11 @@ describe('SyslogCardComponent', () => {
     expect(itemTexts).toEqual([
       'Use FQDN for Logging: Enabled',
       'Syslog Level: Alert',
-      'Syslog Server: 127.1.2.3',
-      'Syslog Transport: TCP',
+      'Syslog Servers: 127.1.2.3 (TCP)',
       'Include Audit Logs: No',
     ]);
   });
+
 
   it('opens Syslog form when Configure button is pressed', async () => {
     const configureButton = await loader.getHarness(MatButtonHarness.with({ text: 'Configure' }));
@@ -79,13 +84,40 @@ describe('SyslogCardComponent', () => {
         data: {
           fqdn_syslog: true,
           syslog_audit: false,
-          syslog_tls_certificate: undefined,
-          syslog_tls_certificate_authority: undefined,
-          syslog_transport: 'TCP',
           sysloglevel: 'F_ALERT',
-          syslogserver: '127.1.2.3',
+          syslogservers: [
+            {
+              host: '127.1.2.3',
+              transport: 'TCP',
+            },
+          ],
         },
       },
     );
+  });
+
+  it('displays multiple syslog servers correctly', () => {
+    // Access protected method via bracket notation
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    const formatMethod = spectator.component['formatSyslogServers'];
+    const result = formatMethod.call(spectator.component, {
+      syslogservers: [
+        { host: 'server1.com', transport: SyslogTransport.Udp },
+        { host: 'server2.com', transport: SyslogTransport.Tls },
+      ],
+    });
+
+    expect(result).toBe('server1.com (UDP), server2.com (TLS)');
+  });
+
+  it('displays "None" when no syslog servers are configured', () => {
+    // Access protected method via bracket notation
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    const formatMethod = spectator.component['formatSyslogServers'];
+    const result = formatMethod.call(spectator.component, {
+      syslogservers: [],
+    });
+
+    expect(result).toBe('None');
   });
 });

--- a/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.html
+++ b/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.html
@@ -22,33 +22,62 @@
           [required]="true"
         ></ix-select>
 
-        <ix-input
-          formControlName="syslogserver"
-          [label]="'Syslog Server' | translate"
-          [tooltip]="tooltips.syslogserver | translate"
-        ></ix-input>
+        <div formArrayName="syslogservers" role="group" [attr.aria-label]="'Syslog Servers List' | translate">
+          @for (server of syslogServersArray.controls; track server; let i = $index) {
+            <div class="server-group" [formGroupName]="i" [attr.aria-label]="('Syslog Server' | translate) + ' ' + (i + 1)">
+              <h4 [id]="'server-heading-' + i">{{ 'Syslog Server' | translate }} {{ i + 1 }}</h4>
+              <ix-input
+                formControlName="host"
+                [label]="'Host' | translate"
+                [tooltip]="tooltips.syslogserver | translate"
+              ></ix-input>
 
-        <ix-select
-          formControlName="syslog_transport"
-          [label]="'Syslog Transport' | translate"
-          [tooltip]="tooltips.syslog_transport | translate"
-          [options]="transportOptions$"
-        ></ix-select>
+              <ix-select
+                formControlName="transport"
+                [label]="'Transport' | translate"
+                [tooltip]="tooltips.syslog_transport | translate"
+                [options]="transportOptions$"
+              ></ix-select>
 
-        @if (isTlsTransport$ | async) {
-          <ix-select
-            formControlName="syslog_tls_certificate"
-            [label]="'Syslog TLS Certificate' | translate"
-            [tooltip]="tooltips.syslog_transport | translate"
-            [options]="certificateOptions$"
-          ></ix-select>
+              @if (server.value.transport === 'TLS') {
+                <ix-select
+                  formControlName="tls_certificate"
+                  [label]="'TLS Certificate' | translate"
+                  [tooltip]="tooltips.syslog_tls_certificate | translate"
+                  [options]="certificateOptions$"
+                ></ix-select>
+              }
 
-          <ix-select
-            formControlName="syslog_tls_certificate_authority"
-            [label]="'Syslog TLS Certificate Authority' | translate"
-            [options]="certificateAuthorityOptions$"
-            [required]="true"
-          ></ix-select>
+              @if (canRemoveServer) {
+                <button
+                  mat-button
+                  type="button"
+                  color="warn"
+                  [attr.aria-label]="('Remove Syslog Server' | translate) + ' ' + (i + 1)"
+                  (click)="removeServer(i)"
+                >
+                  {{ 'Remove Server' | translate }}
+                </button>
+              }
+            </div>
+          }
+        </div>
+
+        @if (canAddServer) {
+          <button
+            mat-button
+            type="button"
+            class="add-server-button"
+            [attr.aria-label]="'Add another syslog server' | translate"
+            (click)="addServer()"
+          >
+            {{ 'Add Syslog Server' | translate }}
+            <span class="server-limit-hint">({{ syslogServersArray.length }}/2)</span>
+          </button>
+        } @else {
+          <p class="server-limit-message" role="status" aria-live="polite">
+            {{ 'Maximum of 2 syslog servers allowed' | translate }}
+          </p>
         }
 
         <ix-checkbox

--- a/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.scss
+++ b/src/app/pages/system/advanced/syslog/syslog-form/syslog-form.component.scss
@@ -1,0 +1,34 @@
+.server-group {
+  border: 1px solid var(--lines);
+  border-radius: 4px;
+  margin-bottom: 24px;
+  padding: 16px;
+
+  h4 {
+    margin-bottom: 16px;
+    margin-top: 0;
+  }
+
+  button {
+    margin-top: 16px;
+  }
+}
+
+.add-server-button {
+  margin-bottom: 24px;
+  margin-top: 16px;
+  
+  .server-limit-hint {
+    color: var(--fg2);
+    font-size: 0.875rem;
+    margin-left: 8px;
+  }
+}
+
+.server-limit-message {
+  color: var(--fg2);
+  font-size: 0.875rem;
+  margin-bottom: 16px;
+  margin-top: 8px;
+  text-align: center;
+}

--- a/src/assets/ui-searchable-elements.json
+++ b/src/assets/ui-searchable-elements.json
@@ -4801,25 +4801,6 @@
       "System",
       "Advanced Settings",
       "Syslog",
-      "Syslog Transport"
-    ],
-    "synonyms": [],
-    "requiredRoles": [],
-    "visibleTokens": [],
-    "anchorRouterLink": [
-      "/system",
-      "advanced"
-    ],
-    "routerLink": null,
-    "anchor": "syslog-transport",
-    "triggerAnchor": null,
-    "section": "ui"
-  },
-  {
-    "hierarchy": [
-      "System",
-      "Advanced Settings",
-      "Syslog",
       "Include Audit Logs"
     ],
     "synonyms": [],


### PR DESCRIPTION
- Replace single syslogserver with array of up to 2 syslog servers
- Each server can have its own host, transport, and TLS certificate settings
- Add dynamic form controls for adding/removing syslog servers
- Allow configuration with zero syslog servers (disabled state)
- Convert TLS certificate select values to integers for proper API compatibility
- Add conditional validation requiring TLS certificate when transport is TLS
- Improve UX with server count indicators (1/2, 2/2) and limit messaging
- Add ARIA labels for accessibility on dynamic form elements
- Create helper function for FormArray length testing to work around Jest/ngneat incompatibility
- Add comprehensive test coverage for multi-server scenarios
- Use FormArray.clear() instead of while loop for better performance
- Make "None" translatable in server display
- Add styling for server configuration groups

**Changes:**

https://github.com/user-attachments/assets/a1569ad9-b28a-4e0e-ac30-25b9aa18205d

Screen Recording 2025-09-02 at 3.09.45 PM

**Testing:**

Several combinations of syslog servers

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |Now multipole syslog servers are allowed
|Testing         |Multiple syslog servers
