### PR TITLE
NAS-137335 / 26.04 / Add VM disk image import/export functionality

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -937,6 +937,7 @@ export interface ApiCallDirectory {
   'vm.create': { params: [VirtualMachineUpdate]; response: VirtualMachine };
   'vm.delete': { params: VmDeleteParams; response: boolean };
   'vm.device.bind_choices': { params: void; response: Choices };
+  'vm.device.convert': { params: [{ source: string; destination: string }]; response: boolean };
   'vm.device.create': { params: [VmDeviceUpdate]; response: VmDevice };
   'vm.device.delete': { params: [number, VmDeviceDelete?]; response: boolean };
   'vm.device.disk_choices': { params: void; response: Choices };

--- a/src/app/interfaces/api/api-job-directory.interface.ts
+++ b/src/app/interfaces/api/api-job-directory.interface.ts
@@ -213,6 +213,7 @@ export interface ApiJobDirectory {
   };
 
   // VM
+  'vm.device.convert': { params: [{ source: string; destination: string }]; response: boolean };
   'vm.restart': { params: [id: number]; response: void };
   'vm.stop': { params: VmStopParams; response: void };
 }

--- a/src/app/interfaces/vm-device.interface.ts
+++ b/src/app/interfaces/vm-device.interface.ts
@@ -135,7 +135,7 @@ interface VmNicAttributes {
   dtype: VmDeviceType.Nic;
 }
 
