### PR TITLE
NAS-137442 / 26.04 / Fix duplicate audit.query API calls on page load

### DIFF
--- a/src/app/pages/audit/audit.component.spec.ts
+++ b/src/app/pages/audit/audit.component.spec.ts
@@ -98,6 +98,27 @@ describe('AuditComponent', () => {
     expect(spectator.query(FakeProgressBarComponent)).toExist();
   });
 
+  it('prevents duplicate API calls when controller type changes', async () => {
+    // Clear previous calls
+    jest.clearAllMocks();
+
+    // Get the button group harness and change controller type
+    const buttonGroup = await loader.getHarness(IxButtonGroupHarness);
+    await buttonGroup.setValue('Standby');
+
+    // Count audit.query calls after controller type change
+    const auditQueryCalls = (api.call as jest.Mock).mock.calls.filter(
+      (call) => call[0] === 'audit.query',
+    );
+
+    // Should have exactly 2 calls (1 for count, 1 for data) - not duplicated
+    expect(auditQueryCalls).toHaveLength(2);
+
+    // Verify the call includes the remote_controller flag for Standby
+    const dataCall = auditQueryCalls.find((call) => !call[1][0]['query-options']?.count);
+    expect(dataCall?.[1][0]).toHaveProperty('remote_controller', true);
+  });
+
   describe('search', () => {
     it('searches by event, username and service when basic search is used', () => {
       const search = spectator.query(SearchInputComponent)!;


### PR DESCRIPTION
- Remove redundant dataProvider.load() call from createDataProvider()
- Add isInitialLoad flag to prevent effect from triggering initial load
- Let AuditSearchComponent handle initial load via loadParamsFromRoute()
- Effect now only triggers loads on actual controller type or HA license changes

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

Check API calls to audit.query when Audit page loads.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
