### PR TITLE
NAS-137395 / 25.10-RC.1 / Do not require Port in NVMe-oF and show 4420 as placeholder (by william-gr)

### DIFF
--- a/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.html
+++ b/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.html
@@ -18,7 +18,7 @@
           formControlName="addr_trsvcid"
           [label]="'Port' | translate"
           [type]="isFibreChannel ? 'text' : 'number'"
-          [required]="true"
+          [placeholder]="portPlaceholder"
         ></ix-input>
 
         <ix-select

--- a/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.ts
+++ b/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.ts
@@ -23,6 +23,7 @@ import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/for
 import { ModalHeaderComponent } from 'app/modules/slide-ins/components/modal-header/modal-header.component';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { TestDirective } from 'app/modules/test-id/test.directive';
+import { TranslatedString } from 'app/modules/translate/translate.helper';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { NvmeOfService } from 'app/pages/sharing/nvme-of/services/nvme-of.service';
 
@@ -72,7 +73,7 @@ export class PortFormComponent implements OnInit {
 
   protected form = this.formBuilder.group({
     addr_trtype: [NvmeOfTransportType.Tcp],
-    addr_trsvcid: [null as number | string, Validators.required],
+    addr_trsvcid: [null as number | string],
     addr_traddr: ['', Validators.required],
   });
 
@@ -92,6 +93,10 @@ export class PortFormComponent implements OnInit {
     return this.form.value.addr_trtype === NvmeOfTransportType.FibreChannel;
   }
 
+  get portPlaceholder(): TranslatedString {
+    return (this.isFibreChannel ? '' : '4420') as TranslatedString;
+  }
+
   ngOnInit(): void {
     const existingPort = this.slideInRef.getData();
 
@@ -106,6 +111,11 @@ export class PortFormComponent implements OnInit {
     this.isLoading.set(true);
 
     const payload = this.form.getRawValue();
+
+    // Use default port 4420 if no port was specified (only for TCP/RDMA, not for Fibre Channel)
+    if (!payload.addr_trsvcid && !this.isFibreChannel) {
+      payload.addr_trsvcid = 4420;
+    }
 
     const request$ = this.isNew()
       ? this.api.call('nvmet.port.create', [payload])


### PR DESCRIPTION
**Changes:**

<img width="464" height="480" alt="image" src="https://github.com/user-attachments/assets/8932ce5b-99e9-4bcc-b119-8798cdcf0ca5" />

**Testing:**

Try to add nvme Port with a TCP port.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |Port no longer required
|Testing         |Test without and with port


Original PR: https://github.com/truenas/webui/pull/12488