-interface VmDiskAttributes {
+export interface VmDiskAttributes {
   logical_sectorsize: number;
   path: string;
   physical_sectorsize: number;

--- a/src/app/pages/vm/devices/device-list/device-list/device-list.component.html
+++ b/src/app/pages/vm/devices/device-list/device-list/device-list.component.html
@@ -60,6 +60,16 @@
         >
           {{ 'Details' | translate }}
         </a>
+        @if (isDiskDevice(device)) {
+          <a
+            mat-menu-item
+            [ixTest]="[device.id, 'export']"
+            [attr.aria-label]="'Export disk to image file' | translate"
+            (click)="onExportDisk(device)"
+          >
+            {{ 'Export to Image' | translate }}
+          </a>
+        }
       </mat-menu>
     </ng-template>
   </tbody>

--- a/src/app/pages/vm/devices/device-list/device-list/device-list.component.spec.ts
+++ b/src/app/pages/vm/devices/device-list/device-list/device-list.component.spec.ts
@@ -6,16 +6,20 @@ import { MatMenuHarness } from '@angular/material/menu/testing';
 import { createRoutingFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
-import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
+import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
+import { mockCall, mockApi, mockJob } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { VmDeviceType } from 'app/enums/vm.enum';
+import { VmDeviceType, VmDiskMode } from 'app/enums/vm.enum';
+import { VirtualMachine } from 'app/interfaces/virtual-machine.interface';
 import { VmDevice } from 'app/interfaces/vm-device.interface';
+import { DialogService } from 'app/modules/dialog/dialog.service';
 import { BasicSearchComponent } from 'app/modules/forms/search-input/components/basic-search/basic-search.component';
 import { IxTableHarness } from 'app/modules/ix-table/components/ix-table/ix-table.harness';
 import { IxTableCellDirective } from 'app/modules/ix-table/directives/ix-table-cell.directive';
 import { IxTableDetailsRowDirective } from 'app/modules/ix-table/directives/ix-table-details-row.directive';
 import { PageHeaderComponent } from 'app/modules/page-header/page-title-header/page-header.component';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
+import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { DeviceFormComponent } from 'app/pages/vm/devices/device-form/device-form.component';
 import {
@@ -23,6 +27,7 @@ import {
 } from 'app/pages/vm/devices/device-list/device-delete-modal/device-delete-modal.component';
 import { DeviceDetailsComponent } from 'app/pages/vm/devices/device-list/device-details/device-details.component';
 import { DeviceListComponent } from 'app/pages/vm/devices/device-list/device-list/device-list.component';
+import { ExportDiskDialogComponent } from 'app/pages/vm/devices/device-list/export-disk-dialog/export-disk-dialog.component';
 
 describe('DeviceListComponent', () => {
   let spectator: Spectator<DeviceListComponent>;
@@ -43,6 +48,10 @@ describe('DeviceListComponent', () => {
       vm: 4,
       attributes: {
         dtype: VmDeviceType.Disk,
+        path: '/dev/zvol/tank/test-disk',
+        type: VmDiskMode.Ahci,
+        logical_sectorsize: 512,
+        physical_sectorsize: 512,
       },
     },
   ] as VmDevice[];
@@ -61,6 +70,8 @@ describe('DeviceListComponent', () => {
     providers: [
       mockApi([
         mockCall('vm.device.query', devices),
+        mockCall('vm.query', [{ id: 76, name: 'Test VM' } as VirtualMachine]),
+        mockJob('vm.device.convert', fakeSuccessfulJob(true)),
       ]),
       mockAuth(),
       mockProvider(SlideIn, {
@@ -71,6 +82,12 @@ describe('DeviceListComponent', () => {
           afterClosed: () => of(true),
         })),
       }),
+      mockProvider(DialogService, {
+        jobDialog: jest.fn(() => ({
+          afterClosed: () => of({ result: true }),
+        })),
+      }),
+      mockProvider(SnackbarService),
     ],
   });
 
@@ -129,6 +146,63 @@ describe('DeviceListComponent', () => {
 
     expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(DeviceDetailsComponent, {
       data: devices[0],
+    });
+  });
+
+  describe('export disk functionality', () => {
+    it('correctly identifies disk devices', () => {
+      expect(spectator.component.isDiskDevice(devices[0])).toBe(false); // CD-ROM
+      expect(spectator.component.isDiskDevice(devices[1])).toBe(true); // Disk
+
+      // Test with null/undefined
+      expect(spectator.component.isDiskDevice(null)).toBe(false);
+      expect(spectator.component.isDiskDevice(undefined)).toBe(false);
+      expect(spectator.component.isDiskDevice({} as VmDevice)).toBe(false);
+    });
+
+    it('opens export dialog when onExportDisk is called', () => {
+      const dialog = spectator.inject(MatDialog);
+
+      spectator.component.onExportDisk(devices[1]);
+
+      expect(dialog.open).toHaveBeenCalledWith(
+        ExportDiskDialogComponent,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            device: devices[1],
+            vmName: 'Test VM',
+          }),
+        }),
+      );
+    });
+
+    it('handles successful export with job dialog and success message', () => {
+      const dialogService = spectator.inject(DialogService);
+      const snackbar = spectator.inject(SnackbarService);
+      const matDialog = spectator.inject(MatDialog);
+
+      // Mock the export dialog result
+      (matDialog.open as jest.Mock).mockReturnValue({
+        afterClosed: () => of({
+          request: {
+            source: '/dev/zvol/tank/test-disk',
+            destination: '/mnt/exports/vm-disk.qcow2',
+          },
+          destinationPath: '/mnt/exports/vm-disk.qcow2',
+        }),
+      });
+
+      // Mock successful job completion
+      (dialogService.jobDialog as jest.Mock).mockReturnValue({
+        afterClosed: () => of({ result: true }),
+      });
+
+      // Trigger export
+      spectator.component.onExportDisk(devices[1]);
+
+      expect(snackbar.success).toHaveBeenCalledWith(
+        'Disk image successfully exported to /mnt/exports/vm-disk.qcow2',
+      );
     });
   });
 });

