### PR TITLE
NAS-140637 / 27.0.0-BETA.1 / Broken storage usage estimate in snapshot page

### DIFF
--- a/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.html
+++ b/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.html
@@ -1,3 +1,5 @@
-<span
-  [ixTest]="[title, uniqueRowTag(row()), 'row-size']"
->{{ size | ixFileSize }}</span>
+@if (size !== null && size !== undefined) {
+  <span [ixTest]="[title, uniqueRowTag(row()), 'row-size']">{{ size | ixFileSize }}</span>
+} @else {
+  <span [ixTest]="[title, uniqueRowTag(row()), 'row-size']">{{ 'N/A' | translate }}</span>
+}

--- a/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.html
+++ b/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.html
@@ -1,5 +1,7 @@
-@if (size !== null && size !== undefined) {
-  <span [ixTest]="[title, uniqueRowTag(row()), 'row-size']">{{ size | ixFileSize }}</span>
-} @else {
-  <span [ixTest]="[title, uniqueRowTag(row()), 'row-size']">{{ 'N/A' | translate }}</span>
-}
+<span [ixTest]="[title, uniqueRowTag(row()), 'row-size']">
+  @if (size !== null && size !== undefined) {
+    {{ size | ixFileSize }}
+  } @else {
+    {{ 'N/A' | translate }}
+  }
+</span>

--- a/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.spec.ts
+++ b/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.spec.ts
@@ -3,7 +3,7 @@ import { createComponentFactory } from '@ngneat/spectator/jest';
 import { TranslateModule } from '@ngx-translate/core';
 import { IxCellSizeComponent } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component';
 
-interface TestTableData { numberField: number }
+interface TestTableData { numberField: number | null }
 
 describe('IxCellSizeComponent', () => {
   let spectator: Spectator<IxCellSizeComponent<TestTableData>>;
@@ -29,7 +29,7 @@ describe('IxCellSizeComponent', () => {
 
   it('shows N/A when value is null', () => {
     spectator.component.propertyName = 'numberField';
-    spectator.component.setRow({ numberField: null } as unknown as TestTableData);
+    spectator.component.setRow({ numberField: null });
     spectator.detectChanges();
 
     expect(spectator.element.textContent!.trim()).toBe('N/A');

--- a/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.spec.ts
+++ b/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.spec.ts
@@ -1,5 +1,6 @@
 import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory } from '@ngneat/spectator/jest';
+import { TranslateModule } from '@ngx-translate/core';
 import { IxCellSizeComponent } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component';
 
 interface TestTableData { numberField: number }
@@ -9,18 +10,28 @@ describe('IxCellSizeComponent', () => {
 
   const createComponent = createComponentFactory({
     component: IxCellSizeComponent<TestTableData>,
+    imports: [TranslateModule.forRoot()],
     detectChanges: false,
   });
 
   beforeEach(() => {
     spectator = createComponent();
-    spectator.component.propertyName = 'numberField';
-    spectator.component.setRow({ numberField: 5 * 1024 * 1024 * 1024 });
     spectator.component.uniqueRowTag = () => '';
-    spectator.detectChanges();
   });
 
   it('shows file size in template', () => {
+    spectator.component.propertyName = 'numberField';
+    spectator.component.setRow({ numberField: 5 * 1024 * 1024 * 1024 });
+    spectator.detectChanges();
+
     expect(spectator.element.textContent!.trim()).toBe('5 GiB');
+  });
+
+  it('shows N/A when value is null', () => {
+    spectator.component.propertyName = 'numberField';
+    spectator.component.setRow({ numberField: null } as unknown as TestTableData);
+    spectator.detectChanges();
+
+    expect(spectator.element.textContent!.trim()).toBe('N/A');
   });
 });

--- a/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.ts
+++ b/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.ts
@@ -11,8 +11,8 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
   imports: [FileSizePipe, TranslateModule, TestDirective],
 })
 export class IxCellSizeComponent<T> extends ColumnComponent<T> {
-  get size(): number {
-    return this.value as number;
+  get size(): number | null | undefined {
+    return this.value as number | null | undefined;
   }
 }
 

--- a/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.ts
+++ b/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-size/ix-cell-size.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
 import { ColumnComponent, Column } from 'app/modules/ix-table/interfaces/column-component.class';
 import { FileSizePipe } from 'app/modules/pipes/file-size/file-size.pipe';
 import { TestDirective } from 'app/modules/test-id/test.directive';
@@ -7,7 +8,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
   selector: 'ix-cell-size',
   templateUrl: './ix-cell-size.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FileSizePipe, TestDirective],
+  imports: [FileSizePipe, TranslateModule, TestDirective],
 })
 export class IxCellSizeComponent<T> extends ColumnComponent<T> {
   get size(): number {


### PR DESCRIPTION
Testing: see ticket.

Preview:
<img width="1728" height="616" alt="Screenshot 2026-04-13 at 15 03 51" src="https://github.com/user-attachments/assets/e93d0b2b-5628-4b1c-b362-97af0dafe0a2" />


Before:

<img width="1727" height="616" alt="Screenshot 2026-04-13 at 15 04 06" src="https://github.com/user-attachments/assets/77024c34-444e-486a-acff-892296dcea06" />
