### PR TITLE
Fix mocking job responses

### DIFF
--- a/src/app/modules/websocket-debug-panel/services/mock-response.service.ts
+++ b/src/app/modules/websocket-debug-panel/services/mock-response.service.ts
@@ -148,39 +148,73 @@ export class MockResponseService implements OnDestroy {
   }
 
   private scheduleEvents(message: RequestMessage, events: MockEvent[]): void {
-    const eventIds: number[] = [];
-    let totalDelay = 0;
+    const jobId = this.getNextJobId();
+    const eventIds: number[] = [jobId];
 
+    // Send initial "added" event immediately
+    const addedEvent: CollectionUpdateMessage = {
+      jsonrpc: '2.0',
+      method: 'collection_update',
+      params: {
+        msg: CollectionChangeType.Added,
+        collection: 'core.get_jobs',
+        id: jobId,
+        fields: {
+          id: jobId,
+          message_ids: [message.id],
+          method: message.method,
+          arguments: message.params,
+          transient: false,
+          description: null,
+          abortable: false,
+          logs_path: null,
+          logs_excerpt: null,
+          progress: {
+            percent: 0,
+            description: '',
+            extra: null,
+          },
+          result: null,
+          result_encoding_error: null,
+          error: null,
+          exception: null,
+          exc_info: null,
+          state: 'WAITING',
+          time_started: { $date: Date.now() },
+          time_finished: null,
+        },
+      },
+    };
+    this.mockResponses$.next(addedEvent);
+
+    // Schedule subsequent events
+    let totalDelay = 0;
     events.forEach((event) => {
-      const eventId = this.getNextJobId();
-      eventIds.push(eventId);
       totalDelay += event.delay || 0;
 
       const eventSubscription = timer(totalDelay).pipe(take(1)).subscribe(() => {
-        this.emitEvent(message, event, eventId);
+        this.emitEvent(message, event, jobId);
       });
-      this.eventSubscriptions.set(`${message.id}-event-${eventId}`, eventSubscription);
+      this.eventSubscriptions.set(`${message.id}-event-${jobId}`, eventSubscription);
     });
 
     this.activeEvents.set(message.id, eventIds);
   }
 
-  private emitEvent(message: RequestMessage, event: MockEvent, eventId: number): void {
+  private emitEvent(message: RequestMessage, event: MockEvent, jobId: number): void {
     const updateMessage: CollectionUpdateMessage = {
       jsonrpc: '2.0',
       method: 'collection_update',
       params: {
         msg: CollectionChangeType.Changed,
         collection: 'core.get_jobs',
-        id: eventId,
+        id: jobId,
         fields: {
           ...event.fields,
-          id: event.fields.id || eventId,
+          id: jobId,
           message_ids: event.fields.message_ids || [message.id],
           method: event.fields.method || message.method,
           arguments: event.fields.arguments || message.params,
-          transient: event.fields.transient ?? true,
-          time_started: event.fields.time_started || { $date: Date.now() },
         },
       },
     };

--- a/src/app/modules/websocket-debug-panel/websocket-debug-panel.component.scss
+++ b/src/app/modules/websocket-debug-panel/websocket-debug-panel.component.scss
@@ -14,7 +14,7 @@
   transform: translateX(100%);
   transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1);
   width: var(--debug-panel-width);
-  z-index: 999;
+  z-index: 100000;
 
   &.open {
     transform: translateX(0);

--- a/src/app/modules/websocket/api.service.ts
+++ b/src/app/modules/websocket/api.service.ts
@@ -188,8 +188,13 @@ export class ApiService {
         return throwError(() => new ApiCallError(message.error as JsonRpcError));
       }
 
-      performance.mark(`${method} - ${uuid} - end`);
-      performance.measure(method, `${method} - ${uuid} - start`, `${method} - ${uuid} - end`);
+      try {
+        performance.mark(`${method} - ${uuid} - end`);
+        performance.measure(method, `${method} - ${uuid} - start`, `${method} - ${uuid} - end`);
+      } catch (error) {
+        // Ignore performance measurement errors (e.g., when start mark doesn't exist for mocked responses)
+        console.warn(`Performance measurement failed for ${method}:`, error);
+      }
       return of(message);
     });
   }


### PR DESCRIPTION
The first collection update event is always using "added" type with the job id.

**Testing:**

Create a mocked job response by adding events to the call and see the UI behaves correctly.
One idea is to use update.run
<img width="488" height="954" alt="Screenshot 2025-10-01 at 11 15 00 AM" src="https://github.com/user-attachments/assets/96f92447-cd2f-460a-8d15-6579a7133895" />


https://github.com/user-attachments/assets/947246c1-6680-4a8b-be8d-45fd4c342c8f



### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
