### PR TITLE
NAS-138641 / 26.04 / Fix validation errors not displaying on form init

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.html
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.html
@@ -1,4 +1,4 @@
-@if (control().touched || control().dirty) {
+@if (control().touched || control().dirty || showErrorsForUntouched) {
   <div class="form-error" role="alert" aria-live="polite">
     @for (message of messages; track trackMessage(message)) {
       <mat-error>

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
@@ -48,6 +48,8 @@ describe('IxErrorsComponent', () => {
     spectator.detectComponentChanges();
 
     expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: Minimum value is 10');
+    expect(spectator.query('.form-error')).toExist();
+    expect(spectator.query('mat-error')).toHaveText('Minimum value is 10');
   });
 
   it('does not announce errors when control is in PENDING state', () => {

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
@@ -40,4 +40,13 @@ describe('IxErrorsComponent', () => {
 
     expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: Custom error');
   });
+
+  it('displays errors immediately when control has errors on init', () => {
+    const invalidControl = new FormControl(5, [Validators.min(10)]);
+
+    spectator.setHostInput('control', invalidControl);
+    spectator.detectComponentChanges();
+
+    expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: Minimum value is 10');
+  });
 });

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
@@ -78,4 +78,13 @@ describe('IxErrorsComponent', () => {
 
     expect(spectator.component.messages).toEqual([]);
   });
+
+  it('does not mark control as touched when displaying initial errors', () => {
+    const invalidControl = new FormControl(5, [Validators.min(10)]);
+
+    spectator.setHostInput('control', invalidControl);
+    spectator.detectComponentChanges();
+
+    expect(invalidControl.touched).toBe(false);
+  });
 });

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
@@ -49,4 +49,33 @@ describe('IxErrorsComponent', () => {
 
     expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: Minimum value is 10');
   });
+
+  it('does not announce errors when control is in PENDING state', () => {
+    jest.clearAllMocks();
+
+    const asyncControl = new FormControl('', {
+      asyncValidators: () => new Promise(() => {}),
+    });
+
+    spectator.setHostInput('control', asyncControl);
+    spectator.detectComponentChanges();
+
+    expect(spectator.inject(LiveAnnouncer).announce).not.toHaveBeenCalled();
+  });
+
+  it('clears errors when control becomes valid', () => {
+    const dynamicControl = new FormControl('', [Validators.required]);
+
+    spectator.setHostInput('control', dynamicControl);
+    spectator.detectComponentChanges();
+
+    expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: Name is required');
+
+    jest.clearAllMocks();
+
+    dynamicControl.setValue('valid value');
+    spectator.detectComponentChanges();
+
+    expect(spectator.component.messages).toEqual([]);
+  });
 });

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
@@ -66,19 +66,31 @@ describe('IxErrorsComponent', () => {
   });
 
   it('clears errors when control becomes valid', () => {
-    const dynamicControl = new FormControl('', [Validators.required]);
+    const dynamicControl = new FormControl('invalid', [Validators.minLength(10)]);
 
     spectator.setHostInput('control', dynamicControl);
     spectator.detectComponentChanges();
 
-    expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: Name is required');
+    expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: The length of Name should be at least 10');
 
     jest.clearAllMocks();
 
-    dynamicControl.setValue('valid value');
+    dynamicControl.setValue('valid value with length');
     spectator.detectComponentChanges();
 
     expect(spectator.component.messages).toEqual([]);
+  });
+
+  it('does not display errors for empty required fields on init (new form scenario)', () => {
+    jest.clearAllMocks();
+
+    const emptyRequiredControl = new FormControl('', [Validators.required]);
+
+    spectator.setHostInput('control', emptyRequiredControl);
+    spectator.detectComponentChanges();
+
+    expect(spectator.query('.form-error')).not.toExist();
+    expect(spectator.inject(LiveAnnouncer).announce).not.toHaveBeenCalled();
   });
 
   it('does not mark control as touched when displaying initial errors', () => {

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -104,6 +104,9 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
     ).subscribe(() => {
       this.handleErrors();
     });
+
+    // Handle errors immediately in case control already has errors on init
+    this.handleErrors();
   }
 
   private handleErrors(): void {

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -108,6 +108,11 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
    */
   private subscribeToControlStatusChanges(): void {
     this.statusChangeSubscription?.unsubscribe();
+
+    // Check status before subscription to avoid race condition where status
+    // might change between subscription setup and the check.
+    const shouldHandleImmediately = this.control().status !== 'PENDING';
+
     this.statusChangeSubscription = this.control().statusChanges.pipe(
       filter((status) => status !== 'PENDING'),
       untilDestroyed(this),
@@ -118,7 +123,7 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
     // Handle errors immediately if control is not in PENDING state.
     // Skip marking as touched on initial display to avoid triggering
     // side effects like auto-opening editable components.
-    if (this.control().status !== 'PENDING') {
+    if (shouldHandleImmediately) {
       this.handleErrors({ skipMarkAsTouched: true });
     }
   }

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -41,6 +41,7 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
 
   private statusChangeSubscription: Subscription;
   messages: string[] = [];
+  protected showErrorsForUntouched = false;
 
   readonly defaultErrMessages = {
     min: (min: number) => this.translate.instant('Minimum value is {min}', { min }),
@@ -124,6 +125,11 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
     // Skip marking as touched on initial display to avoid triggering
     // side effects like auto-opening editable components.
     if (shouldHandleImmediately) {
+      // If control has errors on init, show them even if control is untouched.
+      // This handles the case where form is populated with invalid data from API.
+      if (this.control().errors) {
+        this.showErrorsForUntouched = true;
+      }
       this.handleErrors({ skipMarkAsTouched: true });
     }
   }

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -125,12 +125,16 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
     // Skip marking as touched on initial display to avoid triggering
     // side effects like auto-opening editable components.
     if (shouldHandleImmediately) {
-      // If control has errors on init, show them even if control is untouched.
-      // This handles the case where form is populated with invalid data from API.
-      if (this.control().errors) {
+      // Only show errors for untouched controls if the control has a value.
+      // This handles edit forms with invalid data from API, while not showing
+      // errors for empty required fields in new forms.
+      const controlValue = this.control().value;
+      const hasValue = controlValue !== null && controlValue !== undefined && controlValue !== '';
+
+      if (this.control().errors && hasValue) {
         this.showErrorsForUntouched = true;
+        this.handleErrors({ skipMarkAsTouched: true });
       }
-      this.handleErrors({ skipMarkAsTouched: true });
     }
   }
 

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -95,8 +95,18 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
     this.statusChangeSubscription?.unsubscribe();
   }
 
+  /**
+   * Subscribes to control status changes to update error messages.
+   *
+   * This manually works around Angular issue where statusChanges doesn't emit
+   * on initial control setup: https://github.com/angular/angular/issues/10816
+   *
+   * We also handle errors immediately on subscription if the control is not
+   * in PENDING state, ensuring validation errors present at initialization
+   * (e.g., when a form is populated with invalid data from the backend)
+   * are displayed right away without requiring user interaction.
+   */
   private subscribeToControlStatusChanges(): void {
-    // This manually works around: https://github.com/angular/angular/issues/10816
     this.statusChangeSubscription?.unsubscribe();
     this.statusChangeSubscription = this.control().statusChanges.pipe(
       filter((status) => status !== 'PENDING'),
@@ -105,8 +115,10 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
       this.handleErrors();
     });
 
-    // Handle errors immediately in case control already has errors on init
-    this.handleErrors();
+    // Handle errors immediately if control is not in PENDING state
+    if (this.control().status !== 'PENDING') {
+      this.handleErrors();
+    }
   }
 
   private handleErrors(): void {

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -115,13 +115,15 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
       this.handleErrors();
     });
 
