### PR TITLE
NAS-137665 / 26.04 / Credentials/ACME DNS-Auth: Validation messages appear as errors after attempting to save the form

### DIFF
--- a/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.html
+++ b/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.html
@@ -22,7 +22,6 @@
           [options]="authenticatorOptions$"
           [tooltip]="helptext.providerTooltip | translate"
           [required]="true"
-          (ngModelChange)="onAuthenticatorTypeChanged($event)"
         ></ix-select>
       </ix-fieldset>
 
@@ -31,6 +30,26 @@
           [dynamicSection]="dynamicSection"
           [dynamicForm]="formGroup"
         ></ix-dynamic-form>
+
+        @if (isCloudflareAuthenticator() && formGroup.errors) {
+          <div class="cloudflare-validation-error">
+            @if (formGroup.hasError('cloudflareEmailInvalid')) {
+              <p>{{ formGroup.getError('cloudflareEmailInvalid')?.message }}</p>
+            }
+            @if (formGroup.hasError('cloudflareMutuallyExclusive')) {
+              <p>{{ formGroup.getError('cloudflareMutuallyExclusive')?.message }}</p>
+            }
+            @if (formGroup.hasError('cloudflareApiKey')) {
+              <p>{{ formGroup.getError('cloudflareApiKey')?.message }}</p>
+            }
+            @if (formGroup.hasError('cloudflareEmailRequired')) {
+              <p>{{ formGroup.getError('cloudflareEmailRequired')?.message }}</p>
+            }
+            @if (formGroup.hasError('cloudflareAuth')) {
+              <p>{{ formGroup.getError('cloudflareAuth')?.message }}</p>
+            }
+          </div>
+        }
       }
 
       <ix-form-actions>

--- a/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.html
+++ b/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.html
@@ -32,23 +32,31 @@
         ></ix-dynamic-form>
 
         @if (isCloudflareAuthenticator() && formGroup.errors) {
-          <div class="cloudflare-validation-error">
-            @if (formGroup.hasError('cloudflareEmailInvalid')) {
-              <p>{{ formGroup.getError('cloudflareEmailInvalid')?.message }}</p>
-            }
-            @if (formGroup.hasError('cloudflareMutuallyExclusive')) {
-              <p>{{ formGroup.getError('cloudflareMutuallyExclusive')?.message }}</p>
-            }
-            @if (formGroup.hasError('cloudflareApiKey')) {
-              <p>{{ formGroup.getError('cloudflareApiKey')?.message }}</p>
-            }
-            @if (formGroup.hasError('cloudflareEmailRequired')) {
-              <p>{{ formGroup.getError('cloudflareEmailRequired')?.message }}</p>
-            }
-            @if (formGroup.hasError('cloudflareAuth')) {
+          @if (formGroup.hasError('cloudflareAuth')) {
+            <div class="cloudflare-hint">
               <p>{{ formGroup.getError('cloudflareAuth')?.message }}</p>
-            }
-          </div>
+            </div>
+          }
+
+          @if (formGroup.hasError('cloudflareEmailInvalid')
+            || formGroup.hasError('cloudflareMutuallyExclusive')
+            || formGroup.hasError('cloudflareApiKey')
+            || formGroup.hasError('cloudflareEmailRequired')) {
+            <div class="cloudflare-validation-error">
+              @if (formGroup.hasError('cloudflareEmailInvalid')) {
+                <p>{{ formGroup.getError('cloudflareEmailInvalid')?.message }}</p>
+              }
+              @if (formGroup.hasError('cloudflareMutuallyExclusive')) {
+                <p>{{ formGroup.getError('cloudflareMutuallyExclusive')?.message }}</p>
+              }
+              @if (formGroup.hasError('cloudflareApiKey')) {
+                <p>{{ formGroup.getError('cloudflareApiKey')?.message }}</p>
+              }
+              @if (formGroup.hasError('cloudflareEmailRequired')) {
+                <p>{{ formGroup.getError('cloudflareEmailRequired')?.message }}</p>
+              }
+            </div>
+          }
         }
       }
 

