### PR TITLE
NAS-137683: Main nav menu navigation issue

### DIFF
--- a/src/app/modules/master-detail-view/master-detail-view.component.html
+++ b/src/app/modules/master-detail-view/master-detail-view.component.html
@@ -7,7 +7,7 @@
     <div
       class="details-container"
       ixDetailsHeight
-      [class.details-container-mobile]="showMobileDetails()"
+      [class.details-container-mobile]="showMobileDetails() && isMobileView()"
     >
       <div class="header-container">
         @if (isMobileView()) {

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -211,7 +211,7 @@ export class AppInfoCardComponent {
         untilDestroyed(this),
       )
       .subscribe(() => {
-        this.router.navigate(['/apps', 'installed'], { state: { hideMobileDetails: true } });
+        this.router.navigate(['/apps', 'installed']);
       });
   }
 

--- a/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.html
@@ -33,7 +33,7 @@
     matSortActive="application"
     matSortDirection="asc"
     matSortDisableClear
-    (matSortChange)="sortChanged($event)"
+    (matSortChange)="setDatasourceWithSort($event)"
   >
     <div class="app-header-row">
       <div>
@@ -91,7 +91,7 @@
     matSortActive="application"
     matSortDirection="asc"
     class="app-wrapper"
-    (matSortChange)="sortChanged($event)"
+    (matSortChange)="setDatasourceWithSort($event)"
   >
     <div class="app-inner">
       <div class="apps-rows">

--- a/src/app/pages/apps/components/installed-apps/installed-apps.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps.component.html
@@ -39,7 +39,6 @@
   <ix-installed-apps-list
     #masterList
     master
-    [isMobileView]="masterDetailView.isMobileView()"
     (toggleShowMobileDetails)="masterDetailView.toggleShowMobileDetails($event)"
   ></ix-installed-apps-list>
 

--- a/src/app/pages/audit/audit.component.html
+++ b/src/app/pages/audit/audit.component.html
@@ -23,11 +23,11 @@
   #masterDetailView="masterDetailViewContext"
   [selectedItem]="dataProvider.expandedRow"
   [ixUiSearch]="searchableElements.elements.audit"
+  (mobileDetailsClosed)="dataProvider.expandedRow = null"
 >
   <ix-audit-list
     master
     [dataProvider]="dataProvider"
-    [isMobileView]="masterDetailView.isMobileView()"
     (toggleShowMobileDetails)="masterDetailView.toggleShowMobileDetails($event)"
   ></ix-audit-list>
 

--- a/src/app/pages/audit/components/audit-list/audit-list.component.html
+++ b/src/app/pages/audit/components/audit-list/audit-list.component.html
@@ -1,20 +1,21 @@
 <ix-audit-search
   [dataProvider]="dataProvider()"
-  [isMobileView]="isMobileView()"
 ></ix-audit-search>
 
-@if (!isMobileView()) {
-  <ng-container [ngTemplateOutlet]="thead"></ng-container>
-}
+<div class="sticky-header">
+  <thead
+    class="audit-header-row"
+    ix-table-head
+    [columns]="columns"
+    [dataProvider]="dataProvider()"
+  ></thead>
+</div>
 
 <ix-table
   [ixUiSearch]="searchableElements.elements.audit"
   [ix-table-empty]="!(dataProvider().currentPageCount$ | async)"
   [emptyConfig]="emptyService.defaultEmptyConfig(dataProvider().emptyType$ | async)"
 >
-  @if (isMobileView()) {
-    <ng-container [ngTemplateOutlet]="thead"></ng-container>
-  }
   <tbody
     ix-table-body
     detailsRowIdentifier="audit_id"
@@ -59,13 +60,3 @@
   [currentPage]="dataProvider().pagination.pageNumber"
 ></ix-table-pager>
 
-<ng-template #thead>
-  <div class="sticky-header">
-    <thead
-      class="audit-header-row"
-      ix-table-head
-      [columns]="columns"
-      [dataProvider]="dataProvider()"
-    ></thead>
-  </div>
-</ng-template>

