### PR TITLE
NAS-137694 / 26.04 / fix: update on `pool.snapshottask.query`

### DIFF
--- a/src/app/interfaces/api/api-event-directory.interface.ts
+++ b/src/app/interfaces/api/api-event-directory.interface.ts
@@ -9,6 +9,7 @@ import { DockerStatusData } from 'app/interfaces/docker-config.interface';
 import { FailoverDisabledReasonEvent } from 'app/interfaces/failover-disabled-reasons.interface';
 import { Group } from 'app/interfaces/group.interface';
 import { Job } from 'app/interfaces/job.interface';
+import { PeriodicSnapshotTask } from 'app/interfaces/periodic-snapshot-task.interface';
 import { Pool } from 'app/interfaces/pool.interface';
 import { FailoverRebootInfo, SystemRebootInfo } from 'app/interfaces/reboot-info.interface';
 import { ReportingRealtimeUpdate } from 'app/interfaces/reporting.interface';
@@ -51,5 +52,6 @@ export interface ApiEventDirectory {
   'vm.query': { response: VirtualMachine };
   'zfs.pool.scan': { response: PoolScan };
   'pool.snapshot.query': { response: ZfsSnapshot };
+  'pool.snapshottask.query': { response: PeriodicSnapshotTask };
   'directoryservices.status': { response: DirectoryServicesStatus };
 }

--- a/src/app/pages/data-protection/snapshot-task/snapshot-task-list/snapshot-task-list.component.spec.ts
+++ b/src/app/pages/data-protection/snapshot-task/snapshot-task-list/snapshot-task-list.component.spec.ts
@@ -5,12 +5,13 @@ import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
 import { MockComponent, MockPipe } from 'ng-mocks';
-import { of } from 'rxjs';
-import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
+import { of, Subject } from 'rxjs';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { CollectionChangeType } from 'app/enums/api.enum';
 import { JobState } from 'app/enums/job-state.enum';
 import { LifetimeUnit } from 'app/enums/lifetime-unit.enum';
-import { PeriodicSnapshotTaskUi } from 'app/interfaces/periodic-snapshot-task.interface';
+import { ApiEvent } from 'app/interfaces/api-message.interface';
+import { PeriodicSnapshotTaskUi, PeriodicSnapshotTask } from 'app/interfaces/periodic-snapshot-task.interface';
 import { ScheduleDescriptionPipe } from 'app/modules/dates/pipes/schedule-description/schedule-description.pipe';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { BasicSearchComponent } from 'app/modules/forms/search-input/components/basic-search/basic-search.component';
@@ -43,6 +44,7 @@ describe('SnapshotTaskListComponent', () => {
   let spectator: Spectator<SnapshotTaskListComponent>;
   let loader: HarnessLoader;
   let table: IxTableHarness;
+  const event$ = new Subject<ApiEvent<PeriodicSnapshotTask>>();
 
   const snapshotTasksList = [
     {
@@ -95,9 +97,10 @@ describe('SnapshotTaskListComponent', () => {
     ],
     providers: [
       mockAuth(),
-      mockApi([
-        mockCall('pool.snapshottask.query', snapshotTasksList),
-      ]),
+      mockProvider(ApiService, {
+        call: jest.fn().mockReturnValue(of(snapshotTasksList)),
+        subscribe: jest.fn().mockReturnValue(event$),
+      }),
       mockProvider(DialogService, {
         confirm: jest.fn(() => of(true)),
       }),
@@ -177,5 +180,21 @@ describe('SnapshotTaskListComponent', () => {
     });
 
     expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('pool.snapshottask.query');
+  });
+
+  it('reloads the data provider when an event is received from pool.snapshottask.query', () => {
+    const api = spectator.inject(ApiService);
+    expect(api.subscribe).toHaveBeenCalledWith('pool.snapshottask.query');
+
+    jest.spyOn(spectator.component.dataProvider, 'load');
+
+    event$.next({
+      collection: 'pool.snapshottask.query',
+      id: snapshotTasksList[0].id,
+      msg: CollectionChangeType.Changed,
+      fields: { state: { state: JobState.Finished } } as PeriodicSnapshotTask,
+    });
+
+    expect(spectator.component.dataProvider.load).toHaveBeenCalled();
   });
 });

--- a/src/app/pages/data-protection/snapshot-task/snapshot-task-list/snapshot-task-list.component.ts
+++ b/src/app/pages/data-protection/snapshot-task/snapshot-task-list/snapshot-task-list.component.ts
@@ -198,6 +198,11 @@ export class SnapshotTaskListComponent implements OnInit {
     this.dataProvider.emptyType$.pipe(untilDestroyed(this)).subscribe(() => {
       this.onListFiltered(this.searchQuery());
     });
+
+    this.api.subscribe('pool.snapshottask.query').pipe(
+      tap(() => this.getSnapshotTasks()),
+      untilDestroyed(this),
+    ).subscribe();
   }
 
   protected getSnapshotTasks(): void {


### PR DESCRIPTION
**Changes:**

* previously, the snapshot tasks page only updated once when first opened or when a UI element was added.
* this fix subscribes to `pool.snapshottask.query` and calls `getSnapshotTasks` when receiving an event.

**Testing:**

here are the testing instructions directly from the ticket, modified to note the expected and observed behavior:
1.  Configure a new Periodic Snapshot Task from Data Protection page  (Note: if edit a previously configured Snapshot that was successfully Finished, it doesn’t always get updated to Pending state so may not see the issue without creating a new task)
    * For ease, set the Schedule to “Custom” and enter any time within the next few minutes to execute.  Select any dataset and leave all other parameters at default.  Save.
2. Monitor the Periodic Snapshot Tasks table to confirm the task is created in the table
3. Confirm that the next run accurately shows the countdown and the State of the task shows “PENDING”.  Wait for the task to execute.
4. **With this PR:** Observe that the task should update to "FINISHED" when it completes

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
