### PR TITLE
NAS-137646 / 25.10.0 / User UI: Enabling SSH access does not save although the text says that the user was updated (by AlexKarpov98)

### DIFF
--- a/src/app/pages/credentials/users/user-form/auth-section/auth-section.component.html
+++ b/src/app/pages/credentials/users/user-form/auth-section/auth-section.component.html
@@ -52,5 +52,11 @@
         [tooltip]="tooltips.sshpubkey | translate"
       ></ix-textarea>
     }
+
+    @if (sshAccess() && form.hasError('sshAccessRequired')) {
+      <div class="ssh-access-error">
+        {{ form.getError('sshAccessRequired')?.message | translate }}
+      </div>
+    }
   </ix-fieldset>
 </form>

--- a/src/app/pages/credentials/users/user-form/auth-section/auth-section.component.scss
+++ b/src/app/pages/credentials/users/user-form/auth-section/auth-section.component.scss
@@ -6,3 +6,7 @@
 .password-input {
   margin-bottom: 0;
 }
+
+.ssh-access-error {
+  color: var(--error);
+}

--- a/src/app/pages/credentials/users/user-form/auth-section/auth-section.component.spec.ts
+++ b/src/app/pages/credentials/users/user-form/auth-section/auth-section.component.spec.ts
@@ -185,12 +185,19 @@ describe('AuthSectionComponent', () => {
       expect(await loader.getHarness(IxCheckboxHarness.with({ label: 'Allow SSH Login with Password (not recommended)' }))).toBeTruthy();
     });
 
-    it('disables "Allow SSH Login with Password" when password is disabled', async () => {
+    it('provides SSH access through key-based authentication when password is disabled', async () => {
+      // When password is disabled, users can still get SSH access via SSH keys
       await form.fillForm({ 'Disable Password': true });
 
-      expect(await form.getDisabledState()).toMatchObject({
-        'Allow SSH Login with Password (not recommended)': true,
-      });
+      // SSH key field should still be available for SSH access
+      expect(await loader.getHarness(IxTextareaHarness.with({ label: 'Public SSH Key' }))).toBeTruthy();
+
+      // User can enter an SSH key to enable SSH access
+      await form.fillForm({ 'Public SSH Key': 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ...' });
+
+      expect(spectator.inject(UserFormStore).updateUserConfig).toHaveBeenCalledWith(expect.objectContaining({
+        sshpubkey: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ...',
+      }));
     });
 
     it('disables Disable Password when "Allow SSH Login with Password" is set', async () => {
@@ -199,6 +206,16 @@ describe('AuthSectionComponent', () => {
       expect(await form.getDisabledState()).toMatchObject({
         'Disable Password': true,
       });
+    });
+
+    it('requires validation when SSH access is enabled but no authentication method is provided', async () => {
+      // SSH password should not be automatically enabled - users need to choose
+      expect(await form.getValues()).toMatchObject({
+        'Allow SSH Login with Password (not recommended)': false,
+      });
+
+      // Without any authentication method, form should have validation error
+      expect(spectator.component.form.hasError('sshAccessRequired')).toBe(true);
     });
 
     it('updates the store when SSH fields are changed', async () => {
@@ -227,6 +244,26 @@ describe('AuthSectionComponent', () => {
         'Public SSH Key': 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ...',
         'Allow SSH Login with Password (not recommended)': true,
       });
+    });
+
+    it('validates that SSH access requires at least one authentication method', async () => {
+      // Without auto-enable logic, SSH password should be false by default
+      expect(spectator.component.form.value.ssh_password_enabled).toBe(false);
+
+      // Form should have SSH access validation error since no authentication method is configured
+      expect(spectator.component.form.hasError('sshAccessRequired')).toBe(true);
+
+      // Enable SSH password authentication should remove the error
+      await form.fillForm({ 'Allow SSH Login with Password (not recommended)': true });
+      expect(spectator.component.form.hasError('sshAccessRequired')).toBe(false);
+
+      // Disable SSH password authentication should bring back the error
+      await form.fillForm({ 'Allow SSH Login with Password (not recommended)': false });
+      expect(spectator.component.form.hasError('sshAccessRequired')).toBe(true);
+
+      // Adding SSH key should remove SSH access error
+      await form.fillForm({ 'Public SSH Key': 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ...' });
+      expect(spectator.component.form.hasError('sshAccessRequired')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 734153f3456c821c69ef756d042cf45a53bb81f3
    git cherry-pick -x 57efaab806aad14136b2ad4d1ac8bb5c039c2b1a
    git cherry-pick -x 664c3664665ca6047171f33ab6d7bf56494f8d05

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x b769964bdab0cdc1845f22f65de0babdc3cbb442

Testing: see ticket.
No validation was present for SSH checkbox logic. Now it's added and form works as expected. Tests added.

Preview:


https://github.com/user-attachments/assets/6c3996f5-8797-40c6-a196-d8a4265965ce



Original PR: https://github.com/truenas/webui/pull/12584
