### PR TITLE
NAS-137672 / 25.10.0 / fix: correct file extensions and MIME types for certificate and CSR downloads (by mattwyatt-ix)

### DIFF
--- a/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.spec.ts
@@ -126,6 +126,7 @@ describe('CertificateEditComponent', () => {
           certificate: '--BEGIN CERTIFICATE--',
           name: 'ray',
           extension: 'crt',
+          mimeType: 'application/x-x509-user-cert',
         } as ViewCertificateDialogData,
       });
     });
@@ -138,7 +139,8 @@ describe('CertificateEditComponent', () => {
         data: {
           certificate: '--BEGIN RSA PRIVATE KEY--',
           name: 'ray',
-          extension: 'crt',
+          extension: 'key',
+          mimeType: 'application/x-pem-file',
         } as ViewCertificateDialogData,
       });
     });
@@ -180,6 +182,20 @@ describe('CertificateEditComponent', () => {
     it('does not show add to trusted store checkbox for CSR', async () => {
       const addToTrustedStoreCheckbox = await loader.getHarnessOrNull(IxCheckboxHarness.with({ label: 'Add to trusted store' }));
       expect(addToTrustedStoreCheckbox).not.toExist();
+    });
+
+    it('opens modal for CSR when View/Download CSR is pressed', async () => {
+      const button = await loader.getHarness(MatButtonHarness.with({ text: 'View/Download CSR' }));
+      await button.click();
+
+      expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(ViewCertificateDialog, {
+        data: {
+          certificate: '--BEGIN CERTIFICATE REQUEST--',
+          name: 'ray',
+          extension: 'csr',
+          mimeType: 'application/pkcs10',
+        } as ViewCertificateDialogData,
+      });
     });
 
     it('opens SlideIn for creating ACME certificates when Create ACME Certificate is pressed', async () => {

--- a/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.ts
+++ b/src/app/pages/credentials/certificates-dash/certificate-edit/certificate-edit.component.ts
@@ -111,7 +111,8 @@ export class CertificateEditComponent implements OnInit {
       data: {
         certificate: this.isCsr ? this.certificate.CSR : this.certificate.certificate,
         name: this.certificate.name,
-        extension: 'crt',
+        extension: this.isCsr ? 'csr' : 'crt',
+        mimeType: this.isCsr ? 'application/pkcs10' : 'application/x-x509-user-cert',
       } as ViewCertificateDialogData,
     });
   }
@@ -121,7 +122,8 @@ export class CertificateEditComponent implements OnInit {
       data: {
         certificate: this.certificate.privatekey,
         name: this.certificate.name,
-        extension: 'crt',
+        extension: 'key',
+        mimeType: 'application/x-pem-file',
       } as ViewCertificateDialogData,
     });
   }

--- a/src/app/pages/credentials/certificates-dash/view-certificate-dialog/view-certificate-dialog-data.interface.ts
+++ b/src/app/pages/credentials/certificates-dash/view-certificate-dialog/view-certificate-dialog-data.interface.ts
@@ -2,4 +2,5 @@ export interface ViewCertificateDialogData {
   certificate: string;
   name: string;
   extension: string;
+  mimeType: string;
 }

--- a/src/app/pages/credentials/certificates-dash/view-certificate-dialog/view-certificate-dialog.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/view-certificate-dialog/view-certificate-dialog.component.spec.ts
@@ -24,6 +24,7 @@ describe('ViewCertificateDialogComponent', () => {
           name: 'truenas',
           certificate: '---BEGIN CERTIFICATE---',
           extension: 'crt',
+          mimeType: 'application/x-x509-user-cert',
         } as ViewCertificateDialogData,
       },
       mockProvider(DownloadService),
@@ -53,6 +54,7 @@ describe('ViewCertificateDialogComponent', () => {
     const button = await loader.getHarness(MatButtonHarness.with({ text: 'Download' }));
     await button.click();
 
-    expect(spectator.inject(DownloadService).downloadText).toHaveBeenCalledWith('---BEGIN CERTIFICATE---', 'truenas.crt');
+    const expectedBlob = new Blob(['---BEGIN CERTIFICATE---'], { type: 'application/x-x509-user-cert' });
+    expect(spectator.inject(DownloadService).downloadBlob).toHaveBeenCalledWith(expectedBlob, 'truenas.crt');
   });
 });

--- a/src/app/pages/credentials/certificates-dash/view-certificate-dialog/view-certificate-dialog.component.ts
+++ b/src/app/pages/credentials/certificates-dash/view-certificate-dialog/view-certificate-dialog.component.ts
@@ -33,7 +33,8 @@ export class ViewCertificateDialog {
 
   onDownloadPressed(): void {
     const fileName = `${this.data.name}.${this.data.extension}`;
+    const blob = new Blob([this.data.certificate], { type: this.data.mimeType });
 
-    this.download.downloadText(this.data.certificate, fileName);
+    this.download.downloadBlob(blob, fileName);
   }
 }


### PR DESCRIPTION
**Changes:**

in the Certificate Signing Requests edit menu, the file downloaded when clicking "View/Download CSR" or "View/Download Key" had the incorrect extension of `.crt`. this PR adds logic to download a `.csr` and a `.key` respectively as well as sets the MIME types in the download to the following across the entire `CertificateEditComponent`.
| file extension | mime type |
|----------------|-------------|
| `.crt`               | `application/x-x509-user-cert` |
| `.csr`               | `application/pkcs10` |
| `.key`              | `application/x-pem-file` |

**Testing:**

1. navigate to the `credentials/certificates` page.
2. inside the "Certificate Signing Requests" component, create a CSR if necessary.
3. click on the ellipses menu next to a CSR and select "Edit".
4. download the CSR and observe that it has the `.csr` extension, then download the private key and observe that it has the `.key` extension.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/12618
