### PR TITLE
NAS-137321 / 25.10-RC.1 / Display Port not displayed when you expand "Name" on Virtual Machines (by AlexKarpov98)

### DIFF
--- a/src/app/pages/vm/vm-list.component.spec.ts
+++ b/src/app/pages/vm/vm-list.component.spec.ts
@@ -5,11 +5,13 @@ import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
 import { MockComponent } from 'ng-mocks';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { VmState } from 'app/enums/vm.enum';
+import { CollectionChangeType } from 'app/enums/api.enum';
+import { VmBootloader, VmDeviceType, VmDisplayType, VmState } from 'app/enums/vm.enum';
 import { VirtualMachine } from 'app/interfaces/virtual-machine.interface';
+import { VmDisplayDevice } from 'app/interfaces/vm-device.interface';
 import { SearchInput1Component } from 'app/modules/forms/search-input1/search-input1.component';
 import { IxTableHarness } from 'app/modules/ix-table/components/ix-table/ix-table.harness';
 import {
@@ -19,6 +21,7 @@ import { IxTableDetailsRowDirective } from 'app/modules/ix-table/directives/ix-t
 import { PageHeaderComponent } from 'app/modules/page-header/page-title-header/page-header.component';
 import { FileSizePipe } from 'app/modules/pipes/file-size/file-size.pipe';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
+import { ApiService } from 'app/modules/websocket/api.service';
 import { VmListComponent } from 'app/pages/vm/vm-list.component';
 import { VmWizardComponent } from 'app/pages/vm/vm-wizard/vm-wizard.component';
 import { SystemGeneralService } from 'app/services/system-general.service';
@@ -34,6 +37,18 @@ const virtualMachines = [
       pid: 12028,
       domain_state: 'RUNNING',
     },
+    display_available: true,
+    devices: [
+      {
+        id: 1,
+        attributes: {
+          dtype: VmDeviceType.Display,
+          type: VmDisplayType.Vnc,
+          port: 5900,
+        },
+      },
+    ] as VmDisplayDevice[],
+    bootloader: VmBootloader.Uefi,
   },
   {
     id: 3,
@@ -44,6 +59,31 @@ const virtualMachines = [
       pid: null,
       domain_state: 'SHUTOFF',
     },
+    display_available: false,
+    devices: [],
+    bootloader: VmBootloader.Uefi,
+  },
+  {
+    id: 4,
+    name: 'test_with_spice',
+    autostart: true,
+    status: {
+      state: VmState.Running,
+      pid: 12029,
+      domain_state: 'RUNNING',
+    },
+    display_available: true,
+    devices: [
+      {
+        id: 2,
+        attributes: {
+          dtype: VmDeviceType.Display,
+          type: VmDisplayType.Spice,
+          port: 5901,
+        },
+      },
+    ] as VmDisplayDevice[],
+    bootloader: VmBootloader.Uefi,
   },
 ] as VirtualMachine[];
 