-    // Handle errors immediately if control is not in PENDING state
+    // Handle errors immediately if control is not in PENDING state.
+    // Skip marking as touched on initial display to avoid triggering
+    // side effects like auto-opening editable components.
     if (this.control().status !== 'PENDING') {
-      this.handleErrors();
+      this.handleErrors({ skipMarkAsTouched: true });
     }
   }
 
-  private handleErrors(): void {
+  private handleErrors(options: { skipMarkAsTouched?: boolean } = {}): void {
     const newErrors: (string | null)[] = Object.keys(this.control().errors || []).map((error) => {
       if (error === ixManualValidateError) {
         return null;
@@ -136,7 +138,7 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
 
     this.messages = newErrors.filter((message) => !!message) as string[];
 
-    if (this.control().errors) {
+    if (this.control().errors && !options.skipMarkAsTouched) {
       this.control().markAllAsTouched();
     }
 

--- a/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.html
+++ b/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.html
@@ -40,7 +40,7 @@
           type="number"
           [label]="'Timeout (seconds)' | translate"
           [required]="true"
-          [tooltip]="'Connection timeout for directory service operations (1-40 seconds)' | translate"
+          [tooltip]="'Connection timeout for directory service operations (5-60 seconds)' | translate"
         ></ix-input>
 
         <ix-input

--- a/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
@@ -105,7 +105,7 @@ export class DirectoryServicesFormComponent implements OnInit {
     enable: [false, Validators.required],
     enable_account_cache: [true, Validators.required],
     enable_dns_updates: [false, Validators.required],
-    timeout: [30, [Validators.required, Validators.min(1), Validators.max(40)]],
+    timeout: [30, [Validators.required, Validators.min(5), Validators.max(60)]],
     kerberos_realm: [null],
   });
 

--- a/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
@@ -82,6 +82,7 @@ export class DirectoryServicesFormComponent implements OnInit {
   protected readonly previousConfig = signal<DirectoryServicesConfig | null>(null);
   protected readonly isLoading = signal(false);
   protected readonly requiredRoles = [Role.DirectoryServiceWrite];
+  private readonly mainFormValid = signal(false);
 
   // Validation states are now managed by the validation service
   protected credentialData: DirectoryServiceCredential | null = null;
@@ -90,14 +91,13 @@ export class DirectoryServicesFormComponent implements OnInit {
 
   protected readonly isFormValid = computed(() => {
     return this.validationService.calculateFormValidity(
-      this.form,
+      this.mainFormValid(),
       this.form.controls.service_type.value,
     );
   });
 
   private updateFormValidity(): void {
-    // Validation is now computed automatically via the validation service
-    this.cdr.markForCheck();
+    this.mainFormValid.set(this.form.valid);
   }
 
   protected readonly form = this.fb.group({
@@ -300,8 +300,8 @@ export class DirectoryServicesFormComponent implements OnInit {
   }
 
   private setupFormWatchers(): void {
-    // Watch for main form changes
-    this.form.valueChanges.pipe(
+    // Watch for main form status changes (validity)
+    this.form.statusChanges.pipe(
       untilDestroyed(this),
     ).subscribe(() => {
       this.updateFormValidity();

--- a/src/app/pages/directory-service/components/directory-services-form/services/directory-service-validation.service.spec.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/services/directory-service-validation.service.spec.ts
@@ -56,7 +56,7 @@ describe('DirectoryServiceValidationService', () => {
   describe('calculateFormValidity', () => {
     it('should return false when no service type is selected', () => {
       testForm.patchValue({ service_type: null });
-      const isValid = service.calculateFormValidity(testForm, null);
+      const isValid = service.calculateFormValidity(testForm.valid, null);
       expect(isValid).toBe(false);
     });
 
@@ -69,7 +69,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setActiveDirectoryValid(true);
       service.setCredentialValid(true);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.ActiveDirectory);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.ActiveDirectory);
       expect(isValid).toBe(true);
     });
 
@@ -82,7 +82,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setActiveDirectoryValid(false);
       service.setCredentialValid(true);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.ActiveDirectory);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.ActiveDirectory);
       expect(isValid).toBe(false);
     });
 
@@ -95,7 +95,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setActiveDirectoryValid(true);
       service.setCredentialValid(false);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.ActiveDirectory);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.ActiveDirectory);
       expect(isValid).toBe(false);
     });
 
@@ -108,7 +108,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setActiveDirectoryValid(true);
       service.setCredentialValid(true);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.ActiveDirectory);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.ActiveDirectory);
       expect(isValid).toBe(false);
     });
 
@@ -122,7 +122,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setLdapValid(true);
       service.setCredentialValid(true);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.Ldap);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.Ldap);
       expect(isValid).toBe(true);
     });
   });

