### PR TITLE
NAS-140244 / 26.0.0-BETA.2 / overwrite URL for TNC registration button  (by mattwyatt-ix)

### DIFF
--- a/src/app/modules/truenas-connect/services/truenas-connect.service.spec.ts
+++ b/src/app/modules/truenas-connect/services/truenas-connect.service.spec.ts
@@ -12,7 +12,7 @@ import {
 } from 'app/enums/truenas-connect-status.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { TruenasConnectConfig } from 'app/interfaces/truenas-connect-config.interface';
-import { TruenasConnectService, resetGlobalTruenasConnectWindow } from 'app/modules/truenas-connect/services/truenas-connect.service';
+import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 import { WebSocketStatusService } from 'app/services/websocket-status.service';
@@ -71,8 +71,6 @@ describe('TruenasConnectService', () => {
 
   beforeEach(() => {
     spectator = createService();
-    // Reset global window reference for clean test state
-    resetGlobalTruenasConnectWindow();
   });
 
   it('should disable a tnc service', () => {
@@ -127,14 +125,14 @@ describe('TruenasConnectService', () => {
     );
     expect(windowMock.open).toHaveBeenCalledWith(
       url,
-      'TrueNASConnect',
+      'TrueNAS Connect',
       'menubar=yes,location=yes,resizable=yes,scrollbars=yes,status=yes',
     );
     expect(mockTncWindow.focus).toHaveBeenCalled();
     expect(errorHandler.withErrorHandler).toHaveBeenCalled();
   });
 
-  it('should reuse existing window when connecting again', () => {
+  it('should navigate existing window to new URL when connecting again', () => {
     const windowMock = spectator.inject(WINDOW) as unknown as jest.Mocked<Window>;
 
     // Mock an existing window object that's still open
@@ -151,7 +149,7 @@ describe('TruenasConnectService', () => {
     expect(windowMock.open).toHaveBeenCalledTimes(1);
     expect(windowMock.open).toHaveBeenCalledWith(
       firstUrl,
-      'TrueNASConnect',
+      'TrueNAS Connect',
       'menubar=yes,location=yes,resizable=yes,scrollbars=yes,status=yes',
     );
     expect(mockTncWindow.focus).toHaveBeenCalledTimes(1);
@@ -159,59 +157,19 @@ describe('TruenasConnectService', () => {
     // Reset focus mock to test the second call
     mockTncWindow.focus.mockClear();
 
-    // Second connection - should reuse existing window with empty URL (focus only)
+    // Second connection - should navigate existing window to new URL
     const secondUrl = 'https://second-url.com';
     spectator.service.openTruenasConnectWindow(secondUrl);
 
-    // Should call open again but with empty URL for focus only
+    // Should call open again with the new URL, which navigates the existing window
     expect(windowMock.open).toHaveBeenCalledTimes(2);
-    expect(windowMock.open).toHaveBeenNthCalledWith(2, '', 'TrueNASConnect');
-    expect(mockTncWindow.focus).toHaveBeenCalledTimes(1); // Called once in the second attempt
-    // URL should NOT be changed - no navigation
-    expect(mockTncWindow.location.href).toBe(''); // Original URL unchanged
-  });
-
-  it('should open new window when existing window is closed', () => {
-    const windowMock = spectator.inject(WINDOW) as unknown as jest.Mocked<Window>;
-
-    // Mock an existing window object that's closed
-    const mockClosedWindow = {
-      closed: true,
-      location: { href: '' },
-      focus: jest.fn(),
-    };
-
-    // Mock a new window object
-    const mockNewWindow = {
-      closed: false,
-      location: { href: '' },
-      focus: jest.fn(),
-    };
-
-    windowMock.open = jest.fn()
-      .mockReturnValueOnce(mockClosedWindow)
-      .mockReturnValueOnce(mockNewWindow);
-
-    // First connection - open window
-    const firstUrl = 'https://first-url.com';
-    spectator.service.openTruenasConnectWindow(firstUrl);
-    expect(windowMock.open).toHaveBeenCalledTimes(1);
-
-    // Simulate window being closed
-    mockClosedWindow.closed = true;
-
-    // Second connection - should open new window since previous is closed
-    const secondUrl = 'https://second-url.com';
-    spectator.service.openTruenasConnectWindow(secondUrl);
-
-    // Should open new window since previous was closed
-    expect(windowMock.open).toHaveBeenCalledTimes(2);
-    expect(windowMock.open).toHaveBeenLastCalledWith(
+    expect(windowMock.open).toHaveBeenNthCalledWith(
+      2,
       secondUrl,
-      'TrueNASConnect',
+      'TrueNAS Connect',
       'menubar=yes,location=yes,resizable=yes,scrollbars=yes,status=yes',
     );
-    expect(mockNewWindow.focus).toHaveBeenCalled();
+    expect(mockTncWindow.focus).toHaveBeenCalledTimes(1);
   });
 
   it('should open window using openWindow public method', () => {
@@ -228,73 +186,13 @@ describe('TruenasConnectService', () => {
 
     expect(windowMock.open).toHaveBeenCalledWith(
       testUrl,
-      'TrueNASConnect',
+      'TrueNAS Connect',
       'menubar=yes,location=yes,resizable=yes,scrollbars=yes,status=yes',
     );
     expect(mockTncWindow.focus).toHaveBeenCalled();
   });
 
-  it('should not reload page when navigating to same URL in existing window', () => {
-    const windowMock = spectator.inject(WINDOW) as unknown as jest.Mocked<Window>;
-    const sameUrl = 'https://same-url.com';
-
-    // Mock an existing window object that's already on the target URL
-    const mockTncWindow = {
-      closed: false,
-      location: { href: sameUrl },
-      focus: jest.fn(),
-    };
-    windowMock.open = jest.fn().mockReturnValue(mockTncWindow);
-
-    // First connection - open window
-    spectator.service.openTruenasConnectWindow(sameUrl);
-    expect(windowMock.open).toHaveBeenCalledTimes(1);
-
-    // Reset focus mock and location.href setter
-    mockTncWindow.focus.mockClear();
-    const originalHref = mockTncWindow.location.href;
-
-    // Second connection with same URL - should only focus, not navigate
-    spectator.service.openTruenasConnectWindow(sameUrl);
-
-    // Should call open again with empty URL (focus only) and not change location
-    expect(windowMock.open).toHaveBeenCalledTimes(2); // Called twice: first with URL, second with empty
-    expect(windowMock.open).toHaveBeenNthCalledWith(2, '', 'TrueNASConnect');
-    expect(mockTncWindow.focus).toHaveBeenCalledTimes(1);
-    expect(mockTncWindow.location.href).toBe(originalHref); // URL unchanged
-  });
-
-  it('should focus existing window without navigation even with different URL', () => {
-    const windowMock = spectator.inject(WINDOW) as unknown as jest.Mocked<Window>;
-    const firstUrl = 'https://first-url.com';
-    const secondUrl = 'https://second-url.com';
-
-    // Mock an existing window object
-    const mockTncWindow = {
-      closed: false,
-      location: { href: firstUrl },
-      focus: jest.fn(),
-    };
-    windowMock.open = jest.fn().mockReturnValue(mockTncWindow);
-
-    // First connection
-    spectator.service.openTruenasConnectWindow(firstUrl);
-    expect(windowMock.open).toHaveBeenCalledTimes(1);
-
-    // Reset focus mock
-    mockTncWindow.focus.mockClear();
-
-    // Second connection with different URL - should only focus, no navigation
-    spectator.service.openTruenasConnectWindow(secondUrl);
-
-    // Should call open with empty URL (focus only) and not navigate
-    expect(windowMock.open).toHaveBeenCalledTimes(2); // Called twice: first with URL, second with empty
-    expect(windowMock.open).toHaveBeenNthCalledWith(2, '', 'TrueNASConnect');
-    expect(mockTncWindow.focus).toHaveBeenCalledTimes(1);
-    expect(mockTncWindow.location.href).toBe(firstUrl); // URL unchanged - stays at original
-  });
-
-  it('should fetch config and subscribe to updates when authenticated', () => {
+  it('should test getConfig method', () => {
     expect(spectator.service.config()).toEqual(config);
     expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('tn_connect.config');
     expect(spectator.inject(ApiService).subscribe).toHaveBeenCalledWith('tn_connect.config');

--- a/src/app/modules/truenas-connect/services/truenas-connect.service.ts
+++ b/src/app/modules/truenas-connect/services/truenas-connect.service.ts
@@ -12,13 +12,6 @@ import { ApiService } from 'app/modules/websocket/api.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 import { WebSocketStatusService } from 'app/services/websocket-status.service';
 
-// Global reference to persist across potential service reinstantiation
-let globalTruenasConnectWindow: Window | null = null;
-
-// Export function to reset global state for testing
-export function resetGlobalTruenasConnectWindow(): void {
-  globalTruenasConnectWindow = null;
-}
 
 @Injectable({
   providedIn: 'root',
@@ -101,33 +94,17 @@ export class TruenasConnectService {
   }
 
   openTruenasConnectWindow(url: string): void {
-    const truenasTabName = 'TrueNASConnect';
-
-    if (!globalTruenasConnectWindow || globalTruenasConnectWindow.closed) {
-      // First time, or the old tab was closed - open new window with URL
-      const windowFeatures = 'menubar=yes,location=yes,resizable=yes,scrollbars=yes,status=yes';
-      globalTruenasConnectWindow = this.window.open(url, truenasTabName, windowFeatures);
-
-      if (globalTruenasConnectWindow) {
-        globalTruenasConnectWindow.focus();
-      }
-      return;
-    }
-
-    // Tab is still open - just focus it without navigation/reload
-    // Use empty URL to focus only, no reload
-    const existingWindow = this.window.open('', truenasTabName);
-    if (existingWindow && !existingWindow.closed) {
-      existingWindow.focus();
-      globalTruenasConnectWindow = existingWindow; // Update reference
-      return;
-    }
-
-    // Window reference was stale, open new one
+    const truenasTabName = 'TrueNAS Connect';
     const windowFeatures = 'menubar=yes,location=yes,resizable=yes,scrollbars=yes,status=yes';
-    globalTruenasConnectWindow = this.window.open(url, truenasTabName, windowFeatures);
-    if (globalTruenasConnectWindow) {
-      globalTruenasConnectWindow.focus();
+
+    // always call window.open with the URL - this will either:
+    // 1. if the tab doesn't exist, it will be created and registration will be navigated to.
+    // 2. if the tab DOES exist, then its URL will be set to the registration URL. this will
+    //    overwrite any other URL in the tab, which is what we want.
+    const truenasConnectWindow = this.window.open(url, truenasTabName, windowFeatures);
+
+    if (truenasConnectWindow) {
+      truenasConnectWindow.focus();
     }
   }
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 56dd3f16b781aa4b27b86858c653f8f1bed2dc6f
    git cherry-pick -x 1d514dd179ea554ccf2e8bf3c310e854c06470bd

If the original PR was merged via a squash, you can just cherry-pick the squashed commit:

    git reset --hard HEAD~1
    git cherry-pick -x 8a9de631bf80f9765953f83d7fee3e977adcde39

**Changes:**
this changes the behavior of the TNC `Get Connected` button to always overwrite the URL of the tab with the registration URL. this prevents situations where the URL has since changed due to registration cancellation or similar. users trying to re-register the system would have to close the tab first before clicking the `Get Connected` button a second time would bring them back to the registration modal.

**Testing:**
click the `Get Connected` button a bunch of times! it should *always* bring you to the registration modal. this should happen in all the following cases:
1. no TrueNAS Connect tab is open
2. a TrueNAS Connect tab is open with the registration modal
3. a TrueNAS Connect tab is open on the dashboard

and any more you can think of.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/13433
