### PR TITLE
NAS-137692 / 26.04 / Make 2FA setup optional and add unset functionality

### DIFF
--- a/src/app/helptext/system/2fa.ts
+++ b/src/app/helptext/system/2fa.ts
@@ -15,7 +15,7 @@ export const helptext2fa = {
   },
 
   allSetUp: T('Two-Factor authentication has been configured.'),
-  enabledGloballyButNotForUser: T('Two-Factor authentication is required on this system, but it\'s not yet configured for your user. Please configure it now.'),
+  enabledGloballyButNotForUser: T('Two-Factor authentication is enabled on this system, but it\'s not yet configured for your user. Please configure it now.'),
   globallyDisabled: T('Two-Factor authentication is not enabled on this this system. You can configure your personal settings, but they will have no effect until two-factor authentication is enabled globally by system administrator.'),
   qrCodeMessage: T('Scan this QR Code with your authenticator app of choice. The next time you try to login, you will be asked to enter an One Time Password (OTP) from your authenticator app. This step is extremely important. Without the OTP you will be locked out of this system.'),
 

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -242,6 +242,8 @@ export class AuthService implements OnDestroy {
         this.api.clearSubscriptions();
         this.sessionInitialized = false;
         this.pendingAuthData = null;
+        this.loggedInUser$.next(null); // Clear user data on logout
+        this.cachedGlobalTwoFactorConfig$.next(null); // Clear cached 2FA config
       }),
     );
   }

--- a/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.html
+++ b/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.html
@@ -27,18 +27,25 @@
       </div>
 
       @if (globalTwoFactorConfig()?.enabled) {
-        <div
-          class="content-wrapper"
-          [class.not-available]="!user.twofactor_auth_configured"
-        >
-          <ix-icon name="mdi-cellphone-lock"></ix-icon>
-          <span class="label">
-            @if (user.twofactor_auth_configured) {
-              {{ 'Has Two-Factor Authentication' | translate }}
-            } @else {
-              {{ 'No Two-Factor Authentication' | translate }}
-            }
-          </span>
+        <div class="content-wrapper">
+          <div class="flex-container" [class.not-available]="!user.twofactor_auth_configured">
+            <ix-icon name="mdi-cellphone-lock"></ix-icon>
+            <span class="label">
+              @if (user.twofactor_auth_configured) {
+                {{ 'Has Two-Factor Authentication' | translate }}
+              } @else {
+                {{ 'No Two-Factor Authentication' | translate }}
+              }
+            </span>
+          </div>
+          @if (!user.twofactor_auth_configured && isCurrentUser()) {
+            <a
+              routerLink="/two-factor-auth"
+              [ixTest]="['setup-2fa', user.username]"
+            >
+              {{ 'Set up 2FA' | translate }}
+            </a>
+          }
         </div>
       }
 

--- a/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.scss
+++ b/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.scss
@@ -21,6 +21,7 @@ mat-card-content p {
     color: var(--primary);
     cursor: pointer;
     margin-left: auto;
+    opacity: 1 !important; // Ensure links are always fully visible
     text-decoration: underline;
   }
 
