### PR TITLE
NAS-137815 / 26.04 / User UI: SSH access field are mixed Cased

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git log:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git log:*)"
-    ],
-    "deny": [],
-    "ask": []
-  }
-}

--- a/src/app/pages/credentials/groups/group-form/group-form.component.html
+++ b/src/app/pages/credentials/groups/group-form/group-form.component.html
@@ -35,22 +35,22 @@
 
         <ix-chips
           formControlName="sudo_commands"
-          [label]="'Allowed sudo commands' | translate"
+          [label]="'Allowed Sudo Commands' | translate"
         ></ix-chips>
 
         <ix-checkbox
           formControlName="sudo_commands_all"
-          [label]="'Allow all sudo commands' | translate"
+          [label]="'Allow All Sudo Commands' | translate"
         ></ix-checkbox>
 
         <ix-chips
           formControlName="sudo_commands_nopasswd"
-          [label]="'Allowed sudo commands with no password' | translate"
+          [label]="'Allowed Sudo Commands with No Password' | translate"
         ></ix-chips>
 
         <ix-checkbox
           formControlName="sudo_commands_nopasswd_all"
-          [label]="'Allow all sudo commands with no password' | translate"
+          [label]="'Allow All Sudo Commands with No Password' | translate"
         ></ix-checkbox>
 
         <ix-checkbox

