### PR TITLE
NAS-137665 / 26.04 / feat: add dynamic validation to the cloudflare DNS auth form

### DIFF
--- a/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.spec.ts
@@ -13,6 +13,7 @@ import { DnsAuthenticator } from 'app/interfaces/dns-authenticator.interface';
 import { Option } from 'app/interfaces/option.interface';
 import { Schema } from 'app/interfaces/schema.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
+import { IxInputHarness } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.harness';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -204,7 +205,9 @@ describe('AcmednsFormComponent', () => {
         'API Token': '',
       });
 
-      expect(spectator.query('.form-error > * > span').textContent.toLowerCase()).toBe('api key is required');
+      const errorMsg = await loader.getHarness(IxInputHarness.with({ label: 'API Key' }))
+        .then((harness) => harness.getErrorText());
+      expect(errorMsg.toLowerCase()).toBe('api key is required');
     });
 
     it('requires an email address when API key is supplied', async () => {
@@ -216,7 +219,9 @@ describe('AcmednsFormComponent', () => {
         'API Token': '',
       });
 
-      expect(spectator.query('.form-error > * > span').textContent.toLowerCase()).toBe('cloudflare email is required');
+      const errorMsg = await loader.getHarness(IxInputHarness.with({ label: 'Cloudflare Email' }))
+        .then((harness) => harness.getErrorText());
+      expect(errorMsg.toLowerCase()).toBe('cloudflare email is required');
     });
 
     it('will not permit an email nor API key to be used with token', async () => {
@@ -228,7 +233,9 @@ describe('AcmednsFormComponent', () => {
         'API Token': 'some_token',
       });
 
-      expect(spectator.query('.form-error > * > span').textContent.toLowerCase()).toBe('email/api key cannot be used with token');
+      const errorMsg = await loader.getHarness(IxInputHarness.with({ label: 'Cloudflare Email' }))
+        .then((harness) => harness.getErrorText());
+      expect(errorMsg.toLowerCase()).toBe('email/api key cannot be used with api token');
     });
 
     it('will correctly swap which fields are required when emptying other fields', async () => {
@@ -249,7 +256,9 @@ describe('AcmednsFormComponent', () => {
 
       // this tests for null since there *won't* be any errors. reason for this is the only way
       // to trigger the behavior we're testing is to make the form valid.
-      expect(spectator.query('.form-error > * > span')).toBeNull();
+      let errorMsg = await loader.getHarness(IxInputHarness.with({ label: 'Cloudflare Email' }))
+        .then((harness) => harness.getErrorText());
+      expect(errorMsg.toLowerCase()).toBe('');
 
       await form.fillForm({
         Name: 'name_edit',
@@ -265,7 +274,9 @@ describe('AcmednsFormComponent', () => {
         'API Token': '',
       });
 
-      expect(spectator.query('.form-error > * > span').textContent.toLowerCase()).toBe('api key is required');
+      errorMsg = await loader.getHarness(IxInputHarness.with({ label: 'API Token' }))
+        .then((harness) => harness.getErrorText());
+      expect(errorMsg.toLowerCase()).toBe('');
     });
   });
 });


### PR DESCRIPTION
**Changes:**

when configuring a Cloudflare ACME DNS authenticator on the `credentials/certificates` page, the email and API key fields are mutually exclusive with the API token field. these requirements weren't actually formalized in the UI and weren't revealed until a user submitted the form. this PR adds dynamic validation to the page to properly show requirements as the user edits the form.

**Testing:**

1. navigate to the "Credentials" menu on the left and choose "Certificates".
2. click the "Add" button on the ACME DNS-Authenticators section. the "Cloudflare" DNS authenticator is already selected.
3. edit the fields on the form and observe that the required fields change as you input and clear each field.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
