### PR TITLE
Use pool.query with count: true for a faster response

### DIFF
--- a/src/app/pages/data-protection/data-protection-dashboard.component.html
+++ b/src/app/pages/data-protection/data-protection-dashboard.component.html
@@ -1,6 +1,6 @@
 <ix-page-header [loading]="pools() === null"></ix-page-header>
 
-@if (pools()?.length === 0 && pools() !== null) {
+@if (pools() === 0) {
   <ix-empty
     [conf]="emptyConfig"
     [requiredRoles]="requiredRoles"

--- a/src/app/pages/data-protection/data-protection-dashboard.component.ts
+++ b/src/app/pages/data-protection/data-protection-dashboard.component.ts
@@ -3,6 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
 import { dataProtectionEmptyConfig } from 'app/constants/empty-configs';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { Role } from 'app/enums/role.enum';
@@ -51,5 +52,5 @@ export class DataProtectionDashboardComponent {
     },
   };
 
-  readonly pools = toSignal(this.api.call('pool.query'), { initialValue: null });
+  readonly pools = toSignal(this.api.call('pool.query', [[], { count: true }]) as unknown as Observable<number>, { initialValue: null });
 }

--- a/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.html
@@ -1,6 +1,6 @@
 <ix-page-header [loading]="pools() === null"></ix-page-header>
 
-@if (pools()?.length === 0 && pools() !== null) {
+@if (pools() === 0) {
   <ix-empty
     [conf]="emptyConfig"
     [requiredRoles]="requiredRoles"

--- a/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.ts
@@ -3,6 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
 import { sharesEmptyConfig } from 'app/constants/empty-configs';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { Role } from 'app/enums/role.enum';
@@ -50,5 +51,5 @@ export class SharesDashboardComponent {
     },
   };
 
-  readonly pools = toSignal(this.api.call('pool.query'), { initialValue: null });
+  readonly pools = toSignal(this.api.call('pool.query', [[], { count: true }]) as unknown as Observable<number>, { initialValue: null });
 }


### PR DESCRIPTION
**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

Data protection and sharing still loads properly with and without a pool.
PS: mock with pool.query returning 0 or 1 will work.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
