### PR TITLE
NAS-137781 / 25.10.0 / Do not show update summary if there is a release notes (by william-gr)

### DIFF
--- a/src/app/pages/system/update/update.component.html
+++ b/src/app/pages/system/update/update.component.html
@@ -86,7 +86,7 @@
       <h4 class="hint">{{ 'Network activity has been administratively disabled for update operation. Please use Manual Update.' | translate }}</h4>
     }
 
-    @if (changelog() || newVersion()?.release_notes_url) {
+    @if ((changelog() || newVersion()?.release_notes_url) && !newVersion()?.release_notes) {
       <div class="update-summary">
         <h3>
           {{ 'Update Summary for {version}' | translate: { version: newVersion().version } }}
@@ -114,7 +114,7 @@
 
     @if (newVersion()?.release_notes) {
       <div class="release-notes-section">
-        <h3>{{ 'Release Notes' | translate }}</h3>
+        <h3>{{ 'Release Notes for {version}' | translate: { version: newVersion().version } }}</h3>
         <div class="release-notes-content">
           <ix-dynamic-markdown 
             [content]="newVersion().release_notes"


### PR DESCRIPTION
**Changes:**

Do not show summary/release notes url if there is a proper markdown release notes available.

**Testing:**

Try page with and without release notes url and with release notes.

Original PR: https://github.com/truenas/webui/pull/12625