--- a/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.scss
+++ b/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.scss
@@ -1,9 +1,20 @@
-.cloudflare-validation-error {
-  color: var(--error);
+%error {
   margin: 0 12px 24px;
 
   p {
     font-size: 12px;
     margin: 0;
   }
+}
+
+.cloudflare-validation-error {
+  @extend %error;
+
+  color: var(--error);
+}
+
+.cloudflare-hint {
+  @extend %error;
+
+  color: var(--yellow);
 }

--- a/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.scss
+++ b/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.scss
@@ -1,0 +1,9 @@
+.cloudflare-validation-error {
+  color: var(--error);
+  margin: 0 12px 24px;
+
+  p {
+    font-size: 12px;
+    margin: 0;
+  }
+}

--- a/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.spec.ts
@@ -26,8 +26,8 @@ describe('AcmednsFormComponent', () => {
   const existingAcmedns = {
     id: 123,
     name: 'name_test',
-    authenticator: DnsAuthenticatorType.Route53,
     attributes: {
+      authenticator: DnsAuthenticatorType.Route53,
       access_key_id: 'access_key_id',
       secret_access_key: 'secret_access_key',
     },
@@ -108,29 +108,25 @@ describe('AcmednsFormComponent', () => {
       ]);
 
       const values = await form.getValues();
-      const disabledState = await form.getDisabledState();
 
-      expect(values).toEqual({
-        Name: 'name_test',
-        Authenticator: 'route53',
-        'Access Key ID': 'access_key_id',
-        'Secret Access Key': 'secret_access_key',
-      });
-
-      expect(disabledState).toEqual({
-        Name: false,
-        Authenticator: false,
-        'Access Key ID': false,
-        'Secret Access Key': false,
-      });
+      // Form shows values for the selected authenticator (route53)
+      expect(values.Name).toBe('name_test');
+      expect(values.Authenticator).toBe('route53');
+      expect(values['Access Key ID']).toBe('access_key_id');
+      expect(values['Secret Access Key']).toBe('secret_access_key');
     });
 
     it('edits existing DNS Authenticator when form opened for edit is submitted', async () => {
+      // First change the authenticator type
+      await form.fillForm({
+        Authenticator: 'cloudflare',
+      });
+
+      spectator.detectChanges();
+
+      // Now fill the cloudflare-specific fields
       await form.fillForm({
         Name: 'name_edit',
-        Authenticator: 'cloudflare',
-        'Cloudflare Email': '',
-        'API Key': '',
         'API Token': 'new_api_token',
       });
 
@@ -181,6 +177,170 @@ describe('AcmednsFormComponent', () => {
         },
       }]);
       expect(spectator.inject(SlideInRef).close).toHaveBeenCalled();
+    });
+  });
+
+  describe('Cloudflare validation', () => {
+    beforeEach(async () => {
+      spectator = createComponent();
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+      form = await loader.getHarness(IxFormHarness);
+    });
+
+    it('shows error when Cloudflare Email is invalid', async () => {
+      await form.fillForm({
+        Name: 'test',
+        Authenticator: 'cloudflare',
+        'Cloudflare Email': 'invalid-email',
+      });
+
+      spectator.detectChanges();
+
+      expect(spectator.component.formGroup.errors).toEqual({
+        cloudflareEmailInvalid: {
+          message: 'Cloudflare Email must be a valid email address',
+        },
+      });
+
+      const errorElement = spectator.query('.cloudflare-validation-error');
+      expect(errorElement).toBeTruthy();
+      expect(errorElement.textContent).toContain('Cloudflare Email must be a valid email address');
+    });
+
+    it('shows error when both API Token and API Key are provided', async () => {
+      await form.fillForm({
+        Name: 'test',
+        Authenticator: 'cloudflare',
+        'API Token': 'test_token',
+        'API Key': 'test_key',
+      });
+
+      spectator.detectChanges();
+
+      expect(spectator.component.formGroup.errors).toEqual({
+        cloudflareMutuallyExclusive: {
+          message: 'You can use either an API Token or the combination of Cloudflare Email + API Key, but not both',
+        },
+      });
+
+      const errorElement = spectator.query('.cloudflare-validation-error');
+      expect(errorElement).toBeTruthy();
+      expect(errorElement.textContent).toContain('You can use either an API Token or the combination of Cloudflare Email + API Key, but not both');
+    });
+
+    it('shows error when Cloudflare Email is provided without API Key', async () => {
+      await form.fillForm({
+        Name: 'test',
+        Authenticator: 'cloudflare',
+        'Cloudflare Email': 'test@example.com',
+        'API Key': '',
+      });
+
+      spectator.detectChanges();
+
+      expect(spectator.component.formGroup.errors).toEqual({
+        cloudflareApiKey: {
+          message: 'Cloudflare Email requires Global API Key',
+        },
+      });
+
+      const errorElement = spectator.query('.cloudflare-validation-error');
+      expect(errorElement).toBeTruthy();
+      expect(errorElement.textContent).toContain('Cloudflare Email requires Global API Key');
+    });
+
+    it('shows error when API Key is provided without Cloudflare Email', async () => {
+      await form.fillForm({
+        Name: 'test',
+        Authenticator: 'cloudflare',
+        'API Key': 'test_key',
+      });
+
+      spectator.detectChanges();
+
+      expect(spectator.component.formGroup.errors).toEqual({
+        cloudflareEmailRequired: {
+          message: 'API Key requires Cloudflare Email',
+        },
+      });
+
+      const errorElement = spectator.query('.cloudflare-validation-error');
+      expect(errorElement).toBeTruthy();
+      expect(errorElement.textContent).toContain('API Key requires Cloudflare Email');
+    });
+
+    it('shows error when neither API Token nor API Key is provided after user interaction', async () => {
+      // First, user types something
+      await form.fillForm({
+        Name: 'test',
+        Authenticator: 'cloudflare',
+        'API Token': 'test',
+      });
+
+      spectator.detectChanges();
+
+      // Then user clears it
+      await form.fillForm({
+        'API Token': '',
+      });
+
+      spectator.detectChanges();
+
+      expect(spectator.component.formGroup.errors).toEqual({
+        cloudflareAuth: {
+          message: 'Either API Token or Cloudflare Email + API Key must be provided',
+        },
+      });
+
+      const errorElement = spectator.query('.cloudflare-validation-error');
+      expect(errorElement).toBeTruthy();
+      expect(errorElement.textContent).toContain('Either API Token or Cloudflare Email + API Key must be provided');
+    });
+
+    it('validates successfully with API Token only', async () => {
+      await form.fillForm({
+        Name: 'test',
+        Authenticator: 'cloudflare',
+        'API Token': 'test_token',
+      });
+
+      spectator.detectChanges();
+
+      expect(spectator.component.formGroup.errors).toBeNull();
+    });
+
+    it('validates successfully with Email and API Key', async () => {
+      await form.fillForm({
+        Name: 'test',
+        Authenticator: 'cloudflare',
+        'Cloudflare Email': 'test@example.com',
+        'API Key': 'test_key',
+      });
+
+      spectator.detectChanges();
+
+      expect(spectator.component.formGroup.errors).toBeNull();
+    });
+
+    it('does not validate for non-Cloudflare authenticators', async () => {
+      // First change to route53
+      await form.fillForm({
+        Name: 'test',
+        Authenticator: 'route53',
+      });
+
+      spectator.detectChanges();
+
+      // Now fill route53-specific fields
+      await form.fillForm({
+        'Access Key ID': 'test_key',
+        'Secret Access Key': 'test_secret',
+      });
+
+      spectator.detectChanges();
+
+      // Cloudflare validator shouldn't run for route53
+      expect(spectator.component.formGroup.errors).toBeNull();
     });
   });
 });

