### PR TITLE
NAS-137428 / 26.04 / Applications Network reporting bytes vs bits

### DIFF
--- a/src/app/modules/pipes/network-speed/network-speed.pipe.spec.ts
+++ b/src/app/modules/pipes/network-speed/network-speed.pipe.spec.ts
@@ -8,6 +8,6 @@ describe('NetworkSpeedPipe', () => {
   it('converts values to bits per second', () => {
     spectator = createPipe('{{ 1000 | ixNetworkSpeed }}');
 
-    expect(spectator.element).toHaveText('1 kb/s');
+    expect(spectator.element).toHaveText('1 kB/s');
   });
 });

--- a/src/app/modules/pipes/network-speed/network-speed.pipe.ts
+++ b/src/app/modules/pipes/network-speed/network-speed.pipe.ts
@@ -10,7 +10,7 @@ export class NetworkSpeedPipe implements PipeTransform {
 
   transform(value: number): string {
     return this.translate.instant('{bits}/s', {
-      bits: buildNormalizedFileSize(value, 'b', 10),
+      bits: buildNormalizedFileSize(value, 'B', 10),
     });
   }
 }

--- a/src/app/pages/apps/components/installed-apps/app-row/app-row.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/app-row/app-row.component.spec.ts
@@ -89,7 +89,7 @@ describe('AppRowComponent', () => {
     expect(spectator.query('.cell-cpu')).toHaveText('90%');
     expect(spectator.query('.cell-ram')).toHaveText('80 MiB');
     expect(spectator.query('.cell-io')).toHaveText('1 KiB - 2 KiB');
-    expect(spectator.query('.cell-network')).toHaveText('6.14 kb/s - 8.19 kb/s');
+    expect(spectator.query('.cell-network')).toHaveText('6.14 kB/s - 8.19 kB/s');
   });
 
   describe('actions', () => {

--- a/src/app/pages/dashboard/widgets/apps/common/app-network-info/app-network-info.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/apps/common/app-network-info/app-network-info.component.spec.ts
@@ -47,8 +47,8 @@ describe('AppNetworkInfoComponent', () => {
 
   it('checks in-out rows', () => {
     const inOutRows = spectator.queryAll('.in-out-row');
-    expect(inOutRows[0]).toHaveText('In: 984 b/s');
-    expect(inOutRows[1]).toHaveText('Out: 3.65 kb/s');
+    expect(inOutRows[0]).toHaveText('In: 984 B/s');
+    expect(inOutRows[1]).toHaveText('Out: 3.65 kB/s');
   });
 
   it('should generate correct network chart data', () => {

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.spec.ts
@@ -120,8 +120,8 @@ describe('WidgetInterfaceComponent', () => {
 
     it('shows interface traffic', fakeAsync(() => {
       spectator.tick(1);
-      expect(spectator.query('.info-list-item.in')).toHaveText('In:16.38 kb/s');
-      expect(spectator.query('.info-list-item.out')).toHaveText('Out:32.77 kb/s');
+      expect(spectator.query('.info-list-item.in')).toHaveText('In:16.38 kB/s');
+      expect(spectator.query('.info-list-item.out')).toHaveText('Out:32.77 kB/s');
     }));
 
     it('shows a chart with network traffic', () => {
@@ -170,8 +170,8 @@ describe('WidgetInterfaceComponent', () => {
 
       expect(spectator.query('.info-header-title')).toHaveText('ens1');
       expect(spectator.query('.info-list-item.state')).toHaveText('LINK STATE UP');
-      expect(spectator.query('.info-list-item.in')).toHaveText('In:16.38 kb/s');
-      expect(spectator.query('.info-list-item.out')).toHaveText('Out:32.77 kb/s');
+      expect(spectator.query('.info-list-item.in')).toHaveText('In:16.38 kB/s');
+      expect(spectator.query('.info-list-item.out')).toHaveText('Out:32.77 kB/s');
     });
   });
 
@@ -204,8 +204,8 @@ describe('WidgetInterfaceComponent', () => {
 
     it('shows interface traffic', fakeAsync(() => {
       spectator.tick(1);
-      expect(spectator.query('.info-list-item.in')).toHaveText('In:16.38 kb/s');
-      expect(spectator.query('.info-list-item.out')).toHaveText('Out:32.77 kb/s');
+      expect(spectator.query('.info-list-item.in')).toHaveText('In:16.38 kB/s');
+      expect(spectator.query('.info-list-item.out')).toHaveText('Out:32.77 kB/s');
     }));
 
     it('shows a chart with network traffic', () => {
@@ -277,8 +277,8 @@ describe('WidgetInterfaceComponent', () => {
 
     it('shows interface traffic', fakeAsync(() => {
       spectator.tick(1);
-      expect(spectator.query('.info-list-item.in')).toHaveText('In:16.38 kb/s');
-      expect(spectator.query('.info-list-item.out')).toHaveText('Out:32.77 kb/s');
+      expect(spectator.query('.info-list-item.in')).toHaveText('In:16.38 kB/s');
+      expect(spectator.query('.info-list-item.out')).toHaveText('Out:32.77 kB/s');
     }));
 
     it('ensures chart is not rendered', fakeAsync(() => {


### PR DESCRIPTION
Testing: see ticket.

The idea: more appropriate abbreviation should be capital 'B' (B/s, kB/s, MB/s)