@@ -35,6 +36,11 @@ mat-card-content p {
 
 .not-available {
   opacity: 0.6;
+
+  // Don't affect links inside not-available elements
+  a {
+    opacity: 1 !important;
+  }
 }
 
 .flex-container {

--- a/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.ts
+++ b/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.ts
@@ -77,6 +77,11 @@ export class UserAccessCardComponent {
   protected readonly searchableElements = userAccessCardElements;
 
   protected readonly globalTwoFactorConfig = toSignal(this.authService.getGlobalTwoFactorConfig());
+  protected readonly currentUser = toSignal(this.authService.user$);
+
+  protected readonly isCurrentUser = computed(() => {
+    return this.currentUser()?.pw_name === this.user().username;
+  });
 
   readonly sshAccessStatus = computed<string | null>(() => {
     if (this.user().sshpubkey && this.user().ssh_password_enabled) {

--- a/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.html
+++ b/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.html
@@ -1,22 +1,24 @@
 <div class="wrapper">
   <h2>
-    {{ 'Complete to proceed:' | translate }}
+    {{ 'Setup Two-Factor Authentication' | translate }}
   </h2>
 
   <div class="container">
     <div [class.step-finished]="canFinish()">
-      <ix-two-factor></ix-two-factor>
+      <ix-two-factor [isSetupDialog]="true" (skipSetup)="onSkipSetup()"></ix-two-factor>
     </div>
   </div>
 
   @if (canFinish()) {
-    <button
-      mat-button
-      color="primary"
-      matDialogClose
-      ixTest="finish-first-stig-login"
-    >
-      {{ 'Finish' | translate }}
-    </button>
+    <div class="dialog-actions">
+      <button
+        mat-button
+        color="primary"
+        matDialogClose
+        ixTest="finish-first-stig-login"
+      >
+        {{ 'Finish' | translate }}
+      </button>
+    </div>
   }
 </div>

--- a/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.scss
+++ b/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.scss
@@ -85,3 +85,10 @@
   justify-content: center;
   width: 100%;
 }
+
+.dialog-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 24px;
+}

--- a/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.ts
+++ b/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
-import { MatDialogClose } from '@angular/material/dialog';
+import { MatDialogClose, MatDialogRef } from '@angular/material/dialog';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
 import { map } from 'rxjs';
@@ -25,8 +25,13 @@ import { TwoFactorComponent } from 'app/pages/two-factor-auth/two-factor.compone
 })
 export class TwoFactorSetupDialog {
   private authService = inject(AuthService);
+  private dialogRef = inject(MatDialogRef<TwoFactorSetupDialog>);
 
   protected canFinish = toSignal(
     this.authService.userTwoFactorConfig$.pipe(map((config) => config.secret_configured)),
   );
+
+  protected onSkipSetup(): void {
+    this.dialogRef.close(true);
+  }
 }

--- a/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-form/global-two-factor-form.component.ts
+++ b/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-form/global-two-factor-form.component.ts
@@ -68,7 +68,7 @@ export class GlobalTwoFactorAuthFormComponent implements OnInit {
     ssh: [false],
   });
 
-  enableWarning: string = this.translate.instant('Once enabled, users will be required to set up two factor authentication next time they login.');
+  enableWarning: string = this.translate.instant('Once enabled, users will be prompted to set up two-factor authentication next time they login. They can choose to skip the setup if desired.');
 
   protected twoFactorConfig: GlobalTwoFactorConfig;
 

--- a/src/app/pages/two-factor-auth/two-factor.component.html
+++ b/src/app/pages/two-factor-auth/two-factor.component.html
@@ -19,20 +19,45 @@
       }
       @if (globalTwoFactorEnabled() && !userTwoFactorAuthConfigured()) {
         <p>
-          {{ 'Two-Factor Authentication has been enabled on this system. You are required to setup your 2FA authentication. You will not be able to proceed without setting up 2FA for your account. Make sure to scan the QR code with your authenticator app in the end before logging out of the system or navigating away. Otherwise, you will be locked out of the system and will be unable to login after logging out.' | translate }}
+          {{ 'Two-Factor Authentication has been enabled on this system. It is strongly recommended to set up 2FA for your account to enhance security. Make sure to scan the QR code with your authenticator app before logging out or navigating away, otherwise you may have difficulty accessing your account later.' | translate }}
         </p>
       }
-      <button
-        mat-button
-        color="primary"
-        type="button"
-        ixTest="renew-secret"
-        [disabled]="isFormLoading()"
-        [ixUiSearch]="searchableElements.elements.configure2FaSecret"
-        (click)="renewSecretOrEnable2Fa()"
-      >
-        {{ userTwoFactorAuthConfigured() ? ('Renew 2FA Secret' | translate) : ('Configure 2FA Secret' | translate) }}
-      </button>
+      <div class="button-group">
+        <button
+          mat-button
+          color="primary"
+          type="button"
+          ixTest="renew-secret"
+          [disabled]="isFormLoading()"
+          [ixUiSearch]="searchableElements.elements.configure2FaSecret"
+          (click)="renewSecretOrEnable2Fa()"
+        >
+          {{ userTwoFactorAuthConfigured() ? ('Renew 2FA Secret' | translate) : ('Configure 2FA Secret' | translate) }}
+        </button>
+        @if (userTwoFactorAuthConfigured()) {
+          <button
+            mat-button
+            color="warn"
+            type="button"
+            ixTest="unset-2fa-secret"
+            [disabled]="isFormLoading()"
+            (click)="unset2FaSecret()"
+          >
+            {{ 'Unset 2FA Secret' | translate }}
+          </button>
+        }
+        @if (isSetupDialog() && !userTwoFactorAuthConfigured()) {
+          <button
+            mat-button
+            type="button"
+            ixTest="skip-2fa-setup"
+            [disabled]="isFormLoading()"
+            (click)="onSkipSetup()"
+          >
+            {{ 'Skip Setup' | translate }}
+          </button>
+        }
+      </div>
     </div>
   </mat-card-actions>
 

