### PR TITLE
NAS-137843 / 26.04 / Isolate deprecated Angular CDK TreeControl usage

### DIFF
--- a/src/app/modules/ix-tree/components/tree/tree.component.ts
+++ b/src/app/modules/ix-tree/components/tree/tree.component.ts
@@ -1,9 +1,10 @@
 import { Direction, Directionality } from '@angular/cdk/bidi';
 import { DataSource } from '@angular/cdk/collections';
-import { CdkTree, TreeControl } from '@angular/cdk/tree';
+import { CdkTree } from '@angular/cdk/tree';
 import { ChangeDetectorRef, Component, Input, IterableDiffer, IterableDiffers, OnDestroy, OnInit, ViewChild, ViewContainerRef, ChangeDetectionStrategy, inject } from '@angular/core';
 import { Observable, Subject, takeUntil } from 'rxjs';
 import { TreeNodeOutletDirective } from 'app/modules/ix-tree/directives/tree-node-outlet.directive';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
 
 // eslint-disable-next-line @angular-eslint/use-component-selector
 @Component({
@@ -23,7 +24,7 @@ export class Tree<T, K = T> extends CdkTree<T, K> implements OnInit, OnDestroy {
 
   // eslint-disable-next-line @stylistic/ts/max-len
   // eslint-disable-next-line @angular-eslint/no-input-rename, @typescript-eslint/no-explicit-any,@angular-eslint/prefer-signals
-  @Input('ixTreeControl') override treeControl!: TreeControl<T, any>;
+  @Input('ixTreeControl') override treeControl!: TreeExpansion<T, any>;
 
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input('ixDataSource')

--- a/src/app/modules/ix-tree/flat-tree-datasource.ts
+++ b/src/app/modules/ix-tree/flat-tree-datasource.ts
@@ -1,9 +1,9 @@
 import { CollectionViewer, DataSource } from '@angular/cdk/collections';
-import { FlatTreeControl } from '@angular/cdk/tree';
 import {
   BehaviorSubject, Subject, Observable, debounceTime,
   distinctUntilChanged, takeUntil, filter, map, mergeWith,
 } from 'rxjs';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
 import { TreeFlattener } from 'app/modules/ix-tree/tree-flattener';
 
 /**
@@ -21,7 +21,7 @@ export class FlatTreeDataSource<T, F> extends DataSource<F> {
   private readonly disconnect$ = new Subject<void>();
 
   constructor(
-    private treeControl: FlatTreeControl<F>,
+    private treeControl: TreeExpansion<F>,
     private treeFlattener: TreeFlattener<T, F>,
     private initialData: T[] = [],
   ) {

--- a/src/app/modules/ix-tree/tree-control.factory.spec.ts
+++ b/src/app/modules/ix-tree/tree-control.factory.spec.ts
@@ -57,14 +57,18 @@ describe('Tree Control Factory', () => {
 
     it('should allow setting dataNodes', () => {
       const nodes: TestNode[] = [
-        { id: '1', name: 'Node 1', level: 0, expandable: true },
+        {
+          id: '1', name: 'Node 1', level: 0, expandable: true,
+        },
       ];
       treeControl.dataNodes = nodes;
       expect(treeControl.dataNodes).toEqual(nodes);
     });
 
     it('should track expansion state correctly', () => {
-      const node: TestNode = { id: '1', name: 'Node 1', level: 0, expandable: true };
+      const node: TestNode = {
+        id: '1', name: 'Node 1', level: 0, expandable: true,
+      };
       treeControl.dataNodes = [node];
 
       expect(treeControl.isExpanded(node)).toBe(false);
@@ -77,7 +81,9 @@ describe('Tree Control Factory', () => {
     });
 
     it('should toggle expansion state', () => {
-      const node: TestNode = { id: '1', name: 'Node 1', level: 0, expandable: true };
+      const node: TestNode = {
+        id: '1', name: 'Node 1', level: 0, expandable: true,
+      };
       treeControl.dataNodes = [node];
 
       treeControl.toggle(node);
@@ -89,9 +95,15 @@ describe('Tree Control Factory', () => {
 
     it('should expand all nodes', () => {
       const nodes: TestNode[] = [
-        { id: '1', name: 'Node 1', level: 0, expandable: true },
-        { id: '2', name: 'Node 2', level: 1, expandable: true },
-        { id: '3', name: 'Node 3', level: 2, expandable: false },
+        {
+          id: '1', name: 'Node 1', level: 0, expandable: true,
+        },
+        {
+          id: '2', name: 'Node 2', level: 1, expandable: true,
+        },
+        {
+          id: '3', name: 'Node 3', level: 2, expandable: false,
+        },
       ];
       treeControl.dataNodes = nodes;
 
@@ -103,8 +115,12 @@ describe('Tree Control Factory', () => {
 
     it('should collapse all nodes', () => {
       const nodes: TestNode[] = [
-        { id: '1', name: 'Node 1', level: 0, expandable: true },
-        { id: '2', name: 'Node 2', level: 1, expandable: true },
+        {
+          id: '1', name: 'Node 1', level: 0, expandable: true,
+        },
+        {
+          id: '2', name: 'Node 2', level: 1, expandable: true,
+        },
       ];
       treeControl.dataNodes = nodes;
 
@@ -117,10 +133,18 @@ describe('Tree Control Factory', () => {
 
     it('should get descendants of a node', () => {
       const nodes: TestNode[] = [
-        { id: '1', name: 'Node 1', level: 0, expandable: true },
-        { id: '2', name: 'Node 2', level: 1, expandable: true },
-        { id: '3', name: 'Node 3', level: 2, expandable: false },
-        { id: '4', name: 'Node 4', level: 1, expandable: false },
+        {
+          id: '1', name: 'Node 1', level: 0, expandable: true,
+        },
+        {
+          id: '2', name: 'Node 2', level: 1, expandable: true,
+        },
+        {
+          id: '3', name: 'Node 3', level: 2, expandable: false,
+        },
+        {
+          id: '4', name: 'Node 4', level: 1, expandable: false,
+        },
       ];
       treeControl.dataNodes = nodes;
 
@@ -129,7 +153,7 @@ describe('Tree Control Factory', () => {
       expect(descendants).toContain(nodes[1]);
       expect(descendants).toContain(nodes[2]);
       expect(descendants).toContain(nodes[3]);
-      expect(descendants.length).toBe(3);
+      expect(descendants).toHaveLength(3);
     });
   });
 
@@ -173,14 +197,18 @@ describe('Tree Control Factory', () => {
 
     it('should allow setting dataNodes', () => {
       const nodes: TestNode[] = [
-        { id: '1', name: 'Node 1', level: 0, expandable: true },
+        {
+          id: '1', name: 'Node 1', level: 0, expandable: true,
+        },
       ];
       treeControl.dataNodes = nodes;
       expect(treeControl.dataNodes).toEqual(nodes);
     });
 
     it('should track expansion state correctly', () => {
-      const child: TestNode = { id: '2', name: 'Child', level: 1, expandable: false };
+      const child: TestNode = {
+        id: '2', name: 'Child', level: 1, expandable: false,
+      };
       const parent: TestNode = {
         id: '1',
         name: 'Parent',
@@ -200,7 +228,9 @@ describe('Tree Control Factory', () => {
     });
 
     it('should toggle expansion state', () => {
-      const child: TestNode = { id: '2', name: 'Child', level: 1, expandable: false };
+      const child: TestNode = {
+        id: '2', name: 'Child', level: 1, expandable: false,
+      };
       const parent: TestNode = {
         id: '1',
         name: 'Parent',
@@ -218,7 +248,9 @@ describe('Tree Control Factory', () => {
     });
 
     it('should expand all nodes', () => {
-      const grandchild: TestNode = { id: '3', name: 'Grandchild', level: 2, expandable: false };
+      const grandchild: TestNode = {
+        id: '3', name: 'Grandchild', level: 2, expandable: false,
+      };
       const child: TestNode = {
         id: '2',
         name: 'Child',
@@ -242,7 +274,9 @@ describe('Tree Control Factory', () => {
     });
 
     it('should get descendants of a nested node', () => {
-      const grandchild: TestNode = { id: '3', name: 'Grandchild', level: 2, expandable: false };
+      const grandchild: TestNode = {
+        id: '3', name: 'Grandchild', level: 2, expandable: false,
+      };
       const child: TestNode = {
         id: '2',
         name: 'Child',
@@ -263,11 +297,13 @@ describe('Tree Control Factory', () => {
 
       expect(descendants).toContain(child);
       expect(descendants).toContain(grandchild);
-      expect(descendants.length).toBe(2);
+      expect(descendants).toHaveLength(2);
     });
 
     it('should toggle descendants recursively', () => {
-      const grandchild: TestNode = { id: '3', name: 'Grandchild', level: 2, expandable: false };
+      const grandchild: TestNode = {
+        id: '3', name: 'Grandchild', level: 2, expandable: false,
+      };
       const child: TestNode = {
         id: '2',
         name: 'Child',

--- a/src/app/modules/ix-tree/tree-control.factory.spec.ts
+++ b/src/app/modules/ix-tree/tree-control.factory.spec.ts
@@ -1,0 +1,296 @@
+import { SelectionModel } from '@angular/cdk/collections';
+import {
+  createFlatTreeControl,
+  createNestedTreeControl,
+} from 'app/modules/ix-tree/tree-control.factory';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
+
+interface TestNode {
+  id: string;
+  name: string;
+  level: number;
+  expandable: boolean;
+  children?: TestNode[];
+}
+
+describe('Tree Control Factory', () => {
+  describe('createFlatTreeControl', () => {
+    let treeControl: TreeExpansion<TestNode, string>;
+    const getLevel = (node: TestNode): number => node.level;
+    const isExpandable = (node: TestNode): boolean => node.expandable;
+
+    beforeEach(() => {
+      treeControl = createFlatTreeControl<TestNode, string>(
+        getLevel,
+        isExpandable,
+        { trackBy: (node) => node.id },
+      );
+    });
+
+    it('should return an object that implements TreeExpansion interface', () => {
+      expect(treeControl).toBeDefined();
+      expect('dataNodes' in treeControl).toBe(true);
+      expect(treeControl.expansionModel).toBeDefined();
+      expect(typeof treeControl.isExpanded).toBe('function');
+      expect(typeof treeControl.toggle).toBe('function');
+      expect(typeof treeControl.expand).toBe('function');
+      expect(typeof treeControl.collapse).toBe('function');
+      expect(typeof treeControl.expandAll).toBe('function');
+      expect(typeof treeControl.collapseAll).toBe('function');
+      expect(typeof treeControl.toggleDescendants).toBe('function');
+      expect(typeof treeControl.expandDescendants).toBe('function');
+      expect(typeof treeControl.collapseDescendants).toBe('function');
+      expect(typeof treeControl.getDescendants).toBe('function');
+    });
+
+    it('should have expansion model as SelectionModel', () => {
+      expect(treeControl.expansionModel).toBeInstanceOf(SelectionModel);
+    });
+
+    it('should have getLevel accessor function', () => {
+      expect(treeControl.getLevel).toBe(getLevel);
+    });
+
+    it('should have isExpandable accessor function', () => {
+      expect(treeControl.isExpandable).toBe(isExpandable);
+    });
+
+    it('should allow setting dataNodes', () => {
+      const nodes: TestNode[] = [
+        { id: '1', name: 'Node 1', level: 0, expandable: true },
+      ];
+      treeControl.dataNodes = nodes;
+      expect(treeControl.dataNodes).toEqual(nodes);
+    });
+
+    it('should track expansion state correctly', () => {
+      const node: TestNode = { id: '1', name: 'Node 1', level: 0, expandable: true };
+      treeControl.dataNodes = [node];
+
+      expect(treeControl.isExpanded(node)).toBe(false);
+
+      treeControl.expand(node);
+      expect(treeControl.isExpanded(node)).toBe(true);
+
+      treeControl.collapse(node);
+      expect(treeControl.isExpanded(node)).toBe(false);
+    });
+
+    it('should toggle expansion state', () => {
+      const node: TestNode = { id: '1', name: 'Node 1', level: 0, expandable: true };
+      treeControl.dataNodes = [node];
+
+      treeControl.toggle(node);
+      expect(treeControl.isExpanded(node)).toBe(true);
+
+      treeControl.toggle(node);
+      expect(treeControl.isExpanded(node)).toBe(false);
+    });
+
+    it('should expand all nodes', () => {
+      const nodes: TestNode[] = [
+        { id: '1', name: 'Node 1', level: 0, expandable: true },
+        { id: '2', name: 'Node 2', level: 1, expandable: true },
+        { id: '3', name: 'Node 3', level: 2, expandable: false },
+      ];
+      treeControl.dataNodes = nodes;
+
+      treeControl.expandAll();
+
+      expect(treeControl.isExpanded(nodes[0])).toBe(true);
+      expect(treeControl.isExpanded(nodes[1])).toBe(true);
+    });
+
+    it('should collapse all nodes', () => {
+      const nodes: TestNode[] = [
+        { id: '1', name: 'Node 1', level: 0, expandable: true },
+        { id: '2', name: 'Node 2', level: 1, expandable: true },
+      ];
+      treeControl.dataNodes = nodes;
+
+      treeControl.expandAll();
+      treeControl.collapseAll();
+
+      expect(treeControl.isExpanded(nodes[0])).toBe(false);
+      expect(treeControl.isExpanded(nodes[1])).toBe(false);
+    });
+
+    it('should get descendants of a node', () => {
+      const nodes: TestNode[] = [
+        { id: '1', name: 'Node 1', level: 0, expandable: true },
+        { id: '2', name: 'Node 2', level: 1, expandable: true },
+        { id: '3', name: 'Node 3', level: 2, expandable: false },
+        { id: '4', name: 'Node 4', level: 1, expandable: false },
+      ];
+      treeControl.dataNodes = nodes;
+
+      const descendants = treeControl.getDescendants(nodes[0]);
+
+      expect(descendants).toContain(nodes[1]);
+      expect(descendants).toContain(nodes[2]);
+      expect(descendants).toContain(nodes[3]);
+      expect(descendants.length).toBe(3);
+    });
+  });
+
+  describe('createNestedTreeControl', () => {
+    let treeControl: TreeExpansion<TestNode, string>;
+    const getChildren = (node: TestNode): TestNode[] | undefined => node.children;
+
+    beforeEach(() => {
+      treeControl = createNestedTreeControl<TestNode, string>(
+        getChildren,
+        {
+          isExpandable: (node) => !!node.children?.length,
+          trackBy: (node) => node.id,
+        },
+      );
+    });
+
+    it('should return an object that implements TreeExpansion interface', () => {
+      expect(treeControl).toBeDefined();
+      expect('dataNodes' in treeControl).toBe(true);
+      expect(treeControl.expansionModel).toBeDefined();
+      expect(typeof treeControl.isExpanded).toBe('function');
+      expect(typeof treeControl.toggle).toBe('function');
+      expect(typeof treeControl.expand).toBe('function');
+      expect(typeof treeControl.collapse).toBe('function');
+      expect(typeof treeControl.expandAll).toBe('function');
+      expect(typeof treeControl.collapseAll).toBe('function');
+      expect(typeof treeControl.toggleDescendants).toBe('function');
+      expect(typeof treeControl.expandDescendants).toBe('function');
+      expect(typeof treeControl.collapseDescendants).toBe('function');
+      expect(typeof treeControl.getDescendants).toBe('function');
+    });
+
+    it('should have expansion model as SelectionModel', () => {
+      expect(treeControl.expansionModel).toBeInstanceOf(SelectionModel);
+    });
+
+    it('should have getChildren accessor function', () => {
+      expect(treeControl.getChildren).toBe(getChildren);
+    });
+
+    it('should allow setting dataNodes', () => {
+      const nodes: TestNode[] = [
+        { id: '1', name: 'Node 1', level: 0, expandable: true },
+      ];
+      treeControl.dataNodes = nodes;
+      expect(treeControl.dataNodes).toEqual(nodes);
+    });
+
+    it('should track expansion state correctly', () => {
+      const child: TestNode = { id: '2', name: 'Child', level: 1, expandable: false };
+      const parent: TestNode = {
+        id: '1',
+        name: 'Parent',
+        level: 0,
+        expandable: true,
+        children: [child],
+      };
+      treeControl.dataNodes = [parent];
+
+      expect(treeControl.isExpanded(parent)).toBe(false);
+
+      treeControl.expand(parent);
+      expect(treeControl.isExpanded(parent)).toBe(true);
+
+      treeControl.collapse(parent);
+      expect(treeControl.isExpanded(parent)).toBe(false);
+    });
+
+    it('should toggle expansion state', () => {
+      const child: TestNode = { id: '2', name: 'Child', level: 1, expandable: false };
+      const parent: TestNode = {
+        id: '1',
+        name: 'Parent',
+        level: 0,
+        expandable: true,
+        children: [child],
+      };
+      treeControl.dataNodes = [parent];
+
+      treeControl.toggle(parent);
+      expect(treeControl.isExpanded(parent)).toBe(true);
+
+      treeControl.toggle(parent);
+      expect(treeControl.isExpanded(parent)).toBe(false);
+    });
+
+    it('should expand all nodes', () => {
+      const grandchild: TestNode = { id: '3', name: 'Grandchild', level: 2, expandable: false };
+      const child: TestNode = {
+        id: '2',
+        name: 'Child',
+        level: 1,
+        expandable: true,
+        children: [grandchild],
+      };
+      const parent: TestNode = {
+        id: '1',
+        name: 'Parent',
+        level: 0,
+        expandable: true,
+        children: [child],
+      };
+      treeControl.dataNodes = [parent];
+
+      treeControl.expandAll();
+
+      expect(treeControl.isExpanded(parent)).toBe(true);
+      expect(treeControl.isExpanded(child)).toBe(true);
+    });
+
+    it('should get descendants of a nested node', () => {
+      const grandchild: TestNode = { id: '3', name: 'Grandchild', level: 2, expandable: false };
+      const child: TestNode = {
+        id: '2',
+        name: 'Child',
+        level: 1,
+        expandable: true,
+        children: [grandchild],
+      };
+      const parent: TestNode = {
+        id: '1',
+        name: 'Parent',
+        level: 0,
+        expandable: true,
+        children: [child],
+      };
+      treeControl.dataNodes = [parent];
+
+      const descendants = treeControl.getDescendants(parent);
+
+      expect(descendants).toContain(child);
+      expect(descendants).toContain(grandchild);
+      expect(descendants.length).toBe(2);
+    });
+
+    it('should toggle descendants recursively', () => {
+      const grandchild: TestNode = { id: '3', name: 'Grandchild', level: 2, expandable: false };
+      const child: TestNode = {
+        id: '2',
+        name: 'Child',
+        level: 1,
+        expandable: true,
+        children: [grandchild],
+      };
+      const parent: TestNode = {
+        id: '1',
+        name: 'Parent',
+        level: 0,
+        expandable: true,
+        children: [child],
+      };
+      treeControl.dataNodes = [parent];
+
+      treeControl.toggleDescendants(parent);
+      expect(treeControl.isExpanded(parent)).toBe(true);
+      expect(treeControl.isExpanded(child)).toBe(true);
+
+      treeControl.toggleDescendants(parent);
+      expect(treeControl.isExpanded(parent)).toBe(false);
+      expect(treeControl.isExpanded(child)).toBe(false);
+    });
+  });
+});

--- a/src/app/modules/ix-tree/tree-control.factory.ts
+++ b/src/app/modules/ix-tree/tree-control.factory.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/deprecation */
 import { FlatTreeControl, NestedTreeControl } from '@angular/cdk/tree';
 import { Observable } from 'rxjs';
 import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';

--- a/src/app/modules/ix-tree/tree-control.factory.ts
+++ b/src/app/modules/ix-tree/tree-control.factory.ts
@@ -1,0 +1,108 @@
+/* eslint-disable sonarjs/deprecation */
+import { FlatTreeControl, NestedTreeControl } from '@angular/cdk/tree';
+import { Observable } from 'rxjs';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
+
+/**
+ * Factory functions for creating tree controls without triggering deprecation warnings
+ * in consuming code.
+ *
+ * ## Why we still use deprecated TreeControl classes
+ *
+ * Angular CDK deprecated TreeControl, FlatTreeControl, and NestedTreeControl in v19,
+ * with plans to remove them in v21. However, a complete replacement API has not been
+ * provided yet.
+ *
+ * ### The Problem with Current Migration Path
+ *
+ * The deprecation message suggests using `levelAccessor` or `childrenAccessor` on CdkTree,
+ * but these are only for describing your data structure - they don't provide:
+ *
+ * 1. **Programmatic access to expansion state** - CdkTree's `_expansionModel` is private
+ * 2. **Access to data nodes** - Needed for operations like `expandAll()`
+ * 3. **Helper methods** - Like `getDescendants()`, `isExpandable()`, `getLevel()`
+ * 4. **External expansion control** - Our data sources need to react to expansion changes
+ *
+ * ### Why Our Custom Architecture Requires TreeControl
+ *
+ * The ix-tree module has custom components (`TreeDataSource`, `TreeFlattener`) that were
+ * designed around the TreeControl interface:
+ *
+ * - `TreeDataSource` needs access to `expansionModel.changed` to re-render when nodes expand/collapse
+ * - `TreeFlattener.expandFlattenedNodes()` needs `isExpanded()` to filter the flattened tree
+ * - Components need `dataNodes`, `getLevel()`, `isExpandable()` for tree operations
+ *
+ * ### Our Solution: Centralized Technical Debt
+ *
+ * This file encapsulates ALL usage of deprecated TreeControl classes in the codebase:
+ *
+ * - Rest of the codebase works with the `TreeExpansion` interface (not deprecated)
+ * - Deprecation warnings are suppressed only in this file
+ * - When Angular provides a proper replacement API (before v21), we only update this file
+ *
+ * ### Expected Timeline
+ *
+ * Angular will need to provide a complete replacement before removing TreeControl in v21.
+ * When they do, we'll implement the new API here and keep the same `TreeExpansion` interface,
+ * making the migration transparent to consuming code.
+ *
+ * @see https://github.com/angular/components/issues/29856 - GitHub issue discussing the migration gap
+ */
+
+/** Optional configuration for flat tree control */
+export interface FlatTreeControlOptions<T, K> {
+  trackBy?: (dataNode: T) => K;
+}
+
+/** Optional configuration for nested tree control */
+export interface NestedTreeControlOptions<T, K> {
+  isExpandable?: (dataNode: T) => boolean;
+  trackBy?: (dataNode: T) => K;
+}
+
+/**
+ * Creates a flat tree control for managing expansion state of flat tree structures.
+ *
+ * @param getLevel - Function that returns the level/depth of a node
+ * @param isExpandable - Function that returns whether a node can be expanded
+ * @param options - Optional configuration including trackBy function
+ * @returns TreeExpansion instance for managing tree state
+ *
+ * @example
+ * ```ts
+ * const treeControl = createFlatTreeControl<DatasetDetails, string>(
+ *   (dataset) => (dataset?.name?.split('/')?.length || 0) - 1,
+ *   (dataset) => Number(dataset?.children?.length) > 0,
+ *   { trackBy: (dataset) => dataset.id }
+ * );
+ * ```
+ */
+export function createFlatTreeControl<T, K = T>(
+  getLevel: (dataNode: T) => number,
+  isExpandable: (dataNode: T) => boolean,
+  options?: FlatTreeControlOptions<T, K>,
+): TreeExpansion<T, K> {
+  return new FlatTreeControl<T, K>(getLevel, isExpandable, options);
+}
+
+/**
+ * Creates a nested tree control for managing expansion state of nested tree structures.
+ *
+ * @param getChildren - Function that returns the children of a node
+ * @param options - Optional configuration including isExpandable and trackBy functions
+ * @returns TreeExpansion instance for managing tree state
+ *
+ * @example
+ * ```ts
+ * const treeControl = createNestedTreeControl<VDevNode, string>(
+ *   (vdev) => vdev.children,
+ *   { trackBy: (vdev) => vdev.guid }
+ * );
+ * ```
+ */
+export function createNestedTreeControl<T, K = T>(
+  getChildren: (dataNode: T) => Observable<T[]> | T[] | undefined | null,
+  options?: NestedTreeControlOptions<T, K>,
+): TreeExpansion<T, K> {
+  return new NestedTreeControl<T, K>(getChildren, options);
+}

--- a/src/app/modules/ix-tree/tree-datasource.ts
+++ b/src/app/modules/ix-tree/tree-datasource.ts
@@ -1,9 +1,9 @@
 import { DataSource, CollectionViewer } from '@angular/cdk/collections';
-import { FlatTreeControl } from '@angular/cdk/tree';
 import {
   BehaviorSubject, Subject, Observable, map, filter,
   debounceTime, distinctUntilChanged, takeUntil, merge,
 } from 'rxjs';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
 import { TreeFlattener } from 'app/modules/ix-tree/tree-flattener';
 
 export class TreeDataSource<T, F, K = F> extends DataSource<F> {
@@ -38,7 +38,7 @@ export class TreeDataSource<T, F, K = F> extends DataSource<F> {
   }
 
   constructor(
-    private treeControl: FlatTreeControl<F, K>,
+    private treeControl: TreeExpansion<F, K>,
     private treeFlattener: TreeFlattener<T, F, K>,
     private initialData: T[] = [],
   ) {

--- a/src/app/modules/ix-tree/tree-expansion.interface.ts
+++ b/src/app/modules/ix-tree/tree-expansion.interface.ts
@@ -1,0 +1,62 @@
+import { SelectionModel } from '@angular/cdk/collections';
+import { Observable } from 'rxjs';
+
+/**
+ * Interface for tree expansion state management.
+ * This interface replaces the deprecated TreeControl from @angular/cdk/tree.
+ *
+ * It provides the same methods as the deprecated TreeControl interface
+ * without directly referencing the deprecated type.
+ *
+ * Both FlatTreeControl and NestedTreeControl implement all these methods,
+ * so this interface maintains full compatibility with existing code.
+ */
+export interface TreeExpansion<T, K = T> {
+  /** The saved tree nodes data for `expandAll` action. */
+  dataNodes: T[];
+
+  /** The expansion model */
+  expansionModel: SelectionModel<K>;
+
+  /** Whether the data node is expanded or collapsed. Return true if it's expanded. */
+  isExpanded(dataNode: T): boolean;
+
+  /** Get all descendants of a data node */
+  getDescendants(dataNode: T): T[];
+
+  /** Expand or collapse data node */
+  toggle(dataNode: T): void;
+
+  /** Expand one data node */
+  expand(dataNode: T): void;
+
+  /** Collapse one data node */
+  collapse(dataNode: T): void;
+
+  /** Expand all the dataNodes in the tree */
+  expandAll(): void;
+
+  /** Collapse all the dataNodes in the tree */
+  collapseAll(): void;
+
+  /** Toggle a data node by expand/collapse it and all its descendants */
+  toggleDescendants(dataNode: T): void;
+
+  /** Expand a data node and all its descendants */
+  expandDescendants(dataNode: T): void;
+
+  /** Collapse a data node and all its descendants */
+  collapseDescendants(dataNode: T): void;
+
+  /** Get depth of a given data node, return the level number. This is for flat tree node. */
+  readonly getLevel: (dataNode: T) => number;
+
+  /**
+   * Whether the data node is expandable. Returns true if expandable.
+   * This is for flat tree node.
+   */
+  readonly isExpandable: (dataNode: T) => boolean;
+
+  /** Gets a stream that emits whenever the given data node's children change. */
+  readonly getChildren: (dataNode: T) => Observable<T[]> | T[] | undefined | null;
+}

--- a/src/app/modules/ix-tree/tree-flattener.ts
+++ b/src/app/modules/ix-tree/tree-flattener.ts
@@ -1,5 +1,5 @@
-import { TreeControl } from '@angular/cdk/tree';
 import { Observable, take } from 'rxjs';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
 
 export class TreeFlattener<T, F, K = F> {
   constructor(
@@ -53,7 +53,7 @@ export class TreeFlattener<T, F, K = F> {
    * Expand flattened node with current expansion status.
    * The returned list may have different length.
    */
-  expandFlattenedNodes(nodes: F[], treeControl: TreeControl<F, K>): F[] {
+  expandFlattenedNodes(nodes: F[], treeExpansion: TreeExpansion<F, K>): F[] {
     const results: F[] = [];
     const currentExpand: boolean[] = [];
     currentExpand[0] = true;
@@ -67,7 +67,7 @@ export class TreeFlattener<T, F, K = F> {
         results.push(node);
       }
       if (this.isExpandable(node)) {
-        currentExpand[this.getLevel(node) + 1] = treeControl.isExpanded(node);
+        currentExpand[this.getLevel(node) + 1] = treeExpansion.isExpanded(node);
       }
     });
     return results;

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -3,7 +3,7 @@ import {
   BreakpointState,
   BreakpointObserver,
 } from '@angular/cdk/layout';
-import { CdkTreeNodePadding, FlatTreeControl } from '@angular/cdk/tree';
+import { CdkTreeNodePadding } from '@angular/cdk/tree';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, AfterViewInit, OnDestroy, ElementRef, TrackByFunction, HostBinding, computed, viewChild, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -43,7 +43,9 @@ import {
 } from 'app/modules/ix-tree/components/tree-virtual-scroll-view/tree-virtual-scroll-view.component';
 import { TreeNodeDefDirective } from 'app/modules/ix-tree/directives/tree-node-def.directive';
 import { TreeNodeToggleDirective } from 'app/modules/ix-tree/directives/tree-node-toggle.directive';
+import { createFlatTreeControl } from 'app/modules/ix-tree/tree-control.factory';
 import { TreeDataSource } from 'app/modules/ix-tree/tree-datasource';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
 import { TreeFlattener } from 'app/modules/ix-tree/tree-flattener';
 import { LayoutService } from 'app/modules/layout/layout.service';
 import { FakeProgressBarComponent } from 'app/modules/loader/components/fake-progress-bar/fake-progress-bar.component';
@@ -151,7 +153,7 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
   // Flat API
   getLevel = (dataset: DatasetDetails): number => (dataset?.name?.split('/')?.length || 0) - 1;
   isExpandable = (dataset: DatasetDetails): boolean => Number(dataset?.children?.length) > 0;
-  treeControl = new FlatTreeControl<DatasetDetails, string>(
+  treeControl: TreeExpansion<DatasetDetails, string> = createFlatTreeControl<DatasetDetails, string>(
     this.getLevel,
     this.isExpandable,
     { trackBy: (dataset: DatasetDetails) => dataset.id },

--- a/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-disks/manual-selection-disks.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/manual-selection-disks/manual-selection-disks.component.ts
@@ -1,4 +1,3 @@
-import { NestedTreeControl } from '@angular/cdk/tree';
 import { NgClass, AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, input, OnInit, inject } from '@angular/core';
 import { RouterLinkActive } from '@angular/router';
@@ -20,6 +19,8 @@ import { TreeNodeDefDirective } from 'app/modules/ix-tree/directives/tree-node-d
 import { TreeNodeOutletDirective } from 'app/modules/ix-tree/directives/tree-node-outlet.directive';
 import { TreeNodeToggleDirective } from 'app/modules/ix-tree/directives/tree-node-toggle.directive';
 import { NestedTreeDataSource } from 'app/modules/ix-tree/nested-tree-datasource';
+import { createNestedTreeControl } from 'app/modules/ix-tree/tree-control.factory';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
 import { DiskInfoComponent } from 'app/pages/storage/modules/pool-manager/components/manual-disk-selection/components/disk-info/disk-info.component';
 import {
   ManualDiskSelectionFilters,
@@ -79,9 +80,10 @@ export class ManualSelectionDisksComponent implements OnInit {
   readonly enclosures = input.required<Enclosure[]>();
 
   dataSource: NestedTreeDataSource<DiskOrGroup>;
-  treeControl = new NestedTreeControl<DiskOrGroup, string>((node) => node.children, {
-    trackBy: (node) => node.identifier,
-  });
+  treeControl: TreeExpansion<DiskOrGroup, string> = createNestedTreeControl<DiskOrGroup, string>(
+    (node) => node.children,
+    { trackBy: (node) => node.identifier },
+  );
 
   filtersUpdated = new BehaviorSubject<ManualDiskSelectionFilters>({});
 

--- a/src/app/pages/storage/modules/vdevs/components/vdevs-list/vdevs-list.component.ts
+++ b/src/app/pages/storage/modules/vdevs/components/vdevs-list/vdevs-list.component.ts
@@ -1,4 +1,3 @@
-import { NestedTreeControl } from '@angular/cdk/tree';
 import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, input, output, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -22,6 +21,8 @@ import { TreeNodeDefDirective } from 'app/modules/ix-tree/directives/tree-node-d
 import { TreeNodeOutletDirective } from 'app/modules/ix-tree/directives/tree-node-outlet.directive';
 import { TreeNodeToggleDirective } from 'app/modules/ix-tree/directives/tree-node-toggle.directive';
 import { NestedTreeDataSource } from 'app/modules/ix-tree/nested-tree-datasource';
+import { createNestedTreeControl } from 'app/modules/ix-tree/tree-control.factory';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
 import { flattenTreeWithFilter } from 'app/modules/ix-tree/utils/flattern-tree-with-filter';
 import { LayoutService } from 'app/modules/layout/layout.service';
 import { FakeProgressBarComponent } from 'app/modules/loader/components/fake-progress-bar/fake-progress-bar.component';
@@ -77,9 +78,13 @@ export class VDevsListComponent implements OnInit {
 
   protected dataSource: NestedTreeDataSource<VDevNestedDataNode>;
 
-  protected treeControl = new NestedTreeControl<VDevNestedDataNode, string>((vdev) => vdev.children, {
-    trackBy: (vdev) => vdev.guid,
-  });
+  protected treeControl: TreeExpansion<VDevNestedDataNode, string> = createNestedTreeControl<
+    VDevNestedDataNode,
+    string
+  >(
+    (vdev) => vdev.children,
+    { trackBy: (vdev) => vdev.guid },
+  );
 
   protected readonly hasNestedChild = (_: number, node: VDevNestedDataNode): boolean => {
     return Boolean(node.children?.length);

--- a/src/app/pages/storage/modules/vdevs/components/zfs-info-card/zfs-info-card.component.ts
+++ b/src/app/pages/storage/modules/vdevs/components/zfs-info-card/zfs-info-card.component.ts
@@ -113,11 +113,15 @@ export class ZfsInfoCardComponent {
   });
 
   readonly canDetachDisk = computed(() => {
+    const parentItem = this.topologyParentItem();
+    if (!parentItem) {
+      return false;
+    }
     return [
       TopologyItemType.Mirror,
       TopologyItemType.Replacing,
       TopologyItemType.Spare,
-    ].includes(this.topologyParentItem().type);
+    ].includes(parentItem.type);
   });
 
   readonly canOfflineDisk = computed(() => {

--- a/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.html
+++ b/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.html
@@ -35,22 +35,23 @@
       </mat-accordion>
     }
 
-    <div class="tree-header">
-      <div class="name-header">
-        <span >{{ 'Name' | translate }}</span>
+    @if (dataSource) {
+      <div class="tree-header">
+        <div class="name-header">
+          <span >{{ 'Name' | translate }}</span>
+        </div>
+        <div>{{ 'Status' | translate }}</div>
+        <div>{{ 'Read' | translate }}</div>
+        <div>{{ 'Write' | translate }}</div>
+        <div>{{ 'Checksum' | translate }}</div>
+        <div>{{ 'Errors' | translate }}</div>
       </div>
-      <div>{{ 'Status' | translate }}</div>
-      <div>{{ 'Read' | translate }}</div>
-      <div>{{ 'Write' | translate }}</div>
-      <div>{{ 'Checksum' | translate }}</div>
-      <div>{{ 'Errors' | translate }}</div>
-    </div>
 
-    <ix-tree-view
-      class="tree"
-      [ixDataSource]="dataSource"
-      [ixTreeControl]="treeControl"
-    >
+      <ix-tree-view
+        class="tree"
+        [ixDataSource]="dataSource"
+        [ixTreeControl]="treeControl"
+      >
       <ix-tree-node
         *treeNodeDef="let topologyItem; dataSource: dataSource"
         [treeNodeDefDataSource]="dataSource"
@@ -95,6 +96,7 @@
           <ng-container treeNodeOutlet></ng-container>
         }
       </ix-nested-tree-node>
-    </ix-tree-view>
+      </ix-tree-view>
+    }
   </div>
 </div>

--- a/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.ts
+++ b/src/app/pages/system/bootenv/bootenv-status/bootenv-status.component.ts
@@ -1,4 +1,3 @@
-import { NestedTreeControl } from '@angular/cdk/tree';
 import { ChangeDetectionStrategy, Component, OnInit, signal, inject } from '@angular/core';
 import { MatIconButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
@@ -24,6 +23,8 @@ import { TreeNodeDefDirective } from 'app/modules/ix-tree/directives/tree-node-d
 import { TreeNodeOutletDirective } from 'app/modules/ix-tree/directives/tree-node-outlet.directive';
 import { TreeNodeToggleDirective } from 'app/modules/ix-tree/directives/tree-node-toggle.directive';
 import { NestedTreeDataSource } from 'app/modules/ix-tree/nested-tree-datasource';
+import { createNestedTreeControl } from 'app/modules/ix-tree/tree-control.factory';
+import { TreeExpansion } from 'app/modules/ix-tree/tree-expansion.interface';
 import { FakeProgressBarComponent } from 'app/modules/loader/components/fake-progress-bar/fake-progress-bar.component';
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
@@ -87,9 +88,10 @@ export class BootStatusListComponent implements OnInit {
 
   protected isLoading = signal(false);
   dataSource: NestedTreeDataSource<VDevNestedDataNode>;
-  treeControl = new NestedTreeControl<VDevNestedDataNode, string>((vdev) => vdev.children, {
-    trackBy: (vdev) => vdev.guid,
-  });
+  treeControl: TreeExpansion<VDevNestedDataNode, string> = createNestedTreeControl<VDevNestedDataNode, string>(
+    (vdev) => vdev.children,
+    { trackBy: (vdev) => vdev.guid },
+  );
 
   poolInstance: PoolInstance;
   readonly hasNestedChild = (_: number, node: VDevNestedDataNode): boolean => {


### PR DESCRIPTION
Address TreeControl deprecation warnings by creating an abstraction layer that centralizes usage of deprecated classes in a single location.

- Create TreeExpansion interface to abstract tree control functionality
- Create factory functions (createFlatTreeControl/createNestedTreeControl) to encapsulate deprecated FlatTreeControl and NestedTreeControl usage
- Update ix-tree module components to use TreeExpansion interface
- Update consuming components (datasets, vdevs, bootenv, pool-manager) to use factory functions instead of direct instantiation
- Add comprehensive test coverage for factory functions (19 tests)

- Fix bootenv-status component rendering tree before dataSource initialized
- Fix zfs-info-card null pointer when topologyParentItem is not provided

Angular CDK deprecated TreeControl in v19 but hasn't provided a complete replacement API yet. The suggested levelAccessor/childrenAccessor only describe data structure - they don't provide:

- Programmatic access to expansion state (_expansionModel is private)
- Access to data nodes (needed for expandAll/collapseAll)
- Helper methods (getDescendants, isExpandable, getLevel)
- External expansion control (needed by TreeDataSource/TreeFlattener)

This approach centralizes the technical debt in tree-control.factory.ts where deprecation warnings are suppressed. When Angular provides a proper replacement API (before v21), only this factory file needs updating.

The rest of the codebase works with TreeExpansion interface which will remain stable regardless of underlying implementation changes.

- All existing tests pass (35 tests across 6 test suites)
- New factory tests verify TreeExpansion interface compliance
- Build succeeds with no errors
- Deprecation warnings only appear in factory file (intentionally suppressed)