### PR TITLE
NAS-137936 / 26.04 / fix: display mirrored VDEVs on storage page

### DIFF
--- a/src/app/modules/ix-tree/nested-tree-datasource.ts
+++ b/src/app/modules/ix-tree/nested-tree-datasource.ts
@@ -77,9 +77,8 @@ export class NestedTreeDataSource<T extends { children?: T[] }> extends DataSour
   private sort(value: T[]): T[] {
     return value.map((item) => {
       if (item.children?.length) {
-        item.children.sort(this.sortComparer);
+        item.children = this.sort(item.children.toSorted(this.sortComparer)) as T['children'];
       }
-      this.sort(item.children);
       return item;
     });
   }


### PR DESCRIPTION
**Changes:**

previously, mirrored VDEVs were broken in the `/storage/1/vdevs` page because we were trying to sort a read-only array in place. the error we'd see in the web console was:
```
TypeError: 0 is read-only
    sort nested-tree-datasource.ts:80
    sort nested-tree-datasource.ts:78
    sort nested-tree-datasource.ts:82
    sort nested-tree-datasource.ts:78
    set data nested-tree-datasource.ts:26
    createDataSource vdevs-list.component.ts:175
    setupTree vdevs-list.component.ts:119
    RxJS 3
error-handler.service.ts:71:17
```

this PR reassigns the array instead of mutating it.

**Testing:**
1. create a mirrored VDEV in the storage management page
2. navigate to the storage homepage and click the "View VDEVs" button
3. observe that the VDEV shows up and no errors appear in the console

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