--- a/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/acmedns-form/acmedns-form.component.spec.ts
@@ -269,19 +269,10 @@ describe('AcmednsFormComponent', () => {
       expect(errorElement.textContent).toContain('API Key requires Cloudflare Email');
     });
 
-    it('shows error when neither API Token nor API Key is provided after user interaction', async () => {
-      // First, user types something
+    it('shows hint when neither API Token nor API Key is provided', async () => {
       await form.fillForm({
         Name: 'test',
         Authenticator: 'cloudflare',
-        'API Token': 'test',
-      });
-
-      spectator.detectChanges();
-
-      // Then user clears it
-      await form.fillForm({
-        'API Token': '',
       });
 
       spectator.detectChanges();
@@ -292,9 +283,31 @@ describe('AcmednsFormComponent', () => {
         },
       });
 
+      // When cloudflareAuth is the only error, it shows as a hint (not red)
+      const hintElement = spectator.query('.cloudflare-hint');
+      expect(hintElement).toBeTruthy();
+      expect(hintElement.textContent).toContain('Either API Token or Cloudflare Email + API Key must be provided');
+    });
+
+    it('shows cloudflareAuth as hint always (never as red error)', async () => {
+      await form.fillForm({
+        Name: 'test',
+        Authenticator: 'cloudflare',
+        'Cloudflare Email': 'invalid-email',
+      });
+
+      spectator.detectChanges();
+
+      // Invalid email creates cloudflareEmailInvalid error (red)
+      // Validator returns first error, so only emailInvalid is present
+      expect(spectator.component.formGroup.errors?.['cloudflareEmailInvalid']).toBeTruthy();
+
       const errorElement = spectator.query('.cloudflare-validation-error');
       expect(errorElement).toBeTruthy();
-      expect(errorElement.textContent).toContain('Either API Token or Cloudflare Email + API Key must be provided');
+      expect(errorElement.textContent).toContain('Cloudflare Email must be a valid email address');
+
+      // cloudflareAuth should never appear in the error section (only as hint)
+      expect(errorElement.textContent).not.toContain('Either API Token or Cloudflare Email + API Key must be provided');
     });
 
     it('validates successfully with API Token only', async () => {

--- a/src/app/pages/credentials/certificates-dash/acmedns-form/cloudflare-auth.validator.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/acmedns-form/cloudflare-auth.validator.spec.ts
@@ -1,0 +1,288 @@
+import { FormControl, FormGroup } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { CloudflareAuthValidator } from './cloudflare-auth.validator';
+
+describe('CloudflareAuthValidator', () => {
+  let translateService: TranslateService;
+  let formGroup: FormGroup;
+
+  beforeEach(() => {
+    translateService = {
+      instant: jest.fn((key: string) => key),
+    } as unknown as TranslateService;
+
+    formGroup = new FormGroup({
+      cloudflare_email: new FormControl(''),
+      api_key: new FormControl(''),
+      api_token: new FormControl(''),
+    });
+  });
+
+  describe('validateEmailFormat', () => {
+    it('should return null when email is empty', () => {
+      formGroup.patchValue({
+        cloudflare_email: '',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareAuth: {
+          message: 'Either API Token or Cloudflare Email + API Key must be provided',
+        },
+      });
+    });
+
+    it('should return error when email format is invalid', () => {
+      formGroup.patchValue({
+        cloudflare_email: 'invalid-email',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareEmailInvalid: {
+          message: 'Cloudflare Email must be a valid email address',
+        },
+      });
+    });
+
+    it('should pass when email format is valid', () => {
+      formGroup.patchValue({
+        cloudflare_email: 'test@example.com',
+        api_key: 'test_key',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('validateMutualExclusivity', () => {
+    it('should return error when both API Token and API Key are provided', () => {
+      formGroup.patchValue({
+        api_token: 'test_token',
+        api_key: 'test_key',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareMutuallyExclusive: {
+          message: 'You can use either an API Token or the combination of Cloudflare Email + API Key, but not both',
+        },
+      });
+    });
+
+    it('should pass when only API Token is provided', () => {
+      formGroup.patchValue({
+        api_token: 'test_token',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toBeNull();
+    });
+
+    it('should pass when only API Key with Email is provided', () => {
+      formGroup.patchValue({
+        cloudflare_email: 'test@example.com',
+        api_key: 'test_key',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('validateEmailRequiresKey', () => {
+    it('should return error when email is provided without API Key', () => {
+      formGroup.patchValue({
+        cloudflare_email: 'test@example.com',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareApiKey: {
+          message: 'Cloudflare Email requires Global API Key',
+        },
+      });
+    });
+
+    it('should pass when email is provided with API Key', () => {
+      formGroup.patchValue({
+        cloudflare_email: 'test@example.com',
+        api_key: 'test_key',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('validateKeyRequiresEmail', () => {
+    it('should return error when API Key is provided without email', () => {
+      formGroup.patchValue({
+        api_key: 'test_key',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareEmailRequired: {
+          message: 'API Key requires Cloudflare Email',
+        },
+      });
+    });
+
+    it('should pass when API Key is provided with email', () => {
+      formGroup.patchValue({
+        cloudflare_email: 'test@example.com',
+        api_key: 'test_key',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('validateAtLeastOneMethod', () => {
+    it('should return error when neither API Token nor API Key is provided', () => {
+      formGroup.patchValue({
+        cloudflare_email: '',
+        api_key: '',
+        api_token: '',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareAuth: {
+          message: 'Either API Token or Cloudflare Email + API Key must be provided',
+        },
+      });
+    });
+
+    it('should pass when API Token is provided', () => {
+      formGroup.patchValue({
+        api_token: 'test_token',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toBeNull();
+    });
+
+    it('should pass when API Key is provided with email', () => {
+      formGroup.patchValue({
+        cloudflare_email: 'test@example.com',
+        api_key: 'test_key',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('field value trimming', () => {
+    it('should trim whitespace from field values', () => {
+      formGroup.patchValue({
+        cloudflare_email: '  test@example.com  ',
+        api_key: '  test_key  ',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toBeNull();
+    });
+
+    it('should treat whitespace-only values as empty', () => {
+      formGroup.patchValue({
+        cloudflare_email: '   ',
+        api_key: '   ',
+        api_token: '   ',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareAuth: {
+          message: 'Either API Token or Cloudflare Email + API Key must be provided',
+        },
+      });
+    });
+  });
+
+  describe('validation order', () => {
+    it('should validate email format before other validations', () => {
+      formGroup.patchValue({
+        cloudflare_email: 'invalid-email',
+        api_key: 'test_key',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareEmailInvalid: {
+          message: 'Cloudflare Email must be a valid email address',
+        },
+      });
+    });
+
+    it('should validate mutual exclusivity before dependency validations', () => {
+      formGroup.patchValue({
+        cloudflare_email: 'test@example.com',
+        api_key: 'test_key',
+        api_token: 'test_token',
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareMutuallyExclusive: {
+          message: 'You can use either an API Token or the combination of Cloudflare Email + API Key, but not both',
+        },
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle null values', () => {
+      formGroup.patchValue({
+        cloudflare_email: null,
+        api_key: null,
+        api_token: null,
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareAuth: {
+          message: 'Either API Token or Cloudflare Email + API Key must be provided',
+        },
+      });
+    });
+
+    it('should handle undefined values', () => {
+      formGroup.patchValue({
+        cloudflare_email: undefined,
+        api_key: undefined,
+        api_token: undefined,
+      });
+
+      const result = CloudflareAuthValidator.validate(translateService)(formGroup);
+
+      expect(result).toEqual({
+        cloudflareAuth: {
+          message: 'Either API Token or Cloudflare Email + API Key must be provided',
+        },
+      });
+    });
+  });
+});

--- a/src/app/pages/credentials/certificates-dash/acmedns-form/cloudflare-auth.validator.ts
+++ b/src/app/pages/credentials/certificates-dash/acmedns-form/cloudflare-auth.validator.ts
@@ -1,0 +1,99 @@
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+
+export class CloudflareAuthValidator {
+  static validate(translate: TranslateService) {
+    return (formGroup: AbstractControl): ValidationErrors | null => {
+      const cloudflareEmail = CloudflareAuthValidator.getFieldValue(formGroup, 'cloudflare_email');
+      const apiKey = CloudflareAuthValidator.getFieldValue(formGroup, 'api_key');
+      const apiToken = CloudflareAuthValidator.getFieldValue(formGroup, 'api_token');
+
+      return CloudflareAuthValidator.validateEmailFormat(cloudflareEmail, translate)
+        || CloudflareAuthValidator.validateMutualExclusivity(apiToken, apiKey, translate)
+        || CloudflareAuthValidator.validateEmailRequiresKey(cloudflareEmail, apiKey, translate)
+        || CloudflareAuthValidator.validateKeyRequiresEmail(apiKey, cloudflareEmail, translate)
+        || CloudflareAuthValidator.validateAtLeastOneMethod(apiToken, apiKey, translate)
+        || null;
+    };
+  }
+
+  private static getFieldValue(formGroup: AbstractControl, fieldName: string): string {
+    return (formGroup.get(fieldName)?.value as string | null)?.trim() || '';
+  }
+
+  private static validateEmailFormat(email: string, translate: TranslateService): ValidationErrors | null {
+    if (!email) return null;
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return {
+        cloudflareEmailInvalid: {
+          message: translate.instant('Cloudflare Email must be a valid email address'),
+        },
+      };
+    }
+    return null;
+  }
+
+  private static validateMutualExclusivity(
+    apiToken: string,
+    apiKey: string,
+    translate: TranslateService,
+  ): ValidationErrors | null {
+    if (apiToken && apiKey) {
+      return {
+        cloudflareMutuallyExclusive: {
+          message: translate.instant(
+            'You can use either an API Token or the combination of Cloudflare Email + API Key, but not both',
+          ),
+        },
+      };
+    }
+    return null;
+  }
+
+  private static validateEmailRequiresKey(
+    email: string,
+    apiKey: string,
+    translate: TranslateService,
+  ): ValidationErrors | null {
+    if (email && !apiKey) {
+      return {
+        cloudflareApiKey: {
+          message: translate.instant('Cloudflare Email requires Global API Key'),
+        },
+      };
+    }
+    return null;
+  }
+
+  private static validateKeyRequiresEmail(
+    apiKey: string,
+    email: string,
+    translate: TranslateService,
+  ): ValidationErrors | null {
+    if (apiKey && !email) {
+      return {
+        cloudflareEmailRequired: {
+          message: translate.instant('API Key requires Cloudflare Email'),
+        },
+      };
+    }
+    return null;
+  }
+
+  private static validateAtLeastOneMethod(
+    apiToken: string,
+    apiKey: string,
+    translate: TranslateService,
+  ): ValidationErrors | null {
+    if (!apiToken && !apiKey) {
+      return {
+        cloudflareAuth: {
+          message: translate.instant('Either API Token or Cloudflare Email + API Key must be provided'),
+        },
+      };
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
Testing: see ticket.
I moved the validator into it's own file [`cloudflare-auth.validator.ts`] with tests, so that the main form is not overloaded.

Preview:


https://github.com/user-attachments/assets/4cfde877-28e2-4117-9bc5-15676dfb6eb9