--- a/src/app/pages/credentials/groups/group-form/group-form.component.spec.ts
+++ b/src/app/pages/credentials/groups/group-form/group-form.component.spec.ts
@@ -108,8 +108,8 @@ describe('GroupFormComponent', () => {
       await form.fillForm({
         Name: 'new',
         'SMB Group': true,
-        'Allow all sudo commands': true,
-        'Allowed sudo commands with no password': ['ls'],
+        'Allow All Sudo Commands': true,
+        'Allowed Sudo Commands with No Password': ['ls'],
       });
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -148,10 +148,10 @@ describe('GroupFormComponent', () => {
       expect(values).toEqual({
         GID: '1111',
         Name: 'editing',
-        'Allow all sudo commands': false,
-        'Allowed sudo commands': [],
-        'Allow all sudo commands with no password': true,
-        'Allowed sudo commands with no password': [],
+        'Allow All Sudo Commands': false,
+        'Allowed Sudo Commands': [],
+        'Allow All Sudo Commands with No Password': true,
+        'Allowed Sudo Commands with No Password': [],
         'SMB Group': false,
         Privileges: ['Privilege 1'],
       });
@@ -162,7 +162,7 @@ describe('GroupFormComponent', () => {
       await form.fillForm({
         Name: 'updated',
         'SMB Group': true,
-        'Allow all sudo commands with no password': false,
+        'Allow All Sudo Commands with No Password': false,
         Privileges: ['Privilege 1'],
       });
 
@@ -189,7 +189,7 @@ describe('GroupFormComponent', () => {
       await form.fillForm({
         Name: 'updated',
         'SMB Group': true,
-        'Allow all sudo commands with no password': false,
+        'Allow All Sudo Commands with No Password': false,
         Privileges: ['Privilege 2'],
       });
 

--- a/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.html
+++ b/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.html
@@ -141,13 +141,13 @@
       @if (!noShellAccess() && (user.sudo_commands?.length || user.sudo_commands_nopasswd?.length)) {
         <div class="additional-info">
           <div>
-            {{ 'Allowed sudo commands' | translate }}:
-            {{ user.sudo_commands.join(', ') }}
+            {{ 'Allowed Sudo Commands' | translate }}:
+            {{ formatSudoCommands(user.sudo_commands) }}
           </div>
 
           <div>
             {{ 'Allowed Sudo Commands (No Password)' | translate }}:
-            {{ user.sudo_commands_nopasswd.join(', ') }}
+            {{ formatSudoCommands(user.sudo_commands_nopasswd) }}
           </div>
         </div>
       }

--- a/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.spec.ts
+++ b/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.spec.ts
@@ -152,7 +152,7 @@ describe('UserAccessCardComponent', () => {
     expect(shellAccessSection).toHaveText('Shell Access: /bin/bash');
 
     const additionalShellAccessInfo = spectator.query('.additional-info');
-    expect(additionalShellAccessInfo).toHaveText('Allowed sudo commands: command1, command2  Allowed Sudo Commands (No Password): command3');
+    expect(additionalShellAccessInfo).toHaveText('Allowed Sudo Commands: command1, command2  Allowed Sudo Commands (No Password): command3');
   });
 
   it('clears two-factor authentication when Clear Two-Factor Authentication is clicked', async () => {

--- a/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.ts
+++ b/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.ts
@@ -11,6 +11,7 @@ import { RouterLink } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { filter, switchMap } from 'rxjs';
+import { allCommands } from 'app/constants/all-commands.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { Role, roleNames } from 'app/enums/role.enum';
@@ -186,5 +187,15 @@ export class UserAccessCardComponent {
       this.snackbar.success(this.translate.instant('Two-Factor Authentication settings cleared'));
       this.reloadUsers.emit();
     });
+  }
+
+  protected formatSudoCommands(commands: string[]): string {
+    if (!commands?.length) {
+      return '';
+    }
+
+    return commands
+      .map((cmd) => (cmd === allCommands ? this.translate.instant('All') : cmd))
+      .join(', ');
   }
 }

--- a/src/app/pages/credentials/users/user-form/additional-details-section/additional-details-section.component.html
+++ b/src/app/pages/credentials/users/user-form/additional-details-section/additional-details-section.component.html
@@ -177,7 +177,7 @@
               <div view>
                 @if (getSudoCommands()) {
                   <div>
-                    {{ 'Allowed sudo commands' | translate }}:
+                    {{ 'Allowed Sudo Commands' | translate }}:
                     {{ getSudoCommands() }}
                   </div>
                 }
@@ -194,25 +194,25 @@
             <div edit class="extra-controls-container">
               <ix-checkbox
                 formControlName="sudo_commands_all"
-                [label]="'Allow all sudo commands' | translate"
+                [label]="'Allow All Sudo Commands' | translate"
               ></ix-checkbox>
 
               @if (!form.controls.sudo_commands_all.value) {
                 <ix-chips
                   formControlName="sudo_commands"
-                  [label]="'Allowed sudo commands' | translate"
+                  [label]="'Allowed Sudo Commands' | translate"
                 ></ix-chips>
               }
 
               <ix-checkbox
                 formControlName="sudo_commands_nopasswd_all"
-                [label]="'Allow all sudo commands with no password' | translate"
+                [label]="'Allow All Sudo Commands with No Password' | translate"
               ></ix-checkbox>
 
               @if (!form.controls.sudo_commands_nopasswd_all.value) {
                 <ix-chips
                   formControlName="sudo_commands_nopasswd"
-                  [label]="'Allowed sudo commands with no password' | translate"
+                  [label]="'Allowed Sudo Commands with No Password' | translate"
                 ></ix-chips>
               }
             </div>

--- a/src/app/pages/credentials/users/user-form/additional-details-section/additional-details-section.component.spec.ts
+++ b/src/app/pages/credentials/users/user-form/additional-details-section/additional-details-section.component.spec.ts
@@ -122,7 +122,7 @@ describe('AdditionalDetailsSectionComponent', () => {
       const table = await loader.getHarness(DetailsTableHarness);
       const values = await table.getValues();
 
-      expect(values['Sudo Commands']).toContain('Allowed sudo commands: ALL');
+      expect(values['Sudo Commands']).toContain('Allowed Sudo Commands: All');
       expect(values['Sudo Commands']).toContain('Allowed Sudo Commands (No Password): rm -rf /');
     });
 
@@ -226,7 +226,7 @@ describe('AdditionalDetailsSectionComponent', () => {
         Groups: 'Primary Group: test-group  Auxiliary Groups:  test-group-2, test-group-3',
         'Home Directory': '/home/test',
         Shell: '/usr/bin/bash',
-        'Sudo Commands': 'Allowed sudo commands: ALL  Allowed Sudo Commands (No Password): rm -rf /',
+        'Sudo Commands': 'Allowed Sudo Commands: All  Allowed Sudo Commands (No Password): rm -rf /',
       });
 
       expect(spectator.inject(UserFormStore).updateSetupDetails).toHaveBeenCalledWith({

--- a/src/app/pages/credentials/users/user-form/additional-details-section/additional-details-section.component.ts
+++ b/src/app/pages/credentials/users/user-form/additional-details-section/additional-details-section.component.ts
@@ -279,7 +279,7 @@ export class AdditionalDetailsSectionComponent implements OnInit {
 
   protected getSudoCommands(): string {
     if (this.form.controls.sudo_commands_all.value) {
-      return allCommands;
+      return this.translate.instant('All');
     }
 
     return this.form.controls.sudo_commands.value?.join(', ') || '';
@@ -287,7 +287,7 @@ export class AdditionalDetailsSectionComponent implements OnInit {
 
   protected getSudoCommandsNoPasswd(): string {
     if (this.form.controls.sudo_commands_nopasswd_all.value) {
-      return allCommands;
+      return this.translate.instant('All');
     }
 
     return this.form.controls.sudo_commands_nopasswd.value?.join(', ') || '';

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -761,6 +761,7 @@ body {
     display: flex;
     flex: 1 0 auto;
     padding-left: 0;
+    word-break: break-word;
   }
 
   .mdc-data-table__cell,


### PR DESCRIPTION
Testing: see ticket.

We should no longer see mixed cased text for SSH.
As well improved text when `ALL`  sudo commands are allowed to be shown as `All` for users - with translations available.