### PR TITLE
NAS-137861 / 25.10.0 / Fix editing a zvol (by william-gr)

### DIFF
--- a/src/app/pages/datasets/components/zvol-form/zvol-form.component.spec.ts
+++ b/src/app/pages/datasets/components/zvol-form/zvol-form.component.spec.ts
@@ -335,7 +335,6 @@ describe('ZvolFormComponent', () => {
         compression: 'LZ4',
         deduplication: 'OFF',
         force_size: false,
-        inherit_encryption: true,
         readonly: 'INHERIT',
         snapdev: 'INHERIT',
         sync: 'STANDARD',

--- a/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
+++ b/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
@@ -611,7 +611,8 @@ export class ZvolFormComponent implements OnInit {
           data.encryption_options.algorithm = data.algorithm;
         }
 
-        // Keep inherit_encryption in the payload - don't delete it
+        // Delete all encryption-related fields when editing
+        delete data.inherit_encryption;
         delete data.key;
         delete data.generate_key;
         delete data.passphrase;


### PR DESCRIPTION
`inherit_encryption` should not be sent to the API on update.

**Testing:**

Add a zvol then try to edit it (e.g. change size)


Original PR: https://github.com/truenas/webui/pull/12655