--- a/src/app/pages/vm/devices/device-list/export-disk-dialog/export-disk-dialog.component.html
+++ b/src/app/pages/vm/devices/device-list/export-disk-dialog/export-disk-dialog.component.html
@@ -1,0 +1,60 @@
+<h1 mat-dialog-title>{{ 'Export Disk to Image' | translate }}</h1>
+
+<mat-dialog-content>
+  <form [formGroup]="form">
+    <div class="info-message">
+      <p>{{ 'This operation will export the VM disk contents to a portable image file. The exported image can be imported into other TrueNAS systems or virtualization platforms like VMware, VirtualBox, or QEMU/KVM. Export time varies based on disk size and storage pool performance.' | translate }}</p>
+    </div>
+
+    <div class="source-info">
+      <p>{{ 'Source Disk' | translate }}: <strong>{{ sourcePath }}</strong></p>
+    </div>
+
+    <ix-explorer
+      formControlName="destinationDir"
+      [label]="'Destination Directory' | translate"
+      [required]="true"
+      [nodeProvider]="treeNodeProvider"
+      [tooltip]="'Select the directory where the disk image will be exported' | translate"
+    ></ix-explorer>
+
+    <ix-input
+      formControlName="imageName"
+      [label]="'Image Name' | translate"
+      [required]="true"
+      [tooltip]="'Enter the name for the exported image file. The appropriate extension will be added automatically based on the selected format.' | translate"
+    ></ix-input>
+
+    <ix-select
+      formControlName="format"
+      [label]="'Image Format' | translate"
+      [required]="true"
+      [options]="formatOptions$"
+      [tooltip]="'Select the format for the exported disk image' | translate"
+    ></ix-select>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <ix-form-actions>
+    <button
+      mat-button
+      ixTest="cancel"
+      type="button"
+      [mat-dialog-close]="false"
+    >
+      {{ 'Cancel' | translate }}
+    </button>
+    <button
+      mat-button
+      ixTest="export"
+      color="primary"
+      type="button"
+      [disabled]="!form.valid"
+      [attr.aria-label]="'Export disk image' | translate"
+      (click)="onSubmit()"
+    >
+      {{ 'Export' | translate }}
+    </button>
+  </ix-form-actions>
+</mat-dialog-actions>

--- a/src/app/pages/vm/devices/device-list/export-disk-dialog/export-disk-dialog.component.scss
+++ b/src/app/pages/vm/devices/device-list/export-disk-dialog/export-disk-dialog.component.scss
@@ -1,0 +1,25 @@
+.info-message {
+  background-color: var(--primary-bg);
+  border-left: 4px solid var(--primary);
+  border-radius: 4px;
+  margin-bottom: 20px;
+  padding: 16px;
+
+  p {
+    color: var(--fg1);
+    line-height: 1.5;
+    margin: 0;
+  }
+}
+
+.source-info {
+  background-color: var(--bg2);
+  border-radius: 4px;
+  margin-bottom: 16px;
+  padding: 12px;
+
+  p {
+    color: var(--fg2);
+    margin: 0;
+  }
+}

