### PR TITLE
Fix translate pipe error

### DIFF
--- a/src/app/pages/system/update/update.component.html
+++ b/src/app/pages/system/update/update.component.html
@@ -26,7 +26,7 @@
             </div>
             @if (doesNotMatchProfile() && currentVersionProfile()) {
               <div class="profile-mismatch">
-                {{ '(from {profile} profile)' | translate: { profile: currentVersionProfile() } }}
+                {{ '(from {profile} profile)' | translate : { profile: currentVersionProfile() } }}
               </div>
               }
           </div>
@@ -89,7 +89,7 @@
     @if (changelog() || newVersion()?.release_notes_url) {
       <div class="update-summary">
         <h3>
-          {{ 'Update Summary for {version}' | translate: { version: newVersion().version } }}
+          {{ 'Update Summary for {version}' | translate : { version: newVersion().version } }}
         </h3>
 
         @if (changelog()) {


### PR DESCRIPTION
This will fix the translation error due to the character : stuck to the translate keyword

<img width="862" height="472" alt="2025-09-16_14-49-58" src="https://github.com/user-attachments/assets/5553525f-e123-44b4-a9f7-a38106ab572b" />
<img width="660" height="122" alt="2025-09-16_14-50-24" src="https://github.com/user-attachments/assets/f48ecc7d-305a-4e22-bc99-476feab4edb9" />
