### PR TITLE
NAS-140404 / 27.0.0-BETA.1 / TrueCloud Backup Task: Validation error appears unexpectedly when clicking "Add New" in Credentials dropdown

### DIFF
--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
@@ -1,5 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
@@ -14,6 +15,7 @@ import { DialogService } from 'app/modules/dialog/dialog.service';
 import {
   CloudCredentialsSelectComponent,
 } from 'app/modules/forms/custom-selects/cloud-credentials-select/cloud-credentials-select.component';
+import { addNewIxSelectValue } from 'app/modules/forms/ix-forms/components/ix-select/ix-select-with-new-option.directive';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
@@ -148,6 +150,16 @@ describe('CloudBackupFormComponent', () => {
       expect(await useAbsolutePathsControl.isDisabled()).toBe(true);
       expect(await useAbsolutePathsControl.getValue()).toBe(false);
     });
+
+    it('does not call getBuckets when credentials value is ADD_NEW', fakeAsync(() => {
+      const cloudCredentialService = spectator.inject(CloudCredentialService);
+      cloudCredentialService.getBuckets = jest.fn(() => of([]));
+
+      spectator.component.form.controls.credentials.setValue(addNewIxSelectValue as unknown as number);
+      tick();
+
+      expect(cloudCredentialService.getBuckets).not.toHaveBeenCalled();
+    }));
 
     it('adds a new cloud backup task and creates a new bucket', async () => {
       const form = await loader.getHarness(IxFormHarness);

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
@@ -7,7 +7,7 @@ import { FormBuilder, FormControl } from '@ngneat/reactive-forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { TnBannerComponent, TnBannerActionDirective } from '@truenas/ui-components';
 import {
-  debounceTime, distinctUntilChanged, map, of,
+  debounceTime, distinctUntilChanged, filter, map, of,
 } from 'rxjs';
 import { slashRootNode } from 'app/constants/basic-root-nodes.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
@@ -289,12 +289,11 @@ export class CloudBackupFormComponent implements OnInit {
 
   private listenForCredentialsChanges(): void {
     this.form.controls.credentials.valueChanges
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        filter((credentialId) => credentialId?.toString() !== addNewIxSelectValue),
+        takeUntilDestroyed(this.destroyRef),
+      )
       .subscribe((credentialId) => {
-        if (credentialId?.toString() === addNewIxSelectValue) {
-          return;
-        }
-
         if (credentialId !== (this.editingTask?.credentials?.id || null)) {
           this.form.controls.bucket.patchValue('');
         }

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts
@@ -28,6 +28,7 @@ import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-ex
 import { TreeNodeProvider } from 'app/modules/forms/ix-forms/components/ix-explorer/tree-node-provider.interface';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
+import { addNewIxSelectValue } from 'app/modules/forms/ix-forms/components/ix-select/ix-select-with-new-option.directive';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import { IxTextareaComponent } from 'app/modules/forms/ix-forms/components/ix-textarea/ix-textarea.component';
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
@@ -290,6 +291,10 @@ export class CloudBackupFormComponent implements OnInit {
     this.form.controls.credentials.valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((credentialId) => {
+        if (credentialId?.toString() === addNewIxSelectValue) {
+          return;
+        }
+
         if (credentialId !== (this.editingTask?.credentials?.id || null)) {
           this.form.controls.bucket.patchValue('');
         }


### PR DESCRIPTION
Automated fix for [NAS-140404](https://ixsystems.atlassian.net/browse/NAS-140404)

Requested by: U010F6A94RF

## Changes

The environment file is needed for tests to run, so it's fine to leave it. It's likely in `.gitignore` anyway since it's generated by `yarn ui reset`.

## Summary of Changes

**File Modified:** `src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.ts`

**Root Cause:** When a user clicks "Add New" in the Credentials dropdown of the TrueCloud Backup Task form, the `IxSelectWithNewOption` directive temporarily sets the form control's value to the string `"ADD_NEW"`. The `listenForCredentialsChanges()` method in `CloudBackupFormComponent` was listening to `credentials.valueChanges` and immediately calling `loadBucketOptions(credentialId)` with this `"ADD_NEW"` string value. This triggered an API call to `cloudsync.list_buckets` with `"ADD_NEW"` as the credential ID, which the backend correctly rejected with the validation error: *"Validation errors: credentials_id: Input should be a valid integer"*.

**Fix:** Added an early return guard in `listenForCredentialsChanges()` that checks if the credential value is the `addNewIxSelectValue` (`"ADD_NEW"`) sentinel. When detected, the method returns immediately without making the API call. This is consistent with how the similar `CloudSyncFormComponent` already handles this case.

**Changes:**
1. Added import of `addNewIxSelectValue` from the `ix-select-with-new-option.directive` module
2. Added guard check `if (credentialId?.toString() === addNewIxSelectValue) { return; }` at the top of the `credentials.valueChanges` subscription handler
