### PR TITLE
NAS-137520 / 26.04 / Fix IPMI VLAN validation preventing form save

### DIFF
--- a/src/app/pages/system/network/components/ipmi-card/ipmi-form/ipmi-form.component.spec.ts
+++ b/src/app/pages/system/network/components/ipmi-card/ipmi-form/ipmi-form.component.spec.ts
@@ -288,4 +288,32 @@ describe('IpmiFormComponent', () => {
       expect(spectator.inject(ApiService).call).toHaveBeenLastCalledWith('ipmi.chassis.identify', [OnOff.Off]);
     });
   });
+
+  describe('VLAN validation', () => {
+    beforeEach(async () => {
+      await setupTest(ProductType.Enterprise);
+    });
+
+    it('does not require VLAN ID when Enable VLAN is false', async () => {
+      const enableVlanCheckbox = await form.getControl('Enable VLAN') as IxCheckboxHarness;
+      await enableVlanCheckbox.setValue(false);
+
+      expect(spectator.component.form.valid).toBe(true);
+      expect(spectator.component.form.controls.vlan_id.hasError('required')).toBe(false);
+    });
+
+    it('clears VLAN ID value when Enable VLAN is disabled', async () => {
+      // First enable VLAN and set a value
+      const enableVlanCheckbox = await form.getControl('Enable VLAN') as IxCheckboxHarness;
+      await enableVlanCheckbox.setValue(true);
+
+      const vlanIdInput = await form.getControl('VLAN ID') as IxInputHarness;
+      await vlanIdInput.setValue('10');
+
+      // Then disable VLAN
+      await enableVlanCheckbox.setValue(false);
+
+      expect(spectator.component.form.controls.vlan_id.value).toBeNull();
+    });
+  });
 });

--- a/src/app/pages/system/network/components/ipmi-card/ipmi-form/ipmi-form.component.ts
+++ b/src/app/pages/system/network/components/ipmi-card/ipmi-form/ipmi-form.component.ts
@@ -96,7 +96,7 @@ export class IpmiFormComponent implements OnInit {
     gateway: ['', ipv4Validator()],
     netmask: ['', ipv4Validator()],
     vlan_id_enable: [false],
-    vlan_id: [null as number | null, [Validators.required]],
+    vlan_id: [null as number | null],
     password: ['', [
       this.validatorsService.withMessage(
         Validators.maxLength(20),
@@ -194,6 +194,14 @@ export class IpmiFormComponent implements OnInit {
       vlan_id: ipmi.vlan_id || null,
       vlan_id_enable: ipmi.vlan_id_enable,
     });
+
+    // Set initial vlan_id validation based on vlan_id_enable state
+    if (ipmi.vlan_id_enable) {
+      this.form.controls.vlan_id.addValidators([Validators.required]);
+    } else {
+      this.form.controls.vlan_id.removeValidators([Validators.required]);
+    }
+    this.form.controls.vlan_id.updateValueAndValidity();
   }
 
   private loadDataOnRemoteControllerChange(): void {
@@ -274,6 +282,19 @@ export class IpmiFormComponent implements OnInit {
     this.form.controls.ipaddress.disabledWhile(stateDhcp$);
     this.form.controls.gateway.disabledWhile(stateDhcp$);
     this.form.controls.netmask.disabledWhile(stateDhcp$);
+
+    // Make vlan_id required only when vlan_id_enable is true
+    this.form.controls.vlan_id_enable.valueChanges
+      .pipe(untilDestroyed(this))
+      .subscribe((vlanEnabled) => {
+        if (vlanEnabled) {
+          this.form.controls.vlan_id.addValidators([Validators.required]);
+        } else {
+          this.form.controls.vlan_id.removeValidators([Validators.required]);
+          this.form.controls.vlan_id.setValue(null);
+        }
+        this.form.controls.vlan_id.updateValueAndValidity();
+      });
 
     this.form.controls.ipaddress.valueChanges
       .pipe(untilDestroyed(this))


### PR DESCRIPTION
IPMI network configuration form was incorrectly requiring VLAN ID even when "Enable VLAN" was unchecked, preventing users from saving configuration.

- Remove unconditional required validator from vlan_id field
- Add dynamic validation that only requires VLAN ID when VLAN is enabled
- Clear VLAN ID value when VLAN is disabled
- Add tests to verify correct validation behavior

Fixes issue where Save button remained disabled due to invalid VLAN ID field.

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
