### PR TITLE
NAS-137360 / 25.10-RC.1 / auto-generated SSH Keypair should be displayed on new SSH Connection creation (by gmbok19)

### DIFF
--- a/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.spec.ts
+++ b/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.spec.ts
@@ -57,6 +57,7 @@ describe('SshConnectionFormComponent', () => {
           { id: 1, name: 'key1' },
           { id: 2, name: 'key2' },
         ]),
+        addSshConnection: jest.fn(() => of(existingConnection)),
       }),
       mockProvider(DialogService),
       mockProvider(MatDialogRef),
@@ -155,7 +156,7 @@ describe('SshConnectionFormComponent', () => {
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await saveButton.click();
 
-      expect(api.call).toHaveBeenCalledWith('keychaincredential.setup_ssh_connection', [{
+      expect(spectator.inject(KeychainCredentialService).addSshConnection).toHaveBeenCalledWith({
         setup_type: SshConnectionsSetupMethod.Manual,
         connection_name: 'New',
         private_key: {
@@ -169,7 +170,7 @@ describe('SshConnectionFormComponent', () => {
           remote_host_key: 'ssh-rsaNew',
           username: 'john',
         },
-      }]);
+      });
       expect(closeSlideInRef).toHaveBeenCalledWith({ response: existingConnection });
     });
 
@@ -192,7 +193,7 @@ describe('SshConnectionFormComponent', () => {
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await saveButton.click();
 
-      expect(api.call).toHaveBeenCalledWith('keychaincredential.setup_ssh_connection', [{
+      expect(spectator.inject(KeychainCredentialService).addSshConnection).toHaveBeenCalledWith({
         connection_name: 'Update',
         setup_type: SshConnectionsSetupMethod.SemiAutomatic,
         private_key: {
@@ -208,7 +209,7 @@ describe('SshConnectionFormComponent', () => {
           admin_username: 'admin',
           sudo: true,
         },
-      }]);
+      });
     });
 
     it('gets remote host key and puts it in corresponding textarea when Discover Remote Host Key is pressed', async () => {
@@ -246,7 +247,7 @@ describe('SshConnectionFormComponent', () => {
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
       await saveButton.click();
 
-      expect(api.call).toHaveBeenCalledWith('keychaincredential.setup_ssh_connection', [{
+      expect(spectator.inject(KeychainCredentialService).addSshConnection).toHaveBeenCalledWith({
         connection_name: 'Test',
         setup_type: SshConnectionsSetupMethod.SemiAutomatic,
         private_key: {
@@ -262,7 +263,7 @@ describe('SshConnectionFormComponent', () => {
           admin_username: 'root',
           sudo: false,
         },
-      }]);
+      });
     });
   });
 });

--- a/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/ssh-connection-form/ssh-connection-form.component.ts
@@ -271,7 +271,7 @@ export class SshConnectionFormComponent implements OnInit {
       };
     }
 
-    return this.api.call('keychaincredential.setup_ssh_connection', [params]).pipe(
+    return this.keychainCredentialService.addSshConnection(params).pipe(
       catchError((error: unknown) => {
         const apiError = extractApiErrorDetails(error);
         if (apiError?.errname?.includes(sslCertificationError) || apiError?.reason?.includes(sslCertificationError)) {
@@ -285,7 +285,7 @@ export class SshConnectionFormComponent implements OnInit {
             switchMap((retry) => {
               if (retry) {
                 params.semi_automatic_setup.verify_ssl = false;
-                return this.api.call('keychaincredential.setup_ssh_connection', [params]);
+                return this.keychainCredentialService.addSshConnection(params);
               }
               return throwError(() => error);
             }),

--- a/src/app/pages/credentials/backup-credentials/ssh-keypair-card/ssh-keypair-card.component.spec.ts
+++ b/src/app/pages/credentials/backup-credentials/ssh-keypair-card/ssh-keypair-card.component.spec.ts
@@ -4,7 +4,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { KeychainSshKeyPair } from 'app/interfaces/keychain-credential.interface';
@@ -78,6 +78,7 @@ describe('SshKeypairCardComponent', () => {
       mockProvider(DownloadService),
       mockProvider(KeychainCredentialService, {
         getSshKeys: jest.fn(() => of(credentials)),
+        refetchSshKeys: new Subject<void>(),
       }),
       mockAuth(),
     ],

--- a/src/app/pages/credentials/backup-credentials/ssh-keypair-card/ssh-keypair-card.component.ts
+++ b/src/app/pages/credentials/backup-credentials/ssh-keypair-card/ssh-keypair-card.component.ts
@@ -110,6 +110,10 @@ export class SshKeypairCardComponent implements OnInit {
     this.dataProvider = new AsyncDataProvider<KeychainSshKeyPair>(credentials$);
     this.setDefaultSort();
     this.getCredentials();
+
+    this.keychainCredentialService.refetchSshKeys
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.getCredentials());
   }
 
   getCredentials(): void {

--- a/src/app/services/keychain-credential.service.spec.ts
+++ b/src/app/services/keychain-credential.service.spec.ts
@@ -1,0 +1,113 @@
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { of } from 'rxjs';
+import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
+import { KeychainCredentialType } from 'app/enums/keychain-credential-type.enum';
+import { SshConnectionsSetupMethod } from 'app/enums/ssh-connections-setup-method.enum';
+import { KeychainSshCredentials, KeychainSshKeyPair } from 'app/interfaces/keychain-credential.interface';
+import { SshConnectionSetup } from 'app/interfaces/ssh-connection-setup.interface';
+import { ApiService } from 'app/modules/websocket/api.service';
+import { KeychainCredentialService } from './keychain-credential.service';
+
+describe('KeychainCredentialService', () => {
+  let spectator: SpectatorService<KeychainCredentialService>;
+  let service: KeychainCredentialService;
+
+  const sshKeys = [
+    { id: 1, name: 'key1' },
+    { id: 2, name: 'key2' },
+  ] as KeychainSshKeyPair[];
+
+  const sshConnections = [
+    { id: 1, name: 'connection1' },
+    { id: 2, name: 'connection2' },
+  ] as KeychainSshCredentials[];
+
+  const connectionSetup = {
+    setup_type: SshConnectionsSetupMethod.Manual,
+    connection_name: 'test',
+    private_key: { generate_key: false, existing_key_id: 1 },
+  } as SshConnectionSetup;
+
+  const newConnection = {
+    id: 3,
+    name: 'test',
+  } as KeychainSshCredentials;
+
+  const createService = createServiceFactory({
+    service: KeychainCredentialService,
+    providers: [
+      mockApi([
+        mockCall('keychaincredential.query', sshKeys),
+        mockCall('keychaincredential.setup_ssh_connection', newConnection),
+      ]),
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+    service = spectator.service;
+  });
+
+  describe('getSshKeys', () => {
+    it('should return SSH keys', () => {
+      service.getSshKeys().subscribe((keys) => {
+        expect(keys).toEqual(sshKeys);
+      });
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('keychaincredential.query', [
+        [['type', '=', KeychainCredentialType.SshKeyPair]],
+      ]);
+    });
+  });
+
+  describe('getSshConnections', () => {
+    beforeEach(() => {
+      const api = spectator.inject(ApiService);
+      (api.call as jest.Mock).mockReturnValue(of(sshConnections));
+    });
+
+    it('should return SSH connections', () => {
+      service.getSshConnections().subscribe((connections) => {
+        expect(connections).toEqual(sshConnections);
+      });
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('keychaincredential.query', [
+        [['type', '=', KeychainCredentialType.SshCredentials]],
+      ]);
+    });
+  });
+
+  describe('addSshConnection', () => {
+    it('should add SSH connection and trigger refetch when generating new key', () => {
+      const refetchSpy = jest.spyOn(service.refetchSshKeys, 'next');
+      const setupWithNewKey = {
+        ...connectionSetup,
+        private_key: { generate_key: true, name: 'test-key' },
+      };
+
+      service.addSshConnection(setupWithNewKey).subscribe((connection) => {
+        expect(connection).toEqual(newConnection);
+      });
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith(
+        'keychaincredential.setup_ssh_connection',
+        [setupWithNewKey],
+      );
+      expect(refetchSpy).toHaveBeenCalled();
+    });
+
+    it('should add SSH connection and NOT trigger refetch when using existing key', () => {
+      const refetchSpy = jest.spyOn(service.refetchSshKeys, 'next');
+
+      service.addSshConnection(connectionSetup).subscribe((connection) => {
+        expect(connection).toEqual(newConnection);
+      });
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith(
+        'keychaincredential.setup_ssh_connection',
+        [connectionSetup],
+      );
+      expect(refetchSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/services/keychain-credential.service.ts
+++ b/src/app/services/keychain-credential.service.ts
@@ -24,7 +24,11 @@ export class KeychainCredentialService {
   addSshConnection(connection: SshConnectionSetup): Observable<KeychainSshCredentials> {
     return this.api.call('keychaincredential.setup_ssh_connection', [connection])
       .pipe(tap(() => {
-        this.refetchSshKeys.next();
+      // Only refetch if a new key was generated
+        const willGenerateNewKey = connection.private_key?.generate_key === true;
+        if (willGenerateNewKey) {
+          this.refetchSshKeys.next();
+        }
       }));
   }
 }

--- a/src/app/services/keychain-credential.service.ts
+++ b/src/app/services/keychain-credential.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, Subject, tap } from 'rxjs';
 import { KeychainCredentialType } from 'app/enums/keychain-credential-type.enum';
 import { KeychainSshCredentials, KeychainSshKeyPair } from 'app/interfaces/keychain-credential.interface';
+import { SshConnectionSetup } from 'app/interfaces/ssh-connection-setup.interface';
 import { ApiService } from 'app/modules/websocket/api.service';
 
 @Injectable({
@@ -9,6 +10,7 @@ import { ApiService } from 'app/modules/websocket/api.service';
 })
 export class KeychainCredentialService {
   protected api = inject(ApiService);
+  refetchSshKeys = new Subject<void>();
 
 
   getSshKeys(): Observable<KeychainSshKeyPair[]> {
@@ -17,5 +19,12 @@ export class KeychainCredentialService {
 
   getSshConnections(): Observable<KeychainSshCredentials[]> {
     return this.api.call('keychaincredential.query', [[['type', '=', KeychainCredentialType.SshCredentials]]]) as Observable<KeychainSshCredentials[]>;
+  }
+
+  addSshConnection(connection: SshConnectionSetup): Observable<KeychainSshCredentials> {
+    return this.api.call('keychaincredential.setup_ssh_connection', [connection])
+      .pipe(tap(() => {
+        this.refetchSshKeys.next();
+      }));
   }
 }


### PR DESCRIPTION
**Changes:**
- The auto-generated SSH keypair should be displayed immediately after creating a new SSH connection.

https://github.com/user-attachments/assets/afdcba50-ec2a-4879-a898-1d9481fe3565


**Testing:**
1. Navigate to Credentials -> Backup Credentials
2. Click `Add` button in SSH Connection
3. Fill out and submit the form
4. If `Generate New` is selected as Private Key, it will immediately update the list of SSH Keypairs after form submission


### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/12491
