### PR TITLE
NAS-137661 / 25.10-RC.1 / User UI: Back button is not working (by AlexKarpov98)

### DIFF
--- a/src/app/modules/master-detail-view/master-detail-view.component.html
+++ b/src/app/modules/master-detail-view/master-detail-view.component.html
@@ -12,7 +12,7 @@
       <div class="header-container">
         @if (isMobileView()) {
           <ix-mobile-back-button
-            (close)="toggleShowMobileDetails(false)"
+            (closed)="toggleShowMobileDetails(false)"
           ></ix-mobile-back-button>
         }
         <h3 class="header">

--- a/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.html
+++ b/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.html
@@ -2,7 +2,7 @@
   <h3 class="title" [class.no-buttons]="dataset().locked || isZvol()">
     <div class="mobile-prefix">
       <ix-mobile-back-button
-        (close)="onCloseMobileDetails()"
+        (closed)="onCloseMobileDetails()"
       ></ix-mobile-back-button>
       {{ 'Details for' | translate }}
     </div>


### PR DESCRIPTION
Not sure why there is no lint error for such cases.
`(close)` instead of `(closed)` used 



Original PR: https://github.com/truenas/webui/pull/12585
