### PR TITLE
NAS-137913 / 25.10.0 / Fix filesystem.file_tail_follow WebSocket subscription parameter format (by william-gr)

### DIFF
--- a/src/app/modules/dialog/components/job-progress/job-progress-dialog.component.spec.ts
+++ b/src/app/modules/dialog/components/job-progress/job-progress-dialog.component.spec.ts
@@ -203,5 +203,35 @@ describe('JobProgressDialogComponent', () => {
     expect(spectator.inject(MatDialogRef).disableClose).toBe(false);
   });
 
-  // TODO: Test cases for realtime jobs.
+  describe('realtime logs', () => {
+    it('subscribes to filesystem.file_tail_follow with JSON format when showRealtimeLogs is true and logs_path is provided', () => {
+      const jobWithLogs = {
+        ...testJob,
+        logs_path: '/var/log/test.log',
+      } as Job;
+
+      spectator = createComponent({
+        providers: [
+          mockProvider(ApiService, {
+            subscribe: jest.fn(() => of({
+              fields: {
+                data: 'Log line 1\nLog line 2\n',
+              },
+            })),
+          }),
+          {
+            provide: MAT_DIALOG_DATA,
+            useValue: {
+              job$: of(jobWithLogs),
+              showRealtimeLogs: true,
+            } as JobProgressDialogConfig<unknown>,
+          },
+        ],
+      });
+
+      expect(spectator.inject(ApiService).subscribe).toHaveBeenCalledWith(
+        `filesystem.file_tail_follow:${JSON.stringify({ path: '/var/log/test.log' })}`,
+      );
+    });
+  });
 });

--- a/src/app/modules/dialog/components/job-progress/job-progress-dialog.component.ts
+++ b/src/app/modules/dialog/components/job-progress/job-progress-dialog.component.ts
@@ -212,7 +212,7 @@ export class JobProgressDialog<T> implements OnInit, AfterViewChecked {
   private getRealtimeLogs(): Subscription {
     this.realtimeLogsSubscribed = true;
     this.cdr.markForCheck();
-    return this.api.subscribe(`filesystem.file_tail_follow:${this.job.logs_path}`)
+    return this.api.subscribe(`filesystem.file_tail_follow:${JSON.stringify({ path: this.job.logs_path })}`)
       .pipe(map((apiEvent) => apiEvent.fields), untilDestroyed(this))
       .subscribe((logs) => {
         if (logs?.data && typeof logs.data === 'string') {

--- a/src/app/modules/layout/console-footer/console-messages.store.spec.ts
+++ b/src/app/modules/layout/console-footer/console-messages.store.spec.ts
@@ -26,7 +26,7 @@ describe('ConsoleMessagesStore', () => {
     spectator.service.subscribeToMessageUpdates();
 
     expect(spectator.inject(ApiService).subscribe)
-      .toHaveBeenCalledWith('filesystem.file_tail_follow:/var/log/messages:500');
+      .toHaveBeenCalledWith(`filesystem.file_tail_follow:${JSON.stringify({ path: '/var/log/messages', tail_lines: 500 })}`);
     const state = await firstValueFrom(spectator.service.state$);
     expect(state).toEqual({
       lines: [

--- a/src/app/modules/layout/console-footer/console-messages.store.ts
+++ b/src/app/modules/layout/console-footer/console-messages.store.ts
@@ -22,7 +22,7 @@ export class ConsoleMessagesStore extends ComponentStore<ConsoleMessagesState> i
   lines$ = this.select((state) => state.lines.join('\n'));
   lastThreeLogLines$ = this.select((state) => state.lines.slice(-3).join('\n'));
 
-  private readonly logPath = 'filesystem.file_tail_follow:/var/log/messages:500';
+  private readonly logPath = `filesystem.file_tail_follow:${JSON.stringify({ path: '/var/log/messages', tail_lines: 500 })}` as const;
   private readonly maxMessages = 500;
 
   private addMessage = this.updater((state, message: string) => {
@@ -39,7 +39,7 @@ export class ConsoleMessagesStore extends ComponentStore<ConsoleMessagesState> i
   }
 
   subscribeToMessageUpdates(): void {
-    this.api.subscribe(this.logPath)
+    this.api.subscribe<'filesystem.file_tail_follow'>(this.logPath)
       .pipe(
         map((event) => event.fields),
         filter((log) => typeof log?.data === 'string'),


### PR DESCRIPTION
Update WebSocket subscriptions to use JSON-encoded parameters instead of colon-separated strings for filesystem.file_tail_follow calls in job progress dialog and console messages store.


**Testing:**

Enable console messages in General Settings -> UI

Original PR: https://github.com/truenas/webui/pull/12654