--- a/src/app/pages/vm/devices/device-list/export-disk-dialog/export-disk-dialog.component.spec.ts
+++ b/src/app/pages/vm/devices/device-list/export-disk-dialog/export-disk-dialog.component.spec.ts
@@ -1,0 +1,113 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { VmDeviceType, VmDiskMode } from 'app/enums/vm.enum';
+import { VmDiskDevice } from 'app/interfaces/vm-device.interface';
+import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
+import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
+import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
+import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
+import { FilesystemService } from 'app/services/filesystem.service';
+import {
+  ExportDiskDialogComponent,
+  ExportDiskDialogData,
+} from './export-disk-dialog.component';
+
+describe('ExportDiskDialogComponent', () => {
+  let spectator: Spectator<ExportDiskDialogComponent>;
+  let loader: HarnessLoader;
+  let form: IxFormHarness;
+  const mockDevice: VmDiskDevice = {
+    id: 1,
+    dtype: VmDeviceType.Disk,
+    vm: 1,
+    order: 1,
+    attributes: {
+      dtype: VmDeviceType.Disk,
+      path: '/dev/zvol/tank/vm-disk',
+      logical_sectorsize: 512,
+      physical_sectorsize: 4096,
+      type: VmDiskMode.Ahci,
+    },
+  } as VmDiskDevice;
+
+  const mockDialogData: ExportDiskDialogData = {
+    device: mockDevice,
+    vmName: 'test-vm',
+  };
+
+  const createComponent = createComponentFactory({
+    component: ExportDiskDialogComponent,
+    imports: [
+      ReactiveFormsModule,
+      IxExplorerComponent,
+      IxInputComponent,
+      IxSelectComponent,
+    ],
+    providers: [
+      mockProvider(FilesystemService, {
+        getFilesystemNodeProvider: jest.fn(() => jest.fn()),
+      }),
+      mockProvider(MatDialogRef),
+      {
+        provide: MAT_DIALOG_DATA,
+        useValue: mockDialogData,
+      },
+    ],
+  });
+
+  beforeEach(async () => {
+    spectator = createComponent();
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+    form = await loader.getHarness(IxFormHarness);
+  });
+
+  it('shows the source disk path', () => {
+    const sourceInfo = spectator.query('.source-info strong');
+    expect(sourceInfo).toHaveText('/dev/zvol/tank/vm-disk');
+  });
+
+  it('initializes form with default values', async () => {
+    const values = await form.getValues();
+    expect(values['Destination Directory']).toBe('');
+    expect(values['Image Name']).toContain('test-vm_disk_');
+    expect(values['Image Format']).toBe('QCOW2 - QEMU Copy On Write');
+  });
+
+  it('closes dialog with export data when form is submitted', async () => {
+    await form.fillForm({
+      'Destination Directory': '/mnt/exports',
+      'Image Name': 'my-vm-disk',
+      'Image Format': 'VMDK - VMware Virtual Machine Disk',
+    });
+
+    spectator.click(spectator.query('button[ixTest="export"]'));
+
+    expect(spectator.inject(MatDialogRef).close).toHaveBeenCalledWith({
+      request: {
+        source: '/dev/zvol/tank/vm-disk',
+        destination: '/mnt/exports/my-vm-disk.vmdk',
+      },
+      destinationPath: '/mnt/exports/my-vm-disk.vmdk',
+    });
+  });
+
+  it('disables submit button when form is invalid', () => {
+    // Clear required fields to make the form invalid
+    spectator.component.form.patchValue({ destinationDir: '', imageName: '' });
+    spectator.detectChanges();
+
+    const submitButton = spectator.query('button[ixTest="export"]');
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('provides format options for image export', () => {
+    const formatOptions = spectator.component.imageFormats;
+    expect(formatOptions).toHaveLength(6);
+    expect(formatOptions.map((format) => format.value)).toEqual([
+      'qcow2', 'qed', 'raw', 'vdi', 'vhdx', 'vmdk',
+    ]);
+  });
+});

--- a/src/app/pages/vm/devices/device-list/export-disk-dialog/export-disk-dialog.component.ts
+++ b/src/app/pages/vm/devices/device-list/export-disk-dialog/export-disk-dialog.component.ts
@@ -1,0 +1,127 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import {
+  MatDialogRef,
+  MatDialogClose,
+  MatDialogTitle,
+  MatDialogContent,
+  MatDialogActions,
+  MAT_DIALOG_DATA,
+} from '@angular/material/dialog';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { TranslateModule } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
+import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
+import { VmDiskDevice } from 'app/interfaces/vm-device.interface';
+import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
+import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
+import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
+import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
+import { TestDirective } from 'app/modules/test-id/test.directive';
+import { FilesystemService } from 'app/services/filesystem.service';
+
+export interface ExportDiskDialogData {
+  device: VmDiskDevice;
+  vmName: string;
+}
+
+interface ImageFormat {
+  label: string;
+  value: string;
+  extension: string;
+}
+
+@Component({
+  selector: 'ix-export-disk-dialog',
+  templateUrl: './export-disk-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    MatDialogTitle,
+    MatDialogContent,
+    ReactiveFormsModule,
+    IxExplorerComponent,
+    IxInputComponent,
+    IxSelectComponent,
+    MatDialogActions,
+    FormActionsComponent,
+    MatButton,
+    MatDialogClose,
+    TestDirective,
+    TranslateModule,
+    MatProgressBarModule,
+  ],
+})
+export class ExportDiskDialogComponent {
+  private fb = inject(FormBuilder);
+  private filesystemService = inject(FilesystemService);
+  dialogRef = inject(MatDialogRef) as MatDialogRef<ExportDiskDialogComponent>;
+  data = inject<ExportDiskDialogData>(MAT_DIALOG_DATA);
+
+  readonly helptext = helptextVmWizard;
+  readonly imageFormats: ImageFormat[] = [
+    { label: 'QCOW2 - QEMU Copy On Write', value: 'qcow2', extension: '.qcow2' },
+    { label: 'QED - QEMU Enhanced Disk', value: 'qed', extension: '.qed' },
+    { label: 'RAW - Raw Disk Image', value: 'raw', extension: '.raw' },
+    { label: 'VDI - VirtualBox Disk Image', value: 'vdi', extension: '.vdi' },
+    { label: 'VHDX - Hyper-V Virtual Hard Disk', value: 'vhdx', extension: '.vhdx' },
+    { label: 'VMDK - VMware Virtual Machine Disk', value: 'vmdk', extension: '.vmdk' },
+  ];
+
+  form = this.fb.group({
+    destinationDir: ['', [Validators.required]],
+    imageName: [this.generateDefaultImageName(), [Validators.required]],
+    format: ['qcow2', [Validators.required]],
+  });
+
+  readonly treeNodeProvider = this.filesystemService.getFilesystemNodeProvider({
+    directoriesOnly: true,
+  });
+
+  get sourcePath(): string {
+    return this.data.device.attributes.path;
+  }
+
+  get formatOptions$(): Observable<{ label: string; value: string }[]> {
+    return new Observable((observer) => {
+      observer.next(this.imageFormats.map((format) => ({
+        label: format.label,
+        value: format.value,
+      })));
+      observer.complete();
+    });
+  }
+
+  private generateDefaultImageName(): string {
+    const timestamp = new Date().toISOString().split('T')[0];
+    const vmName = this.data.vmName.replace(/[^a-zA-Z0-9-_]/g, '_');
+    return `${vmName}_disk_${timestamp}`;
+  }
+
+  onSubmit(): void {
+    const values = this.form.value;
+    const selectedFormat = this.imageFormats.find((format) => format.value === values.format);
+
+    // Build the full destination path from directory and filename
+    let destinationDir = values.destinationDir?.trim() || '';
+    if (!destinationDir.endsWith('/')) {
+      destinationDir += '/';
+    }
+
+    // Remove any extension from the image name and add the correct one
+    const imageNameWithoutExt = (values.imageName || '').replace(/\.[^/.]+$/, '');
+    const destinationPath = destinationDir + imageNameWithoutExt + (selectedFormat?.extension || '.qcow2');
+
+    const request = {
+      source: this.sourcePath,
+      destination: destinationPath,
+    };
+
+    // Close the dialog and pass the export info
+    this.dialogRef.close({
+      request,
+      destinationPath,
+    });
+  }
+}

--- a/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.html
+++ b/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.html
@@ -4,6 +4,22 @@
     [options]="newOrExistingOptions$"
   ></ix-radio-group>
 
+  <ix-checkbox
+    formControlName="import_image"
+    [label]="'Import Image' | translate"
+    [tooltip]="'Import a disk image (qcow2, qed, raw, vdi, vhdx, vmdk) to the zvol' | translate"
+  ></ix-checkbox>
+
+  @if (isImportingImage) {
+    <ix-explorer
+      formControlName="image_source"
+      [label]="'Image Source' | translate"
+      [required]="true"
+      [nodeProvider]="treeNodeProvider"
+      [tooltip]="'Path to the disk image file to import. Supported formats: qcow2, qed, raw, vdi, vhdx, vmdk' | translate"
+    ></ix-explorer>
+  }
+
   <ix-select
     formControlName="hdd_type"
     [required]="true"

--- a/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.spec.ts
@@ -7,10 +7,12 @@ import { of } from 'rxjs';
 import { GiB } from 'app/constants/bytes.constant';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { VmDiskMode } from 'app/enums/vm.enum';
+import { IxCheckboxHarness } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.harness';
 import { IxRadioGroupHarness } from 'app/modules/forms/ix-forms/components/ix-radio-group/ix-radio-group.harness';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { FreeSpaceValidatorService } from 'app/pages/vm/utils/free-space-validator.service';
 import { DiskStepComponent, NewOrExistingDisk } from 'app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component';
+import { FilesystemService } from 'app/services/filesystem.service';
 
 describe('DiskStepComponent', () => {
   let spectator: Spectator<DiskStepComponent>;
@@ -35,6 +37,9 @@ describe('DiskStepComponent', () => {
       ]),
       mockProvider(FreeSpaceValidatorService, {
         validate: () => of(null),
+      }),
+      mockProvider(FilesystemService, {
+        getFilesystemNodeProvider: jest.fn(() => jest.fn()),
       }),
     ],
   });