--- a/src/app/pages/two-factor-auth/two-factor.component.html
+++ b/src/app/pages/two-factor-auth/two-factor.component.html
@@ -46,7 +46,7 @@
             {{ 'Unset 2FA Secret' | translate }}
           </button>
         }
-        @if (isSetupDialog() && !userTwoFactorAuthConfigured()) {
+        @if (showSkipButton()) {
           <button
             mat-button
             type="button"

--- a/src/app/pages/two-factor-auth/two-factor.component.scss
+++ b/src/app/pages/two-factor-auth/two-factor.component.scss
@@ -34,6 +34,12 @@ button {
   margin-top: 16px;
 }
 
+.button-group {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
 .skeleton-loader {
   width: 100%;
 }

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, signal, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, input, output, signal, inject } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardActions } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
@@ -52,6 +52,9 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
   ],
 })
 export class TwoFactorComponent implements OnInit, OnDestroy {
+  readonly isSetupDialog = input(false);
+  readonly skipSetup = output();
+
   authService = inject(AuthService);
   private dialogService = inject(DialogService);
   private translate = inject(TranslateService);
@@ -168,5 +171,56 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
       });
     }
     return of(true);
+  }
+
+  protected onSkipSetup(): void {
+    this.dialogService.confirm({
+      title: this.translate.instant('Skip Two-Factor Authentication Setup?'),
+      message: this.translate.instant(
+        'Two-factor authentication significantly improves the security of your account. '
+        + 'Are you sure you want to skip this setup? You can enable it later from your user settings.',
+      ),
+      buttonText: this.translate.instant('Skip Setup'),
+      cancelText: this.translate.instant('Continue Setup'),
+      hideCheckbox: true,
+    }).pipe(
+      filter(Boolean),
+      untilDestroyed(this),
+    ).subscribe(() => {
+      this.skipSetup.emit();
+    });
+  }
+
+  protected unset2FaSecret(): void {
+    this.dialogService.confirm({
+      title: this.translate.instant('Unset Two-Factor Authentication?'),
+      message: this.translate.instant(
+        'Are you sure you want to unset two-factor authentication? '
+        + 'This will remove your current 2FA configuration and you will need to set it up again to use 2FA.',
+      ),
+      buttonText: this.translate.instant('Unset 2FA'),
+      cancelText: this.translate.instant('Cancel'),
+      hideCheckbox: true,
+      buttonColor: 'warn',
+    }).pipe(
+      filter(Boolean),
+      switchMap(() => {
+        this.isFormLoading.set(true);
+        return this.authService.user$.pipe(
+          take(1),
+          filter((user) => !!user),
+          switchMap((user) => this.api.call('user.unset_2fa_secret', [user.pw_name])),
+        );
+      }),
+      switchMap(() => this.authService.refreshUser()),
+      tap(() => {
+        this.isFormLoading.set(false);
+        this.userTwoFactorAuthConfigured.set(false);
+        this.showQrCodeWarning = false;
+        this.window.localStorage.setItem('showQr2FaWarning', 'false');
+      }),
+      catchError((error: unknown) => this.handleError(error)),
+      untilDestroyed(this),
+    ).subscribe();
   }
 }


### PR DESCRIPTION
  - Make 2FA setup optional instead of mandatory
    * Add "Skip Setup" button with confirmation dialog to 2FA setup screen
    * Users can now choose to skip 2FA setup and proceed without it
    * Updated warning messages to reflect that 2FA is recommended, not required

  - Add "Unset 2FA Secret" functionality
    * Add warning-level button to remove existing 2FA configuration
    * Calls user.unset_2fa_secret API with username
    * Shows confirmation dialog before removing 2FA

  - Fix 2FA dialog showing on every navigation
    * Dialog now shows only once per session after login
    * Added hasCheckedTwoFactorSetup flag to track if dialog was shown
    * Resets properly on logout for next session

  - Remove admin bypass for /system/* routes
    * Admins now see 2FA setup dialog like all other users
    * Ensures consistent security behavior across all user roles

  - Update UI and messaging
    * Changed "Complete to proceed:" to "Setup Two-Factor Authentication"
    * Updated global 2FA warning from "required" to "prompted to set up"
    * Updated helptext to indicate 2FA is enabled, not required

  - Add comprehensive test coverage
    * Added tests for unset2FaSecret method
    * Added tests for skip setup functionality
    * Added test for dialog showing only once per session
    * Updated admin bypass test to verify new behavior
    * All 53 tests passing


https://github.com/user-attachments/assets/71498251-154d-4363-b951-851495eed92e


**Testing:**

Enable 2FA globally, set up a new full admin user and login with it.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |Change of 2FA behavior, description in the PR message
|Testing         |Behavior change for 2FA
