### PR TITLE
fix(dialog-error): clicking outside dialog emits undefined

### DIFF
--- a/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.spec.ts
@@ -21,7 +21,7 @@ describe('ContainerLogsComponent', () => {
   let loader: HarnessLoader;
 
   describe('When dialog is set a value', () => {
-    const createComponent = createComponentFactoryWithDialogResponse({ tail_lines: 650 } as LogsDetailsDialog['form']['value']);
+    const createComponent = createComponentFactoryWithDialogResponse(false);
 
     beforeEach(() => {
       spectator = createComponent();
@@ -151,7 +151,7 @@ describe('ContainerLogsComponent', () => {
   });
 
   describe('When cancel is clicked', () => {
-    const createComponent = createComponentFactoryWithDialogResponse(false);
+    const createComponent = createComponentFactoryWithDialogResponse(true);
 
     beforeEach(() => {
       spectator = createComponent();
@@ -162,25 +162,7 @@ describe('ContainerLogsComponent', () => {
     }));
   });
 
-  describe('When dialog is dismissed by clicking outside', () => {
-    const createComponent = createComponentFactoryWithDialogResponse(undefined);
-
-    beforeEach(() => {
-      spectator = createComponent();
-    });
-
-    it('navigates back to installed apps', fakeAsync(() => {
-      expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/apps/installed/', undefined, 'ix-test-app']);
-    }));
-
-    it('does not subscribe to logs', fakeAsync(() => {
-      expect(spectator.inject(ApiService).subscribe).not.toHaveBeenCalled();
-    }));
-  });
-
-  function createComponentFactoryWithDialogResponse(
-    response: LogsDetailsDialog['form']['value'] | false | undefined,
-  ): SpectatorFactory<ContainerLogsComponent> {
+  function createComponentFactoryWithDialogResponse(cancel = false): SpectatorFactory<ContainerLogsComponent> {
     return createComponentFactory({
       component: ContainerLogsComponent,
       imports: [
@@ -193,7 +175,15 @@ describe('ContainerLogsComponent', () => {
         mockProvider(Router),
         mockProvider(MatDialog, {
           open: jest.fn(() => ({
-            afterClosed: jest.fn(() => of(response)),
+            afterClosed: jest.fn(() => {
+              if (cancel) {
+                return of(false);
+              }
+
+              return of({
+                tail_lines: 650,
+              } as LogsDetailsDialog['form']['value']);
+            }),
           }) as unknown as MatDialogRef<LogsDetailsDialog>),
         }),
         mockProvider(ApiService, {

--- a/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.spec.ts
+++ b/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.spec.ts
@@ -21,7 +21,7 @@ describe('ContainerLogsComponent', () => {
   let loader: HarnessLoader;
 
   describe('When dialog is set a value', () => {
-    const createComponent = createComponentFactoryWithDialogResponse(false);
+    const createComponent = createComponentFactoryWithDialogResponse({ tail_lines: 650 } as LogsDetailsDialog['form']['value']);
 
     beforeEach(() => {
       spectator = createComponent();
@@ -151,7 +151,7 @@ describe('ContainerLogsComponent', () => {
   });
 
   describe('When cancel is clicked', () => {
-    const createComponent = createComponentFactoryWithDialogResponse(true);
+    const createComponent = createComponentFactoryWithDialogResponse(false);
 
     beforeEach(() => {
       spectator = createComponent();
@@ -162,7 +162,25 @@ describe('ContainerLogsComponent', () => {
     }));
   });
 
-  function createComponentFactoryWithDialogResponse(cancel = false): SpectatorFactory<ContainerLogsComponent> {
+  describe('When dialog is dismissed by clicking outside', () => {
+    const createComponent = createComponentFactoryWithDialogResponse(undefined);
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('navigates back to installed apps', fakeAsync(() => {
+      expect(spectator.inject(Router).navigate).toHaveBeenCalledWith(['/apps/installed/', undefined, 'ix-test-app']);
+    }));
+
+    it('does not subscribe to logs', fakeAsync(() => {
+      expect(spectator.inject(ApiService).subscribe).not.toHaveBeenCalled();
+    }));
+  });
+
+  function createComponentFactoryWithDialogResponse(
+    response: LogsDetailsDialog['form']['value'] | false | undefined,
+  ): SpectatorFactory<ContainerLogsComponent> {
     return createComponentFactory({
       component: ContainerLogsComponent,
       imports: [
@@ -175,15 +193,7 @@ describe('ContainerLogsComponent', () => {
         mockProvider(Router),
         mockProvider(MatDialog, {
           open: jest.fn(() => ({
-            afterClosed: jest.fn(() => {
-              if (cancel) {
-                return of(false);
-              }
-
-              return of({
-                tail_lines: 650,
-              } as LogsDetailsDialog['form']['value']);
-            }),
+            afterClosed: jest.fn(() => of(response)),
           }) as unknown as MatDialogRef<LogsDetailsDialog>),
         }),
         mockProvider(ApiService, {

--- a/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
+++ b/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
@@ -87,7 +87,7 @@ export class ContainerLogsComponent implements OnInit {
     }
 
     this.logsChangedListener = this.matDialog.open(LogsDetailsDialog, { width: '400px' }).afterClosed().pipe(
-      tap((value: LogsDetailsDialog['form']['value'] | boolean) => {
+      tap((value: LogsDetailsDialog['form']['value'] | boolean | undefined) => {
         if (!value) {
           this.router.navigate(['/apps/installed/', this.train, this.appName]);
           return;

--- a/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
+++ b/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
@@ -9,7 +9,7 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import {
-  combineLatest, filter, map, Subscription, switchMap, tap,
+  combineLatest, map, Subscription, switchMap, tap,
 } from 'rxjs';
 import { AppContainerLog } from 'app/interfaces/app.interface';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -96,7 +96,6 @@ export class ContainerLogsComponent implements OnInit {
         this.logs.set([]);
         this.isLoading.set(true);
       }),
-      filter(Boolean),
       switchMap((details: LogsDetailsDialog['form']['value']) => {
         return this.api.subscribe(`app.container_log_follow: ${JSON.stringify({
           app_name: this.appName,

--- a/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
+++ b/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
@@ -9,7 +9,7 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import {
-  combineLatest, map, Subscription, switchMap, tap,
+  combineLatest, filter, map, Subscription, switchMap, tap,
 } from 'rxjs';
 import { AppContainerLog } from 'app/interfaces/app.interface';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -88,7 +88,7 @@ export class ContainerLogsComponent implements OnInit {
 
     this.logsChangedListener = this.matDialog.open(LogsDetailsDialog, { width: '400px' }).afterClosed().pipe(
       tap((value: LogsDetailsDialog['form']['value'] | boolean) => {
-        if (typeof value === 'boolean' && !value) {
+        if (!value) {
           this.router.navigate(['/apps/installed/', this.train, this.appName]);
           return;
         }
@@ -96,6 +96,7 @@ export class ContainerLogsComponent implements OnInit {
         this.logs.set([]);
         this.isLoading.set(true);
       }),
+      filter(Boolean),
       switchMap((details: LogsDetailsDialog['form']['value']) => {
         return this.api.subscribe(`app.container_log_follow: ${JSON.stringify({
           app_name: this.appName,

--- a/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
+++ b/src/app/pages/apps/components/installed-apps/container-logs/container-logs.component.ts
@@ -9,7 +9,7 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import {
-  combineLatest, map, Subscription, switchMap, tap,
+  combineLatest, filter, map, Subscription, switchMap, tap,
 } from 'rxjs';
 import { AppContainerLog } from 'app/interfaces/app.interface';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -87,12 +87,13 @@ export class ContainerLogsComponent implements OnInit {
     }
 
     this.logsChangedListener = this.matDialog.open(LogsDetailsDialog, { width: '400px' }).afterClosed().pipe(
-      tap((value: LogsDetailsDialog['form']['value'] | boolean | undefined) => {
+      tap((value: LogsDetailsDialog['form']['value'] | undefined) => {
         if (!value) {
           this.router.navigate(['/apps/installed/', this.train, this.appName]);
-          return;
         }
-
+      }),
+      filter(Boolean),
+      tap(() => {
         this.logs.set([]);
         this.isLoading.set(true);
       }),
@@ -100,7 +101,7 @@ export class ContainerLogsComponent implements OnInit {
         return this.api.subscribe(`app.container_log_follow: ${JSON.stringify({
           app_name: this.appName,
           container_id: this.containerId,
-          tail_lines: details?.tail_lines || this.defaultTailLines,
+          tail_lines: details.tail_lines || this.defaultTailLines,
         })}`);
       }),
       map((apiEvent) => apiEvent.fields),


### PR DESCRIPTION
**Changes:**

<!-- Briefly describe what changed. -->

When navigating to Apps, clicking an app, then clicking the button for "View logs" it will display a dialog for `Tail Lines`. If you click anywhere outside the dialog it will throw an error `Cannot read properties of undefined (reading 'tail_lines')`. 

To rectify this, we treat undefined the same as "false" (the same as the cancel button on the dialog)

**Testing:**

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

Apps -> click app -> View logs -> dialog opens -> click outside dialog -> error

But this error has already pushed you to the container logs screen, so you sit there at a broken logs screen.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