@@ -61,6 +66,8 @@ describe('DiskStepComponent', () => {
         datastore: 'poolio',
         hdd_path: '',
         volsize: 20 * GiB,
+        import_image: false,
+        image_source: '',
       });
     });
 
@@ -96,6 +103,8 @@ describe('DiskStepComponent', () => {
         hdd_type: VmDiskMode.Virtio,
         datastore: '',
         volsize: null,
+        import_image: false,
+        image_source: '',
       });
     });
 
@@ -110,6 +119,85 @@ describe('DiskStepComponent', () => {
           value: 'VIRTIO at /dev/zvol/poolio/test-327brn',
         },
       ]);
+    });
+  });
+
+  describe('import disk image', () => {
+    beforeEach(async () => {
+      const importCheckbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Import Image' }));
+      await importCheckbox.setValue(true);
+    });
+
+    it('shows image source field when import checkbox is checked', async () => {
+      const formValues = await form.getValues();
+      expect(formValues).toMatchObject({
+        'Import Image': true,
+      });
+
+      const labels = await form.getLabels();
+      expect(labels).toContain('Image Source');
+    });
+
+    it('validates image file extensions', () => {
+      // Set an invalid file extension
+      spectator.component.form.controls.image_source.setValue('/mnt/pool/invalid.txt');
+      spectator.component.form.controls.image_source.updateValueAndValidity();
+
+      expect(spectator.component.form.controls.image_source.errors).toEqual({
+        invalidImageFormat: {
+          message: 'File must be one of the following formats: .qcow2, .qed, .raw, .vdi, .vhdx, .vmdk',
+        },
+      });
+
+      // Set a valid file extension
+      spectator.component.form.controls.image_source.setValue('/mnt/pool/valid.qcow2');
+      spectator.component.form.controls.image_source.updateValueAndValidity();
+
+      expect(spectator.component.form.controls.image_source.errors).toBeNull();
+    });
+
+    it('includes import information in summary when image is selected', async () => {
+      await form.fillForm({
+        'Select Disk Type': 'AHCI',
+        'Zvol Location': 'poolio',
+        Size: '20 GiB',
+      });
+
+      spectator.component.form.controls.image_source.setValue('/mnt/pool/ubuntu.qcow2');
+
+      expect(spectator.component.getSummary()).toEqual([
+        {
+          label: 'Disk',
+          value: 'Create new disk image',
+        },
+        {
+          label: 'Disk Description',
+          value: '20 GiB AHCI at poolio',
+        },
+        {
+          label: 'Import Image',
+          value: 'Yes, from /mnt/pool/ubuntu.qcow2',
+        },
+      ]);
+    });
+
+    it('accepts all supported image formats', () => {
+      const validFormats = ['.qcow2', '.qed', '.raw', '.vdi', '.vhdx', '.vmdk'];
+
+      validFormats.forEach((format) => {
+        const testPath = `/mnt/pool/image${format}`;
+        spectator.component.form.controls.image_source.setValue(testPath);
+        spectator.component.form.controls.image_source.updateValueAndValidity();
+
+        expect(spectator.component.form.controls.image_source.errors).toBeNull();
+      });
+    });
+
+    it('requires image source when import is checked', () => {
+      spectator.component.form.controls.image_source.setValue('');
+      spectator.component.form.controls.image_source.updateValueAndValidity();
+
+      expect(spectator.component.form.controls.image_source.hasError('required')).toBe(true);
     });
   });
 });

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.html
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.html
@@ -6,7 +6,7 @@
 
 <mat-card>
   <mat-card-content>
