### PR TITLE
NAS-137407 / 26.04 / added back the the refresh directory services cache button

### DIFF
--- a/src/app/helptext/directory-service/dashboard.ts
+++ b/src/app/helptext/directory-service/dashboard.ts
@@ -32,4 +32,9 @@ export const helptextDashboard = {
     title: T('Warning'),
     message: T('Changing Advanced settings can be dangerous when done incorrectly. Please use caution before saving.'),
   },
+  rebuildCache: {
+    success: T('Directory Service cache has been rebuilt.'),
+    error: T('Failed to rebuild directory service cache.'),
+    errorTitle: T('Error'),
+  },
 };

--- a/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.spec.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.spec.ts
@@ -3,21 +3,15 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { MockComponents } from 'ng-mocks';
-import { of, throwError } from 'rxjs';
-import { JobProgressDialogRef } from 'app/classes/job-progress-dialog-ref.class';
-import { JobState } from 'app/enums/job-state.enum';
+import { of } from 'rxjs';
 import { DirectoryServicesConfig } from 'app/interfaces/directoryservices-config.interface';
-import { Job } from 'app/interfaces/job.interface';
 import { AuthService } from 'app/modules/auth/auth.service';
-import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
-import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ActiveDirectoryConfigComponent } from 'app/pages/directory-service/components/directory-services-form/active-directory-config/active-directory-config.component';
 import { CredentialConfigComponent } from 'app/pages/directory-service/components/directory-services-form/credential-config/credential-config.component';
 import { IpaConfigComponent } from 'app/pages/directory-service/components/directory-services-form/ipa-config/ipa-config.component';
 import { LdapConfigComponent } from 'app/pages/directory-service/components/directory-services-form/ldap-config/ldap-config.component';
-import { SystemGeneralService } from 'app/services/system-general.service';
 import { DirectoryServicesFormComponent } from './directory-services-form.component';
 
 describe('DirectoryServicesConfigFormComponent', () => {
@@ -47,26 +41,6 @@ describe('DirectoryServicesConfigFormComponent', () => {
       }),
       mockProvider(AuthService, {
         hasRole: jest.fn(() => of(true)),
-      }),
-      mockProvider(DialogService, {
-        jobDialog: jest.fn(() => ({
-          afterClosed: jest.fn(() => of({ description: 'Directory Service cache has been rebuilt.' })),
-        })),
-        error: jest.fn(),
-      }),
-      mockProvider(SnackbarService, {
-        success: jest.fn(),
-      }),
-      mockProvider(SystemGeneralService, {
-        refreshDirServicesCache: jest.fn(() => of({
-          id: 1,
-          method: 'directoryservices.cache_refresh',
-          arguments: [],
-          description: 'Refreshing directory services cache',
-          state: JobState.Success,
-          abortable: false,
-          transient: false,
-        } as Job)),
       }),
     ],
   });
@@ -114,100 +88,6 @@ describe('DirectoryServicesConfigFormComponent', () => {
       });
 
       expect(spectator.query(IpaConfigComponent)).toBeTruthy();
