### PR TITLE
NAS-137604 / 25.10.0 / Enclosure preview & main view does not fit properly (by AlexKarpov98)

### DIFF
--- a/src/app/pages/system/enclosure/components/pages/enclosure-page/enclosure-page.component.scss
+++ b/src/app/pages/system/enclosure/components/pages/enclosure-page/enclosure-page.component.scss
@@ -45,7 +45,6 @@ ix-fake-progress-bar {
     display: flex;
     height: 100%;
     justify-content: center;
-    min-height: 330px;
     padding: 0;
 
     @media (max-width: $breakpoint-md) {
@@ -55,7 +54,7 @@ ix-fake-progress-bar {
 
     ::ng-deep {
       .enclosure-image {
-        max-height: 350px;
+        max-height: max-content;
 
         &.has-side-switch {
           max-height: 300px;

--- a/src/app/pages/system/enclosure/components/pages/enclosure-page/enclosure-selector/enclosure-selector.component.scss
+++ b/src/app/pages/system/enclosure/components/pages/enclosure-page/enclosure-selector/enclosure-selector.component.scss
@@ -47,6 +47,6 @@
 
   .enclosure-image {
     margin: 10px 16px;
-    max-height: 85px;
+    max-height: max-content;
   }
 }


### PR DESCRIPTION
Testing: see ticket.
After https://github.com/truenas/webui/pull/12567 is merged - enclosure mock will work.

Result:

Now rendered properly, full size.

https://github.com/user-attachments/assets/faa9d799-acfc-4ff7-a00e-acb180a4f3ca



Original PR: https://github.com/truenas/webui/pull/12566