--- a/src/app/pages/audit/components/audit-list/audit-list.component.scss
+++ b/src/app/pages/audit/components/audit-list/audit-list.component.scss
@@ -4,7 +4,7 @@
 :host ::ng-deep .sticky-header {
   height: inherit;
   min-height: 48px;
-  top: 38px;
+  top: 50px;
 
   @media(max-width: $breakpoint-md) {
     position: static;

--- a/src/app/pages/audit/components/audit-list/audit-list.component.ts
+++ b/src/app/pages/audit/components/audit-list/audit-list.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, ChangeDetectionStrategy, input, output, computed, inject } from '@angular/core';
 import { MatTooltip } from '@angular/material/tooltip';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
@@ -39,7 +39,6 @@ import { getLogImportantData } from 'app/pages/audit/utils/get-log-important-dat
     IxTableHeadComponent,
     IxTablePagerComponent,
     MatTooltip,
-    NgTemplateOutlet,
     UiSearchDirective,
     AuditSearchComponent,
     TranslateModule,
@@ -52,7 +51,6 @@ export class AuditListComponent {
   private translate = inject(TranslateService);
 
   readonly dataProvider = input.required<AuditApiDataProvider>();
-  readonly isMobileView = input.required<boolean>();
 
   protected readonly searchableElements = auditElements;
   protected readonly toggleShowMobileDetails = output<boolean>();
@@ -99,11 +97,12 @@ export class AuditListComponent {
 
   getUserAvatarForLog(row: AuditEntry): SafeHtml {
     // eslint-disable-next-line sonarjs/no-angular-bypass-sanitization
-    return this.sanitizer.bypassSecurityTrustHtml(toSvg(row.username, this.isMobileView() ? 20 : 30));
+    return this.sanitizer.bypassSecurityTrustHtml(toSvg(row.username, 25));
   }
 
   expanded(row: AuditEntry): void {
-    if (!row || !this.isMobileView()) return;
+    if (!row) return;
+
     this.toggleShowMobileDetails.emit(true);
   }
 }

--- a/src/app/pages/audit/components/audit-search/audit-search.component.html
+++ b/src/app/pages/audit/components/audit-search/audit-search.component.html
@@ -24,28 +24,19 @@
         >
           {{ 'Search' | translate }}
         </button>
-        @if (isMobileView()) {
-          <ng-container [ngTemplateOutlet]="exportButton"></ng-container>
-        }
       </div>
     </div>
-    @if (!isMobileView()) {
-      <ng-container [ngTemplateOutlet]="exportButton"></ng-container>
+    @if (dataProvider().totalRows) {
+      <ix-export-button
+        jobMethod="audit.export"
+        downloadMethod="audit.download_report"
+        [addReportNameArgument]="true"
+        [searchQuery]="searchQuery()"
+        [sorting]="dataProvider().sorting"
+        [defaultFilters]="basicQueryFilters()"
+        [controllerType]="dataProvider().selectedControllerType"
+      ></ix-export-button>
     }
   </div>
 </div>
 
-
-<ng-template #exportButton>
-  @if (dataProvider().totalRows) {
-    <ix-export-button
-      jobMethod="audit.export"
-      downloadMethod="audit.download_report"
-      [addReportNameArgument]="true"
-      [searchQuery]="searchQuery()"
-      [sorting]="dataProvider().sorting"
-      [defaultFilters]="basicQueryFilters()"
-      [controllerType]="dataProvider().selectedControllerType"
-    ></ix-export-button>
-  }
-</ng-template>

--- a/src/app/pages/audit/components/audit-search/audit-search.component.ts
+++ b/src/app/pages/audit/components/audit-search/audit-search.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, OnInit, ChangeDetectionStrategy, input, computed, signal, inject } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { ActivatedRoute } from '@angular/router';
@@ -39,7 +39,6 @@ import { UrlOptionsService } from 'app/services/url-options.service';
     AsyncPipe,
     FakeProgressBarComponent,
     MatButton,
-    NgTemplateOutlet,
     SearchInputComponent,
     TranslateModule,
     ExportButtonComponent,
@@ -53,7 +52,6 @@ export class AuditSearchComponent implements OnInit {
   private translate = inject(TranslateService);
 
   readonly dataProvider = input.required<AuditApiDataProvider>();
-  readonly isMobileView = input.required<boolean>();
 
   protected readonly searchQuery = signal<SearchQuery<AuditEntry>>({ query: '', isBasicQuery: true });
   protected readonly searchProperties = signal<SearchProperty<AuditEntry>[]>([]);

--- a/src/app/pages/credentials/users/all-users/all-users.component.html
+++ b/src/app/pages/credentials/users/all-users/all-users.component.html
@@ -6,13 +6,13 @@
   #masterDetailView="masterDetailViewContext"
   [showDetails]="!!dataProvider.expandedRow"
   [selectedItem]="dataProvider.expandedRow"
+  (mobileDetailsClosed)="dataProvider.expandedRow = null"
 >
   <ix-user-list
     #masterList
     master
     [dataProvider]="dataProvider"
     [ixUiSearch]="searchableElements.elements.list"
-    [isMobileView]="masterDetailView.isMobileView()"
     (toggleShowMobileDetails)="masterDetailView.toggleShowMobileDetails($event)"
     (userSelected)="onUserSelected($event)"
   ></ix-user-list>

--- a/src/app/pages/credentials/users/all-users/user-list/user-list.component.html
+++ b/src/app/pages/credentials/users/all-users/user-list/user-list.component.html
@@ -2,17 +2,19 @@
   [dataProvider]="dataProvider()"
 ></ix-users-search>
 
-@if (!isMobileView()) {
-  <ng-container [ngTemplateOutlet]="thead"></ng-container>
-}
+<div class="sticky-header">
+  <thead
+    class="user-header-row"
+    ix-table-head
+    [columns]="columns"
+    [dataProvider]="dataProvider()"
+  ></thead>
+</div>
 
 <ix-table
   [ix-table-empty]="!(dataProvider().currentPageCount$ | async)"
   [emptyConfig]="emptyService.defaultEmptyConfig(dataProvider().emptyType$ | async)"
 >
-  @if (isMobileView()) {
-    <ng-container [ngTemplateOutlet]="thead"></ng-container>
-  }
   <tbody
     ix-table-body
     detailsRowIdentifier="uid"
@@ -37,14 +39,3 @@
   [pageSize]="+pagination.pageSize"
   [currentPage]="+pagination.pageNumber"
 ></ix-table-pager>
-
-<ng-template #thead>
-  <div class="sticky-header">
-    <thead
-      class="user-header-row"
-      ix-table-head
-      [columns]="columns"
-      [dataProvider]="dataProvider()"
-    ></thead>
-  </div>
-</ng-template>

--- a/src/app/pages/credentials/users/all-users/user-list/user-list.component.scss
+++ b/src/app/pages/credentials/users/all-users/user-list/user-list.component.scss
@@ -4,7 +4,7 @@
 :host ::ng-deep .sticky-header {
   height: inherit;
   min-height: 48px;
-  top: 52px;
+  top: 80px;
 
   @media(max-width: $breakpoint-md) {
     position: static;

--- a/src/app/pages/credentials/users/all-users/user-list/user-list.component.ts
+++ b/src/app/pages/credentials/users/all-users/user-list/user-list.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, ChangeDetectionStrategy, output, input, signal, inject } from '@angular/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -36,7 +36,6 @@ import { UserAccessCellComponent } from './user-access-cell/user-access-cell.com
     IxTableHeadComponent,
     IxTablePagerComponent,
     IxTableCellDirective,
-    NgTemplateOutlet,
     UsersSearchComponent,
     UserAccessCellComponent,
   ],
@@ -46,7 +45,6 @@ export class UserListComponent {
   private translate = inject(TranslateService);
   private searchDirectives = inject(UiSearchDirectivesService);
 
-  readonly isMobileView = input<boolean>();
   readonly toggleShowMobileDetails = output<boolean>();
   readonly userSelected = output<User>();
   protected readonly currentBatch = signal<User[]>([]);
@@ -87,10 +85,7 @@ export class UserListComponent {
 
   navigateToDetails(user: User): void {
     this.userSelected.emit(user);
-
-    if (this.isMobileView()) {
-      this.toggleShowMobileDetails.emit(true);
-    }
+    this.toggleShowMobileDetails.emit(true);
   }
 
   private handlePendingGlobalSearchElement(): void {
@@ -102,8 +97,9 @@ export class UserListComponent {
   }
 
   expanded(row: User): void {
+    if (!row) return;
+
     this.navigateToDetails(row);
-    if (!row || !this.isMobileView()) return;
     this.toggleShowMobileDetails.emit(true);
   }
 }

--- a/src/app/pages/data-protection/cloud-backup/all-cloud-backups/all-cloud-backups.component.html
+++ b/src/app/pages/data-protection/cloud-backup/all-cloud-backups/all-cloud-backups.component.html
@@ -18,13 +18,13 @@
   #masterDetailView="masterDetailViewContext"
   [showDetails]="showDetails"
   [selectedItem]="cloudBackup"
+  (mobileDetailsClosed)="dataProvider.expandedRow = null"
 >
   <ix-cloud-backup-list
     #masterList
     master
     [dataProvider]="dataProvider"
     [cloudBackups]="cloudBackups()"
-    [isMobileView]="masterDetailView.isMobileView()"
     (toggleShowMobileDetails)="masterDetailView.toggleShowMobileDetails($event)"
   ></ix-cloud-backup-list>
 

--- a/src/app/pages/data-protection/cloud-backup/all-cloud-backups/all-cloud-backups.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/all-cloud-backups/all-cloud-backups.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, signal, OnInit, ChangeDetectorRef, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal, OnInit, ChangeDetectorRef, inject, viewChild } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { ActivatedRoute, NavigationStart, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -43,6 +43,8 @@ export class AllCloudBackupsComponent implements OnInit {
   private cdr = inject(ChangeDetectorRef);
   private router = inject(Router);
 
+  protected readonly masterDetailView = viewChild.required(MasterDetailViewComponent);
+
   dataProvider: AsyncDataProvider<CloudBackup>;
   protected readonly cloudBackups = signal<CloudBackup[]>([]);
   protected readonly searchableElements = cloudBackupListElements;
@@ -83,12 +85,15 @@ export class AllCloudBackupsComponent implements OnInit {
           ? cloudBackups.find((cloudBackup) => cloudBackup.id.toString() === id)
           : cloudBackups.find((cloudBackup) => cloudBackup.id === this.dataProvider?.expandedRow?.id);
 
-        if (selectedBackup) {
-          this.dataProvider.expandedRow = selectedBackup;
-        } else if (cloudBackups.length) {
-          const [firstBackup] = cloudBackups;
-          this.dataProvider.expandedRow = firstBackup;
+        if (!this.masterDetailView().isMobileView()) {
+          if (selectedBackup) {
+            this.dataProvider.expandedRow = selectedBackup;
+          } else if (cloudBackups.length) {
+            const [firstBackup] = cloudBackups;
+            this.dataProvider.expandedRow = firstBackup;
+          }
         }
+
         this.cdr.markForCheck();
       }),
     );

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.ts
@@ -73,7 +73,6 @@ export class CloudBackupListComponent {
 
   readonly dataProvider = input.required<AsyncDataProvider<CloudBackup>>();
   readonly cloudBackups = input<CloudBackup[]>([]);
-  readonly isMobileView = input<boolean>(false);
 
   readonly toggleShowMobileDetails = output<boolean>();
   readonly searchQuery = signal<string>('');
@@ -221,7 +220,8 @@ export class CloudBackupListComponent {
   }
 
   expanded(row: CloudBackup): void {
-    if (!row || !this.isMobileView()) return;
+    if (!row) return;
+
     this.toggleShowMobileDetails.emit(true);
   }
 

--- a/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.ts
+++ b/src/app/pages/datasets/components/dataset-details-card/dataset-details-card.component.ts
@@ -104,7 +104,7 @@ export class DatasetDetailsCardComponent {
         untilDestroyed(this),
       )
       .subscribe((parent) => {
-        this.router.navigate(['/datasets', parent?.id], { state: { hideMobileDetails: true } });
+        this.router.navigate(['/datasets', parent?.id]);
       });
   }
 

--- a/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.ts
+++ b/src/app/pages/datasets/components/dataset-details-panel/dataset-details-panel.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, input, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, inject, output } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
 import { Router } from '@angular/router';
@@ -61,6 +61,7 @@ export class DatasetDetailsPanelComponent {
 
   readonly dataset = input.required<DatasetDetails>();
   readonly systemDataset = input<string>();
+  readonly closeMobileDetails = output();
 
   protected readonly requiredRoles = [Role.DatasetWrite];
   protected readonly searchableElements = datasetDetailsPanelElements;
@@ -119,6 +120,6 @@ export class DatasetDetailsPanelComponent {
   }
 
   onCloseMobileDetails(): void {
-    this.router.navigate(['/datasets'], { state: { hideMobileDetails: true } });
+    this.closeMobileDetails.emit();
   }
 }

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
@@ -128,6 +128,7 @@
         <ix-dataset-details-panel
           [dataset]="dataset"
           [systemDataset]="systemDataset()"
+          (closeMobileDetails)="closeMobileDetails()"
         ></ix-dataset-details-panel>
       </div>
     }

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -9,7 +9,7 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, AfterVie
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatIconButton } from '@angular/material/button';
 import {
-  ActivatedRoute, NavigationStart, Router,
+  ActivatedRoute, NavigationSkipped, NavigationStart, Router,
   RouterLink, RouterLinkActive,
 } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -172,12 +172,11 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
 
   constructor() {
     this.router.events
-      .pipe(filter((event) => event instanceof NavigationStart), untilDestroyed(this))
-      .subscribe(() => {
-        if (this.router.currentNavigation()?.extras?.state?.hideMobileDetails) {
-          this.closeMobileDetails();
-        }
-      });
+      .pipe(
+        filter((event) => event instanceof NavigationSkipped || event instanceof NavigationStart),
+        untilDestroyed(this),
+      )
+      .subscribe(() => this.closeMobileDetails());
   }
 
   ngOnInit(): void {
@@ -245,6 +244,7 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
 
   protected closeMobileDetails(): void {
     this.showMobileDetails = false;
+    this.cdr.markForCheck();
   }
 
   protected createPool(): void {

--- a/src/app/pages/instances/components/all-instances/all-instances.component.html
+++ b/src/app/pages/instances/components/all-instances/all-instances.component.html
@@ -13,7 +13,6 @@
     #masterList
     master
     [ixUiSearch]="searchableElements.elements.list"
-    [isMobileView]="masterDetailView.isMobileView()"
     (toggleShowMobileDetails)="masterDetailView.toggleShowMobileDetails($event)"
   ></ix-instance-list>
 

--- a/src/app/pages/instances/components/all-instances/all-instances.component.ts
+++ b/src/app/pages/instances/components/all-instances/all-instances.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { Router, NavigationStart } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
@@ -37,24 +36,12 @@ import { VirtualizationInstancesStore } from 'app/pages/instances/stores/virtual
 export class AllInstancesComponent implements OnInit {
   private configStore = inject(VirtualizationConfigStore);
   private instancesStore = inject(VirtualizationInstancesStore);
-  private router = inject(Router);
   private dialogService = inject(DialogService);
   private window = inject<Window>(WINDOW);
   private translate = inject(TranslateService);
 
   readonly selectedInstance = this.instancesStore.selectedInstance;
-
   protected readonly searchableElements = allInstancesElements;
-
-  constructor() {
-    this.router.events
-      .pipe(filter((event) => event instanceof NavigationStart), untilDestroyed(this))
-      .subscribe(() => {
-        if (this.router.currentNavigation()?.extras?.state?.hideMobileDetails) {
-          this.instancesStore.resetInstance();
-        }
-      });
-  }
 
   ngOnInit(): void {
     this.configStore.initialize();

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-general-info/instance-general-info.component.spec.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-general-info/instance-general-info.component.spec.ts
@@ -144,7 +144,7 @@ describe('InstanceGeneralInfoComponent', () => {
     expect(spectator.inject(DialogService).jobDialog).toHaveBeenCalled();
     expect(spectator.inject(ApiService).job).toHaveBeenLastCalledWith('virt.instance.delete', ['demo']);
 
-    expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/containers'], { state: { hideMobileDetails: true } });
+    expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/containers']);
   });
 
   it('opens edit instance form when Edit is pressed', async () => {

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-general-info/instance-general-info.component.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-general-info/instance-general-info.component.ts
@@ -89,7 +89,7 @@ export class InstanceGeneralInfoComponent {
       this.errorHandler.withErrorHandler(),
       untilDestroyed(this),
     ).subscribe(() => {
-      this.router.navigate(['/containers'], { state: { hideMobileDetails: true } });
+      this.router.navigate(['/containers']);
     });
   }
 }

--- a/src/app/pages/instances/components/all-instances/instance-list/instance-list.component.ts
+++ b/src/app/pages/instances/components/all-instances/instance-list/instance-list.component.ts
@@ -3,7 +3,6 @@ import {
   Component, ChangeDetectionStrategy,
   computed, inject,
   output,
-  input,
   signal,
 } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
@@ -52,7 +51,6 @@ export class InstanceListComponent {
   private layoutService = inject(LayoutService);
 
   readonly instanceId = toSignal(this.activatedRoute.params.pipe(map((params) => params['id'])));
-  readonly isMobileView = input<boolean>();
   readonly toggleShowMobileDetails = output<boolean>();
 
   readonly searchQuery = signal<string>('');
@@ -123,9 +121,7 @@ export class InstanceListComponent {
   navigateToDetails(instance: VirtualizationInstance): void {
     this.layoutService.navigatePreservingScroll(this.router, ['/containers', 'view', instance.id]);
 
-    if (this.isMobileView()) {
-      this.toggleShowMobileDetails.emit(true);
-    }
+    this.toggleShowMobileDetails.emit(true);
   }
 
   resetSelection(): void {

--- a/src/app/pages/sharing/iscsi/target/all-targets/all-targets.component.html
+++ b/src/app/pages/sharing/iscsi/target/all-targets/all-targets.component.html
@@ -5,13 +5,13 @@
   #masterDetailView="masterDetailViewContext"
   [selectedItem]="target"
   [showDetails]="showDetails"
+  (mobileDetailsClosed)="dataProvider.expandedRow = null"
 >
   <ix-iscsi-target-list
     #masterList
     master
     [dataProvider]="dataProvider"
     [targets]="targets()"
-    [isMobileView]="masterDetailView.isMobileView()"
     (toggleShowMobileDetails)="masterDetailView.toggleShowMobileDetails($event)"
   ></ix-iscsi-target-list>
 

--- a/src/app/pages/sharing/iscsi/target/all-targets/all-targets.component.ts
+++ b/src/app/pages/sharing/iscsi/target/all-targets/all-targets.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, signal, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, signal, inject, viewChild } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -41,6 +41,7 @@ export class AllTargetsComponent implements OnInit {
   private matDialog = inject(MatDialog);
   private slideIn = inject(SlideIn);
 
+  protected readonly masterDetailView = viewChild.required(MasterDetailViewComponent);
   protected dataProvider: AsyncDataProvider<IscsiTarget>;
   targets = signal<IscsiTarget[] | null>(null);
 
@@ -55,7 +56,7 @@ export class AllTargetsComponent implements OnInit {
       tap((targets) => {
         this.targets.set(targets);
         const firstTarget = targets[targets.length - 1];
-        if (!this.dataProvider.expandedRow && firstTarget) {
+        if (!this.dataProvider.expandedRow && firstTarget && !this.masterDetailView().isMobileView()) {
           this.dataProvider.expandedRow = firstTarget;
         }
       }),

--- a/src/app/pages/sharing/iscsi/target/all-targets/target-list/target-list.component.ts
+++ b/src/app/pages/sharing/iscsi/target/all-targets/target-list/target-list.component.ts
@@ -64,7 +64,6 @@ export class TargetListComponent implements OnInit {
   private translate = inject(TranslateService);
   private cdr = inject(ChangeDetectorRef);
 
-  readonly isMobileView = input<boolean>();
   readonly toggleShowMobileDetails = output<boolean>();
   readonly dataProvider = input.required<AsyncDataProvider<IscsiTarget>>();
   readonly targets = input<IscsiTarget[]>();
@@ -132,12 +131,10 @@ export class TargetListComponent implements OnInit {
   }
 
   expanded(target: IscsiTarget): void {
-    if (this.isMobileView()) {
-      this.toggleShowMobileDetails.emit(!!target);
-      if (!target) {
-        this.dataProvider().expandedRow = null;
-        this.cdr.markForCheck();
-      }
+    this.toggleShowMobileDetails.emit(!!target);
+    if (!target) {
+      this.dataProvider().expandedRow = null;
+      this.cdr.markForCheck();
     }
   }
 

--- a/src/app/pages/sharing/nvme-of/nvme-of.component.html
+++ b/src/app/pages/sharing/nvme-of/nvme-of.component.html
@@ -26,13 +26,13 @@
   #masterDetailView="masterDetailViewContext"
   [selectedItem]="subsystem"
   [showDetails]="showDetails"
+  (mobileDetailsClosed)="dataProvider.expandedRow = null"
 >
   <ix-subsystems-list
     #masterList
     master
     [dataProvider]="dataProvider"
     [isLoading]="isLoading()"
-    [isMobileView]="masterDetailView.isMobileView()"
     (toggleShowMobileDetails)="masterDetailView.toggleShowMobileDetails($event)"
     (subsystemSelected)="onSubsystemSelected($event)"
     (search)="onFilter($event)"

--- a/src/app/pages/sharing/nvme-of/nvme-of.component.ts
+++ b/src/app/pages/sharing/nvme-of/nvme-of.component.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common';
-import { ChangeDetectionStrategy, Component, effect, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, OnInit, inject, viewChild } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -57,10 +57,10 @@ export class NvmeOfComponent implements OnInit {
   private activatedRoute = inject(ActivatedRoute);
   private location = inject(Location);
 
+  protected readonly masterDetailView = viewChild.required(MasterDetailViewComponent);
+
   protected readonly subsystems = this.nvmeOfStore.subsystems;
-
   protected dataProvider = new ArrayDataProvider<NvmeOfSubsystemDetails>();
-
   private selectedSubsystemName: string | null = null;
 
   protected readonly isLoading = this.nvmeOfStore.isLoading;
@@ -97,7 +97,11 @@ export class NvmeOfComponent implements OnInit {
           const urlName = this.activatedRoute.snapshot.paramMap.get('name');
           const selectedName = this.selectedSubsystemName || urlName;
           const routeSelectedRow = subsystems.find((subsystem) => subsystem.name === selectedName);
-          this.dataProvider.expandedRow = routeSelectedRow || subsystems[0];
+
+          if (!this.masterDetailView().isMobileView()) {
+            this.dataProvider.expandedRow = (routeSelectedRow || subsystems[0]);
+          }
+
           this.selectedSubsystemName = this.dataProvider.expandedRow?.name || null;
           setSubsystemNameInUrl(this.location, this.selectedSubsystemName);
         }

--- a/src/app/pages/sharing/nvme-of/subsystems-list/subsystems-list.component.ts
+++ b/src/app/pages/sharing/nvme-of/subsystems-list/subsystems-list.component.ts
@@ -58,7 +58,6 @@ export class SubsystemsListComponent {
   private cdr = inject(ChangeDetectorRef);
   private searchDirectives = inject(UiSearchDirectivesService);
 
-  readonly isMobileView = input<boolean>();
   readonly isLoading = input(false);
   readonly toggleShowMobileDetails = output<boolean>();
   readonly subsystemSelected = output<NvmeOfSubsystemDetails>();
@@ -112,13 +111,12 @@ export class SubsystemsListComponent {
   }
 
   protected expanded(subsys: NvmeOfSubsystemDetails): void {
-    if (this.isMobileView()) {
-      this.toggleShowMobileDetails.emit(!!subsys);
-      if (!subsys) {
-        this.dataProvider().expandedRow = null;
-        this.cdr.markForCheck();
-      }
+    this.toggleShowMobileDetails.emit(!!subsys);
+    if (!subsys) {
+      this.dataProvider().expandedRow = null;
+      this.cdr.markForCheck();
     }
+
     if (subsys) {
       this.subsystemSelected.emit(subsys);
     }


### PR DESCRIPTION
Testing: see ticket.
I implemented the desired behaviour, the idea:

The behaviour of clicking the left side Datasets button should always be the same, regardless of what is currently loaded in the main window. It's something of a POLA (path of least astonishment) violation to have that button press act in a different way just because the datasets page is currently loaded and showing details of some specific dataset/zvol...

Preview:

https://github.com/user-attachments/assets/d57ee6ba-c156-40c8-912d-6b29b360f9f6

As well - i've cleaned up, removed unnecessary code, improved mobile view accessibility.