### PR TITLE
NAS-137650 / 25.10-RC.1 / role-based access control for the NVMe-oF sharing pages (by william-gr)

### DIFF
--- a/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.html
+++ b/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.html
@@ -1,5 +1,6 @@
 @if (noHostsExist()) {
   <button
+    *ixRequiresRoles="requiredRoles"
     mat-button
     type="button"
     [ixTest]="'add-host'"
@@ -10,6 +11,7 @@
 }
 @else {
   <button
+    *ixRequiresRoles="requiredRoles"
     mat-button
     type="button"
     [ixTest]="'add-host'"

--- a/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.spec.ts
@@ -7,6 +7,7 @@ import { MatMenuHarness } from '@angular/material/menu/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { NvmeOfHost } from 'app/interfaces/nvme-of.interface';
+import { AuthService } from 'app/modules/auth/auth.service';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { AddHostMenuComponent } from 'app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component';
 import { HostFormComponent } from 'app/pages/sharing/nvme-of/hosts/host-form/host-form.component';
@@ -34,6 +35,9 @@ describe('AddHostMenuComponent', () => {
   const createComponent = createComponentFactory({
     component: AddHostMenuComponent,
     providers: [
+      mockProvider(AuthService, {
+        hasRole: jest.fn(() => of(true)),
+      }),
       mockProvider(NvmeOfStore, {
         hosts: allHosts,
       }),

--- a/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.ts
+++ b/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.ts
@@ -7,6 +7,8 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
 import { sortBy } from 'lodash-es';
 import { filter } from 'rxjs/operators';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
+import { Role } from 'app/enums/role.enum';
 import { NvmeOfHost } from 'app/interfaces/nvme-of.interface';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
@@ -29,6 +31,7 @@ import { NvmeOfStore } from 'app/pages/sharing/nvme-of/services/nvme-of.store';
     TranslateModule,
     MatMenuTrigger,
     MatDivider,
+    RequiresRolesDirective,
   ],
 })
 export class AddHostMenuComponent {
@@ -50,6 +53,8 @@ export class AddHostMenuComponent {
     const unusedHosts = this.allHosts().filter((host) => !usedHostIds.includes(host.id));
     return sortBy(unusedHosts, ['hostnqn']);
   });
+
+  protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
 
   protected openHostForm(): void {
     this.slideIn

--- a/src/app/pages/sharing/nvme-of/hosts/host-form/host-form.component.html
+++ b/src/app/pages/sharing/nvme-of/hosts/host-form/host-form.component.html
@@ -107,6 +107,7 @@
 
       <ix-form-actions>
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-button
           type="submit"
           color="primary"

--- a/src/app/pages/sharing/nvme-of/hosts/host-form/host-form.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/hosts/host-form/host-form.component.spec.ts
@@ -2,8 +2,10 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { NvmeOfGlobalConfig, NvmeOfHost } from 'app/interfaces/nvme-of.interface';
+import { AuthService } from 'app/modules/auth/auth.service';
 import { DetailsTableHarness } from 'app/modules/details-table/details-table.harness';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
@@ -33,6 +35,9 @@ describe('HostFormComponent', () => {
       mockProvider(SlideInRef, {
         getData: slideInGetData,
         close: jest.fn(),
+      }),
+      mockProvider(AuthService, {
+        hasRole: jest.fn(() => of(true)),
       }),
     ],
   });

--- a/src/app/pages/sharing/nvme-of/hosts/host-form/host-form.component.ts
+++ b/src/app/pages/sharing/nvme-of/hosts/host-form/host-form.component.ts
@@ -9,6 +9,8 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
 import { omit } from 'lodash-es';
 import { finalize, switchMap } from 'rxjs';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
+import { Role } from 'app/enums/role.enum';
 import { singleArrayToOptions } from 'app/helpers/operators/options.operators';
 import { helptextNvmeOf } from 'app/helptext/sharing/nvme-of/nvme-of';
 import { NvmeOfHost } from 'app/interfaces/nvme-of.interface';
@@ -53,6 +55,7 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
     DetailsTableComponent,
     DetailsItemComponent,
     MatTooltip,
+    RequiresRolesDirective,
   ],
 })
 export class HostFormComponent implements OnInit {
@@ -85,6 +88,8 @@ export class HostFormComponent implements OnInit {
 
   protected isGeneratingHostKey = signal(false);
   protected isGeneratingTrueNasKey = signal(false);
+
+  protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
 
   ngOnInit(): void {
     const existingHost = this.slideInRef.getData();

--- a/src/app/pages/sharing/nvme-of/namespaces/base-namespace-form/base-namespace-form.component.html
+++ b/src/app/pages/sharing/nvme-of/namespaces/base-namespace-form/base-namespace-form.component.html
@@ -60,6 +60,7 @@
 
       <ix-form-actions>
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-button
           color="primary"
           type="submit"

--- a/src/app/pages/sharing/nvme-of/namespaces/base-namespace-form/base-namespace-form.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/namespaces/base-namespace-form/base-namespace-form.component.spec.ts
@@ -4,9 +4,11 @@ import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, Spectator, mockProvider } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
+import { of } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
 import { NvmeOfNamespaceType } from 'app/enums/nvme-of.enum';
 import { NvmeOfNamespace } from 'app/interfaces/nvme-of.interface';
+import { AuthService } from 'app/modules/auth/auth.service';
 import {
   ExplorerCreateZvolComponent,
 } from 'app/modules/forms/ix-forms/components/ix-explorer/explorer-create-zvol/explorer-create-zvol.component';
@@ -29,6 +31,9 @@ describe('BaseNamespaceFormComponent', () => {
       MockComponent(ExplorerCreateZvolComponent),
     ],
     providers: [
+      mockProvider(AuthService, {
+        hasRole: jest.fn(() => of(true)),
+      }),
       mockProvider(FormErrorHandlerService),
       mockProvider(FilesystemService),
       mockProvider(SlideInRef),

--- a/src/app/pages/sharing/nvme-of/namespaces/base-namespace-form/base-namespace-form.component.ts
+++ b/src/app/pages/sharing/nvme-of/namespaces/base-namespace-form/base-namespace-form.component.ts
@@ -7,7 +7,9 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { datasetsRootNode, zvolsRootNode } from 'app/constants/basic-root-nodes.constant';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { NvmeOfNamespaceType } from 'app/enums/nvme-of.enum';
+import { Role } from 'app/enums/role.enum';
 import { NvmeOfNamespace } from 'app/interfaces/nvme-of.interface';
 import { Option } from 'app/interfaces/option.interface';
 import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
@@ -69,6 +71,7 @@ const typeOptions: Option[] = [
     IxButtonGroupComponent,
     IxInputComponent,
     ExplorerCreateZvolComponent,
+    RequiresRolesDirective,
   ],
 })
 export class BaseNamespaceFormComponent implements OnInit, OnChanges {
@@ -104,6 +107,8 @@ export class BaseNamespaceFormComponent implements OnInit, OnChanges {
   protected readonly FormNamespaceType = FormNamespaceType;
 
   protected typeOptions$ = of(translateOptions(this.translate, typeOptions));
+
+  protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
 
   constructor() {
     this.clearPathOnTypeChanges();

--- a/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.html
+++ b/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.html
@@ -1,5 +1,6 @@
 @if (noPortsExist()) {
   <button
+    *ixRequiresRoles="requiredRoles"
     mat-button
     type="button"
     [ixTest]="'add-port'"
@@ -10,6 +11,7 @@
 }
 @else {
   <button
+    *ixRequiresRoles="requiredRoles"
     mat-button
     type="button"
     [ixTest]="'add-port'"

--- a/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.spec.ts
@@ -8,6 +8,7 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { of } from 'rxjs';
 import { NvmeOfTransportType } from 'app/enums/nvme-of.enum';
 import { NvmeOfPort } from 'app/interfaces/nvme-of.interface';
+import { AuthService } from 'app/modules/auth/auth.service';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { AddPortMenuComponent } from 'app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component';
 import { ManagePortsDialog } from 'app/pages/sharing/nvme-of/ports/manage-ports/manage-ports-dialog.component';
@@ -41,6 +42,9 @@ describe('AddPortMenuComponent', () => {
   const createComponent = createComponentFactory({
     component: AddPortMenuComponent,
     providers: [
+      mockProvider(AuthService, {
+        hasRole: jest.fn(() => of(true)),
+      }),
       mockProvider(NvmeOfStore, {
         ports: allPorts,
       }),

--- a/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.ts
+++ b/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.ts
@@ -7,6 +7,8 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
 import { sortBy } from 'lodash-es';
 import { filter } from 'rxjs/operators';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
+import { Role } from 'app/enums/role.enum';
 import { NvmeOfPort } from 'app/interfaces/nvme-of.interface';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
@@ -31,6 +33,7 @@ import { NvmeOfStore } from 'app/pages/sharing/nvme-of/services/nvme-of.store';
     MatMenuTrigger,
     PortDescriptionComponent,
     MatDivider,
+    RequiresRolesDirective,
   ],
 })
 export class AddPortMenuComponent {
@@ -50,6 +53,8 @@ export class AddPortMenuComponent {
     const unusedPorts = this.allPorts().filter((port) => !usedPortIds.includes(port.id));
     return sortBy(unusedPorts, ['addr_trtype', 'addr_traddr', 'addr_trsvcid']);
   });
+
+  protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
 
   protected openPortForm(): void {
     this.slideIn

--- a/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.html
+++ b/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.html
@@ -32,6 +32,7 @@
 
       <ix-form-actions>
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-button
           type="submit"
           color="primary"

--- a/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.spec.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { NvmeOfTransportType } from 'app/enums/nvme-of.enum';
 import { NvmeOfPort } from 'app/interfaces/nvme-of.interface';
+import { AuthService } from 'app/modules/auth/auth.service';
 import { IxSelectHarness } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.harness';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
@@ -39,6 +40,9 @@ describe('PortFormComponent', () => {
       mockProvider(SlideInRef, {
         getData: slideInGetData,
         close: jest.fn(),
+      }),
+      mockProvider(AuthService, {
+        hasRole: jest.fn(() => of(true)),
       }),
     ],
   });

--- a/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.ts
+++ b/src/app/pages/sharing/nvme-of/ports/port-form/port-form.component.ts
@@ -10,7 +10,9 @@ import {
   finalize, switchMap,
 } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { NvmeOfTransportType, nvmeOfTransportTypeLabels } from 'app/enums/nvme-of.enum';
+import { Role } from 'app/enums/role.enum';
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextNvmeOf } from 'app/helptext/sharing/nvme-of/nvme-of';
@@ -45,6 +47,7 @@ import { NvmeOfService } from 'app/pages/sharing/nvme-of/services/nvme-of.servic
     FormActionsComponent,
     MatButton,
     TestDirective,
+    RequiresRolesDirective,
   ],
 })
 export class PortFormComponent implements OnInit {
@@ -70,6 +73,8 @@ export class PortFormComponent implements OnInit {
   );
 
   protected readonly helptext = helptextNvmeOf;
+
+  protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
 
   protected form = this.formBuilder.group({
     addr_trtype: [NvmeOfTransportType.Tcp],

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.html
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.html
@@ -43,6 +43,7 @@
 
               <span class="host-actions">
                 <button
+                  *ixRequiresRoles="requiredRoles"
                   mat-icon-button
                   [ixTest]="['remove-host-association', host.hostnqn]"
                   [matTooltip]="'Remove host from the subsystem' | translate"

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.spec.ts
@@ -3,6 +3,7 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { NvmeOfHost, NvmeOfSubsystemDetails } from 'app/interfaces/nvme-of.interface';
+import { AuthService } from 'app/modules/auth/auth.service';
 import { IxIconHarness } from 'app/modules/ix-icon/ix-icon.harness';
 import { AddHostMenuComponent } from 'app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component';
 import { NvmeOfService } from 'app/pages/sharing/nvme-of/services/nvme-of.service';
@@ -26,6 +27,9 @@ describe('SubsystemHostsCardComponent', () => {
       }),
       mockProvider(NvmeOfStore, {
         initialize: jest.fn(),
+      }),
+      mockProvider(AuthService, {
+        hasRole: jest.fn(() => of(true)),
       }),
     ],
   });

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.ts
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.ts
@@ -8,7 +8,9 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { forkJoin, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
+import { Role } from 'app/enums/role.enum';
 import { helptextNvmeOf } from 'app/helptext/sharing/nvme-of/nvme-of';
 import { NvmeOfSubsystemDetails, NvmeOfHost } from 'app/interfaces/nvme-of.interface';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
@@ -39,6 +41,7 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
     MatIconButton,
     TestDirective,
     UiSearchDirective,
+    RequiresRolesDirective,
   ],
 })
 export class SubsystemHostsCardComponent {
@@ -54,6 +57,8 @@ export class SubsystemHostsCardComponent {
   protected helptext = helptextNvmeOf;
 
   protected readonly searchableElements = subsystemHostsCardElements;
+
+  protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
 
   protected hostAdded(host: NvmeOfHost): void {
     const subsystem = this.subsystem();

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.html
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.html
@@ -3,6 +3,7 @@
     <h3 mat-card-title>{{ 'Namespaces' | translate }}</h3>
 
     <button
+      *ixRequiresRoles="requiredRoles"
       mat-button
       type="button"
       ixTest="add-namespace"
@@ -33,6 +34,7 @@
 
               <span class="namespace-actions">
                 <button
+                  *ixRequiresRoles="requiredRoles"
                   mat-icon-button
                   [ixTest]="['delete-namespace', namespace.device_path]"
                   [matTooltip]="'Delete namespace' | translate"

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.spec.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import { NvmeOfNamespaceType } from 'app/enums/nvme-of.enum';
 import { helptextNvmeOf } from 'app/helptext/sharing/nvme-of/nvme-of';
 import { NvmeOfNamespace, NvmeOfSubsystemDetails } from 'app/interfaces/nvme-of.interface';
+import { AuthService } from 'app/modules/auth/auth.service';
 import { IxIconHarness } from 'app/modules/ix-icon/ix-icon.harness';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { NamespaceDescriptionComponent } from 'app/pages/sharing/nvme-of/namespaces/namespace-description/namespace-description.component';
@@ -32,6 +33,9 @@ describe('SubsystemNamespacesCardComponent', () => {
       }),
       mockProvider(NvmeOfStore, {
         initialize: jest.fn(),
+      }),
+      mockProvider(AuthService, {
+        hasRole: jest.fn(() => of(true)),
       }),
     ],
   });

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.ts
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.ts
@@ -8,7 +8,9 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule } from '@ngx-translate/core';
 import { filter } from 'rxjs';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
+import { Role } from 'app/enums/role.enum';
 import { helptextNvmeOf } from 'app/helptext/sharing/nvme-of/nvme-of';
 import { NvmeOfNamespace, NvmeOfSubsystemDetails } from 'app/interfaces/nvme-of.interface';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
@@ -43,6 +45,7 @@ import { DeleteNamespaceDialogComponent } from './delete-namespace-dialog/delete
     TestDirective,
     UiSearchDirective,
     MatButton,
+    RequiresRolesDirective,
   ],
 })
 export class SubsystemNamespacesCardComponent {
@@ -55,6 +58,8 @@ export class SubsystemNamespacesCardComponent {
   protected readonly helptext = helptextNvmeOf;
 
   protected readonly searchableElements = subsystemNamespacesCardElements;
+
+  protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
 
   protected onAddNamespace(): void {
     this.slideIn.open(NamespaceFormComponent, {

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.html
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.html
@@ -29,6 +29,7 @@
 
               <span class="port-actions">
                 <button
+                  *ixRequiresRoles="requiredRoles"
                   mat-icon-button
                   [ixTest]="['remove-port-association', port.addr_trtype, port.addr_traddr, port.addr_trsvcid]"
                   [matTooltip]="'Remove port from the subsystem' | translate"

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.spec.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import { NvmeOfTransportType } from 'app/enums/nvme-of.enum';
 import { helptextNvmeOf } from 'app/helptext/sharing/nvme-of/nvme-of';
 import { NvmeOfPort, NvmeOfSubsystemDetails } from 'app/interfaces/nvme-of.interface';
+import { AuthService } from 'app/modules/auth/auth.service';
 import { IxIconHarness } from 'app/modules/ix-icon/ix-icon.harness';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { AddPortMenuComponent } from 'app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component';
@@ -33,6 +34,9 @@ describe('SubsystemPortsCardComponent', () => {
       mockProvider(SnackbarService),
       mockProvider(NvmeOfStore, {
         initialize: jest.fn(),
+      }),
+      mockProvider(AuthService, {
+        hasRole: jest.fn(() => of(true)),
       }),
     ],
   });

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.ts
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.ts
@@ -6,7 +6,9 @@ import {
 import { MatTooltip } from '@angular/material/tooltip';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
+import { Role } from 'app/enums/role.enum';
 import { helptextNvmeOf } from 'app/helptext/sharing/nvme-of/nvme-of';
 import { NvmeOfPort, NvmeOfSubsystemDetails } from 'app/interfaces/nvme-of.interface';
 import { IxIconComponent } from 'app/modules/ix-icon/ix-icon.component';
@@ -39,6 +41,7 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
     TestDirective,
     UiSearchDirective,
     MatTooltip,
+    RequiresRolesDirective,
   ],
 })
 export class SubsystemPortsCardComponent {
@@ -54,6 +57,8 @@ export class SubsystemPortsCardComponent {
   protected helptext = helptextNvmeOf;
 
   protected readonly searchableElements = subsystemPortsCardElements;
+
+  protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
 
   protected onPortAdded(port: NvmeOfPort): void {
     this.nvmeOfService.associatePorts(this.subsystem(), [port])

--- a/src/assets/ui-searchable-elements.json
+++ b/src/assets/ui-searchable-elements.json
@@ -2931,7 +2931,9 @@
       "Add Namespace"
     ],
     "synonyms": [],
-    "requiredRoles": [],
+    "requiredRoles": [
+      "SHARING_NVME_TARGET_WRITE"
+    ],
     "visibleTokens": [],
     "anchorRouterLink": [
       "/sharing",


### PR DESCRIPTION

**Changes:**

  1. NVMe List Pages - Added role restrictions (Role.SharingNvmeTargetWrite) to:
    - Main "Add Subsystem" button in nvme-of.component.html (already had it)
    - Add/Delete buttons in subsystem cards
  2. NVMe Form/Edit Pages - Added role restrictions to save buttons in:
    - base-namespace-form - Save button for adding/editing namespaces
    - host-form - Save button for adding/editing hosts
    - port-form - Save button for adding/editing ports
  3. Subsystem Detail Cards - Added role restrictions to action buttons:
    - SubsystemNamespacesCard: Add namespace button and delete namespace buttons
    - SubsystemHostsCard: Add host menu and remove host association buttons
    - SubsystemPortsCard: Add port menu and remove port association buttons
  4. Menu Components - Added role restrictions to:
    - AddHostMenu: Add button with dropdown for selecting/creating hosts
    - AddPortMenu: Add button with dropdown for selecting/creating ports

  Key Implementation Details:

  - Used RequiresRolesDirective with *ixRequiresRoles attribute
  - Applied Role.SharingNvmeTargetWrite role consistently across all NVMe sharing components
  - Followed the same pattern as iSCSI pages for consistency
  - Updated test files to include AuthService mock to prevent test failures

  Result:

  Readonly admins will now be unable to:
  - Add new NVMe subsystems, namespaces, hosts, or ports
  - Delete existing items
  - Save changes when editing items
  - Remove associations between subsystems and hosts/ports

**Testing:**

Try to add/save things with readonly user

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/12589
