### PR TITLE
NAS-137656 / 25.10-RC.1 / Calendar on audit page is not rendered correctly (by AlexKarpov98)

### DIFF
--- a/src/app/modules/forms/search-input/components/advanced-search/advanced-search.component.scss
+++ b/src/app/modules/forms/search-input/components/advanced-search/advanced-search.component.scss
@@ -122,6 +122,10 @@
           width: 100%;
         }
 
+        .mat-calendar-table tr {
+          display: table-row;
+        }
+
         .mat-calendar-body-cell,
         .mat-calendar-body-cell-content {
           cursor: pointer;


### PR DESCRIPTION
Preview:

<img width="316" height="419" alt="Screenshot 2025-09-25 at 13 33 17" src="https://github.com/user-attachments/assets/cfb18568-b0b1-46bc-a2d0-c554aea588f6" />


Original PR: https://github.com/truenas/webui/pull/12604
