### PR TITLE
NAS-137813 / 25.10.0 / fix: send `null` as speed limit when field empty (by mattwyatt-ix)

### DIFF
--- a/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.spec.ts
+++ b/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.spec.ts
@@ -95,12 +95,32 @@ describe('TransportSectionComponent', () => {
         compression: 'LZ4',
         compressed: true,
         large_block: true,
+        speed_limit: null,
         netcat_active_side: null,
         netcat_active_side_listen_address: null,
         netcat_active_side_port_max: null,
         netcat_active_side_port_min: null,
         netcat_passive_side_connect_address: null,
       });
+    });
+
+    it('includes speed_limit as null when not provided in SSH mode', async () => {
+      // make it *something* and get the value
+      await form.fillForm({
+        'SSH Connection': 'connection 1',
+        'Limit(Examples: 500 KiB, 500M, 2 TB)': '1GiB',
+      });
+      const shouldHaveLimit = spectator.component.getPayload();
+      expect(shouldHaveLimit).toHaveProperty('speed_limit', 1 * GiB);
+
+      // then, make it empty and ensure that it does properly return null
+      await form.fillForm({
+        'SSH Connection': 'connection 1',
+        'Limit(Examples: 500 KiB, 500M, 2 TB)': '',
+      });
+
+      const shouldNotHaveLimit = spectator.component.getPayload();
+      expect(shouldNotHaveLimit).toHaveProperty('speed_limit', null);
     });
 
     it('sends compression: null in payload when it is disabled', async () => {

--- a/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.ts
+++ b/src/app/pages/data-protection/replication/replication-form/sections/transport-section/transport-section.component.ts
@@ -122,11 +122,13 @@ export class TransportSectionComponent implements OnChanges {
       return {
         ...omitBy({
           ssh_credentials: values.ssh_credentials,
-          speed_limit: values.speed_limit,
           large_block: values.large_block,
           compressed: values.compressed,
         }, isNull),
         compression: values.compression === CompressionType.Disabled ? null : values.compression,
+        // speed_limit is only available for SSH connections
+        // on all other types of replication tasks it should be null or not submitted at all
+        speed_limit: values.speed_limit || null,
         netcat_active_side: null,
         netcat_active_side_listen_address: null,
         netcat_active_side_port_min: null,


### PR DESCRIPTION
**Changes:**

previously on the replication page, the speed limit would be submitted as an empty string which would cause an `EINVAL` error from the API when editing a replication task. this PR sends `null` if the speed limit is empty, which is what the API is expecting. this PR also changes a test to expect `speed_limit` to always be on the form's value and adds a test to validate whether or not `null` is actually submitted when the field is empty.

**Testing:**

1. set up a TrueNAS SSH replication task on the `data-protection/replication` page. the best way to do this is just to create two local datasets and SSH replicate one of them to the other. 
2. input the "Limit" field as empty. observe that the task saves correctly.
3. input the "Limit" field as some arbitrary value like "1 GiB" and save. ensure that it saves correctly. now, edit the task, clear the field, and save it. observe that the task saves correctly.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/12647
