### PR TITLE
NAS-137883 / 26.04 / Users page: unexpected behavior during account edit that prevents password enable.

### DIFF
--- a/src/app/pages/credentials/users/user-form/auth-section/auth-section.component.ts
+++ b/src/app/pages/credentials/users/user-form/auth-section/auth-section.component.ts
@@ -84,13 +84,14 @@ export class AuthSectionComponent implements OnInit {
       untilDestroyed(this),
     ).subscribe({
       next: () => {
+        const rawValue = this.form.getRawValue();
         this.userStore.updateUserConfig({
-          ssh_password_enabled: this.form.value.ssh_password_enabled,
+          ssh_password_enabled: rawValue.ssh_password_enabled,
           password_disabled: this.smbAccess()
             ? false
-            : this.form.value.password_disabled,
-          password: this.form.value.password,
-          sshpubkey: this.form.value.sshpubkey,
+            : rawValue.password_disabled,
+          password: rawValue.password,
+          sshpubkey: rawValue.sshpubkey,
         });
       },
     });

--- a/src/app/pages/credentials/users/user-form/user-form.component.ts
+++ b/src/app/pages/credentials/users/user-form/user-form.component.ts
@@ -99,10 +99,10 @@ export class UserFormComponent implements OnInit {
 
   protected get formValues(): UserUpdate & { stig_password?: UserStigPasswordOption } {
     return {
-      ...this.form.value,
-      ...this.allowedAccessSection().form.value,
-      ...this.authSection().form.value,
-      ...this.additionalDetailsSection().form.value,
+      ...this.form.getRawValue(),
+      ...this.allowedAccessSection().form.getRawValue(),
+      ...this.authSection().form.getRawValue(),
+      ...this.additionalDetailsSection().form.getRawValue(),
     };
   }
 


### PR DESCRIPTION
  The Fix

  Changed both locations to use getRawValue() instead of .value:
  - auth-section.component.ts:87 - Store updates now use getRawValue() to capture password even when field is
  disabled
  - user-form.component.ts:102-105 - Form submission now uses getRawValue() on all form sections

  This ensures the password value is always captured and sent to the API, regardless of the disabled state of
  the form controls.
  
Before:

https://github.com/user-attachments/assets/099bed6f-5527-4b0a-ace2-0641d48c752b


After:

https://github.com/user-attachments/assets/6e27112c-bf49-42f5-a665-bda91de419fa


