### PR TITLE
NAS-137674 / 26.04 / fix: reverse sorting arrow; up means ascending, down means descending

### DIFF
--- a/src/app/modules/ix-table/components/ix-table-head/ix-table-head.component.html
+++ b/src/app/modules/ix-table/components/ix-table-head/ix-table-head.component.html
@@ -22,10 +22,10 @@
         @if (!column.disableSorting) {
           <div>
             @if (dataProvider().sorting.direction === SortDirection.Asc && dataProvider().sorting.active === idx) {
-              <ix-icon name="mdi-arrow-down" class="sort-icon"></ix-icon>
+              <ix-icon name="mdi-arrow-up" class="sort-icon"></ix-icon>
             }
             @if (dataProvider().sorting.direction === SortDirection.Desc && dataProvider().sorting.active === idx) {
-              <ix-icon name="mdi-arrow-up" class="sort-icon"></ix-icon>
+              <ix-icon name="mdi-arrow-down" class="sort-icon"></ix-icon>
             }
           </div>
         }


### PR DESCRIPTION
**Changes:**

the sorting direction indicator (up or down arrow) was backwards in our sorting menu. when sorting in ascending order, the arrow should point upwards and the items should be ordered low-to-high. when sorting in descending order, the arrow should point downwards and the items should be ordered high-to-low.

**Testing:**

1. navigate to any page with a sortable table view. (the ticket mentions the snapshots view, but the jobs view works just as well)
2. observe that the arrow points upwards when the smallest items are first, and downwards when the largest items are first. 

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
