### PR TITLE
NAS-137530 / 25.10.0 / Fix TrueNAS Connect race condition in claim token generation (by aervin)

### DIFF
--- a/src/app/modules/truenas-connect/components/truenas-connect-status-modal/truenas-connect-status-modal.component.ts
+++ b/src/app/modules/truenas-connect/components/truenas-connect-status-modal/truenas-connect-status-modal.component.ts
@@ -97,9 +97,9 @@ export class TruenasConnectStatusModalComponent {
 
     enableIfNeeded$
       .pipe(
-        // NOW check if we need token generation based on current status
-        switchMap(() => {
-          if (this.tnc.config()?.status === TruenasConnectStatus.ClaimTokenMissing) {
+        // NOW check if we need token generation based on updated config
+        switchMap((config) => {
+          if (config?.status === TruenasConnectStatus.ClaimTokenMissing) {
             return this.tnc.generateToken();
           }
           return of('');


### PR DESCRIPTION
The connect() method was using stale cached config instead of the updated config returned by enableService(). This caused intermittent failures where the claim token generation was skipped, leading to traceback errors when get_registration_uri() was called without a token.

Changed switchMap to use the actual returned config parameter instead of checking this.tnc.config() which may not have been updated yet via WebSocket.

**Testing:**
Register a TrueNAS with TrueNAS Connect. No middleware errors should be thrown.


Original PR: https://github.com/truenas/webui/pull/12571