@@ -51,6 +91,7 @@ describe('VmListComponent', () => {
   let spectator: Spectator<VmListComponent>;
   let loader: HarnessLoader;
   let table: IxTableHarness;
+  let vmSubscriptionSubject$: Subject<unknown>;
 
   const createComponent = createComponentFactory({
     component: VmListComponent,
@@ -90,7 +131,24 @@ describe('VmListComponent', () => {
   });
 
   beforeEach(async () => {
+    vmSubscriptionSubject$ = new Subject();
+
     spectator = createComponent();
+
+    // Mock the subscribe method after component creation
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn(spectator.inject(ApiService), 'subscribe').mockImplementation((): any => {
+      return vmSubscriptionSubject$.asObservable();
+    });
+
+    // Initialize the vmMap with test data
+    virtualMachines.forEach((vm) => {
+      spectator.component.vmMap.set(vm.id, vm);
+    });
+
+    // Initialize the subscription by calling the method directly
+    spectator.component.subscribeToVmEvents();
+
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     table = await loader.getHarness(IxTableHarness);
   });
@@ -100,6 +158,7 @@ describe('VmListComponent', () => {
       ['Name', 'Running', 'Start on Boot'],
       ['test', '', ''],
       ['test_refactoring', '', ''],
+      ['test_with_spice', '', ''],
     ];
 
     const cells = await table.getCellTexts();
@@ -111,5 +170,170 @@ describe('VmListComponent', () => {
     await addButton.click();
 
     expect(spectator.inject(SlideIn).open).toHaveBeenCalledWith(VmWizardComponent);
+  });
+
+  describe('getDisplayPort', () => {
+    it('returns "N/A" when display is not available', () => {
+      const vm = virtualMachines[1]; // test_refactoring with display_available: false
+      const result = spectator.component.getDisplayPort(vm);
+      expect(result).toBe('N/A');
+    });
+
+    it('returns false when no devices exist', () => {
+      const vm = { ...virtualMachines[0], devices: [] as VmDisplayDevice[] };
+      const result = spectator.component.getDisplayPort(vm);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when no display devices exist', () => {
+      const vm = {
+        ...virtualMachines[0],
+        devices: [] as VmDisplayDevice[],
+      };
+      const result = spectator.component.getDisplayPort(vm);
+      expect(result).toBe(false);
+    });
+
+    it('returns VNC port for VNC display device', () => {
+      const vm = virtualMachines[0]; // test with VNC display
+      const result = spectator.component.getDisplayPort(vm);
+      expect(result).toBe('VNC:5900');
+    });
+
+    it('returns SPICE port for SPICE display device', () => {
+      const vm = virtualMachines[2]; // test_with_spice
+      const result = spectator.component.getDisplayPort(vm);
+      expect(result).toBe('SPICE:5901');
+    });
+
+    it('returns multiple ports when multiple display devices exist', () => {
+      const vm = {
+        ...virtualMachines[0],
+        devices: [
+          {
+            attributes: {
+              dtype: VmDeviceType.Display,
+              type: VmDisplayType.Vnc,
+              port: 5900,
+            },
+          },
+          {
+            attributes: {
+              dtype: VmDeviceType.Display,
+              type: VmDisplayType.Spice,
+              port: 5901,
+            },
+          },
+        ] as VmDisplayDevice[],
+      };
+      const result = spectator.component.getDisplayPort(vm);
+      expect(result).toBe('VNC:5900, SPICE:5901');
+    });
+  });
+
+  describe('subscribeToVmEvents', () => {
+    it('should preserve devices when VM update does not include devices', () => {
+      // Initial VM has devices
+      const originalVm = virtualMachines[0];
+      spectator.component.vmMap.set(originalVm.id, originalVm);
+
+      // Simulate a partial update without devices (like a state change)
+      const partialUpdate = {
+        id: originalVm.id,
+        status: { state: VmState.Stopped },
+      };
+
+      vmSubscriptionSubject$.next({
+        msg: CollectionChangeType.Changed,
+        id: originalVm.id,
+        fields: partialUpdate,
+      });
+
+      const updatedVm = spectator.component.vmMap.get(originalVm.id);
+      expect(updatedVm?.devices).toEqual(originalVm.devices);
+      expect(updatedVm?.status?.state).toBe(VmState.Stopped);
+    });
+
+    it('should update devices when VM update includes devices', () => {
+      const originalVm = virtualMachines[0];
+      spectator.component.vmMap.set(originalVm.id, originalVm);
+
+      const newDevices = [
+        {
+          id: 3,
+          attributes: {
+            dtype: VmDeviceType.Display,
+            type: VmDisplayType.Spice,
+            port: 5999,
+          },
+        },
+      ] as VmDisplayDevice[];
+
+      const updateWithDevices = {
+        id: originalVm.id,
+        devices: newDevices,
+        status: originalVm.status,
+      };
+
+      vmSubscriptionSubject$.next({
+        msg: CollectionChangeType.Changed,
+        id: originalVm.id,
+        fields: updateWithDevices,
+      });
+
+      const updatedVm = spectator.component.vmMap.get(originalVm.id);
+      expect(updatedVm?.devices).toEqual(newDevices);
+    });
+
+    it('should add new VM to map when VM is added', () => {
+      const newVm = {
+        id: 999,
+        name: 'new_vm',
+        devices: [],
+        display_available: false,
+      } as VirtualMachine;
+
+      vmSubscriptionSubject$.next({
+        msg: CollectionChangeType.Added,
+        id: newVm.id,
+        fields: newVm,
+      });
+
+      expect(spectator.component.vmMap.get(newVm.id)).toEqual(newVm);
+    });
+
+    it('should remove VM from map when VM is removed', () => {
+      const vmToRemove = virtualMachines[0];
+      spectator.component.vmMap.set(vmToRemove.id, vmToRemove);
+
+      vmSubscriptionSubject$.next({
+        msg: CollectionChangeType.Removed,
+        id: vmToRemove.id,
+      });
+
+      expect(spectator.component.vmMap.has(vmToRemove.id)).toBe(false);
+    });
+  });
+
+  describe('getDisplayPortSortValue', () => {
+    it('returns MAX_SAFE_INTEGER for VMs without display available', () => {
+      const vm = virtualMachines[1]; // display_available: false
+      const result = spectator.component.getDisplayPortSortValue(vm);
+      expect(result).toBe(Number.MAX_SAFE_INTEGER);
+    });
+
+    it('returns lowest port number for sorting when multiple display devices exist', () => {
+      const vm = {
+        ...virtualMachines[0],
+        devices: [
+          { attributes: { dtype: VmDeviceType.Display, port: 5902 } },
+          { attributes: { dtype: VmDeviceType.Display, port: 5900 } },
+          { attributes: { dtype: VmDeviceType.Display, port: 5901 } },
+        ] as VmDisplayDevice[],
+      };
+
+      const result = spectator.component.getDisplayPortSortValue(vm);
+      expect(result).toBe(5900);
+    });
   });
 });


### PR DESCRIPTION
Code review should be enough.
It's hard to reproduce the bug actually.

The issue described:

  `this.vmMap.set(vmId, { ...this.vmMap.get(vmId), ...updatedVm });`

  This line is using object spread to merge the existing VM data with the updated data. However, if the
  devices array is not included in the updatedVm (which is likely the case for partial updates), the
  existing devices array will be lost when the spread operation occurs.

  The issue is that when partial VM updates come through (like state changes), the devices property might
   not be included, causing the display port information to disappear until a full refresh happens.

Original PR: https://github.com/truenas/webui/pull/12483