-    });
-  });
-
-  describe('onRebuildCachePressed', () => {
-    it('should call systemGeneralService.refreshDirServicesCache and show success message', () => {
-      const systemGeneralService = spectator.inject(SystemGeneralService);
-      const dialogService = spectator.inject(DialogService);
-      const snackbarService = spectator.inject(SnackbarService);
-
-      const mockJob = {
-        id: 1,
-        method: 'directoryservices.cache_refresh',
-        arguments: [],
-        description: 'Refreshing directory services cache',
-        state: JobState.Success,
-        abortable: false,
-        transient: false,
-      } as Job;
-
-      jest.spyOn(systemGeneralService, 'refreshDirServicesCache').mockReturnValue(of(mockJob));
-      const mockDialogRef = {
-        afterClosed: jest.fn(() => of({ description: 'Cache rebuilt successfully' })),
-      } as unknown as JobProgressDialogRef<unknown>;
-      jest.spyOn(dialogService, 'jobDialog').mockReturnValue(mockDialogRef);
-
-      const rebuildButton = spectator.query('[ixTest="rebuild-cache"]') as HTMLButtonElement;
-      rebuildButton.click();
-
-      expect(systemGeneralService.refreshDirServicesCache).toHaveBeenCalled();
-      expect(dialogService.jobDialog).toHaveBeenCalled();
-      expect(snackbarService.success).toHaveBeenCalledWith('Cache rebuilt successfully');
-    });
-
-    it('should show error dialog when cache rebuild fails', () => {
-      const systemGeneralService = spectator.inject(SystemGeneralService);
-      const dialogService = spectator.inject(DialogService);
-
-      // Mock console.error to prevent test failure
-      jest.spyOn(console, 'error').mockImplementation();
-
-      const mockJob = {
-        id: 1,
-        method: 'directoryservices.cache_refresh',
-        arguments: [],
-        description: 'Refreshing directory services cache',
-        state: JobState.Success,
-        abortable: false,
-        transient: false,
-      } as Job;
-
-      jest.spyOn(systemGeneralService, 'refreshDirServicesCache').mockReturnValue(of(mockJob));
-
-      // Mock jobDialog to return a dialog ref that emits an error from afterClosed
-      const mockDialogRef = {
-        afterClosed: jest.fn(() => throwError(() => new Error('Cache rebuild failed'))),
-      } as unknown as JobProgressDialogRef<unknown>;
-      jest.spyOn(dialogService, 'jobDialog').mockReturnValue(mockDialogRef);
-      jest.spyOn(dialogService, 'error');
-
-      const rebuildButton = spectator.query('[ixTest="rebuild-cache"]') as HTMLButtonElement;
-      rebuildButton.click();
-
-      expect(dialogService.error).toHaveBeenCalledWith({
-        title: 'Error',
-        message: 'Failed to rebuild directory service cache.',
-      });
-      expect(console.error).toHaveBeenCalledWith('Failed to rebuild directory service cache:', expect.any(Error));
-    });
-
-    it('should show default success message when no description is provided', () => {
-      const systemGeneralService = spectator.inject(SystemGeneralService);
-      const dialogService = spectator.inject(DialogService);
-      const snackbarService = spectator.inject(SnackbarService);
-
-      const mockJob = {
-        id: 1,
-        method: 'directoryservices.cache_refresh',
-        arguments: [],
-        description: 'Refreshing directory services cache',
-        state: JobState.Success,
-        abortable: false,
-        transient: false,
-      } as Job;
-
-      jest.spyOn(systemGeneralService, 'refreshDirServicesCache').mockReturnValue(of(mockJob));
-      const mockDialogRef = {
-        afterClosed: jest.fn(() => of({ description: null })),
-      } as unknown as JobProgressDialogRef<unknown>;
-      jest.spyOn(dialogService, 'jobDialog').mockReturnValue(mockDialogRef);
-
-      const rebuildButton = spectator.query('[ixTest="rebuild-cache"]') as HTMLButtonElement;
-      rebuildButton.click();
-
-      expect(snackbarService.success).toHaveBeenCalledWith('Directory Service cache has been rebuilt.');
     });
   });
 });

--- a/src/app/pages/directory-service/directory-services.component.ts
+++ b/src/app/pages/directory-service/directory-services.component.ts
@@ -392,6 +392,10 @@ export class DirectoryServicesComponent implements OnInit {
   }
 
   protected onRebuildCachePressed(): void {
+    if (this.isLoading()) {
+      return;
+    }
+
     this.isLoading.set(true);
     this.dialog
       .jobDialog(this.systemGeneralService.refreshDirServicesCache())
@@ -403,15 +407,15 @@ export class DirectoryServicesComponent implements OnInit {
       .subscribe({
         next: ({ description }) => {
           this.snackbarService.success(
-            this.translate.instant(description || 'Directory Service cache has been rebuilt.'),
+            this.translate.instant(description || helptextDashboard.rebuildCache.success),
           );
         },
         error: (error: unknown) => {
           const errorMessage = error instanceof Error && error.message
             ? error.message
-            : 'Failed to rebuild directory service cache.';
+            : helptextDashboard.rebuildCache.error;
           this.dialog.error({
-            title: this.translate.instant('Error'),
+            title: this.translate.instant(helptextDashboard.rebuildCache.errorTitle),
             message: this.translate.instant(errorMessage),
           });
           console.error('Failed to rebuild directory service cache:', error);


### PR DESCRIPTION
**Changes:**
- added `Rebuild Directory Service Cache` to directory-services-form
<img width="303" height="187" alt="image" src="https://github.com/user-attachments/assets/622a667a-747c-4b0f-8754-1761fefbac8b" />



**Testing:**
1. Navigate to Directory Service page
2. Configure and enable directory service
3. In the card, click the the menu icon 
4. Click `Rebuild Directory Service Cache`

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