-    <mat-vertical-stepper [linear]="true" (selectionChange)="updateSummary()">
+    <mat-vertical-stepper #stepper [linear]="true" (selectionChange)="updateSummary()">
       <ix-use-ix-icons-in-stepper></ix-use-ix-icons-in-stepper>
 
       <mat-step [stepControl]="osStep().form">

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -13,8 +13,10 @@ import {
 import { catchError, defaultIfEmpty } from 'rxjs/operators';
 import { GiB, MiB } from 'app/constants/bytes.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
+import { DatasetType } from 'app/enums/dataset.enum';
 import { Role } from 'app/enums/role.enum';
 import { VmDeviceType, VmDisplayType, VmNicType, VmOs } from 'app/enums/vm.enum';
+import { DatasetCreate } from 'app/interfaces/dataset.interface';
 import { VirtualMachine, VirtualMachineUpdate } from 'app/interfaces/virtual-machine.interface';
 import { VmDevice, VmDeviceUpdate } from 'app/interfaces/vm-device.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -95,6 +97,7 @@ export class VmWizardComponent implements OnInit {
   protected readonly networkInterfaceStep = viewChild.required(NetworkInterfaceStepComponent);
   protected readonly installationMediaStep = viewChild.required(InstallationMediaStepComponent);
   protected readonly gpuStep = viewChild.required(GpuStepComponent);
+  protected readonly stepper = viewChild.required(MatStepper);
 
   protected readonly requiredRoles = [Role.VmWrite];
 
@@ -160,8 +163,21 @@ export class VmWizardComponent implements OnInit {
     this.isLoading = true;
     this.cdr.markForCheck();
 
-    this.createVm().pipe(
-      switchMap((vm) => this.createDevices(vm)),
+    // Track the zvol path if we create one for import
+    let importedZvolPath: string | null = null;
+
+    // Start with image import if needed
+    const startFlow$ = this.diskForm.import_image && this.diskForm.image_source
+      ? this.handleImageImportBeforeVmCreation().pipe(
+        switchMap((zvolPath) => {
+          importedZvolPath = zvolPath;
+          return this.createVm();
+        }),
+      )
+      : this.createVm();
+
+    startFlow$.pipe(
+      switchMap((vm) => this.createDevices(vm, importedZvolPath)),
       untilDestroyed(this),
     )
       .subscribe({
@@ -173,7 +189,19 @@ export class VmWizardComponent implements OnInit {
         },
         error: (error: unknown) => {
           this.isLoading = false;
-          this.errorHandler.showErrorModal(error);
+
+          // Check if this is an image conversion error
+          if (this.diskForm.import_image && error instanceof Error && error.message.includes('Image conversion failed')) {
+            // Set error on the image_source field
+            this.diskStep().form.controls.image_source.setErrors({
+              conversionFailed: { message: error.message },
+            });
+            // Navigate back to step 3 (disk step)
+            this.stepper().selectedIndex = 2;
+          } else {
+            // For other errors, show the error modal
+            this.errorHandler.showErrorModal(error);
+          }
           this.cdr.markForCheck();
         },
       });
@@ -228,10 +256,10 @@ export class VmWizardComponent implements OnInit {
     return this.api.call('vm.create', [vmPayload]);
   }
 
-  private createDevices(vm: VirtualMachine): Observable<unknown[]> {
+  private createDevices(vm: VirtualMachine, importedZvolPath: string | null = null): Observable<unknown[]> {
     const requests: Observable<unknown>[] = [
       this.getNicRequest(vm),
-      this.getDiskRequest(vm),
+      this.getDiskRequest(vm, importedZvolPath),
     ];
 
     if (this.mediaForm.iso_path) {
@@ -263,7 +291,21 @@ export class VmWizardComponent implements OnInit {
     });
   }
 
-  private getDiskRequest(vm: VirtualMachine): Observable<VmDevice | null> {
+  private getDiskRequest(vm: VirtualMachine, importedZvolPath: string | null = null): Observable<VmDevice | null> {
+    // If we already created and imported to a zvol, just attach it
+    if (importedZvolPath) {
+      return this.makeDeviceRequest(vm.id, {
+        attributes: {
+          dtype: VmDeviceType.Disk,
+          path: importedZvolPath,
+          type: this.diskForm.hdd_type,
+          physical_sectorsize: null,
+          logical_sectorsize: null,
+        },
+      });
+    }
+
+    // Normal flow: create new zvol or use existing
     if (this.diskForm.newOrExisting === NewOrExistingDisk.New) {
       const hdd = this.diskForm.datastore + '/' + this.osForm.name.replace(/\s+/g, '-') + '-' + Math.random().toString(36).substring(7);
       return this.makeDeviceRequest(vm.id, {
@@ -342,5 +384,84 @@ export class VmWizardComponent implements OnInit {
           return of(null);
         }),
       );
+  }
+
+  private handleImageImportBeforeVmCreation(): Observable<string | null> {
+    if (this.diskForm.newOrExisting === NewOrExistingDisk.New) {
+      // Create zvol first, then convert image to it
+      const zvolName = this.diskForm.datastore + '/' + this.osForm.name.replace(/\s+/g, '-') + '-' + Math.random().toString(36).substring(7);
+      const zvolPath = `/dev/zvol/${zvolName}`;
+
+      return this.api.call('pool.dataset.create', [{
+        name: zvolName,
+        type: DatasetType.Volume,
+        volsize: this.diskForm.volsize || 10 * GiB,
+      } as DatasetCreate]).pipe(
+        switchMap(() => {
+          // Now convert the image to the created zvol
+          const jobDialog = this.dialogService.jobDialog(
+            this.api.job('vm.device.convert', [{
+              source: this.diskForm.image_source,
+              destination: zvolPath,
+            }]),
+            {
+              title: this.translate.instant('Converting disk image'),
+              description: this.translate.instant('Converting {source} to {destination}', {
+                source: this.diskForm.image_source,
+                destination: zvolPath,
+              }),
+            },
+          );
+
+          return jobDialog.afterClosed().pipe(
+            switchMap(() => of(zvolPath)), // Return the path for later use
+            catchError((conversionError: unknown) => {
+              // Conversion failed, clean up the zvol we just created
+              const errorReport = this.errorParser.parseError(conversionError);
+              const errorMessage = Array.isArray(errorReport) ? errorReport[0]?.message : errorReport.message;
+
+              return this.api.call('pool.dataset.delete', [zvolName, { recursive: false }]).pipe(
+                switchMap(() => {
+                  // Re-throw with formatted message
+                  throw new Error(`Image conversion failed: ${errorMessage || 'Unknown error'}`);
+                }),
+                catchError(() => {
+                  // If cleanup fails, still throw the conversion error
+                  throw new Error(`Image conversion failed: ${errorMessage || 'Unknown error'}`);
+                }),
+              );
+            }),
+          );
+        }),
+        catchError((error: unknown) => {
+          // Don't show error here, it will be shown in onSubmit's error handler
+          throw error;
+        }),
+      );
+    }
+    // For existing disk, just convert to it
+    const jobDialog = this.dialogService.jobDialog(
+      this.api.job('vm.device.convert', [{
+        source: this.diskForm.image_source,
+        destination: this.diskForm.hdd_path,
+      }]),
+      {
+        title: this.translate.instant('Converting disk image'),
+        description: this.translate.instant('Converting {source} to {destination}', {
+          source: this.diskForm.image_source,
+          destination: this.diskForm.hdd_path,
+        }),
+      },
+    );
+
+    return jobDialog.afterClosed().pipe(
+      switchMap(() => of(null)), // No new path created, will use existing
+      catchError((error: unknown) => {
+        // Format and re-throw as conversion error
+        const errorReport = this.errorParser.parseError(error);
+        const errorMessage = Array.isArray(errorReport) ? errorReport[0]?.message : errorReport.message;
+        throw new Error(`Image conversion failed: ${errorMessage || 'Unknown error'}`);
+      }),
+    );
   }
 }


### PR DESCRIPTION
Implement disk image import during VM creation with support for qcow2, qed, raw, vdi, vhdx, and vmdk formats. Add server-side file browser, format validation, progress dialogs, and automatic cleanup on failure. Add export functionality to convert VM disks to portable image files with format selection and job tracking. Include comprehensive test coverage (22 tests) and proper error handling for both features.

**Changes:**


https://github.com/user-attachments/assets/8705a7d1-245c-4f6f-8eef-756bd9173e58


https://github.com/user-attachments/assets/11360188-4ecd-4f71-9ee4-0b380c775cf9



**Testing:**

Create a VM importing image and export a disk to image.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |New feature to import/export image
|Testing         |New feature to import/export image