--- a/src/app/pages/directory-service/components/directory-services-form/services/directory-service-validation.service.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/services/directory-service-validation.service.ts
@@ -38,11 +38,10 @@ export class DirectoryServiceValidationService {
    * Calculate overall form validity based on selected service type and component validities
    */
   calculateFormValidity(
-    mainForm: FormGroup,
+    mainFormValid: boolean,
     selectedServiceType: DirectoryServiceType | null,
   ): boolean {
     const credentialValid = this.credentialValid();
-    const formValid = mainForm.valid;
 
     // Only validate the configuration component for the selected service type
     // If no service type is selected, form should be invalid
@@ -55,7 +54,7 @@ export class DirectoryServiceValidationService {
       configValid = this.ipaValid();
     }
 
-    return configValid && credentialValid && formValid;
+    return configValid && credentialValid && mainFormValid;
   }
 
   /**


### PR DESCRIPTION
- Handle errors immediately in ix-errors when control already has errors
- Update directory services timeout validation to 5-60 seconds

**Changes:**

<img width="466" height="534" alt="Screenshot 2025-12-03 at 10 18 48 AM" src="https://github.com/user-attachments/assets/aee8b0df-4217-4bb9-a93b-aaa2cd4312ba" />

**Testing:**

Use a form (in this case directory services) and mock the API response to return a value outside the validation, in this case we saw the issue on directory services.
