### PR TITLE
NAS-137636 / 25.10.0 / always send inherit_encryption in zvol form (by william-gr)

### DIFF
--- a/src/app/pages/datasets/components/zvol-form/zvol-form.component.spec.ts
+++ b/src/app/pages/datasets/components/zvol-form/zvol-form.component.spec.ts
@@ -193,6 +193,7 @@ describe('ZvolFormComponent', () => {
         volblocksize: '16K',
         readonly: OnOff.On,
         snapdev: DatasetSnapdev.Visible,
+        inherit_encryption: false,
         encryption: true,
         encryption_options: {
           algorithm: 'AES-128-CCM',
@@ -282,9 +283,9 @@ describe('ZvolFormComponent', () => {
       expect(createCall[1][0]).toMatchObject({
         name: 'parentId/encrypted-zvol',
         type: DatasetType.Volume,
+        inherit_encryption: true,
         // Should NOT include encryption field when inherit_encryption is true
       });
-      expect(createCall[1][0].inherit_encryption).toBeUndefined(); // inherit_encryption should be deleted from payload
       expect(createCall[1][0].encryption).toBeUndefined(); // encryption should not be sent when inheriting
     });
   });
@@ -334,6 +335,7 @@ describe('ZvolFormComponent', () => {
         compression: 'LZ4',
         deduplication: 'OFF',
         force_size: false,
+        inherit_encryption: true,
         readonly: 'INHERIT',
         snapdev: 'INHERIT',
         sync: 'STANDARD',

--- a/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
+++ b/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
@@ -570,7 +570,7 @@ export class ZvolFormComponent implements OnInit {
       }
       data.encryption_options.algorithm = data.algorithm;
     }
-    delete data.inherit_encryption;
+    // Keep inherit_encryption in the payload - don't delete it
     delete data.key;
     delete data.generate_key;
     delete data.passphrase;
@@ -611,7 +611,7 @@ export class ZvolFormComponent implements OnInit {
           data.encryption_options.algorithm = data.algorithm;
         }
 
-        delete data.inherit_encryption;
+        // Keep inherit_encryption in the payload - don't delete it
         delete data.key;
         delete data.generate_key;
         delete data.passphrase;


### PR DESCRIPTION
**Testing:**

Try to create an encrypted and not encrypted zvol when parent dataset is encrypted and when it isn't.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/12581
