### PR TITLE
NAS-140311 / 27.0.0-BETA.1 / Improve pool vdev construction for special (metadata) vdevs

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/existing-configuration-preview/existing-configuration-preview.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/existing-configuration-preview/existing-configuration-preview.component.ts
@@ -17,6 +17,7 @@ import { FileSizePipe } from 'app/modules/pipes/file-size/file-size.pipe';
 import { MapValuePipe } from 'app/modules/pipes/map-value/map-value.pipe';
 import { TopologyCategoryDescriptionPipe } from 'app/pages/storage/modules/pool-manager/pipes/topology-category-description.pipe';
 import { PoolManagerTopology, PoolManagerTopologyCategory } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
+import { resolveTopologyLayout } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 const defaultCategory: PoolManagerTopologyCategory = {
   layout: null,
@@ -77,11 +78,7 @@ export class ExistingConfigurationPreviewComponent implements OnChanges {
     for (const type of vdevTypes) {
       managerTopology[type] = cloneDeep(defaultCategory);
 
-      let firstVdevType = topology[type][0].type;
-      if (firstVdevType === TopologyItemType.Disk && !topology[type][0].children?.length) {
-        firstVdevType = TopologyItemType.Stripe;
-      }
-      managerTopology[type].layout = firstVdevType as unknown as CreateVdevLayout;
+      managerTopology[type].layout = resolveTopologyLayout(topology[type]);
 
       const allCategoryVdevsDisks = [];
       for (const vdev of topology[type]) {
@@ -93,7 +90,7 @@ export class ExistingConfigurationPreviewComponent implements OnChanges {
         }
         managerTopology[type].width = vdev.children?.length || 1;
 
-        if (firstVdevType === TopologyItemType.Stripe) {
+        if (managerTopology[type].layout === CreateVdevLayout.Stripe) {
           const vdevDisk = this.disks().find((disk) => disk.devname === vdev.disk);
           allCategoryVdevsDisks.push(cloneDeep(vdevDisk));
           managerTopology[type].vdevs.push([cloneDeep(vdevDisk)]);

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -11,7 +11,7 @@
     ></ix-select>
   </div>
 } @else {
-  @if (isDataVdev() || isMetadataVdev()) {
+  @if (isDataVdev() || isMetadataVdev() || isDedupVdev()) {
     <ix-input
       [ixTestOverride]="['layout']"
       [keepLastPart]="true"
@@ -22,6 +22,12 @@
       [required]="false"
     ></ix-input>
   }
+}
+
+@if (requiresDataParity()) {
+  <p class="layout-restriction-hint">
+    {{ layoutRestrictionHint() }}
+  </p>
 }
 
 @if (usesDraidLayout) {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -24,7 +24,7 @@
   }
 }
 
-@if (requiresDataParity()) {
+@if (showLayoutRestrictionHint()) {
   <p class="layout-restriction-hint">
     {{ layoutRestrictionHint() }}
   </p>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -11,7 +11,7 @@
     ></ix-select>
   </div>
 } @else {
-  @if (isDataVdev() || isMetadataVdev() || isDedupVdev()) {
+  @if (isDataVdev()) {
     <ix-input
       [ixTestOverride]="['layout']"
       [keepLastPart]="true"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -8,6 +8,7 @@
       [tooltip]="'Select VDEV layout. This is the first step in setting up your VDEVs.' | translate"
       [options]="vdevLayoutOptions$ | translateOptions"
       [required]="true"
+      [hint]="layoutRestrictionHint()"
     ></ix-select>
   </div>
 } @else {
@@ -22,12 +23,6 @@
       [required]="false"
     ></ix-input>
   }
-}
-
-@if (showLayoutRestrictionHint()) {
-  <p class="layout-restriction-hint">
-    {{ layoutRestrictionHint() }}
-  </p>
 }
 
 @if (usesDraidLayout) {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.html
@@ -38,6 +38,7 @@
     [inventory]="inventory()"
     [type]="type()"
     [isStepActive]="isStepActive()"
+    [minMirrorWidth]="minMirrorWidth()"
   ></ix-normal-selection>
 }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.scss
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.scss
@@ -12,3 +12,10 @@
 .required-disks-hint {
   padding-left: 30px;
 }
+
+.layout-restriction-hint {
+  color: var(--fg2);
+  font-size: 12px;
+  margin: 4px 0 0;
+  padding: 0 30px;
+}

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.scss
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.scss
@@ -12,10 +12,3 @@
 .required-disks-hint {
   padding-left: 30px;
 }
-
-.layout-restriction-hint {
-  color: var(--fg2);
-  font-size: 12px;
-  margin: 4px 0 0;
-  padding: 0 30px;
-}

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
@@ -109,6 +109,14 @@ describe('AutomatedDiskSelection', () => {
     expect(await layoutSelect!.getValue()).toBe('');
   });
 
+  it('keeps the sole allowed layout selected after a reset when parity-locked', () => {
+    spectator.setInput('limitLayouts', [CreateVdevLayout.Raidz2]);
+
+    resetStep$.next(VDevType.Data);
+
+    expect(spectator.component.layoutControl.value).toBe(CreateVdevLayout.Raidz2);
+  });
+
   it('updates layout in store when it is changed', async () => {
     await layoutSelect!.setValue('Mirror');
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
@@ -117,4 +117,24 @@ describe('AutomatedDiskSelection', () => {
       CreateVdevLayout.Mirror,
     );
   });
+
+  it('does not show the data parity hint for data vdevs', () => {
+    expect(spectator.query('.layout-restriction-hint')).toBeNull();
+  });
+
+  it('shows a data parity hint for special (metadata) vdevs', () => {
+    spectator.setInput('type', VDevType.Special);
+
+    const hint = spectator.query('.layout-restriction-hint');
+    expect(hint).not.toBeNull();
+    expect(hint!.textContent).toContain('Special and deduplication vdevs');
+  });
+
+  it('shows a data parity hint for dedup vdevs', () => {
+    spectator.setInput('type', VDevType.Dedup);
+
+    const hint = spectator.query('.layout-restriction-hint');
+    expect(hint).not.toBeNull();
+    expect(hint!.textContent).toContain('Special and deduplication vdevs');
+  });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
@@ -130,16 +130,24 @@ describe('AutomatedDiskSelection', () => {
     expect(spectator.query('.layout-restriction-hint')).toBeNull();
   });
 
-  it('shows a data parity hint for special (metadata) vdevs', () => {
+  it('does not show the data parity hint for metadata vdevs when any layout is allowed', () => {
     spectator.setInput('type', VDevType.Special);
+
+    expect(spectator.query('.layout-restriction-hint')).toBeNull();
+  });
+
+  it('shows the data parity hint for metadata vdevs when the layout is locked to a single option', () => {
+    spectator.setInput('type', VDevType.Special);
+    spectator.setInput('limitLayouts', [CreateVdevLayout.Raidz2]);
 
     const hint = spectator.query('.layout-restriction-hint');
     expect(hint).not.toBeNull();
     expect(hint!.textContent).toContain('Special and deduplication vdevs');
   });
 
-  it('shows a data parity hint for dedup vdevs', () => {
+  it('shows the data parity hint for dedup vdevs when the layout is locked to a single option', () => {
     spectator.setInput('type', VDevType.Dedup);
+    spectator.setInput('limitLayouts', [CreateVdevLayout.Raidz2]);
 
     const hint = spectator.query('.layout-restriction-hint');
     expect(hint).not.toBeNull();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
@@ -127,20 +127,20 @@ describe('AutomatedDiskSelection', () => {
   });
 
   it('does not show the data parity hint for data vdevs', () => {
-    expect(spectator.query('.layout-restriction-hint')).toBeNull();
+    expect(spectator.query('mat-hint')).toBeNull();
   });
 
   it('does not show the data parity hint for metadata vdevs when any layout is allowed', () => {
     spectator.setInput('type', VDevType.Special);
 
-    expect(spectator.query('.layout-restriction-hint')).toBeNull();
+    expect(spectator.query('mat-hint')).toBeNull();
   });
 
   it('shows the data parity hint for metadata vdevs when the layout is locked to a single option', () => {
     spectator.setInput('type', VDevType.Special);
     spectator.setInput('limitLayouts', [CreateVdevLayout.Raidz2]);
 
-    const hint = spectator.query('.layout-restriction-hint');
+    const hint = spectator.query('mat-hint');
     expect(hint).not.toBeNull();
     expect(hint!.textContent).toContain('Special and deduplication vdevs');
   });
@@ -149,7 +149,7 @@ describe('AutomatedDiskSelection', () => {
     spectator.setInput('type', VDevType.Dedup);
     spectator.setInput('limitLayouts', [CreateVdevLayout.Raidz2]);
 
-    const hint = spectator.query('.layout-restriction-hint');
+    const hint = spectator.query('mat-hint');
     expect(hint).not.toBeNull();
     expect(hint!.textContent).toContain('Special and deduplication vdevs');
   });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.spec.ts
@@ -136,21 +136,32 @@ describe('AutomatedDiskSelection', () => {
     expect(spectator.query('mat-hint')).toBeNull();
   });
 
-  it('shows the data parity hint for metadata vdevs when the layout is locked to a single option', () => {
+  it('shows the single-layout hint for metadata vdevs when the layout is strict-locked', () => {
     spectator.setInput('type', VDevType.Special);
     spectator.setInput('limitLayouts', [CreateVdevLayout.Raidz2]);
 
     const hint = spectator.query('mat-hint');
     expect(hint).not.toBeNull();
-    expect(hint!.textContent).toContain('Special and deduplication vdevs');
+    expect(hint!.textContent).toContain('Locked to this layout');
   });
 
-  it('shows the data parity hint for dedup vdevs when the layout is locked to a single option', () => {
+  it('shows the single-layout hint for dedup vdevs when the layout is strict-locked', () => {
     spectator.setInput('type', VDevType.Dedup);
     spectator.setInput('limitLayouts', [CreateVdevLayout.Raidz2]);
 
     const hint = spectator.query('mat-hint');
     expect(hint).not.toBeNull();
-    expect(hint!.textContent).toContain('Special and deduplication vdevs');
+    expect(hint!.textContent).toContain('Locked to this layout');
+  });
+
+  it('shows the parity-level hint for metadata vdevs when multiple layouts match data parity', () => {
+    spectator.setInput('type', VDevType.Special);
+    spectator.setInput('limitLayouts', [
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+    ]);
+
+    const hint = spectator.query('mat-hint');
+    expect(hint).not.toBeNull();
+    expect(hint!.textContent).toContain('tolerate at least as many drive failures');
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -46,6 +46,7 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
   readonly inventory = input<DetailsDisk[]>([]);
   readonly canChangeLayout = input(false);
   readonly limitLayouts = input<readonly CreateVdevLayout[]>([]);
+  readonly minMirrorWidth = input<number>(2);
 
   readonly layoutControl = new FormControl(null as CreateVdevLayout | null, Validators.required);
 
@@ -65,18 +66,30 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
   });
 
   /**
-   * Non-empty only when a special/dedup step is locked to a single layout —
-   * the dropdown shows one choice and the hint explains why. Rendered as a
+   * Explains the parity lock on special/dedup layout dropdowns. Rendered as a
    * mat-hint on the layout select so screen readers pick it up via the form
    * field's aria-describedby wiring.
+   *   - No hint when the Stripe option is present (data has no redundancy, so
+   *     there's no meaningful restriction to explain).
+   *   - Exact-match copy when only one layout remains (pool already has vdevs
+   *     in this category — we lock to that layout, not just its parity).
+   *   - Parity-level copy otherwise (a 3-way mirror alongside RAIDZ2, etc.).
    */
   protected layoutRestrictionHint = computed(() => {
-    if (!this.requiresDataParity() || this.limitLayouts().length !== 1) {
+    if (!this.requiresDataParity()) {
       return '';
     }
-
+    const layouts = this.limitLayouts();
+    if (!layouts.length || layouts.includes(CreateVdevLayout.Stripe)) {
+      return '';
+    }
+    if (layouts.length === 1) {
+      return this.translate.instant(
+        'Locked to this layout because the pool already has special or deduplication vdevs using it. dRAID layouts are not available for these vdev types.',
+      );
+    }
     return this.translate.instant(
-      'Special and deduplication vdevs must use the same layout as the data vdevs so the pool keeps consistent redundancy. dRAID layouts are not available for these vdev types.',
+      'Special and deduplication vdevs must tolerate at least as many drive failures as the data vdevs. dRAID layouts are not available for these vdev types.',
     );
   });
 
@@ -149,6 +162,15 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
     const cannotChangeLayout = this.canChangeLayout() === false;
     const hasSingleChoice = limitLayouts.length === 1;
     if (cannotChangeLayout || hasSingleChoice) {
+      setValueIfNotSame(this.layoutControl, limitLayouts[0]);
+      return;
+    }
+    // Data layout can change after the user picked a special/dedup layout
+    // (e.g. data switches from RAIDZ1 to RAIDZ2 and our previous Stripe pick
+    // is no longer permitted). Snap to the first still-valid option rather
+    // than leaving the control on a stale selection that isn't in the menu.
+    const currentValue = this.layoutControl.value;
+    if (currentValue && !limitLayouts.includes(currentValue)) {
       setValueIfNotSame(this.layoutControl, limitLayouts[0]);
     }
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -66,7 +66,7 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
   });
 
   protected dataLayoutTooltip = computed(() => {
-    if (this.isDataVdev() || this.requiresDataParity()) {
+    if (this.isDataVdev()) {
       return this.translate.instant('Read only field: The layout of this device has been preselected to match the layout of the existing Data devices in the pool');
     }
 
@@ -129,7 +129,10 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
     )
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
-        this.layoutControl.setValue(this.canChangeLayout() ? null : this.limitLayouts()[0]);
+        const limitLayouts = this.limitLayouts();
+        const hasSingleChoice = limitLayouts.length === 1;
+        const shouldPreselect = !this.canChangeLayout() || hasSingleChoice;
+        this.layoutControl.setValue(shouldPreselect ? limitLayouts[0] : null);
       });
   }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, DestroyRef, computed, input, OnChan
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { merge, of } from 'rxjs';
+import { of } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 import { CreateVdevLayout, vdevLayoutOptions, VDevType } from 'app/enums/v-dev-type.enum';
 import { DetailsDisk } from 'app/interfaces/disk.interface';
@@ -120,19 +120,24 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
   }
 
   private listenForResetEvents(): void {
-    merge(
-      this.store.startOver$,
-      this.store.resetStep$.pipe(filter((vdevType) => vdevType === this.type())),
-    )
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        const limitLayouts = this.limitLayouts();
-        const hasSingleChoice = limitLayouts.length === 1;
-        const shouldPreselect = !this.canChangeLayout() || hasSingleChoice;
-        // Always setValue (even when same) so valueChanges re-syncs the store
-        // after a resetStep clears topology[type].layout to null.
-        this.layoutControl.setValue(shouldPreselect ? limitLayouts[0] : null);
-      });
+    // Start over wipes every category, so clear the control and let the
+    // reactive parity-lock subscription re-apply the lock asynchronously if
+    // data layout is still set. Reading limitLayouts here would observe the
+    // pre-reset value (the store state update follows startOver$.next()).
+    this.store.startOver$.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.layoutControl.setValue(null));
+
+    // Reset-step only clears this category; re-apply the current lock so a
+    // parity-locked step preserves its forced layout after the user resets it.
+    this.store.resetStep$.pipe(
+      filter((vdevType) => vdevType === this.type()),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(() => {
+      const limitLayouts = this.limitLayouts();
+      const hasSingleChoice = limitLayouts.length === 1;
+      const shouldPreselect = !this.canChangeLayout() || hasSingleChoice;
+      this.layoutControl.setValue(shouldPreselect ? limitLayouts[0] : null);
+    });
   }
 
   private updateLayoutOptionsFromLimitedLayouts(limitLayouts: readonly CreateVdevLayout[]): void {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -45,7 +45,7 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
   readonly type = input<VDevType>();
   readonly inventory = input<DetailsDisk[]>([]);
   readonly canChangeLayout = input(false);
-  readonly limitLayouts = input<CreateVdevLayout[]>([]);
+  readonly limitLayouts = input<readonly CreateVdevLayout[]>([]);
 
   readonly layoutControl = new FormControl(null as CreateVdevLayout | null, Validators.required);
 
@@ -135,7 +135,7 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
       });
   }
 
-  private updateLayoutOptionsFromLimitedLayouts(limitLayouts: CreateVdevLayout[]): void {
+  private updateLayoutOptionsFromLimitedLayouts(limitLayouts: readonly CreateVdevLayout[]): void {
     const allowedLayouts = vdevLayoutOptions.filter((option) => limitLayouts.includes(option.value));
     this.vdevLayoutOptions$ = of(allowedLayouts);
     if (!limitLayouts.length) {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -132,11 +132,9 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
         const limitLayouts = this.limitLayouts();
         const hasSingleChoice = limitLayouts.length === 1;
         const shouldPreselect = !this.canChangeLayout() || hasSingleChoice;
-        if (shouldPreselect) {
-          setValueIfNotSame(this.layoutControl, limitLayouts[0]);
-        } else {
-          this.layoutControl.setValue(null);
-        }
+        // Always setValue (even when same) so valueChanges re-syncs the store
+        // after a resetStep clears topology[type].layout to null.
+        this.layoutControl.setValue(shouldPreselect ? limitLayouts[0] : null);
       });
   }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -136,8 +136,12 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
   private updateLayoutOptionsFromLimitedLayouts(limitLayouts: CreateVdevLayout[]): void {
     const allowedLayouts = vdevLayoutOptions.filter((option) => limitLayouts.includes(option.value));
     this.vdevLayoutOptions$ = of(allowedLayouts);
+    if (!limitLayouts.length) {
+      return;
+    }
     const cannotChangeLayout = this.canChangeLayout() === false;
-    if (cannotChangeLayout && limitLayouts.length) {
+    const hasSingleChoice = limitLayouts.length === 1;
+    if (cannotChangeLayout || hasSingleChoice) {
       setValueIfNotSame(this.layoutControl, limitLayouts[0]);
     }
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -53,12 +53,34 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
     return this.type() === VDevType.Data;
   });
 
+  protected isMetadataVdev = computed(() => {
+    return this.type() === VDevType.Special;
+  });
+
+  protected isDedupVdev = computed(() => {
+    return this.type() === VDevType.Dedup;
+  });
+
+  protected requiresDataParity = computed(() => {
+    return this.isMetadataVdev() || this.isDedupVdev();
+  });
+
   protected dataLayoutTooltip = computed(() => {
-    if (this.isDataVdev()) {
+    if (this.isDataVdev() || this.requiresDataParity()) {
       return this.translate.instant('Read only field: The layout of this device has been preselected to match the layout of the existing Data devices in the pool');
     }
 
     return '';
+  });
+
+  protected layoutRestrictionHint = computed(() => {
+    if (!this.requiresDataParity()) {
+      return '';
+    }
+
+    return this.translate.instant(
+      'Special and deduplication vdevs must use the same layout as the data vdevs so the pool keeps consistent redundancy. dRAID layouts are not available for these vdev types.',
+    );
   });
 
   protected vdevLayoutOptions$ = of<SelectOption<CreateVdevLayout>[]>([]);
@@ -77,10 +99,6 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
   protected get usesDraidLayout(): boolean {
     return !!this.layoutControl.value && isDraidLayout(this.layoutControl.value);
   }
-
-  protected isMetadataVdev = computed(() => {
-    return this.type() === VDevType.Special;
-  });
 
   private updateStoreOnChanges(): void {
     this.store.isLoading$

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -65,6 +65,15 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
     return this.isMetadataVdev() || this.isDedupVdev();
   });
 
+  /**
+   * True only when a parity-dependent vdev type currently has exactly one
+   * allowed layout — i.e. the dropdown shows a single option the user cannot
+   * change. That's the only case where the hint explains the constraint.
+   */
+  protected showLayoutRestrictionHint = computed(() => {
+    return this.requiresDataParity() && this.limitLayouts().length === 1;
+  });
+
   protected dataLayoutTooltip = computed(() => {
     if (this.isDataVdev()) {
       return this.translate.instant('Read only field: this Data VDEV\'s layout is locked to match the existing Data devices in the pool.');

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -1,12 +1,10 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, computed, input, OnChanges, inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { of } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 import { CreateVdevLayout, vdevLayoutOptions, VDevType } from 'app/enums/v-dev-type.enum';
 import { DetailsDisk } from 'app/interfaces/disk.interface';
-import { SelectOption } from 'app/interfaces/option.interface';
 import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
@@ -93,7 +91,14 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
     );
   });
 
-  protected vdevLayoutOptions$ = of<SelectOption<CreateVdevLayout>[]>([]);
+  /**
+   * Derived reactively from limitLayouts() so the async pipe binds to a stable
+   * Observable; imperative reassignment would force a re-subscription on every
+   * input change.
+   */
+  protected vdevLayoutOptions$ = toObservable(computed(() => (
+    vdevLayoutOptions.filter((option) => this.limitLayouts().includes(option.value))
+  )));
 
   constructor() {
     this.updateStoreOnChanges();
@@ -102,12 +107,27 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
 
   ngOnChanges(changes: IxSimpleChanges<this>): void {
     if (hasDeepChanges(changes, 'limitLayouts')) {
-      this.updateLayoutOptionsFromLimitedLayouts(changes.limitLayouts.currentValue);
+      this.syncLayoutControlWithLimits(changes.limitLayouts.currentValue);
     }
   }
 
   protected get usesDraidLayout(): boolean {
     return !!this.layoutControl.value && isDraidLayout(this.layoutControl.value);
+  }
+
+  /**
+   * Returns the layout the control must be pinned to given `limitLayouts`, or
+   * null when the user is free to pick. Shared by reset handlers and the
+   * input-change sync so both sites stay in lockstep.
+   */
+  private forcedLayoutFor(limitLayouts: readonly CreateVdevLayout[]): CreateVdevLayout | null {
+    if (!limitLayouts.length) {
+      return null;
+    }
+    if (!this.canChangeLayout() || limitLayouts.length === 1) {
+      return limitLayouts[0];
+    }
+    return null;
   }
 
   private updateStoreOnChanges(): void {
@@ -146,23 +166,17 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
       filter((vdevType) => vdevType === this.type()),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe(() => {
-      const limitLayouts = this.limitLayouts();
-      const hasSingleChoice = limitLayouts.length === 1;
-      const shouldPreselect = !this.canChangeLayout() || hasSingleChoice;
-      this.layoutControl.setValue(shouldPreselect ? limitLayouts[0] : null);
+      this.layoutControl.setValue(this.forcedLayoutFor(this.limitLayouts()));
     });
   }
 
-  private updateLayoutOptionsFromLimitedLayouts(limitLayouts: readonly CreateVdevLayout[]): void {
-    const allowedLayouts = vdevLayoutOptions.filter((option) => limitLayouts.includes(option.value));
-    this.vdevLayoutOptions$ = of(allowedLayouts);
+  private syncLayoutControlWithLimits(limitLayouts: readonly CreateVdevLayout[]): void {
     if (!limitLayouts.length) {
       return;
     }
-    const cannotChangeLayout = this.canChangeLayout() === false;
-    const hasSingleChoice = limitLayouts.length === 1;
-    if (cannotChangeLayout || hasSingleChoice) {
-      setValueIfNotSame(this.layoutControl, limitLayouts[0]);
+    const forcedLayout = this.forcedLayoutFor(limitLayouts);
+    if (forcedLayout !== null) {
+      setValueIfNotSame(this.layoutControl, forcedLayout);
       return;
     }
     // Data layout can change after the user picked a special/dedup layout

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -67,7 +67,7 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
 
   protected dataLayoutTooltip = computed(() => {
     if (this.isDataVdev()) {
-      return this.translate.instant('Read only field: The layout of this device has been preselected to match the layout of the existing Data devices in the pool');
+      return this.translate.instant('Read only field: this Data VDEV\'s layout is locked to match the existing Data devices in the pool.');
     }
 
     return '';
@@ -132,7 +132,11 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
         const limitLayouts = this.limitLayouts();
         const hasSingleChoice = limitLayouts.length === 1;
         const shouldPreselect = !this.canChangeLayout() || hasSingleChoice;
-        this.layoutControl.setValue(shouldPreselect ? limitLayouts[0] : null);
+        if (shouldPreselect) {
+          setValueIfNotSame(this.layoutControl, limitLayouts[0]);
+        } else {
+          this.layoutControl.setValue(null);
+        }
       });
   }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/automated-disk-selection.component.ts
@@ -49,29 +49,11 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
 
   readonly layoutControl = new FormControl(null as CreateVdevLayout | null, Validators.required);
 
-  protected isDataVdev = computed(() => {
-    return this.type() === VDevType.Data;
-  });
-
-  protected isMetadataVdev = computed(() => {
-    return this.type() === VDevType.Special;
-  });
-
-  protected isDedupVdev = computed(() => {
-    return this.type() === VDevType.Dedup;
-  });
+  protected isDataVdev = computed(() => this.type() === VDevType.Data);
 
   protected requiresDataParity = computed(() => {
-    return this.isMetadataVdev() || this.isDedupVdev();
-  });
-
-  /**
-   * True only when a parity-dependent vdev type currently has exactly one
-   * allowed layout — i.e. the dropdown shows a single option the user cannot
-   * change. That's the only case where the hint explains the constraint.
-   */
-  protected showLayoutRestrictionHint = computed(() => {
-    return this.requiresDataParity() && this.limitLayouts().length === 1;
+    const type = this.type();
+    return type === VDevType.Special || type === VDevType.Dedup;
   });
 
   protected dataLayoutTooltip = computed(() => {
@@ -82,8 +64,14 @@ export class AutomatedDiskSelectionComponent implements OnChanges {
     return '';
   });
 
+  /**
+   * Non-empty only when a special/dedup step is locked to a single layout —
+   * the dropdown shows one choice and the hint explains why. Rendered as a
+   * mat-hint on the layout select so screen readers pick it up via the form
+   * field's aria-describedby wiring.
+   */
   protected layoutRestrictionHint = computed(() => {
-    if (!this.requiresDataParity()) {
+    if (!this.requiresDataParity() || this.limitLayouts().length !== 1) {
       return '';
     }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/normal-selection/normal-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/normal-selection/normal-selection.component.spec.ts
@@ -3,7 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { of, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { TiB } from 'app/constants/bytes.constant';
 import { DiskType } from 'app/enums/disk-type.enum';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
@@ -89,22 +89,6 @@ describe('NormalSelectionComponent', () => {
     providers: [
       mockProvider(PoolManagerStore, {
         openManualSelectionDialog: jest.fn(),
-        getLayoutsForVdevType: jest.fn((vdevType: VDevType) => {
-          switch (vdevType) {
-            case VDevType.Cache:
-              return of([CreateVdevLayout.Stripe]);
-            case VDevType.Dedup:
-              return of([CreateVdevLayout.Mirror]);
-            case VDevType.Log:
-              return of([CreateVdevLayout.Mirror, CreateVdevLayout.Stripe]);
-            case VDevType.Spare:
-              return of([CreateVdevLayout.Stripe]);
-            case VDevType.Special:
-              return of([CreateVdevLayout.Mirror]);
-            default:
-              return of(Object.values(CreateVdevLayout));
-          }
-        }),
         startOver$,
         resetStep$,
       }),

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/normal-selection/normal-selection.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/normal-selection/normal-selection.component.spec.ts
@@ -122,6 +122,22 @@ describe('NormalSelectionComponent', () => {
     expect(await vdevsSelect.getOptionLabels()).toStrictEqual(['1', '2', '3']);
   });
 
+  it('raises the mirror width floor when minMirrorWidth is set', async () => {
+    spectator.setInput('layout', CreateVdevLayout.Mirror);
+    spectator.setInput('minMirrorWidth', 3);
+    await sizeSelect.setValue('12 TiB (HDD)');
+
+    expect(await widthSelect.getOptionLabels()).toStrictEqual(['3', '4', '5', '6', '7']);
+  });
+
+  it('does not affect non-Mirror layouts when minMirrorWidth is set', async () => {
+    spectator.setInput('layout', CreateVdevLayout.Raidz1);
+    spectator.setInput('minMirrorWidth', 4);
+    await sizeSelect.setValue('12 TiB (HDD)');
+
+    expect(await widthSelect.getOptionLabels()).toStrictEqual(['3', '4', '5', '6', '7']);
+  });
+
   it('updates width and vdev options when layout changes to Raidz1', async () => {
     spectator.setInput('layout', CreateVdevLayout.Raidz1);
     await sizeSelect.setValue('12 TiB (HDD)');

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/normal-selection/normal-selection.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/automated-disk-selection/normal-selection/normal-selection.component.ts
@@ -46,6 +46,8 @@ export class NormalSelectionComponent implements OnInit, OnChanges {
   readonly layout = input.required<CreateVdevLayout>();
   readonly isStepActive = input<boolean>();
   readonly inventory = input.required<DetailsDisk[]>();
+  /** Raised by parity-locked steps so special/dedup mirrors can't fall below the data vdev's redundancy. */
+  readonly minMirrorWidth = input<number>(2);
 
   form = this.formBuilder.group({
     width: [{ value: null as number | null, disabled: true }, Validators.required],
@@ -58,7 +60,11 @@ export class NormalSelectionComponent implements OnInit, OnChanges {
   private selectedDisks: DetailsDisk[] = [];
 
   ngOnChanges(changes: IxSimpleChanges<this>): void {
-    if (hasDeepChanges(changes, 'inventory') || hasDeepChanges(changes, 'layout')) {
+    if (
+      hasDeepChanges(changes, 'inventory')
+      || hasDeepChanges(changes, 'layout')
+      || hasDeepChanges(changes, 'minMirrorWidth')
+    ) {
       this.updateWidthOptions();
     }
   }
@@ -72,6 +78,19 @@ export class NormalSelectionComponent implements OnInit, OnChanges {
   protected isNumberOfVdevsLimitedToOne = computed(() => {
     return this.type() === VDevType.Spare || this.type() === VDevType.Cache || this.type() === VDevType.Log;
   });
+
+  /**
+   * Layout's intrinsic minimum width, raised to minMirrorWidth when the
+   * layout is Mirror. For other layouts the input is ignored — RAIDZ width
+   * is governed by its own parity, not by the data vdev's.
+   */
+  private effectiveMinWidth(): number {
+    const layoutMin = minDisksPerLayout[this.layout()];
+    if (this.layout() === CreateVdevLayout.Mirror) {
+      return Math.max(layoutMin, this.minMirrorWidth());
+    }
+    return layoutMin;
+  }
 
   protected onDisksSelected(disks: DetailsDisk[]): void {
     this.selectedDisks = disks;
@@ -126,7 +145,7 @@ export class NormalSelectionComponent implements OnInit, OnChanges {
     if (!availableDisks) {
       return;
     }
-    const minRequired = minDisksPerLayout[this.layout()];
+    const minRequired = this.effectiveMinWidth();
     let nextOptions: Option[] = [];
 
     if (availableDisks && minRequired && availableDisks >= minRequired) {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.html
@@ -6,6 +6,7 @@
   <ix-automated-disk-selection
     class="content-container"
     [limitLayouts]="limitLayouts()"
+    [minMirrorWidth]="minMirrorWidth()"
     [type]="type()"
     [canChangeLayout]="canChangeLayout()"
     [inventory]="inventory()"

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.ts
@@ -26,7 +26,7 @@ export class LayoutStepComponent implements OnInit {
   readonly description = input<string>();
 
   readonly canChangeLayout = input(false);
-  readonly limitLayouts = input<CreateVdevLayout[]>([]);
+  readonly limitLayouts = input<readonly CreateVdevLayout[]>([]);
 
   readonly inventory = input<DetailsDisk[]>([]);
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component.ts
@@ -27,6 +27,8 @@ export class LayoutStepComponent implements OnInit {
 
   readonly canChangeLayout = input(false);
   readonly limitLayouts = input<readonly CreateVdevLayout[]>([]);
+  /** Mirror width floor; propagated to NormalSelectionComponent so parity-locked steps disallow weaker mirrors. */
+  readonly minMirrorWidth = input<number>(2);
 
   readonly inventory = input<DetailsDisk[]>([]);
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.ts
@@ -5,7 +5,7 @@ import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
 import { map } from 'rxjs';
-import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { TestDirective } from 'app/modules/test-id/test.directive';
@@ -14,7 +14,7 @@ import {
 } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { parseDraidVdevName } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { resolveTopologyLayout } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-data-wizard-step',
@@ -50,21 +50,13 @@ export class DataWizardStepComponent implements OnInit {
 
   ngOnInit(): void {
     this.addVdevsStore.pool$.pipe(
-      map((pool) => pool?.topology[VDevType.Data]),
+      map((pool) => resolveTopologyLayout(pool?.topology[VDevType.Data])),
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe((dataTopology) => {
-      if (!dataTopology?.length) {
+    ).subscribe((layout) => {
+      if (!layout) {
         return;
       }
-      // TODO: Similar code in poolTopologyToStoreTopology
-      let type = dataTopology[0].type;
-      if (type === TopologyItemType.Disk && !dataTopology[0].children.length) {
-        type = TopologyItemType.Stripe;
-      } else if (type === TopologyItemType.Draid) {
-        const parsedVdevName = parseDraidVdevName(dataTopology[0].name);
-        type = parsedVdevName.layout as unknown as TopologyItemType;
-      }
-      this.allowedLayouts = [type] as unknown as CreateVdevLayout[];
+      this.allowedLayouts = [layout];
       this.canChangeLayout = false;
       this.cdr.markForCheck();
     });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.ts
@@ -45,8 +45,8 @@ export class DataWizardStepComponent implements OnInit {
   protected readonly vDevType = VDevType;
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Data);
   protected allowedLayouts = Object.values(CreateVdevLayout) as CreateVdevLayout[];
-  readonly helptext = helptextPoolCreation;
-  canChangeLayout = true;
+  protected readonly helptext = helptextPoolCreation;
+  protected canChangeLayout = true;
 
   ngOnInit(): void {
     this.addVdevsStore.pool$.pipe(

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.ts
@@ -62,11 +62,11 @@ export class DataWizardStepComponent implements OnInit {
     });
   }
 
-  goToReviewStep(): void {
+  protected goToReviewStep(): void {
     this.goToLastStep.emit();
   }
 
-  resetStep(): void {
+  protected resetStep(): void {
     this.store.resetStep(VDevType.Data);
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.ts
@@ -5,13 +5,14 @@ import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
 import { map } from 'rxjs';
-import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
+import { resolveTopologyLayout } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-log-wizard-step',
@@ -49,21 +50,15 @@ export class LogWizardStepComponent implements OnInit {
 
   ngOnInit(): void {
     this.addVdevsStore.pool$.pipe(
-      map((pool) => pool?.topology[VDevType.Log]),
+      map((pool) => resolveTopologyLayout(pool?.topology[VDevType.Log])),
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe({
-      next: (logTopology) => {
-        if (!logTopology?.length) {
-          return;
-        }
-        let type = logTopology[0].type;
-        if (type === TopologyItemType.Disk && !logTopology[0].children.length) {
-          type = TopologyItemType.Stripe;
-        }
-        this.allowedLayouts = [type] as unknown as CreateVdevLayout[];
-        this.canChangeLayout = false;
-        this.cdr.markForCheck();
-      },
+    ).subscribe((layout) => {
+      if (!layout) {
+        return;
+      }
+      this.allowedLayouts = [layout];
+      this.canChangeLayout = false;
+      this.cdr.markForCheck();
     });
   }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.ts
@@ -62,11 +62,11 @@ export class LogWizardStepComponent implements OnInit {
     });
   }
 
-  goToReviewStep(): void {
+  protected goToReviewStep(): void {
     this.goToLastStep.emit();
   }
 
-  resetStep(): void {
+  protected resetStep(): void {
     this.store.resetStep(VDevType.Log);
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.ts
@@ -40,10 +40,10 @@ export class LogWizardStepComponent implements OnInit {
 
   readonly goToLastStep = output();
 
-  canChangeLayout = true;
+  protected canChangeLayout = true;
 
   protected readonly vDevType = VDevType;
-  readonly helptext = helptextPoolCreation;
+  protected readonly helptext = helptextPoolCreation;
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Log);
   protected allowedLayouts = [CreateVdevLayout.Mirror, CreateVdevLayout.Stripe];

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
@@ -4,6 +4,7 @@
   [inventory]="(inventory$ | async) || []"
   [canChangeLayout]="true"
   [limitLayouts]="allowedLayouts"
+  [minMirrorWidth]="minMirrorWidth"
   [isStepActive]="isStepActive()"
 ></ix-layout-step>
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
@@ -2,7 +2,7 @@
   [description]="helptext.specialVdevDescription | translate"
   [type]="vDevType.Special"
   [inventory]="(inventory$ | async) || []"
-  [canChangeLayout]="canChangeLayout"
+  [canChangeLayout]="true"
   [limitLayouts]="allowedLayouts"
   [isStepActive]="isStepActive()"
 ></ix-layout-step>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
@@ -2,7 +2,7 @@
   [description]="helptext.specialVdevDescription | translate"
   [type]="vDevType.Special"
   [inventory]="(inventory$ | async) || []"
-  [canChangeLayout]="true"
+  [canChangeLayout]="canChangeLayout"
   [limitLayouts]="allowedLayouts"
   [isStepActive]="isStepActive()"
 ></ix-layout-step>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -82,7 +82,7 @@ describe('MetadataWizardStepComponent', () => {
     it('locks special layout to match the wizard data layout', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
-      expect(layoutComponent.canChangeLayout).toBe(false);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -92,7 +92,7 @@ describe('MetadataWizardStepComponent', () => {
     it('allows any non-dRAID layout', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.canChangeLayout).toBe(true);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
       expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     });
   });
@@ -104,7 +104,7 @@ describe('MetadataWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBe(false);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -124,7 +124,7 @@ describe('MetadataWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBe(false);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -170,7 +170,7 @@ describe('MetadataWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
-      expect(layoutComponent.canChangeLayout).toBe(false);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -82,7 +82,7 @@ describe('MetadataWizardStepComponent', () => {
     it('locks special layout to match the wizard data layout', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(false);
     });
   });
 
@@ -92,7 +92,7 @@ describe('MetadataWizardStepComponent', () => {
     it('allows any non-dRAID layout', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(true);
       expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     });
   });
@@ -104,7 +104,7 @@ describe('MetadataWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(false);
     });
   });
 
@@ -124,7 +124,7 @@ describe('MetadataWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(false);
     });
   });
 
@@ -170,7 +170,7 @@ describe('MetadataWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(false);
     });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -6,6 +6,7 @@ import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
+import { DetailsDisk } from 'app/interfaces/disk.interface';
 import { Pool } from 'app/interfaces/pool.interface';
 import { VDevItem } from 'app/interfaces/storage.interface';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
@@ -18,23 +19,9 @@ describe('MetadataWizardStepComponent', () => {
   let spectator: Spectator<MetadataWizardStepComponent>;
 
   const fakeInventory = [
-    {
-      identifier: '{serial_lunid}8HG7MZJH_5000cca2700de678',
-      name: 'sdo',
-      number: 2272,
-      serial: '8HG7MZJH',
-      size: 12000138625024,
-      type: 'HDD',
-    },
-    {
-      identifier: '{serial_lunid}8DJ61EBH_5000cca2537bba6c',
-      name: 'sdv',
-      number: 16720,
-      serial: '8DJ61EBH',
-      size: 12000138625024,
-      type: 'HDD',
-    },
-  ];
+    { name: 'sdo', size: 12000138625024 },
+    { name: 'sdv', size: 12000138625024 },
+  ] as DetailsDisk[];
 
   const makeFactory = ({
     pool = null,

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -63,7 +63,7 @@ describe('MetadataWizardStepComponent', () => {
     expect(layoutComponent.description).toBe(helptextPoolCreation.specialVdevDescription);
     expect(layoutComponent.canChangeLayout).toBeTruthy();
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.limitLayouts).toStrictEqual(nonDraidLayouts);
+    expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     expect(layoutComponent.type).toStrictEqual(VDevType.Special);
   });
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -8,6 +8,7 @@ import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { MetadataWizardStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component';
 import { PoolManagerStore, PoolManagerTopology } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
+import { nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 describe('MetadataWizardStepComponent', () => {
   let spectator: Spectator<MetadataWizardStepComponent>;
@@ -60,7 +61,7 @@ describe('MetadataWizardStepComponent', () => {
     expect(layoutComponent.description).toBe(helptextPoolCreation.specialVdevDescription);
     expect(layoutComponent.canChangeLayout).toBeTruthy();
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.limitLayouts).toStrictEqual(Object.values(CreateVdevLayout));
+    expect(layoutComponent.limitLayouts).toStrictEqual(nonDraidLayouts);
     expect(layoutComponent.type).toStrictEqual(VDevType.Special);
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -39,9 +39,11 @@ describe('MetadataWizardStepComponent', () => {
   const makeFactory = ({
     pool = null,
     dataLayout = null,
+    specialLayout = null,
   }: {
     pool?: Partial<Pool> | null;
     dataLayout?: CreateVdevLayout | null;
+    specialLayout?: CreateVdevLayout | null;
   } = {}): SpectatorFactory<MetadataWizardStepComponent> => createComponentFactory({
     component: MetadataWizardStepComponent,
     declarations: [
@@ -56,6 +58,7 @@ describe('MetadataWizardStepComponent', () => {
       mockProvider(PoolManagerStore, {
         topology$: of({
           [VDevType.Data]: { layout: dataLayout },
+          [VDevType.Special]: { layout: specialLayout },
         } as PoolManagerTopology),
         getInventoryForStep: jest.fn(() => of(fakeInventory)),
       }),
@@ -79,7 +82,7 @@ describe('MetadataWizardStepComponent', () => {
     it('locks special layout to match the wizard data layout', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
-      expect(layoutComponent.canChangeLayout).toBeFalsy();
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -101,7 +104,7 @@ describe('MetadataWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBeFalsy();
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -121,7 +124,33 @@ describe('MetadataWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBeFalsy();
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
+    });
+  });
+
+  describe('when the locked layout no longer allows the current store selection', () => {
+    const createComponent = makeFactory({
+      dataLayout: CreateVdevLayout.Raidz2,
+      specialLayout: CreateVdevLayout.Mirror,
+    });
+
+    it('resets the special step so the invalid selection is cleared', () => {
+      spectator = createComponent();
+      const store = spectator.inject(PoolManagerStore);
+      expect(store.resetStep).toHaveBeenCalledWith(VDevType.Special);
+    });
+  });
+
+  describe('when the current store layout matches the lock', () => {
+    const createComponent = makeFactory({
+      dataLayout: CreateVdevLayout.Raidz2,
+      specialLayout: CreateVdevLayout.Raidz2,
+    });
+
+    it('does not reset the special step', () => {
+      spectator = createComponent();
+      const store = spectator.inject(PoolManagerStore);
+      expect(store.resetStep).not.toHaveBeenCalled();
     });
   });
 
@@ -141,7 +170,7 @@ describe('MetadataWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
-      expect(layoutComponent.canChangeLayout).toBeFalsy();
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -1,5 +1,7 @@
 import { CdkStepper } from '@angular/cdk/stepper';
-import { mockProvider, Spectator, createComponentFactory } from '@ngneat/spectator/jest';
+import {
+  mockProvider, Spectator, SpectatorFactory, createComponentFactory,
+} from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
@@ -34,7 +36,13 @@ describe('MetadataWizardStepComponent', () => {
     },
   ];
 
-  const createComponent = createComponentFactory({
+  const makeFactory = ({
+    pool = null,
+    dataLayout = null,
+  }: {
+    pool?: Partial<Pool> | null;
+    dataLayout?: CreateVdevLayout | null;
+  } = {}): SpectatorFactory<MetadataWizardStepComponent> => createComponentFactory({
     component: MetadataWizardStepComponent,
     declarations: [
       MockComponent(LayoutStepComponent),
@@ -42,59 +50,32 @@ describe('MetadataWizardStepComponent', () => {
     providers: [
       mockProvider(CdkStepper),
       mockProvider(AddVdevsStore, {
-        pool$: of(null),
+        pool$: of(pool as Pool | null),
         isLoading$: of(false),
       }),
       mockProvider(PoolManagerStore, {
         topology$: of({
-          [VDevType.Data]: { layout: CreateVdevLayout.Raidz1 },
+          [VDevType.Data]: { layout: dataLayout },
         } as PoolManagerTopology),
         getInventoryForStep: jest.fn(() => of(fakeInventory)),
       }),
     ],
   });
 
-  beforeEach(() => {
-    spectator = createComponent();
-  });
-
-  it('has the correct inputs', () => {
-    const layoutComponent = spectator.query(LayoutStepComponent)!;
-    expect(layoutComponent.description).toBe(helptextPoolCreation.specialVdevDescription);
-    expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.type).toStrictEqual(VDevType.Special);
-  });
-
-  describe('when creating a new pool without a data layout chosen yet', () => {
-    const createComponentNoLayout = createComponentFactory({
-      component: MetadataWizardStepComponent,
-      declarations: [
-        MockComponent(LayoutStepComponent),
-      ],
-      providers: [
-        mockProvider(CdkStepper),
-        mockProvider(AddVdevsStore, {
-          pool$: of(null),
-          isLoading$: of(false),
-        }),
-        mockProvider(PoolManagerStore, {
-          topology$: of({
-            [VDevType.Data]: { layout: null },
-          } as PoolManagerTopology),
-          getInventoryForStep: jest.fn(() => of(fakeInventory)),
-        }),
-      ],
-    });
-
-    it('allows any non-dRAID layout when no data layout is set', () => {
-      spectator = createComponentNoLayout();
-      const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
-      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
-    });
-  });
-
   describe('when creating a new pool with a RAIDZ1 data layout', () => {
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1 });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('has the correct inputs', () => {
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.description).toBe(helptextPoolCreation.specialVdevDescription);
+      expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
+      expect(layoutComponent.type).toStrictEqual(VDevType.Special);
+    });
+
     it('locks special layout to match the wizard data layout', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
@@ -102,29 +83,22 @@ describe('MetadataWizardStepComponent', () => {
     });
   });
 
-  describe('when creating a new pool with a DRAID2 data layout', () => {
-    const createComponentDraid = createComponentFactory({
-      component: MetadataWizardStepComponent,
-      declarations: [
-        MockComponent(LayoutStepComponent),
-      ],
-      providers: [
-        mockProvider(CdkStepper),
-        mockProvider(AddVdevsStore, {
-          pool$: of(null),
-          isLoading$: of(false),
-        }),
-        mockProvider(PoolManagerStore, {
-          topology$: of({
-            [VDevType.Data]: { layout: CreateVdevLayout.Draid2 },
-          } as PoolManagerTopology),
-          getInventoryForStep: jest.fn(() => of(fakeInventory)),
-        }),
-      ],
+  describe('when creating a new pool without a data layout chosen yet', () => {
+    const createComponent = makeFactory();
+
+    it('allows any non-dRAID layout', () => {
+      spectator = createComponent();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     });
+  });
+
+  describe('when creating a new pool with a DRAID2 data layout', () => {
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2 });
 
     it('locks special layout to the non-dRAID equivalent', () => {
-      spectator = createComponentDraid();
+      spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
       expect(layoutComponent.canChangeLayout).toBeFalsy();
@@ -132,35 +106,19 @@ describe('MetadataWizardStepComponent', () => {
   });
 
   describe('when adding the first special vdev to an existing pool', () => {
-    const createComponentExistingData = createComponentFactory({
-      component: MetadataWizardStepComponent,
-      declarations: [
-        MockComponent(LayoutStepComponent),
-      ],
-      providers: [
-        mockProvider(CdkStepper),
-        mockProvider(AddVdevsStore, {
-          pool$: of({
-            topology: {
-              [VDevType.Data]: [
-                { type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] },
-              ] as VDevItem[],
-              [VDevType.Special]: [] as VDevItem[],
-            },
-          } as Pool),
-          isLoading$: of(false),
-        }),
-        mockProvider(PoolManagerStore, {
-          topology$: of({
-            [VDevType.Data]: { layout: null },
-          } as PoolManagerTopology),
-          getInventoryForStep: jest.fn(() => of(fakeInventory)),
-        }),
-      ],
+    const createComponent = makeFactory({
+      pool: {
+        topology: {
+          [VDevType.Data]: [
+            { type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] },
+          ] as VDevItem[],
+          [VDevType.Special]: [] as VDevItem[],
+        },
+      } as Pool,
     });
 
     it('locks special layout to match the existing pool data layout', () => {
-      spectator = createComponentExistingData();
+      spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
       expect(layoutComponent.canChangeLayout).toBeFalsy();
@@ -168,34 +126,19 @@ describe('MetadataWizardStepComponent', () => {
   });
 
   describe('when pool has existing special vdevs', () => {
-    const createComponentWithPool = createComponentFactory({
-      component: MetadataWizardStepComponent,
-      declarations: [
-        MockComponent(LayoutStepComponent),
-      ],
-      providers: [
-        mockProvider(CdkStepper),
-        mockProvider(AddVdevsStore, {
-          pool$: of({
-            topology: {
-              [VDevType.Special]: [
-                { type: TopologyItemType.Mirror, children: [{}, {}] },
-              ] as VDevItem[],
-            },
-          } as Pool),
-          isLoading$: of(false),
-        }),
-        mockProvider(PoolManagerStore, {
-          topology$: of({
-            [VDevType.Data]: { layout: CreateVdevLayout.Raidz1 },
-          } as PoolManagerTopology),
-          getInventoryForStep: jest.fn(() => of(fakeInventory)),
-        }),
-      ],
+    const createComponent = makeFactory({
+      pool: {
+        topology: {
+          [VDevType.Special]: [
+            { type: TopologyItemType.Mirror, children: [{}, {}] },
+          ] as VDevItem[],
+        },
+      } as Pool,
+      dataLayout: CreateVdevLayout.Raidz1,
     });
 
     it('locks layout to match existing vdev layout', () => {
-      spectator = createComponentWithPool();
+      spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
       expect(layoutComponent.canChangeLayout).toBeFalsy();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -26,10 +26,12 @@ describe('MetadataWizardStepComponent', () => {
   const makeFactory = ({
     pool = null,
     dataLayout = null,
+    dataWidth = null,
     specialLayout = null,
   }: {
     pool?: Partial<Pool> | null;
     dataLayout?: CreateVdevLayout | null;
+    dataWidth?: number | null;
     specialLayout?: CreateVdevLayout | null;
   } = {}): SpectatorFactory<MetadataWizardStepComponent> => createComponentFactory({
     component: MetadataWizardStepComponent,
@@ -44,7 +46,7 @@ describe('MetadataWizardStepComponent', () => {
       }),
       mockProvider(PoolManagerStore, {
         topology$: of({
-          [VDevType.Data]: { layout: dataLayout },
+          [VDevType.Data]: { layout: dataLayout, width: dataWidth },
           [VDevType.Special]: { layout: specialLayout },
         } as PoolManagerTopology),
         getInventoryForStep: jest.fn(() => of(fakeInventory)),
@@ -53,7 +55,7 @@ describe('MetadataWizardStepComponent', () => {
   });
 
   describe('when creating a new pool with a RAIDZ1 data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1, dataWidth: 3 });
 
     beforeEach(() => {
       spectator = createComponent();
@@ -66,9 +68,12 @@ describe('MetadataWizardStepComponent', () => {
       expect(layoutComponent.type).toStrictEqual(VDevType.Special);
     });
 
-    it('locks special layout to match the wizard data layout', () => {
+    it('allows any layout that tolerates at least 1 drive failure', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
+      expect(layoutComponent.limitLayouts).toStrictEqual([
+        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz1, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+      ]);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
@@ -81,17 +86,34 @@ describe('MetadataWizardStepComponent', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.canChangeLayout).toBeTruthy();
       expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
     });
   });
 
   describe('when creating a new pool with a DRAID2 data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2, dataWidth: 4 });
 
-    it('locks special layout to the non-dRAID equivalent', () => {
+    it('matches dRAID2 parity: RAIDZ2, RAIDZ3, or a 3+-way mirror', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.limitLayouts).toStrictEqual([
+        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+      ]);
+      expect(layoutComponent.minMirrorWidth).toBe(3);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
+    });
+  });
+
+  describe('when creating a new pool with a 3-way mirror data layout', () => {
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Mirror, dataWidth: 3 });
+
+    it('raises minMirrorWidth to match the data mirror width', () => {
+      spectator = createComponent();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([
+        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+      ]);
+      expect(layoutComponent.minMirrorWidth).toBe(3);
     });
   });
 
@@ -107,10 +129,13 @@ describe('MetadataWizardStepComponent', () => {
       } as Pool,
     });
 
-    it('locks special layout to match the existing pool data layout', () => {
+    it('matches existing data parity: RAIDZ2, RAIDZ3, or 3+-way mirror', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.limitLayouts).toStrictEqual([
+        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+      ]);
+      expect(layoutComponent.minMirrorWidth).toBe(3);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
@@ -118,13 +143,17 @@ describe('MetadataWizardStepComponent', () => {
   describe('when the lock changes with a stale store selection', () => {
     const createComponent = makeFactory({
       dataLayout: CreateVdevLayout.Raidz2,
-      specialLayout: CreateVdevLayout.Mirror,
+      dataWidth: 4,
+      specialLayout: CreateVdevLayout.Stripe,
     });
 
-    it('locks limitLayouts to the new lock even while the store selection is stale', () => {
+    it('applies the new parity lock even while the store selection is stale', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.limitLayouts).toStrictEqual([
+        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+      ]);
+      expect(layoutComponent.minMirrorWidth).toBe(3);
     });
   });
 
@@ -138,12 +167,14 @@ describe('MetadataWizardStepComponent', () => {
         },
       } as Pool,
       dataLayout: CreateVdevLayout.Raidz1,
+      dataWidth: 3,
     });
 
-    it('locks layout to match existing vdev layout', () => {
+    it('strict-locks to the existing category layout (no parity-level fan-out)', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -139,6 +139,12 @@ describe('MetadataWizardStepComponent', () => {
       const store = spectator.inject(PoolManagerStore);
       expect(store.resetStep).toHaveBeenCalledWith(VDevType.Special);
     });
+
+    it('keeps the allowed layouts locked to the lock after the reset', () => {
+      spectator = createComponent();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+    });
   });
 
   describe('when the current store layout matches the lock', () => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -128,35 +128,16 @@ describe('MetadataWizardStepComponent', () => {
     });
   });
 
-  describe('when the locked layout no longer allows the current store selection', () => {
+  describe('when the lock changes with a stale store selection', () => {
     const createComponent = makeFactory({
       dataLayout: CreateVdevLayout.Raidz2,
       specialLayout: CreateVdevLayout.Mirror,
     });
 
-    it('resets the special step so the invalid selection is cleared', () => {
-      spectator = createComponent();
-      const store = spectator.inject(PoolManagerStore);
-      expect(store.resetStep).toHaveBeenCalledWith(VDevType.Special);
-    });
-
-    it('keeps the allowed layouts locked to the lock after the reset', () => {
+    it('locks limitLayouts to the new lock even while the store selection is stale', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-    });
-  });
-
-  describe('when the current store layout matches the lock', () => {
-    const createComponent = makeFactory({
-      dataLayout: CreateVdevLayout.Raidz2,
-      specialLayout: CreateVdevLayout.Raidz2,
-    });
-
-    it('does not reset the special step', () => {
-      spectator = createComponent();
-      const store = spectator.inject(PoolManagerStore);
-      expect(store.resetStep).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -61,10 +61,110 @@ describe('MetadataWizardStepComponent', () => {
   it('has the correct inputs', () => {
     const layoutComponent = spectator.query(LayoutStepComponent)!;
     expect(layoutComponent.description).toBe(helptextPoolCreation.specialVdevDescription);
-    expect(layoutComponent.canChangeLayout).toBeTruthy();
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     expect(layoutComponent.type).toStrictEqual(VDevType.Special);
+  });
+
+  describe('when creating a new pool without a data layout chosen yet', () => {
+    const createComponentNoLayout = createComponentFactory({
+      component: MetadataWizardStepComponent,
+      declarations: [
+        MockComponent(LayoutStepComponent),
+      ],
+      providers: [
+        mockProvider(CdkStepper),
+        mockProvider(AddVdevsStore, {
+          pool$: of(null),
+          isLoading$: of(false),
+        }),
+        mockProvider(PoolManagerStore, {
+          topology$: of({
+            [VDevType.Data]: { layout: null },
+          } as PoolManagerTopology),
+          getInventoryForStep: jest.fn(() => of(fakeInventory)),
+        }),
+      ],
+    });
+
+    it('allows any non-dRAID layout when no data layout is set', () => {
+      spectator = createComponentNoLayout();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
+    });
+  });
+
+  describe('when creating a new pool with a RAIDZ1 data layout', () => {
+    it('locks special layout to match the wizard data layout', () => {
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
+      expect(layoutComponent.canChangeLayout).toBeFalsy();
+    });
+  });
+
+  describe('when creating a new pool with a DRAID2 data layout', () => {
+    const createComponentDraid = createComponentFactory({
+      component: MetadataWizardStepComponent,
+      declarations: [
+        MockComponent(LayoutStepComponent),
+      ],
+      providers: [
+        mockProvider(CdkStepper),
+        mockProvider(AddVdevsStore, {
+          pool$: of(null),
+          isLoading$: of(false),
+        }),
+        mockProvider(PoolManagerStore, {
+          topology$: of({
+            [VDevType.Data]: { layout: CreateVdevLayout.Draid2 },
+          } as PoolManagerTopology),
+          getInventoryForStep: jest.fn(() => of(fakeInventory)),
+        }),
+      ],
+    });
+
+    it('locks special layout to the non-dRAID equivalent', () => {
+      spectator = createComponentDraid();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.canChangeLayout).toBeFalsy();
+    });
+  });
+
+  describe('when adding the first special vdev to an existing pool', () => {
+    const createComponentExistingData = createComponentFactory({
+      component: MetadataWizardStepComponent,
+      declarations: [
+        MockComponent(LayoutStepComponent),
+      ],
+      providers: [
+        mockProvider(CdkStepper),
+        mockProvider(AddVdevsStore, {
+          pool$: of({
+            topology: {
+              [VDevType.Data]: [
+                { type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] },
+              ] as VDevItem[],
+              [VDevType.Special]: [] as VDevItem[],
+            },
+          } as Pool),
+          isLoading$: of(false),
+        }),
+        mockProvider(PoolManagerStore, {
+          topology$: of({
+            [VDevType.Data]: { layout: null },
+          } as PoolManagerTopology),
+          getInventoryForStep: jest.fn(() => of(fakeInventory)),
+        }),
+      ],
+    });
+
+    it('locks special layout to match the existing pool data layout', () => {
+      spectator = createComponentExistingData();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.canChangeLayout).toBeFalsy();
+    });
   });
 
   describe('when pool has existing special vdevs', () => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -2,8 +2,10 @@ import { CdkStepper } from '@angular/cdk/stepper';
 import { mockProvider, Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
-import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
+import { Pool } from 'app/interfaces/pool.interface';
+import { VDevItem } from 'app/interfaces/storage.interface';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { MetadataWizardStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component';
@@ -63,5 +65,40 @@ describe('MetadataWizardStepComponent', () => {
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
     expect(layoutComponent.limitLayouts).toStrictEqual(nonDraidLayouts);
     expect(layoutComponent.type).toStrictEqual(VDevType.Special);
+  });
+
+  describe('when pool has existing special vdevs', () => {
+    const createComponentWithPool = createComponentFactory({
+      component: MetadataWizardStepComponent,
+      declarations: [
+        MockComponent(LayoutStepComponent),
+      ],
+      providers: [
+        mockProvider(CdkStepper),
+        mockProvider(AddVdevsStore, {
+          pool$: of({
+            topology: {
+              [VDevType.Special]: [
+                { type: TopologyItemType.Mirror, children: [{}, {}] },
+              ] as VDevItem[],
+            },
+          } as Pool),
+          isLoading$: of(false),
+        }),
+        mockProvider(PoolManagerStore, {
+          topology$: of({
+            [VDevType.Data]: { layout: CreateVdevLayout.Raidz1 },
+          } as PoolManagerTopology),
+          getInventoryForStep: jest.fn(() => of(fakeInventory)),
+        }),
+      ],
+    });
+
+    it('locks layout to match existing vdev layout', () => {
+      spectator = createComponentWithPool();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
+      expect(layoutComponent.canChangeLayout).toBeFalsy();
+    });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -40,7 +40,7 @@ export class MetadataWizardStepComponent implements OnInit {
 
   readonly goToLastStep = output();
 
-  canChangeLayout = true;
+  protected canChangeLayout = true;
 
   protected readonly vDevType = VDevType;
   readonly helptext = helptextPoolCreation;

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -5,14 +5,14 @@ import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
 import { map } from 'rxjs';
-import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
+import { VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { nonDraidEquivalent, nonDraidLayouts, parseDraidVdevName } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { existingVdevLayout, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-metadata-wizard-step',
@@ -58,21 +58,12 @@ export class MetadataWizardStepComponent implements OnInit {
 
   ngOnInit(): void {
     this.addVdevsStore.pool$.pipe(
-      map((pool) => pool?.topology[VDevType.Special]),
+      map((pool) => existingVdevLayout(pool?.topology[VDevType.Special])),
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe((metadataTopology) => {
-      if (!metadataTopology?.length) {
+    ).subscribe((layout) => {
+      if (!layout) {
         return;
       }
-      // TODO: Similar code in poolTopologyToStoreTopology
-      let type = metadataTopology[0].type;
-      if (type === TopologyItemType.Disk && !metadataTopology[0].children.length) {
-        type = TopologyItemType.Stripe;
-      } else if (type === TopologyItemType.Draid) {
-        const parsedVdevName = parseDraidVdevName(metadataTopology[0].name);
-        type = parsedVdevName.layout as unknown as TopologyItemType;
-      }
-      const layout = nonDraidEquivalent(type as unknown as CreateVdevLayout);
       this.allowedLayouts = [layout];
       this.canChangeLayout = false;
       this.cdr.markForCheck();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -42,9 +42,8 @@ export class MetadataWizardStepComponent implements OnInit {
   protected readonly vDevType = VDevType;
   protected readonly helptext = helptextPoolCreation;
 
-  private readonly allAllowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Special);
-  protected allowedLayouts: CreateVdevLayout[] = this.allAllowedLayouts;
+  protected allowedLayouts: readonly CreateVdevLayout[] = nonDraidLayouts;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -58,7 +57,7 @@ export class MetadataWizardStepComponent implements OnInit {
     lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((lockedLayout) => {
-        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : this.allAllowedLayouts;
+        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : nonDraidLayouts;
         this.cdr.markForCheck();
       });
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { map } from 'rxjs';
+import { combineLatest, map } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -12,7 +12,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { existingVdevLayout, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { nonDraidLayouts, resolveSpecialLayoutLock } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-metadata-wizard-step',
@@ -57,15 +57,21 @@ export class MetadataWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.addVdevsStore.pool$.pipe(
-      map((pool) => existingVdevLayout(pool?.topology[VDevType.Special])),
+    combineLatest([this.addVdevsStore.pool$, this.store.topology$]).pipe(
+      map(([pool, topology]) => resolveSpecialLayoutLock(
+        pool?.topology[VDevType.Special],
+        pool?.topology[VDevType.Data],
+        topology[VDevType.Data]?.layout,
+      )),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((layout) => {
       if (!layout) {
-        return;
+        this.allowedLayouts = [...nonDraidLayouts];
+        this.canChangeLayout = true;
+      } else {
+        this.allowedLayouts = [layout];
+        this.canChangeLayout = false;
       }
-      this.allowedLayouts = [layout];
-      this.canChangeLayout = false;
       this.cdr.markForCheck();
     });
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { take } from 'rxjs';
+import { withLatestFrom } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -56,20 +56,15 @@ export class MetadataWizardStepComponent implements OnInit {
 
   ngOnInit(): void {
     lockedSpecialLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special).pipe(
+      withLatestFrom(this.store.topology$),
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe((layout) => {
-      this.allowedLayouts = layout ? [layout] : [...nonDraidLayouts];
-      this.resetIfCurrentLayoutNotAllowed();
-      this.cdr.markForCheck();
-    });
-  }
-
-  private resetIfCurrentLayoutNotAllowed(): void {
-    this.store.topology$.pipe(take(1)).subscribe((topology) => {
+    ).subscribe(([layout, topology]) => {
+      this.allowedLayouts = layout !== null ? [layout] : [...nonDraidLayouts];
       const currentLayout = topology[VDevType.Special]?.layout;
       if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
         this.store.resetStep(VDevType.Special);
       }
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -43,7 +43,7 @@ export class MetadataWizardStepComponent implements OnInit {
   protected canChangeLayout = true;
 
   protected readonly vDevType = VDevType;
-  readonly helptext = helptextPoolCreation;
+  protected readonly helptext = helptextPoolCreation;
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Special);
   protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -44,7 +44,6 @@ export class MetadataWizardStepComponent implements OnInit {
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Special);
   protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
-  protected canChangeLayout = true;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -59,7 +58,6 @@ export class MetadataWizardStepComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ lockedLayout, currentLayout }) => {
         this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : [...nonDraidLayouts];
-        this.canChangeLayout = lockedLayout === null;
         if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
           this.store.resetStep(VDevType.Special);
         }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -57,7 +57,7 @@ export class MetadataWizardStepComponent implements OnInit {
   ngOnInit(): void {
     lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special)
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(({ lockedLayout }) => {
+      .subscribe((lockedLayout) => {
         this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : this.allAllowedLayouts;
         this.cdr.markForCheck();
       });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -5,7 +5,7 @@ import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
 import { map } from 'rxjs';
-import { VDevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { TestDirective } from 'app/modules/test-id/test.directive';
@@ -46,7 +46,7 @@ export class MetadataWizardStepComponent implements OnInit {
   readonly helptext = helptextPoolCreation;
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Special);
-  protected allowedLayouts = nonDraidLayouts;
+  protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
 
   goToReviewStep(): void {
     this.goToLastStep.emit();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -48,11 +48,11 @@ export class MetadataWizardStepComponent implements OnInit {
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Special);
   protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
 
-  goToReviewStep(): void {
+  protected goToReviewStep(): void {
     this.goToLastStep.emit();
   }
 
-  resetStep(): void {
+  protected resetStep(): void {
     this.store.resetStep(VDevType.Special);
   }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { combineLatest, map } from 'rxjs';
+import { combineLatest, distinctUntilChanged, map } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -63,6 +63,7 @@ export class MetadataWizardStepComponent implements OnInit {
         pool?.topology[VDevType.Data],
         topology[VDevType.Data]?.layout,
       )),
+      distinctUntilChanged(),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((layout) => {
       if (!layout) {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -42,8 +42,9 @@ export class MetadataWizardStepComponent implements OnInit {
   protected readonly vDevType = VDevType;
   protected readonly helptext = helptextPoolCreation;
 
+  private readonly allAllowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Special);
-  protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
+  protected allowedLayouts: CreateVdevLayout[] = this.allAllowedLayouts;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -57,7 +58,7 @@ export class MetadataWizardStepComponent implements OnInit {
     lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ lockedLayout, currentLayout }) => {
-        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : [...nonDraidLayouts];
+        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : this.allAllowedLayouts;
         if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
           this.store.resetStep(VDevType.Special);
         }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -57,11 +57,8 @@ export class MetadataWizardStepComponent implements OnInit {
   ngOnInit(): void {
     lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special)
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(({ lockedLayout, currentLayout }) => {
+      .subscribe(({ lockedLayout }) => {
         this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : this.allAllowedLayouts;
-        if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
-          this.store.resetStep(VDevType.Special);
-        }
         this.cdr.markForCheck();
       });
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -11,7 +11,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { lockedParityLayout$, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { nonDraidLayouts, parityLock$ } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-metadata-wizard-step',
@@ -44,6 +44,7 @@ export class MetadataWizardStepComponent implements OnInit {
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Special);
   protected allowedLayouts: readonly CreateVdevLayout[] = nonDraidLayouts;
+  protected minMirrorWidth = 2;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -54,10 +55,11 @@ export class MetadataWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special)
+    parityLock$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special)
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((lockedLayout) => {
-        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : nonDraidLayouts;
+      .subscribe((lock) => {
+        this.allowedLayouts = lock.allowedLayouts;
+        this.minMirrorWidth = lock.minMirrorWidth;
         this.cdr.markForCheck();
       });
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -4,7 +4,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { withLatestFrom } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -12,7 +11,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { lockedSpecialLayout$, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { lockedParityLayout$, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-metadata-wizard-step',
@@ -45,6 +44,7 @@ export class MetadataWizardStepComponent implements OnInit {
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Special);
   protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
+  protected canChangeLayout = true;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -55,16 +55,15 @@ export class MetadataWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    lockedSpecialLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special).pipe(
-      withLatestFrom(this.store.topology$),
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe(([layout, topology]) => {
-      this.allowedLayouts = layout !== null ? [layout] : [...nonDraidLayouts];
-      const currentLayout = topology[VDevType.Special]?.layout;
-      if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
-        this.store.resetStep(VDevType.Special);
-      }
-      this.cdr.markForCheck();
-    });
+    lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(({ lockedLayout, currentLayout }) => {
+        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : [...nonDraidLayouts];
+        this.canChangeLayout = lockedLayout === null;
+        if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
+          this.store.resetStep(VDevType.Special);
+        }
+        this.cdr.markForCheck();
+      });
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -12,7 +12,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { parseDraidVdevName } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { nonDraidEquivalent, nonDraidLayouts, parseDraidVdevName } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-metadata-wizard-step',
@@ -46,7 +46,7 @@ export class MetadataWizardStepComponent implements OnInit {
   readonly helptext = helptextPoolCreation;
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Special);
-  protected allowedLayouts = Object.values(CreateVdevLayout) as CreateVdevLayout[];
+  protected allowedLayouts = nonDraidLayouts;
 
   goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -72,7 +72,8 @@ export class MetadataWizardStepComponent implements OnInit {
         const parsedVdevName = parseDraidVdevName(metadataTopology[0].name);
         type = parsedVdevName.layout as unknown as TopologyItemType;
       }
-      this.allowedLayouts = [type] as unknown as CreateVdevLayout[];
+      const layout = nonDraidEquivalent(type as unknown as CreateVdevLayout);
+      this.allowedLayouts = [layout];
       this.canChangeLayout = false;
       this.cdr.markForCheck();
     });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { combineLatest, distinctUntilChanged, map } from 'rxjs';
+import { take } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -12,7 +12,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { nonDraidLayouts, resolveSpecialLayoutLock } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { lockedSpecialLayout$, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-metadata-wizard-step',
@@ -40,8 +40,6 @@ export class MetadataWizardStepComponent implements OnInit {
 
   readonly goToLastStep = output();
 
-  protected canChangeLayout = true;
-
   protected readonly vDevType = VDevType;
   protected readonly helptext = helptextPoolCreation;
 
@@ -57,23 +55,21 @@ export class MetadataWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    combineLatest([this.addVdevsStore.pool$, this.store.topology$]).pipe(
-      map(([pool, topology]) => resolveSpecialLayoutLock(
-        pool?.topology[VDevType.Special],
-        pool?.topology[VDevType.Data],
-        topology[VDevType.Data]?.layout,
-      )),
-      distinctUntilChanged(),
+    lockedSpecialLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special).pipe(
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((layout) => {
-      if (!layout) {
-        this.allowedLayouts = [...nonDraidLayouts];
-        this.canChangeLayout = true;
-      } else {
-        this.allowedLayouts = [layout];
-        this.canChangeLayout = false;
-      }
+      this.allowedLayouts = layout ? [layout] : [...nonDraidLayouts];
+      this.resetIfCurrentLayoutNotAllowed();
       this.cdr.markForCheck();
+    });
+  }
+
+  private resetIfCurrentLayoutNotAllowed(): void {
+    this.store.topology$.pipe(take(1)).subscribe((topology) => {
+      const currentLayout = topology[VDevType.Special]?.layout;
+      if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
+        this.store.resetStep(VDevType.Special);
+      }
     });
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
@@ -4,6 +4,7 @@
   [inventory]="(inventory$ | async) || []"
   [canChangeLayout]="true"
   [limitLayouts]="allowedLayouts"
+  [minMirrorWidth]="minMirrorWidth"
   [isStepActive]="isStepActive()"
 ></ix-layout-step>
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
@@ -2,7 +2,7 @@
   [description]="helptext.dedupVdevDescription | translate"
   [type]="vDevType.Dedup"
   [inventory]="(inventory$ | async) || []"
-  [canChangeLayout]="canChangeLayout"
+  [canChangeLayout]="true"
   [limitLayouts]="allowedLayouts"
   [isStepActive]="isStepActive()"
 ></ix-layout-step>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
@@ -2,7 +2,7 @@
   [description]="helptext.dedupVdevDescription | translate"
   [type]="vDevType.Dedup"
   [inventory]="(inventory$ | async) || []"
-  [canChangeLayout]="true"
+  [canChangeLayout]="canChangeLayout"
   [limitLayouts]="allowedLayouts"
   [isStepActive]="isStepActive()"
 ></ix-layout-step>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -2,8 +2,10 @@ import { CdkStepper } from '@angular/cdk/stepper';
 import { mockProvider, Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
-import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
+import { Pool } from 'app/interfaces/pool.interface';
+import { VDevItem } from 'app/interfaces/storage.interface';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { DedupWizardStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component';
@@ -63,5 +65,40 @@ describe('DedupWizardStepComponent', () => {
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
     expect(layoutComponent.limitLayouts).toStrictEqual(nonDraidLayouts);
     expect(layoutComponent.type).toStrictEqual(VDevType.Dedup);
+  });
+
+  describe('when pool has existing dedup vdevs', () => {
+    const createComponentWithPool = createComponentFactory({
+      component: DedupWizardStepComponent,
+      declarations: [
+        MockComponent(LayoutStepComponent),
+      ],
+      providers: [
+        mockProvider(CdkStepper),
+        mockProvider(AddVdevsStore, {
+          pool$: of({
+            topology: {
+              [VDevType.Dedup]: [
+                { type: TopologyItemType.Mirror, children: [{}, {}] },
+              ] as VDevItem[],
+            },
+          } as Pool),
+          isLoading$: of(false),
+        }),
+        mockProvider(PoolManagerStore, {
+          topology$: of({
+            [VDevType.Data]: { layout: CreateVdevLayout.Raidz1 },
+          } as PoolManagerTopology),
+          getInventoryForStep: jest.fn(() => of(fakeInventory)),
+        }),
+      ],
+    });
+
+    it('locks layout to match existing vdev layout', () => {
+      spectator = createComponentWithPool();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
+      expect(layoutComponent.canChangeLayout).toBeFalsy();
+    });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -26,10 +26,12 @@ describe('DedupWizardStepComponent', () => {
   const makeFactory = ({
     pool = null,
     dataLayout = null,
+    dataWidth = null,
     dedupLayout = null,
   }: {
     pool?: Partial<Pool> | null;
     dataLayout?: CreateVdevLayout | null;
+    dataWidth?: number | null;
     dedupLayout?: CreateVdevLayout | null;
   } = {}): SpectatorFactory<DedupWizardStepComponent> => createComponentFactory({
     component: DedupWizardStepComponent,
@@ -44,7 +46,7 @@ describe('DedupWizardStepComponent', () => {
       }),
       mockProvider(PoolManagerStore, {
         topology$: of({
-          [VDevType.Data]: { layout: dataLayout },
+          [VDevType.Data]: { layout: dataLayout, width: dataWidth },
           [VDevType.Dedup]: { layout: dedupLayout },
         } as PoolManagerTopology),
         getInventoryForStep: jest.fn(() => of(fakeInventory)),
@@ -53,7 +55,7 @@ describe('DedupWizardStepComponent', () => {
   });
 
   describe('when creating a new pool with a RAIDZ1 data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1, dataWidth: 3 });
 
     beforeEach(() => {
       spectator = createComponent();
@@ -66,9 +68,12 @@ describe('DedupWizardStepComponent', () => {
       expect(layoutComponent.type).toStrictEqual(VDevType.Dedup);
     });
 
-    it('locks dedup layout to match the wizard data layout', () => {
+    it('allows any layout that tolerates at least 1 drive failure', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
+      expect(layoutComponent.limitLayouts).toStrictEqual([
+        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz1, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+      ]);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
@@ -81,16 +86,20 @@ describe('DedupWizardStepComponent', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.canChangeLayout).toBeTruthy();
       expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
     });
   });
 
   describe('when creating a new pool with a DRAID2 data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2, dataWidth: 4 });
 
-    it('locks dedup layout to the non-dRAID equivalent', () => {
+    it('matches dRAID2 parity: RAIDZ2, RAIDZ3, or a 3+-way mirror', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.limitLayouts).toStrictEqual([
+        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+      ]);
+      expect(layoutComponent.minMirrorWidth).toBe(3);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
@@ -107,10 +116,13 @@ describe('DedupWizardStepComponent', () => {
       } as Pool,
     });
 
-    it('locks dedup layout to match the existing pool data layout', () => {
+    it('matches existing data parity: RAIDZ2, RAIDZ3, or 3+-way mirror', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.limitLayouts).toStrictEqual([
+        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+      ]);
+      expect(layoutComponent.minMirrorWidth).toBe(3);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
@@ -118,13 +130,17 @@ describe('DedupWizardStepComponent', () => {
   describe('when the lock changes with a stale store selection', () => {
     const createComponent = makeFactory({
       dataLayout: CreateVdevLayout.Raidz2,
-      dedupLayout: CreateVdevLayout.Mirror,
+      dataWidth: 4,
+      dedupLayout: CreateVdevLayout.Stripe,
     });
 
-    it('locks limitLayouts to the new lock even while the store selection is stale', () => {
+    it('applies the new parity lock even while the store selection is stale', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.limitLayouts).toStrictEqual([
+        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+      ]);
+      expect(layoutComponent.minMirrorWidth).toBe(3);
     });
   });
 
@@ -138,12 +154,14 @@ describe('DedupWizardStepComponent', () => {
         },
       } as Pool,
       dataLayout: CreateVdevLayout.Raidz1,
+      dataWidth: 3,
     });
 
-    it('locks layout to match existing vdev layout', () => {
+    it('strict-locks to the existing category layout (no parity-level fan-out)', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -82,7 +82,7 @@ describe('DedupWizardStepComponent', () => {
     it('locks dedup layout to match the wizard data layout', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
-      expect(layoutComponent.canChangeLayout).toBe(false);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -92,7 +92,7 @@ describe('DedupWizardStepComponent', () => {
     it('allows any non-dRAID layout', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.canChangeLayout).toBe(true);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
       expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     });
   });
@@ -104,7 +104,7 @@ describe('DedupWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBe(false);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -124,7 +124,7 @@ describe('DedupWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBe(false);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -170,7 +170,7 @@ describe('DedupWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
-      expect(layoutComponent.canChangeLayout).toBe(false);
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -10,7 +10,6 @@ import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { DedupWizardStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component';
 import { PoolManagerStore, PoolManagerTopology } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 describe('DedupWizardStepComponent', () => {
   let spectator: Spectator<DedupWizardStepComponent>;
@@ -63,7 +62,7 @@ describe('DedupWizardStepComponent', () => {
     expect(layoutComponent.description).toBe(helptextPoolCreation.dedupVdevDescription);
     expect(layoutComponent.canChangeLayout).toBeTruthy();
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.limitLayouts).toStrictEqual(nonDraidLayouts);
+    expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror, CreateVdevLayout.Stripe]);
     expect(layoutComponent.type).toStrictEqual(VDevType.Dedup);
   });
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -128,35 +128,16 @@ describe('DedupWizardStepComponent', () => {
     });
   });
 
-  describe('when the locked layout no longer allows the current store selection', () => {
+  describe('when the lock changes with a stale store selection', () => {
     const createComponent = makeFactory({
       dataLayout: CreateVdevLayout.Raidz2,
       dedupLayout: CreateVdevLayout.Mirror,
     });
 
-    it('resets the dedup step so the invalid selection is cleared', () => {
-      spectator = createComponent();
-      const store = spectator.inject(PoolManagerStore);
-      expect(store.resetStep).toHaveBeenCalledWith(VDevType.Dedup);
-    });
-
-    it('keeps the allowed layouts locked to the lock after the reset', () => {
+    it('locks limitLayouts to the new lock even while the store selection is stale', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-    });
-  });
-
-  describe('when the current store layout matches the lock', () => {
-    const createComponent = makeFactory({
-      dataLayout: CreateVdevLayout.Raidz2,
-      dedupLayout: CreateVdevLayout.Raidz2,
-    });
-
-    it('does not reset the dedup step', () => {
-      spectator = createComponent();
-      const store = spectator.inject(PoolManagerStore);
-      expect(store.resetStep).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -39,9 +39,11 @@ describe('DedupWizardStepComponent', () => {
   const makeFactory = ({
     pool = null,
     dataLayout = null,
+    dedupLayout = null,
   }: {
     pool?: Partial<Pool> | null;
     dataLayout?: CreateVdevLayout | null;
+    dedupLayout?: CreateVdevLayout | null;
   } = {}): SpectatorFactory<DedupWizardStepComponent> => createComponentFactory({
     component: DedupWizardStepComponent,
     declarations: [
@@ -56,6 +58,7 @@ describe('DedupWizardStepComponent', () => {
       mockProvider(PoolManagerStore, {
         topology$: of({
           [VDevType.Data]: { layout: dataLayout },
+          [VDevType.Dedup]: { layout: dedupLayout },
         } as PoolManagerTopology),
         getInventoryForStep: jest.fn(() => of(fakeInventory)),
       }),
@@ -79,7 +82,7 @@ describe('DedupWizardStepComponent', () => {
     it('locks dedup layout to match the wizard data layout', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
-      expect(layoutComponent.canChangeLayout).toBeFalsy();
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -101,7 +104,7 @@ describe('DedupWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBeFalsy();
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
@@ -121,7 +124,33 @@ describe('DedupWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBeFalsy();
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
+    });
+  });
+
+  describe('when the locked layout no longer allows the current store selection', () => {
+    const createComponent = makeFactory({
+      dataLayout: CreateVdevLayout.Raidz2,
+      dedupLayout: CreateVdevLayout.Mirror,
+    });
+
+    it('resets the dedup step so the invalid selection is cleared', () => {
+      spectator = createComponent();
+      const store = spectator.inject(PoolManagerStore);
+      expect(store.resetStep).toHaveBeenCalledWith(VDevType.Dedup);
+    });
+  });
+
+  describe('when the current store layout matches the lock', () => {
+    const createComponent = makeFactory({
+      dataLayout: CreateVdevLayout.Raidz2,
+      dedupLayout: CreateVdevLayout.Raidz2,
+    });
+
+    it('does not reset the dedup step', () => {
+      spectator = createComponent();
+      const store = spectator.inject(PoolManagerStore);
+      expect(store.resetStep).not.toHaveBeenCalled();
     });
   });
 
@@ -141,7 +170,7 @@ describe('DedupWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
-      expect(layoutComponent.canChangeLayout).toBeFalsy();
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -7,6 +7,7 @@ import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { DedupWizardStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component';
 import { PoolManagerStore, PoolManagerTopology } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
+import { nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 describe('DedupWizardStepComponent', () => {
   let spectator: Spectator<DedupWizardStepComponent>;
@@ -55,7 +56,7 @@ describe('DedupWizardStepComponent', () => {
     expect(layoutComponent.description).toBe(helptextPoolCreation.dedupVdevDescription);
     expect(layoutComponent.canChangeLayout).toBeTruthy();
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror, CreateVdevLayout.Stripe]);
+    expect(layoutComponent.limitLayouts).toStrictEqual(nonDraidLayouts);
     expect(layoutComponent.type).toStrictEqual(VDevType.Dedup);
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -6,6 +6,7 @@ import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
+import { DetailsDisk } from 'app/interfaces/disk.interface';
 import { Pool } from 'app/interfaces/pool.interface';
 import { VDevItem } from 'app/interfaces/storage.interface';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
@@ -18,23 +19,9 @@ describe('DedupWizardStepComponent', () => {
   let spectator: Spectator<DedupWizardStepComponent>;
 
   const fakeInventory = [
-    {
-      identifier: '{serial_lunid}8HG7MZJH_5000cca2700de678',
-      name: 'sdo',
-      number: 2272,
-      serial: '8HG7MZJH',
-      size: 12000138625024,
-      type: 'HDD',
-    },
-    {
-      identifier: '{serial_lunid}8DJ61EBH_5000cca2537bba6c',
-      name: 'sdv',
-      number: 16720,
-      serial: '8DJ61EBH',
-      size: 12000138625024,
-      type: 'HDD',
-    },
-  ];
+    { name: 'sdo', size: 12000138625024 },
+    { name: 'sdv', size: 12000138625024 },
+  ] as DetailsDisk[];
 
   const makeFactory = ({
     pool = null,

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -61,10 +61,110 @@ describe('DedupWizardStepComponent', () => {
   it('has the correct inputs', () => {
     const layoutComponent = spectator.query(LayoutStepComponent)!;
     expect(layoutComponent.description).toBe(helptextPoolCreation.dedupVdevDescription);
-    expect(layoutComponent.canChangeLayout).toBeTruthy();
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     expect(layoutComponent.type).toStrictEqual(VDevType.Dedup);
+  });
+
+  describe('when creating a new pool without a data layout chosen yet', () => {
+    const createComponentNoLayout = createComponentFactory({
+      component: DedupWizardStepComponent,
+      declarations: [
+        MockComponent(LayoutStepComponent),
+      ],
+      providers: [
+        mockProvider(CdkStepper),
+        mockProvider(AddVdevsStore, {
+          pool$: of(null),
+          isLoading$: of(false),
+        }),
+        mockProvider(PoolManagerStore, {
+          topology$: of({
+            [VDevType.Data]: { layout: null },
+          } as PoolManagerTopology),
+          getInventoryForStep: jest.fn(() => of(fakeInventory)),
+        }),
+      ],
+    });
+
+    it('allows any non-dRAID layout when no data layout is set', () => {
+      spectator = createComponentNoLayout();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
+    });
+  });
+
+  describe('when creating a new pool with a RAIDZ1 data layout', () => {
+    it('locks dedup layout to match the wizard data layout', () => {
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
+      expect(layoutComponent.canChangeLayout).toBeFalsy();
+    });
+  });
+
+  describe('when creating a new pool with a DRAID2 data layout', () => {
+    const createComponentDraid = createComponentFactory({
+      component: DedupWizardStepComponent,
+      declarations: [
+        MockComponent(LayoutStepComponent),
+      ],
+      providers: [
+        mockProvider(CdkStepper),
+        mockProvider(AddVdevsStore, {
+          pool$: of(null),
+          isLoading$: of(false),
+        }),
+        mockProvider(PoolManagerStore, {
+          topology$: of({
+            [VDevType.Data]: { layout: CreateVdevLayout.Draid2 },
+          } as PoolManagerTopology),
+          getInventoryForStep: jest.fn(() => of(fakeInventory)),
+        }),
+      ],
+    });
+
+    it('locks dedup layout to the non-dRAID equivalent', () => {
+      spectator = createComponentDraid();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.canChangeLayout).toBeFalsy();
+    });
+  });
+
+  describe('when adding the first dedup vdev to an existing pool', () => {
+    const createComponentExistingData = createComponentFactory({
+      component: DedupWizardStepComponent,
+      declarations: [
+        MockComponent(LayoutStepComponent),
+      ],
+      providers: [
+        mockProvider(CdkStepper),
+        mockProvider(AddVdevsStore, {
+          pool$: of({
+            topology: {
+              [VDevType.Data]: [
+                { type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] },
+              ] as VDevItem[],
+              [VDevType.Dedup]: [] as VDevItem[],
+            },
+          } as Pool),
+          isLoading$: of(false),
+        }),
+        mockProvider(PoolManagerStore, {
+          topology$: of({
+            [VDevType.Data]: { layout: null },
+          } as PoolManagerTopology),
+          getInventoryForStep: jest.fn(() => of(fakeInventory)),
+        }),
+      ],
+    });
+
+    it('locks dedup layout to match the existing pool data layout', () => {
+      spectator = createComponentExistingData();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+      expect(layoutComponent.canChangeLayout).toBeFalsy();
+    });
   });
 
   describe('when pool has existing dedup vdevs', () => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -139,6 +139,12 @@ describe('DedupWizardStepComponent', () => {
       const store = spectator.inject(PoolManagerStore);
       expect(store.resetStep).toHaveBeenCalledWith(VDevType.Dedup);
     });
+
+    it('keeps the allowed layouts locked to the lock after the reset', () => {
+      spectator = createComponent();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+    });
   });
 
   describe('when the current store layout matches the lock', () => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -4,6 +4,7 @@ import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
+import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { DedupWizardStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component';
 import { PoolManagerStore, PoolManagerTopology } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
@@ -38,6 +39,10 @@ describe('DedupWizardStepComponent', () => {
     ],
     providers: [
       mockProvider(CdkStepper),
+      mockProvider(AddVdevsStore, {
+        pool$: of(null),
+        isLoading$: of(false),
+      }),
       mockProvider(PoolManagerStore, {
         topology$: of({
           [VDevType.Data]: { layout: CreateVdevLayout.Raidz1 },

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -10,6 +10,7 @@ import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { DedupWizardStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component';
 import { PoolManagerStore, PoolManagerTopology } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
+import { nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 describe('DedupWizardStepComponent', () => {
   let spectator: Spectator<DedupWizardStepComponent>;
@@ -62,7 +63,7 @@ describe('DedupWizardStepComponent', () => {
     expect(layoutComponent.description).toBe(helptextPoolCreation.dedupVdevDescription);
     expect(layoutComponent.canChangeLayout).toBeTruthy();
     expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror, CreateVdevLayout.Stripe]);
+    expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     expect(layoutComponent.type).toStrictEqual(VDevType.Dedup);
   });
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -82,7 +82,7 @@ describe('DedupWizardStepComponent', () => {
     it('locks dedup layout to match the wizard data layout', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(false);
     });
   });
 
@@ -92,7 +92,7 @@ describe('DedupWizardStepComponent', () => {
     it('allows any non-dRAID layout', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(true);
       expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     });
   });
@@ -104,7 +104,7 @@ describe('DedupWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(false);
     });
   });
 
@@ -124,7 +124,7 @@ describe('DedupWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(false);
     });
   });
 
@@ -170,7 +170,7 @@ describe('DedupWizardStepComponent', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.canChangeLayout).toBe(false);
     });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -1,5 +1,7 @@
 import { CdkStepper } from '@angular/cdk/stepper';
-import { mockProvider, Spectator, createComponentFactory } from '@ngneat/spectator/jest';
+import {
+  mockProvider, Spectator, SpectatorFactory, createComponentFactory,
+} from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
@@ -34,7 +36,13 @@ describe('DedupWizardStepComponent', () => {
     },
   ];
 
-  const createComponent = createComponentFactory({
+  const makeFactory = ({
+    pool = null,
+    dataLayout = null,
+  }: {
+    pool?: Partial<Pool> | null;
+    dataLayout?: CreateVdevLayout | null;
+  } = {}): SpectatorFactory<DedupWizardStepComponent> => createComponentFactory({
     component: DedupWizardStepComponent,
     declarations: [
       MockComponent(LayoutStepComponent),
@@ -42,59 +50,32 @@ describe('DedupWizardStepComponent', () => {
     providers: [
       mockProvider(CdkStepper),
       mockProvider(AddVdevsStore, {
-        pool$: of(null),
+        pool$: of(pool as Pool | null),
         isLoading$: of(false),
       }),
       mockProvider(PoolManagerStore, {
         topology$: of({
-          [VDevType.Data]: { layout: CreateVdevLayout.Raidz1 },
+          [VDevType.Data]: { layout: dataLayout },
         } as PoolManagerTopology),
         getInventoryForStep: jest.fn(() => of(fakeInventory)),
       }),
     ],
   });
 
-  beforeEach(() => {
-    spectator = createComponent();
-  });
-
-  it('has the correct inputs', () => {
-    const layoutComponent = spectator.query(LayoutStepComponent)!;
-    expect(layoutComponent.description).toBe(helptextPoolCreation.dedupVdevDescription);
-    expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
-    expect(layoutComponent.type).toStrictEqual(VDevType.Dedup);
-  });
-
-  describe('when creating a new pool without a data layout chosen yet', () => {
-    const createComponentNoLayout = createComponentFactory({
-      component: DedupWizardStepComponent,
-      declarations: [
-        MockComponent(LayoutStepComponent),
-      ],
-      providers: [
-        mockProvider(CdkStepper),
-        mockProvider(AddVdevsStore, {
-          pool$: of(null),
-          isLoading$: of(false),
-        }),
-        mockProvider(PoolManagerStore, {
-          topology$: of({
-            [VDevType.Data]: { layout: null },
-          } as PoolManagerTopology),
-          getInventoryForStep: jest.fn(() => of(fakeInventory)),
-        }),
-      ],
-    });
-
-    it('allows any non-dRAID layout when no data layout is set', () => {
-      spectator = createComponentNoLayout();
-      const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.canChangeLayout).toBeTruthy();
-      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
-    });
-  });
-
   describe('when creating a new pool with a RAIDZ1 data layout', () => {
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1 });
+
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('has the correct inputs', () => {
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.description).toBe(helptextPoolCreation.dedupVdevDescription);
+      expect(layoutComponent.inventory).toStrictEqual([...fakeInventory]);
+      expect(layoutComponent.type).toStrictEqual(VDevType.Dedup);
+    });
+
     it('locks dedup layout to match the wizard data layout', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz1]);
@@ -102,29 +83,22 @@ describe('DedupWizardStepComponent', () => {
     });
   });
 
-  describe('when creating a new pool with a DRAID2 data layout', () => {
-    const createComponentDraid = createComponentFactory({
-      component: DedupWizardStepComponent,
-      declarations: [
-        MockComponent(LayoutStepComponent),
-      ],
-      providers: [
-        mockProvider(CdkStepper),
-        mockProvider(AddVdevsStore, {
-          pool$: of(null),
-          isLoading$: of(false),
-        }),
-        mockProvider(PoolManagerStore, {
-          topology$: of({
-            [VDevType.Data]: { layout: CreateVdevLayout.Draid2 },
-          } as PoolManagerTopology),
-          getInventoryForStep: jest.fn(() => of(fakeInventory)),
-        }),
-      ],
+  describe('when creating a new pool without a data layout chosen yet', () => {
+    const createComponent = makeFactory();
+
+    it('allows any non-dRAID layout', () => {
+      spectator = createComponent();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.canChangeLayout).toBeTruthy();
+      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
     });
+  });
+
+  describe('when creating a new pool with a DRAID2 data layout', () => {
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2 });
 
     it('locks dedup layout to the non-dRAID equivalent', () => {
-      spectator = createComponentDraid();
+      spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
       expect(layoutComponent.canChangeLayout).toBeFalsy();
@@ -132,35 +106,19 @@ describe('DedupWizardStepComponent', () => {
   });
 
   describe('when adding the first dedup vdev to an existing pool', () => {
-    const createComponentExistingData = createComponentFactory({
-      component: DedupWizardStepComponent,
-      declarations: [
-        MockComponent(LayoutStepComponent),
-      ],
-      providers: [
-        mockProvider(CdkStepper),
-        mockProvider(AddVdevsStore, {
-          pool$: of({
-            topology: {
-              [VDevType.Data]: [
-                { type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] },
-              ] as VDevItem[],
-              [VDevType.Dedup]: [] as VDevItem[],
-            },
-          } as Pool),
-          isLoading$: of(false),
-        }),
-        mockProvider(PoolManagerStore, {
-          topology$: of({
-            [VDevType.Data]: { layout: null },
-          } as PoolManagerTopology),
-          getInventoryForStep: jest.fn(() => of(fakeInventory)),
-        }),
-      ],
+    const createComponent = makeFactory({
+      pool: {
+        topology: {
+          [VDevType.Data]: [
+            { type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] },
+          ] as VDevItem[],
+          [VDevType.Dedup]: [] as VDevItem[],
+        },
+      } as Pool,
     });
 
     it('locks dedup layout to match the existing pool data layout', () => {
-      spectator = createComponentExistingData();
+      spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
       expect(layoutComponent.canChangeLayout).toBeFalsy();
@@ -168,34 +126,19 @@ describe('DedupWizardStepComponent', () => {
   });
 
   describe('when pool has existing dedup vdevs', () => {
-    const createComponentWithPool = createComponentFactory({
-      component: DedupWizardStepComponent,
-      declarations: [
-        MockComponent(LayoutStepComponent),
-      ],
-      providers: [
-        mockProvider(CdkStepper),
-        mockProvider(AddVdevsStore, {
-          pool$: of({
-            topology: {
-              [VDevType.Dedup]: [
-                { type: TopologyItemType.Mirror, children: [{}, {}] },
-              ] as VDevItem[],
-            },
-          } as Pool),
-          isLoading$: of(false),
-        }),
-        mockProvider(PoolManagerStore, {
-          topology$: of({
-            [VDevType.Data]: { layout: CreateVdevLayout.Raidz1 },
-          } as PoolManagerTopology),
-          getInventoryForStep: jest.fn(() => of(fakeInventory)),
-        }),
-      ],
+    const createComponent = makeFactory({
+      pool: {
+        topology: {
+          [VDevType.Dedup]: [
+            { type: TopologyItemType.Mirror, children: [{}, {}] },
+          ] as VDevItem[],
+        },
+      } as Pool,
+      dataLayout: CreateVdevLayout.Raidz1,
     });
 
     it('locks layout to match existing vdev layout', () => {
-      spectator = createComponentWithPool();
+      spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
       expect(layoutComponent.canChangeLayout).toBeFalsy();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -50,11 +50,11 @@ export class DedupWizardStepComponent implements OnInit {
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
   protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
 
-  goToReviewStep(): void {
+  protected goToReviewStep(): void {
     this.goToLastStep.emit();
   }
 
-  resetStep(): void {
+  protected resetStep(): void {
     this.store.resetStep(VDevType.Dedup);
   }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -3,12 +3,13 @@ import { ChangeDetectionStrategy, Component, input, output, inject } from '@angu
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
+import { VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
+import { nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-dedup-wizard-step',
@@ -39,7 +40,7 @@ export class DedupWizardStepComponent {
   readonly helptext = helptextPoolCreation;
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
-  protected allowedLayouts = [CreateVdevLayout.Mirror, CreateVdevLayout.Stripe];
+  protected allowedLayouts = nonDraidLayouts;
 
   goToReviewStep(): void {
     this.goToLastStep.emit();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -13,7 +13,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { lockedParityLayout$, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { nonDraidLayouts, parityLock$ } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-dedup-wizard-step',
@@ -46,6 +46,7 @@ export class DedupWizardStepComponent implements OnInit {
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
   protected allowedLayouts: readonly CreateVdevLayout[] = nonDraidLayouts;
+  protected minMirrorWidth = 2;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -56,10 +57,11 @@ export class DedupWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup)
+    parityLock$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup)
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((lockedLayout) => {
-        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : nonDraidLayouts;
+      .subscribe((lock) => {
+        this.allowedLayouts = lock.allowedLayouts;
+        this.minMirrorWidth = lock.minMirrorWidth;
         this.cdr.markForCheck();
       });
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -42,7 +42,7 @@ export class DedupWizardStepComponent implements OnInit {
 
   readonly goToLastStep = output();
 
-  canChangeLayout = true;
+  protected canChangeLayout = true;
 
   protected readonly vDevType = VDevType;
   readonly helptext = helptextPoolCreation;

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -59,11 +59,8 @@ export class DedupWizardStepComponent implements OnInit {
   ngOnInit(): void {
     lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup)
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(({ lockedLayout, currentLayout }) => {
+      .subscribe(({ lockedLayout }) => {
         this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : this.allAllowedLayouts;
-        if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
-          this.store.resetStep(VDevType.Dedup);
-        }
         this.cdr.markForCheck();
       });
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -6,7 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { combineLatest, distinctUntilChanged, map } from 'rxjs';
+import { take } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -14,7 +14,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { nonDraidLayouts, resolveSpecialLayoutLock } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { lockedSpecialLayout$, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-dedup-wizard-step',
@@ -42,8 +42,6 @@ export class DedupWizardStepComponent implements OnInit {
 
   readonly goToLastStep = output();
 
-  protected canChangeLayout = true;
-
   protected readonly vDevType = VDevType;
   protected readonly helptext = helptextPoolCreation;
 
@@ -59,23 +57,21 @@ export class DedupWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    combineLatest([this.addVdevsStore.pool$, this.store.topology$]).pipe(
-      map(([pool, topology]) => resolveSpecialLayoutLock(
-        pool?.topology[VDevType.Dedup],
-        pool?.topology[VDevType.Data],
-        topology[VDevType.Data]?.layout,
-      )),
-      distinctUntilChanged(),
+    lockedSpecialLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup).pipe(
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((layout) => {
-      if (!layout) {
-        this.allowedLayouts = [...nonDraidLayouts];
-        this.canChangeLayout = true;
-      } else {
-        this.allowedLayouts = [layout];
-        this.canChangeLayout = false;
-      }
+      this.allowedLayouts = layout ? [layout] : [...nonDraidLayouts];
+      this.resetIfCurrentLayoutNotAllowed();
       this.cdr.markForCheck();
+    });
+  }
+
+  private resetIfCurrentLayoutNotAllowed(): void {
+    this.store.topology$.pipe(take(1)).subscribe((topology) => {
+      const currentLayout = topology[VDevType.Dedup]?.layout;
+      if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
+        this.store.resetStep(VDevType.Dedup);
+      }
     });
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -6,7 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { take } from 'rxjs';
+import { withLatestFrom } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -58,20 +58,15 @@ export class DedupWizardStepComponent implements OnInit {
 
   ngOnInit(): void {
     lockedSpecialLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup).pipe(
+      withLatestFrom(this.store.topology$),
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe((layout) => {
-      this.allowedLayouts = layout ? [layout] : [...nonDraidLayouts];
-      this.resetIfCurrentLayoutNotAllowed();
-      this.cdr.markForCheck();
-    });
-  }
-
-  private resetIfCurrentLayoutNotAllowed(): void {
-    this.store.topology$.pipe(take(1)).subscribe((topology) => {
+    ).subscribe(([layout, topology]) => {
+      this.allowedLayouts = layout !== null ? [layout] : [...nonDraidLayouts];
       const currentLayout = topology[VDevType.Dedup]?.layout;
       if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
         this.store.resetStep(VDevType.Dedup);
       }
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -7,7 +7,7 @@ import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
 import { map } from 'rxjs';
-import { VDevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { TestDirective } from 'app/modules/test-id/test.directive';
@@ -48,7 +48,7 @@ export class DedupWizardStepComponent implements OnInit {
   readonly helptext = helptextPoolCreation;
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
-  protected allowedLayouts = nonDraidLayouts;
+  protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
 
   goToReviewStep(): void {
     this.goToLastStep.emit();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -1,15 +1,20 @@
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, output, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, input, OnInit, output, inject,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
+import { map } from 'rxjs';
 import { VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { TestDirective } from 'app/modules/test-id/test.directive';
+import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { existingVdevLayout, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-dedup-wizard-step',
@@ -26,8 +31,11 @@ import { nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/to
     AsyncPipe,
   ],
 })
-export class DedupWizardStepComponent {
+export class DedupWizardStepComponent implements OnInit {
+  private addVdevsStore = inject(AddVdevsStore);
   private store = inject(PoolManagerStore);
+  private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   readonly isStepActive = input<boolean>(false);
   readonly stepWarning = input<string | null>();
@@ -48,5 +56,19 @@ export class DedupWizardStepComponent {
 
   resetStep(): void {
     this.store.resetStep(VDevType.Dedup);
+  }
+
+  ngOnInit(): void {
+    this.addVdevsStore.pool$.pipe(
+      map((pool) => existingVdevLayout(pool?.topology[VDevType.Dedup])),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((layout) => {
+      if (!layout) {
+        return;
+      }
+      this.allowedLayouts = [layout];
+      this.canChangeLayout = false;
+      this.cdr.markForCheck();
+    });
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -46,7 +46,6 @@ export class DedupWizardStepComponent implements OnInit {
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
   protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
-  protected canChangeLayout = true;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -61,7 +60,6 @@ export class DedupWizardStepComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ lockedLayout, currentLayout }) => {
         this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : [...nonDraidLayouts];
-        this.canChangeLayout = lockedLayout === null;
         if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
           this.store.resetStep(VDevType.Dedup);
         }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -6,7 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { map } from 'rxjs';
+import { combineLatest, map } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -14,7 +14,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { existingVdevLayout, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { nonDraidLayouts, resolveSpecialLayoutLock } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-dedup-wizard-step',
@@ -59,15 +59,21 @@ export class DedupWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.addVdevsStore.pool$.pipe(
-      map((pool) => existingVdevLayout(pool?.topology[VDevType.Dedup])),
+    combineLatest([this.addVdevsStore.pool$, this.store.topology$]).pipe(
+      map(([pool, topology]) => resolveSpecialLayoutLock(
+        pool?.topology[VDevType.Dedup],
+        pool?.topology[VDevType.Data],
+        topology[VDevType.Data]?.layout,
+      )),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((layout) => {
       if (!layout) {
-        return;
+        this.allowedLayouts = [...nonDraidLayouts];
+        this.canChangeLayout = true;
+      } else {
+        this.allowedLayouts = [layout];
+        this.canChangeLayout = false;
       }
-      this.allowedLayouts = [layout];
-      this.canChangeLayout = false;
       this.cdr.markForCheck();
     });
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -6,7 +6,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { withLatestFrom } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -14,7 +13,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { lockedSpecialLayout$, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { lockedParityLayout$, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-dedup-wizard-step',
@@ -47,6 +46,7 @@ export class DedupWizardStepComponent implements OnInit {
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
   protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
+  protected canChangeLayout = true;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -57,16 +57,15 @@ export class DedupWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    lockedSpecialLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup).pipe(
-      withLatestFrom(this.store.topology$),
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe(([layout, topology]) => {
-      this.allowedLayouts = layout !== null ? [layout] : [...nonDraidLayouts];
-      const currentLayout = topology[VDevType.Dedup]?.layout;
-      if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
-        this.store.resetStep(VDevType.Dedup);
-      }
-      this.cdr.markForCheck();
-    });
+    lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(({ lockedLayout, currentLayout }) => {
+        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : [...nonDraidLayouts];
+        this.canChangeLayout = lockedLayout === null;
+        if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
+          this.store.resetStep(VDevType.Dedup);
+        }
+        this.cdr.markForCheck();
+      });
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -14,7 +14,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { existingVdevLayout, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { existingVdevLayout } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-dedup-wizard-step',
@@ -48,7 +48,7 @@ export class DedupWizardStepComponent implements OnInit {
   readonly helptext = helptextPoolCreation;
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
-  protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
+  protected allowedLayouts: CreateVdevLayout[] = [CreateVdevLayout.Mirror, CreateVdevLayout.Stripe];
 
   goToReviewStep(): void {
     this.goToLastStep.emit();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -14,7 +14,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AddVdevsStore } from 'app/pages/storage/modules/pool-manager/components/add-vdevs/store/add-vdevs-store.service';
 import { LayoutStepComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/layout-step.component';
 import { PoolManagerStore } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
-import { existingVdevLayout } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import { existingVdevLayout, nonDraidLayouts } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 @Component({
   selector: 'ix-dedup-wizard-step',
@@ -45,10 +45,10 @@ export class DedupWizardStepComponent implements OnInit {
   protected canChangeLayout = true;
 
   protected readonly vDevType = VDevType;
-  readonly helptext = helptextPoolCreation;
+  protected readonly helptext = helptextPoolCreation;
 
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
-  protected allowedLayouts: CreateVdevLayout[] = [CreateVdevLayout.Mirror, CreateVdevLayout.Stripe];
+  protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
 
   goToReviewStep(): void {
     this.goToLastStep.emit();

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -44,9 +44,8 @@ export class DedupWizardStepComponent implements OnInit {
   protected readonly vDevType = VDevType;
   protected readonly helptext = helptextPoolCreation;
 
-  private readonly allAllowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
-  protected allowedLayouts: CreateVdevLayout[] = this.allAllowedLayouts;
+  protected allowedLayouts: readonly CreateVdevLayout[] = nonDraidLayouts;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -60,7 +59,7 @@ export class DedupWizardStepComponent implements OnInit {
     lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((lockedLayout) => {
-        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : this.allAllowedLayouts;
+        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : nonDraidLayouts;
         this.cdr.markForCheck();
       });
   }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -44,8 +44,9 @@ export class DedupWizardStepComponent implements OnInit {
   protected readonly vDevType = VDevType;
   protected readonly helptext = helptextPoolCreation;
 
+  private readonly allAllowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
   protected readonly inventory$ = this.store.getInventoryForStep(VDevType.Dedup);
-  protected allowedLayouts: CreateVdevLayout[] = [...nonDraidLayouts];
+  protected allowedLayouts: CreateVdevLayout[] = this.allAllowedLayouts;
 
   protected goToReviewStep(): void {
     this.goToLastStep.emit();
@@ -59,7 +60,7 @@ export class DedupWizardStepComponent implements OnInit {
     lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ lockedLayout, currentLayout }) => {
-        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : [...nonDraidLayouts];
+        this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : this.allAllowedLayouts;
         if (currentLayout && !this.allowedLayouts.includes(currentLayout)) {
           this.store.resetStep(VDevType.Dedup);
         }

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -59,7 +59,7 @@ export class DedupWizardStepComponent implements OnInit {
   ngOnInit(): void {
     lockedParityLayout$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup)
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(({ lockedLayout }) => {
+      .subscribe((lockedLayout) => {
         this.allowedLayouts = lockedLayout !== null ? [lockedLayout] : this.allAllowedLayouts;
         this.cdr.markForCheck();
       });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -6,7 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { TranslateModule } from '@ngx-translate/core';
-import { combineLatest, map } from 'rxjs';
+import { combineLatest, distinctUntilChanged, map } from 'rxjs';
 import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -65,6 +65,7 @@ export class DedupWizardStepComponent implements OnInit {
         pool?.topology[VDevType.Data],
         topology[VDevType.Data]?.layout,
       )),
+      distinctUntilChanged(),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((layout) => {
       if (!layout) {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/add-vdev-to-pool.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/add-vdev-to-pool.spec.ts
@@ -259,7 +259,6 @@ describe('AddVdevsComponent – Add Vdev to existing pool', () => {
       1,
       {
         topology: {
-          cache: [],
           data: [
             { type: TopologyItemType.Mirror, disks: ['sda3', 'sda0'] },
           ],
@@ -270,7 +269,6 @@ describe('AddVdevsComponent – Add Vdev to existing pool', () => {
             { type: TopologyItemType.Stripe, disks: ['sda1'] },
           ],
           spares: ['sda2'],
-          special: [],
         },
         allow_duplicate_serials: false,
       },

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/draid-pool-creation.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/draid-pool-creation.spec.ts
@@ -180,11 +180,6 @@ describe('PoolManagerComponent – creating dRAID pool', () => {
             draid_spare_disks: 1,
           },
         ],
-        cache: [],
-        dedup: [],
-        spares: [],
-        log: [],
-        special: [],
       },
     }]);
   });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/step-changing.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/step-changing.spec.ts
@@ -166,16 +166,16 @@ describe('PoolManagerComponent – step changing', () => {
       'Number of VDEVs': '1',
     });
 
-    // Setting the data layout parity-locks metadata/dedup, so their layouts
-    // get auto-synced via the shared lockedParityLayout$ subscription — that's
-    // why Special and Dedup appear before Data here even though the user only
-    // touched the Data step.
+    // Stripe data has no redundancy, so the parity lock for metadata/dedup is
+    // unconstrained — it admits every non-dRAID layout, so AutomatedDiskSelection
+    // can't auto-pick one. Special and Dedup therefore stay unmoved until the
+    // user actually visits those steps.
     expect(store.state().categorySequence).toEqual([
       VDevType.Log,
-      VDevType.Spare,
-      VDevType.Cache,
       VDevType.Special,
       VDevType.Dedup,
+      VDevType.Spare,
+      VDevType.Cache,
       VDevType.Data,
     ]);
 
@@ -188,10 +188,10 @@ describe('PoolManagerComponent – step changing', () => {
     });
 
     expect(store.state().categorySequence).toEqual([
-      VDevType.Spare,
-      VDevType.Cache,
       VDevType.Special,
       VDevType.Dedup,
+      VDevType.Spare,
+      VDevType.Cache,
       VDevType.Data,
       VDevType.Log,
     ]);
@@ -204,9 +204,9 @@ describe('PoolManagerComponent – step changing', () => {
     });
 
     expect(store.state().categorySequence).toEqual([
-      VDevType.Cache,
       VDevType.Special,
       VDevType.Dedup,
+      VDevType.Cache,
       VDevType.Data,
       VDevType.Log,
       VDevType.Spare,

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/step-changing.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager/tests/step-changing.spec.ts
@@ -166,12 +166,16 @@ describe('PoolManagerComponent – step changing', () => {
       'Number of VDEVs': '1',
     });
 
+    // Setting the data layout parity-locks metadata/dedup, so their layouts
+    // get auto-synced via the shared lockedParityLayout$ subscription — that's
+    // why Special and Dedup appear before Data here even though the user only
+    // touched the Data step.
     expect(store.state().categorySequence).toEqual([
       VDevType.Log,
-      VDevType.Special,
-      VDevType.Dedup,
       VDevType.Spare,
       VDevType.Cache,
+      VDevType.Special,
+      VDevType.Dedup,
       VDevType.Data,
     ]);
 
@@ -184,10 +188,10 @@ describe('PoolManagerComponent – step changing', () => {
     });
 
     expect(store.state().categorySequence).toEqual([
-      VDevType.Special,
-      VDevType.Dedup,
       VDevType.Spare,
       VDevType.Cache,
+      VDevType.Special,
+      VDevType.Dedup,
       VDevType.Data,
       VDevType.Log,
     ]);
@@ -200,9 +204,9 @@ describe('PoolManagerComponent – step changing', () => {
     });
 
     expect(store.state().categorySequence).toEqual([
+      VDevType.Cache,
       VDevType.Special,
       VDevType.Dedup,
-      VDevType.Cache,
       VDevType.Data,
       VDevType.Log,
       VDevType.Spare,

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -599,7 +599,7 @@ describe('PoolManagerValidationService', () => {
         expect(errors).toContainEqual({
           severity: PoolCreationSeverity.Error,
           step: PoolCreationWizardStep.Metadata,
-          text: 'metadata VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
+          text: 'Metadata VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
         });
       });
     });
@@ -634,7 +634,7 @@ describe('PoolManagerValidationService', () => {
         expect(errors).toContainEqual({
           severity: PoolCreationSeverity.Error,
           step: PoolCreationWizardStep.Dedup,
-          text: 'dedup VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
+          text: 'Dedup VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
         });
       });
     });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -599,7 +599,7 @@ describe('PoolManagerValidationService', () => {
         expect(errors).toContainEqual({
           severity: PoolCreationSeverity.Error,
           step: PoolCreationWizardStep.Metadata,
-          text: 'Metadata VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
+          text: 'Metadata VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.',
         });
       });
     });
@@ -634,7 +634,7 @@ describe('PoolManagerValidationService', () => {
         expect(errors).toContainEqual({
           severity: PoolCreationSeverity.Error,
           step: PoolCreationWizardStep.Dedup,
-          text: 'Dedup VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
+          text: 'Dedup VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.',
         });
       });
     });
@@ -668,7 +668,7 @@ describe('PoolManagerValidationService', () => {
         expect(errors).toContainEqual({
           severity: PoolCreationSeverity.Error,
           step: PoolCreationWizardStep.Metadata,
-          text: 'Metadata VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
+          text: 'Metadata VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.',
         });
       });
     });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -545,4 +545,129 @@ describe('PoolManagerValidationService', () => {
       });
     });
   });
+
+  describe('incomplete optional category validation', () => {
+    const emptyCategory: Partial<PoolManagerTopologyCategory> = { vdevs: [], diskSize: null, layout: null };
+    const dataCategory: Partial<PoolManagerTopologyCategory> = {
+      vdevs: [[{}]] as PoolManagerTopologyCategory['vdevs'],
+      layout: CreateVdevLayout.Raidz2,
+    };
+
+    const sharedProviders = [
+      mockProvider(AddVdevsStore, { pool$: of(null) }),
+      provideMockStore({
+        selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+      }),
+    ];
+    const sharedStoreMock = {
+      name$: of('Pool'),
+      nameErrors$: of(null),
+      enclosureSettings$: of({
+        limitToSingleEnclosure: null,
+        dispersalStrategy: DispersalStrategy.None,
+      }),
+      hasMultipleEnclosuresAfterFirstStep$: of(false),
+    };
+
+    describe('when user picked a disk size for metadata but width was cleared', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: dataCategory,
+              [VDevType.Special]: {
+                ...emptyCategory,
+                diskSize: 12000138625024,
+                layout: CreateVdevLayout.Raidz2,
+                vdevs: [],
+              },
+            }),
+          }),
+          ...sharedProviders,
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('flags metadata step', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Error,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'metadata VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
+        });
+      });
+    });
+
+    describe('when user picked a disk size for dedup but width was cleared', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: dataCategory,
+              [VDevType.Dedup]: {
+                ...emptyCategory,
+                diskSize: 12000138625024,
+                layout: CreateVdevLayout.Raidz2,
+                vdevs: [],
+              },
+            }),
+          }),
+          ...sharedProviders,
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('flags dedup step', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Error,
+          step: PoolCreationWizardStep.Dedup,
+          text: 'dedup VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
+        });
+      });
+    });
+
+    describe('when optional categories were never configured', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: dataCategory,
+              [VDevType.Log]: emptyCategory,
+              [VDevType.Spare]: emptyCategory,
+              [VDevType.Cache]: emptyCategory,
+              [VDevType.Special]: emptyCategory,
+              [VDevType.Dedup]: emptyCategory,
+            }),
+          }),
+          ...sharedProviders,
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('does not flag any incomplete errors', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        const incompleteErrors = errors.filter((err) => err.text.includes('configuration is incomplete'));
+        expect(incompleteErrors).toEqual([]);
+      });
+    });
+  });
 });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -639,6 +639,40 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
+    describe('when user toggled treatDiskSizeAsMinimum on metadata but nothing else', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: dataCategory,
+              [VDevType.Special]: {
+                ...emptyCategory,
+                treatDiskSizeAsMinimum: true,
+                vdevs: [],
+              },
+            }),
+          }),
+          ...sharedProviders,
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('flags metadata step', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Error,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'Metadata VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.',
+        });
+      });
+    });
+
     describe('when user picked a width for metadata but diskSize was never set', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -639,6 +639,40 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
+    describe('when user picked a width for metadata but diskSize was never set', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: dataCategory,
+              [VDevType.Special]: {
+                ...emptyCategory,
+                width: 2,
+                vdevs: [],
+              },
+            }),
+          }),
+          ...sharedProviders,
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('flags metadata step even without a disk size', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Error,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'Metadata VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
+        });
+      });
+    });
+
     describe('when optional categories were never configured', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -673,6 +673,44 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
+    describe.each([
+      [VDevType.Log, PoolCreationWizardStep.Log, 'Log'],
+      [VDevType.Spare, PoolCreationWizardStep.Spare, 'Spare'],
+      [VDevType.Cache, PoolCreationWizardStep.Cache, 'Cache'],
+    ])('when %s category is partially configured', (vdevType, step, label) => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: dataCategory,
+              [vdevType]: {
+                ...emptyCategory,
+                diskSize: 12000138625024,
+                vdevs: [],
+              },
+            }),
+          }),
+          ...sharedProviders,
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it(`flags ${label} step`, async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Error,
+          step,
+          text: `${label} VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.`,
+        });
+      });
+    });
+
     describe('when optional categories were never configured', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -397,23 +397,7 @@ describe('PoolManagerValidationService', () => {
       [VDevType.Special]: {
         hasCustomDiskSelection: false,
         layout: CreateVdevLayout.Stripe,
-        vdevs: [
-          [
-            {
-              identifier: '{serial_lunid}8HG29G5H_5000cca2700430f8',
-              name: 'sdc',
-              subsystem: 'scsi',
-              number: 2080,
-              serial: '8HG29G5H',
-              lunid: '5000cca2700430f8',
-              enclosure: {
-                number: 0,
-                slot: 1,
-              },
-              devname: 'sdc',
-            },
-          ],
-        ],
+        vdevs: [[{ devname: 'sdc' }]],
       },
     });
     const mockEnclosureSettings$ = of({
@@ -476,23 +460,7 @@ describe('PoolManagerValidationService', () => {
       [VDevType.Dedup]: {
         hasCustomDiskSelection: false,
         layout: CreateVdevLayout.Stripe,
-        vdevs: [
-          [
-            {
-              identifier: '{serial_lunid}8HG29G5H_5000cca2700430f8',
-              name: 'sdc',
-              subsystem: 'scsi',
-              number: 2080,
-              serial: '8HG29G5H',
-              lunid: '5000cca2700430f8',
-              enclosure: {
-                number: 0,
-                slot: 1,
-              },
-              devname: 'sdc',
-            },
-          ],
-        ],
+        vdevs: [[{ devname: 'sdc' }]],
       },
     });
     const mockEnclosureSettings$ = of({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -31,6 +31,14 @@ import { isDraidLayout } from 'app/pages/storage/modules/pool-manager/utils/topo
 import { AppState } from 'app/store';
 import { selectHasEnclosureSupport } from 'app/store/system-info/system-info.selectors';
 
+const incompleteCategoryRules: { vdevType: VDevType; step: PoolCreationWizardStep }[] = [
+  { vdevType: VDevType.Log, step: PoolCreationWizardStep.Log },
+  { vdevType: VDevType.Spare, step: PoolCreationWizardStep.Spare },
+  { vdevType: VDevType.Cache, step: PoolCreationWizardStep.Cache },
+  { vdevType: VDevType.Special, step: PoolCreationWizardStep.Metadata },
+  { vdevType: VDevType.Dedup, step: PoolCreationWizardStep.Dedup },
+];
+
 @Injectable()
 export class PoolManagerValidationService {
   protected store = inject(PoolManagerStore);
@@ -313,13 +321,6 @@ export class PoolManagerValidationService {
    * error indicator even though the form inside the step is invalid.
    */
   private validateIncompleteCategories(topology: PoolManagerTopology): PoolCreationError[] {
-    const incompleteCategoryRules: { vdevType: VDevType; step: PoolCreationWizardStep }[] = [
-      { vdevType: VDevType.Log, step: PoolCreationWizardStep.Log },
-      { vdevType: VDevType.Spare, step: PoolCreationWizardStep.Spare },
-      { vdevType: VDevType.Cache, step: PoolCreationWizardStep.Cache },
-      { vdevType: VDevType.Special, step: PoolCreationWizardStep.Metadata },
-      { vdevType: VDevType.Dedup, step: PoolCreationWizardStep.Dedup },
-    ];
     const messageTemplate = T('{vdevType} VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.');
 
     const errors: PoolCreationError[] = [];
@@ -357,7 +358,8 @@ export class PoolManagerValidationService {
       || category.width != null
       || category.vdevsNumber != null
       || category.draidDataDisks != null
-      || category.draidSpareDisks != null;
+      || category.draidSpareDisks != null
+      || category.treatDiskSizeAsMinimum === true;
   }
 
   private validateAddVdevRedundancy(

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -107,6 +107,7 @@ export class PoolManagerValidationService {
       errors.push(...this.validateDuplicateSerialDiskVdevs(topologyCategory));
       errors.push(...this.validateExportedPoolDiskVdevs(topologyCategory));
     });
+    errors.push(...this.validateIncompleteCategories(topology));
     return errors;
   }
 
@@ -299,6 +300,44 @@ export class PoolManagerValidationService {
       errors.push(...this.validateAddVdevRedundancy(topologyCategory, topologyCategoryType));
     });
 
+    errors.push(...this.validateIncompleteCategories(topology));
+
+    return errors;
+  }
+
+  /**
+   * Flags an optional category that the user has partially configured (picked
+   * a disk size) but that currently has no vdevs. The typical trigger is the
+   * data-parity lock changing the metadata/dedup layout, which invalidates a
+   * previously picked width and clears the category's vdevs. Without this,
+   * the Review step silently omits the category and the step header shows no
+   * error indicator even though the form inside the step is invalid.
+   */
+  private validateIncompleteCategories(topology: PoolManagerTopology): PoolCreationError[] {
+    const optionalCategoryToStep: Partial<Record<VDevType, PoolCreationWizardStep>> = {
+      [VDevType.Log]: PoolCreationWizardStep.Log,
+      [VDevType.Spare]: PoolCreationWizardStep.Spare,
+      [VDevType.Cache]: PoolCreationWizardStep.Cache,
+      [VDevType.Special]: PoolCreationWizardStep.Metadata,
+      [VDevType.Dedup]: PoolCreationWizardStep.Dedup,
+    };
+
+    const errors: PoolCreationError[] = [];
+    Object.entries(optionalCategoryToStep).forEach(([vdevType, step]) => {
+      const category = topology[vdevType as VDevType];
+      const startedConfiguring = category?.diskSize !== null && category?.diskSize !== undefined;
+      const hasNoVdevs = !category?.vdevs?.length;
+      if (startedConfiguring && hasNoVdevs) {
+        errors.push({
+          text: this.translate.instant(
+            '{step} VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
+            { step: step as string },
+          ),
+          severity: PoolCreationSeverity.Error,
+          step,
+        });
+      }
+    });
     return errors;
   }
 

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -316,37 +316,17 @@ export class PoolManagerValidationService {
     const incompleteCategoryRules: {
       vdevType: VDevType;
       step: PoolCreationWizardStep;
-      text: string;
+      name: string;
     }[] = [
-      {
-        vdevType: VDevType.Log,
-        step: PoolCreationWizardStep.Log,
-        text: T('Log VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
-      {
-        vdevType: VDevType.Spare,
-        step: PoolCreationWizardStep.Spare,
-        text: T('Spare VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
-      {
-        vdevType: VDevType.Cache,
-        step: PoolCreationWizardStep.Cache,
-        text: T('Cache VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
-      {
-        vdevType: VDevType.Special,
-        step: PoolCreationWizardStep.Metadata,
-        text: T('Metadata VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
-      {
-        vdevType: VDevType.Dedup,
-        step: PoolCreationWizardStep.Dedup,
-        text: T('Dedup VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
+      { vdevType: VDevType.Log, step: PoolCreationWizardStep.Log, name: T('Log') },
+      { vdevType: VDevType.Spare, step: PoolCreationWizardStep.Spare, name: T('Spare') },
+      { vdevType: VDevType.Cache, step: PoolCreationWizardStep.Cache, name: T('Cache') },
+      { vdevType: VDevType.Special, step: PoolCreationWizardStep.Metadata, name: T('Metadata') },
+      { vdevType: VDevType.Dedup, step: PoolCreationWizardStep.Dedup, name: T('Dedup') },
     ];
 
     const errors: PoolCreationError[] = [];
-    incompleteCategoryRules.forEach(({ vdevType, step, text }) => {
+    incompleteCategoryRules.forEach(({ vdevType, step, name }) => {
       const category = topology[vdevType];
       if (!category) {
         return;
@@ -354,7 +334,10 @@ export class PoolManagerValidationService {
       const hasNoVdevs = !category.vdevs?.length;
       if (hasNoVdevs && this.isCategoryPartiallyConfigured(category)) {
         errors.push({
-          text: this.translate.instant(text),
+          text: this.translate.instant(
+            T('{name} VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
+            { name: this.translate.instant(name) },
+          ),
           severity: PoolCreationSeverity.Error,
           step,
         });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -352,7 +352,9 @@ export class PoolManagerValidationService {
    * the user engaged with the category.
    */
   private isCategoryPartiallyConfigured(category: PoolManagerTopologyCategory): boolean {
-    // `!= null` intentionally catches both null and undefined — any touched field counts.
+    // PoolManagerTopologyCategory types these fields as `T | null`, but we use
+    // `!= null` defensively so any future state that leaves a field undefined
+    // (partial fixtures, out-of-band patches) still reads as "not touched".
     return category.diskSize != null
       || category.diskType != null
       || category.width != null

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -365,9 +365,11 @@ export class PoolManagerValidationService {
 
   /**
    * True when the user has touched any of the category's configurable fields.
-   * `layout` is intentionally excluded: Spare/Cache carry a default layout of
-   * Stripe even when untouched, and layout can also be set programmatically by
-   * the data-parity lock.
+   * `layout` is intentionally excluded because it can be set programmatically:
+   * AutomatedDiskSelectionComponent auto-selects the sole choice when a
+   * category has only one allowed layout, and resetTopologyCategory preloads
+   * Stripe for Spare/Cache. A non-null layout therefore does not imply that
+   * the user engaged with the category.
    */
   private isCategoryPartiallyConfigured(category: PoolManagerTopologyCategory): boolean {
     return category.diskSize != null

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -348,9 +348,11 @@ export class PoolManagerValidationService {
     const errors: PoolCreationError[] = [];
     incompleteCategoryRules.forEach(({ vdevType, step, text }) => {
       const category = topology[vdevType];
-      const startedConfiguring = category?.diskSize !== null && category?.diskSize !== undefined;
-      const hasNoVdevs = !category?.vdevs?.length;
-      if (startedConfiguring && hasNoVdevs) {
+      if (!category) {
+        return;
+      }
+      const hasNoVdevs = !category.vdevs?.length;
+      if (hasNoVdevs && this.isCategoryPartiallyConfigured(category)) {
         errors.push({
           text: this.translate.instant(text),
           severity: PoolCreationSeverity.Error,
@@ -359,6 +361,21 @@ export class PoolManagerValidationService {
       }
     });
     return errors;
+  }
+
+  /**
+   * True when the user has touched any of the category's configurable fields.
+   * `layout` is intentionally excluded: Spare/Cache carry a default layout of
+   * Stripe even when untouched, and layout can also be set programmatically by
+   * the data-parity lock.
+   */
+  private isCategoryPartiallyConfigured(category: PoolManagerTopologyCategory): boolean {
+    return category.diskSize != null
+      || category.diskType != null
+      || category.width != null
+      || category.vdevsNumber != null
+      || category.draidDataDisks != null
+      || category.draidSpareDisks != null;
   }
 
   private validateAddVdevRedundancy(

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -5,7 +5,7 @@ import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { uniqBy } from 'lodash-es';
 import { combineLatest, map, Observable } from 'rxjs';
-import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, VDevType, vdevTypeLabels } from 'app/enums/v-dev-type.enum';
 import { helptextPoolCreation } from 'app/helptext/storage/volumes/pool-creation/pool-creation';
 import { Pool } from 'app/interfaces/pool.interface';
 import {
@@ -313,40 +313,17 @@ export class PoolManagerValidationService {
    * error indicator even though the form inside the step is invalid.
    */
   private validateIncompleteCategories(topology: PoolManagerTopology): PoolCreationError[] {
-    const incompleteCategoryRules: {
-      vdevType: VDevType;
-      step: PoolCreationWizardStep;
-      message: string;
-    }[] = [
-      {
-        vdevType: VDevType.Log,
-        step: PoolCreationWizardStep.Log,
-        message: T('Log VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
-      {
-        vdevType: VDevType.Spare,
-        step: PoolCreationWizardStep.Spare,
-        message: T('Spare VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
-      {
-        vdevType: VDevType.Cache,
-        step: PoolCreationWizardStep.Cache,
-        message: T('Cache VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
-      {
-        vdevType: VDevType.Special,
-        step: PoolCreationWizardStep.Metadata,
-        message: T('Metadata VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
-      {
-        vdevType: VDevType.Dedup,
-        step: PoolCreationWizardStep.Dedup,
-        message: T('Dedup VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-      },
+    const incompleteCategoryRules: { vdevType: VDevType; step: PoolCreationWizardStep }[] = [
+      { vdevType: VDevType.Log, step: PoolCreationWizardStep.Log },
+      { vdevType: VDevType.Spare, step: PoolCreationWizardStep.Spare },
+      { vdevType: VDevType.Cache, step: PoolCreationWizardStep.Cache },
+      { vdevType: VDevType.Special, step: PoolCreationWizardStep.Metadata },
+      { vdevType: VDevType.Dedup, step: PoolCreationWizardStep.Dedup },
     ];
+    const messageTemplate = T('{vdevType} VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.');
 
     const errors: PoolCreationError[] = [];
-    incompleteCategoryRules.forEach(({ vdevType, step, message }) => {
+    incompleteCategoryRules.forEach(({ vdevType, step }) => {
       const category = topology[vdevType];
       if (!category) {
         return;
@@ -354,7 +331,9 @@ export class PoolManagerValidationService {
       const hasNoVdevs = !category.vdevs?.length;
       if (hasNoVdevs && this.isCategoryPartiallyConfigured(category)) {
         errors.push({
-          text: this.translate.instant(message),
+          text: this.translate.instant(messageTemplate, {
+            vdevType: this.translate.instant(vdevTypeLabels.get(vdevType)),
+          }),
           severity: PoolCreationSeverity.Error,
           step,
         });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -314,11 +314,16 @@ export class PoolManagerValidationService {
 
   /**
    * Flags an optional category that the user has partially configured (picked
-   * a disk size) but that currently has no vdevs. The typical trigger is the
-   * data-parity lock changing the metadata/dedup layout, which invalidates a
-   * previously picked width and clears the category's vdevs. Without this,
-   * the Review step silently omits the category and the step header shows no
-   * error indicator even though the form inside the step is invalid.
+   * a disk size) but that currently has no vdevs. Runs in both flows:
+   *  - New pool: typical trigger is the data-parity lock changing the
+   *    metadata/dedup layout, which invalidates a previously picked width and
+   *    clears the category's vdevs.
+   *  - Add vdev to existing pool: user picks disk size / width for an optional
+   *    category (Log/Spare/Cache/Special/Dedup) and then clears it, leaving
+   *    state partially filled.
+   * Without this, the Review step silently omits the category and the step
+   * header shows no error indicator even though the form inside the step is
+   * invalid.
    */
   private validateIncompleteCategories(topology: PoolManagerTopology): PoolCreationError[] {
     const messageTemplate = T('{vdevType} VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.');
@@ -331,10 +336,9 @@ export class PoolManagerValidationService {
       }
       const hasNoVdevs = !category.vdevs?.length;
       if (hasNoVdevs && this.isCategoryPartiallyConfigured(category)) {
+        const vdevTypeLabel = this.translate.instant(vdevTypeLabels.get(vdevType) ?? vdevType);
         errors.push({
-          text: this.translate.instant(messageTemplate, {
-            vdevType: this.translate.instant(vdevTypeLabels.get(vdevType) ?? vdevType),
-          }),
+          text: this.translate.instant(messageTemplate, { vdevType: vdevTypeLabel }),
           severity: PoolCreationSeverity.Error,
           step,
         });
@@ -350,11 +354,14 @@ export class PoolManagerValidationService {
    * category has only one allowed layout, and resetTopologyCategory preloads
    * Stripe for Spare/Cache. A non-null layout therefore does not imply that
    * the user engaged with the category.
+   *
+   * We use `!= null` (matching both null and undefined) rather than `!== null`
+   * so partially-populated test fixtures — which cast `Partial<Category>` via
+   * `as` and only fill the fields under test — still register as "not touched"
+   * on unspecified fields. Production state (from the store's initialTopology)
+   * never leaves any of these fields undefined.
    */
   private isCategoryPartiallyConfigured(category: PoolManagerTopologyCategory): boolean {
-    // PoolManagerTopologyCategory types these fields as `T | null`, but we use
-    // `!= null` defensively so any future state that leaves a field undefined
-    // (partial fixtures, out-of-band patches) still reads as "not touched".
     return category.diskSize != null
       || category.diskType != null
       || category.width != null

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -316,17 +316,37 @@ export class PoolManagerValidationService {
     const incompleteCategoryRules: {
       vdevType: VDevType;
       step: PoolCreationWizardStep;
-      name: string;
+      message: string;
     }[] = [
-      { vdevType: VDevType.Log, step: PoolCreationWizardStep.Log, name: T('Log') },
-      { vdevType: VDevType.Spare, step: PoolCreationWizardStep.Spare, name: T('Spare') },
-      { vdevType: VDevType.Cache, step: PoolCreationWizardStep.Cache, name: T('Cache') },
-      { vdevType: VDevType.Special, step: PoolCreationWizardStep.Metadata, name: T('Metadata') },
-      { vdevType: VDevType.Dedup, step: PoolCreationWizardStep.Dedup, name: T('Dedup') },
+      {
+        vdevType: VDevType.Log,
+        step: PoolCreationWizardStep.Log,
+        message: T('Log VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
+      },
+      {
+        vdevType: VDevType.Spare,
+        step: PoolCreationWizardStep.Spare,
+        message: T('Spare VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
+      },
+      {
+        vdevType: VDevType.Cache,
+        step: PoolCreationWizardStep.Cache,
+        message: T('Cache VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
+      },
+      {
+        vdevType: VDevType.Special,
+        step: PoolCreationWizardStep.Metadata,
+        message: T('Metadata VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
+      },
+      {
+        vdevType: VDevType.Dedup,
+        step: PoolCreationWizardStep.Dedup,
+        message: T('Dedup VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
+      },
     ];
 
     const errors: PoolCreationError[] = [];
-    incompleteCategoryRules.forEach(({ vdevType, step, name }) => {
+    incompleteCategoryRules.forEach(({ vdevType, step, message }) => {
       const category = topology[vdevType];
       if (!category) {
         return;
@@ -334,10 +354,7 @@ export class PoolManagerValidationService {
       const hasNoVdevs = !category.vdevs?.length;
       if (hasNoVdevs && this.isCategoryPartiallyConfigured(category)) {
         errors.push({
-          text: this.translate.instant(
-            T('{name} VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
-            { name: this.translate.instant(name) },
-          ),
+          text: this.translate.instant(message),
           severity: PoolCreationSeverity.Error,
           step,
         });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -332,7 +332,7 @@ export class PoolManagerValidationService {
       if (hasNoVdevs && this.isCategoryPartiallyConfigured(category)) {
         errors.push({
           text: this.translate.instant(messageTemplate, {
-            vdevType: this.translate.instant(vdevTypeLabels.get(vdevType)),
+            vdevType: this.translate.instant(vdevTypeLabels.get(vdevType) ?? vdevType),
           }),
           severity: PoolCreationSeverity.Error,
           step,

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -321,27 +321,27 @@ export class PoolManagerValidationService {
       {
         vdevType: VDevType.Log,
         step: PoolCreationWizardStep.Log,
-        text: T('Log VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+        text: T('Log VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
       },
       {
         vdevType: VDevType.Spare,
         step: PoolCreationWizardStep.Spare,
-        text: T('Spare VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+        text: T('Spare VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
       },
       {
         vdevType: VDevType.Cache,
         step: PoolCreationWizardStep.Cache,
-        text: T('Cache VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+        text: T('Cache VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
       },
       {
         vdevType: VDevType.Special,
         step: PoolCreationWizardStep.Metadata,
-        text: T('Metadata VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+        text: T('Metadata VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
       },
       {
         vdevType: VDevType.Dedup,
         step: PoolCreationWizardStep.Dedup,
-        text: T('Dedup VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+        text: T('Dedup VDEV configuration is incomplete. Complete the layout, width and number of VDEVs.'),
       },
     ];
 

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { ValidationErrors } from '@angular/forms';
+import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { uniqBy } from 'lodash-es';
@@ -62,6 +63,7 @@ export class PoolManagerValidationService {
         } else {
           errors.push(...this.validateAddVdevs(topology));
         }
+        errors.push(...this.validateIncompleteCategories(topology));
 
         return uniqBy(errors, 'text')
           .sort((a, b) => {
@@ -107,7 +109,6 @@ export class PoolManagerValidationService {
       errors.push(...this.validateDuplicateSerialDiskVdevs(topologyCategory));
       errors.push(...this.validateExportedPoolDiskVdevs(topologyCategory));
     });
-    errors.push(...this.validateIncompleteCategories(topology));
     return errors;
   }
 
@@ -300,8 +301,6 @@ export class PoolManagerValidationService {
       errors.push(...this.validateAddVdevRedundancy(topologyCategory, topologyCategoryType));
     });
 
-    errors.push(...this.validateIncompleteCategories(topology));
-
     return errors;
   }
 
@@ -314,25 +313,46 @@ export class PoolManagerValidationService {
    * error indicator even though the form inside the step is invalid.
    */
   private validateIncompleteCategories(topology: PoolManagerTopology): PoolCreationError[] {
-    const optionalCategoryToStep: Partial<Record<VDevType, PoolCreationWizardStep>> = {
-      [VDevType.Log]: PoolCreationWizardStep.Log,
-      [VDevType.Spare]: PoolCreationWizardStep.Spare,
-      [VDevType.Cache]: PoolCreationWizardStep.Cache,
-      [VDevType.Special]: PoolCreationWizardStep.Metadata,
-      [VDevType.Dedup]: PoolCreationWizardStep.Dedup,
-    };
+    const incompleteCategoryRules: {
+      vdevType: VDevType;
+      step: PoolCreationWizardStep;
+      text: string;
+    }[] = [
+      {
+        vdevType: VDevType.Log,
+        step: PoolCreationWizardStep.Log,
+        text: T('Log VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+      },
+      {
+        vdevType: VDevType.Spare,
+        step: PoolCreationWizardStep.Spare,
+        text: T('Spare VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+      },
+      {
+        vdevType: VDevType.Cache,
+        step: PoolCreationWizardStep.Cache,
+        text: T('Cache VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+      },
+      {
+        vdevType: VDevType.Special,
+        step: PoolCreationWizardStep.Metadata,
+        text: T('Metadata VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+      },
+      {
+        vdevType: VDevType.Dedup,
+        step: PoolCreationWizardStep.Dedup,
+        text: T('Dedup VDEV configuration is incomplete. Select a valid width and number of VDEVs.'),
+      },
+    ];
 
     const errors: PoolCreationError[] = [];
-    Object.entries(optionalCategoryToStep).forEach(([vdevType, step]) => {
-      const category = topology[vdevType as VDevType];
+    incompleteCategoryRules.forEach(({ vdevType, step, text }) => {
+      const category = topology[vdevType];
       const startedConfiguring = category?.diskSize !== null && category?.diskSize !== undefined;
       const hasNoVdevs = !category?.vdevs?.length;
       if (startedConfiguring && hasNoVdevs) {
         errors.push({
-          text: this.translate.instant(
-            '{step} VDEV configuration is incomplete. Select a valid width and number of VDEVs.',
-            { step: step as string },
-          ),
+          text: this.translate.instant(text),
           severity: PoolCreationSeverity.Error,
           step,
         });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -351,6 +351,7 @@ export class PoolManagerValidationService {
    * the user engaged with the category.
    */
   private isCategoryPartiallyConfigured(category: PoolManagerTopologyCategory): boolean {
+    // `!= null` intentionally catches both null and undefined — any touched field counts.
     return category.diskSize != null
       || category.diskType != null
       || category.width != null

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
@@ -247,8 +247,8 @@ describe('PoolManagerStore', () => {
         vdevsNumber: 1,
         width: 1,
         vdevs: [[disks[2]]],
-        draidDataDisks: 0,
-        draidSpareDisks: 0,
+        draidDataDisks: null,
+        draidSpareDisks: null,
       });
     });
 

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -30,8 +30,6 @@ import {
 } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs.service';
 import {
   isDraidLayout,
-  nonDraidEquivalent,
-  nonDraidLayouts,
   topologyCategoryToDisks,
   topologyToDisks,
 } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
@@ -198,28 +196,6 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
   isUsingDraidLayout(topology: PoolManagerTopology): boolean {
     const { layout } = topology[VDevType.Data];
     return layout !== null && isDraidLayout(layout);
-  }
-
-  getLayoutsForVdevType(vdevType: VDevType): Observable<CreateVdevLayout[]> {
-    switch (vdevType) {
-      case VDevType.Cache:
-        return of([CreateVdevLayout.Stripe]);
-      // Special (metadata) and dedup vdevs don't support dRAID but should match
-      // the redundancy level of the data vdevs for data safety.
-      case VDevType.Dedup:
-      case VDevType.Special: {
-        return this.select((state) => {
-          const { layout } = state.topology[VDevType.Data];
-          return layout !== null ? [nonDraidEquivalent(layout)] : [...nonDraidLayouts];
-        });
-      }
-      case VDevType.Log:
-        return of([CreateVdevLayout.Mirror, CreateVdevLayout.Stripe]);
-      case VDevType.Spare:
-        return of([CreateVdevLayout.Stripe]);
-      default:
-        return of(Object.values(CreateVdevLayout));
-    }
   }
 
   readonly inventory$ = this.select(

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -31,6 +31,7 @@ import {
 import {
   isDraidLayout,
   nonDraidEquivalent,
+  nonDraidLayouts,
   topologyCategoryToDisks,
   topologyToDisks,
 } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
@@ -207,7 +208,7 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
       case VDevType.Special: {
         return this.select((state) => {
           const { layout } = state.topology[VDevType.Data];
-          return layout !== null ? [nonDraidEquivalent(layout)] : [];
+          return layout !== null ? [nonDraidEquivalent(layout)] : nonDraidLayouts;
         });
       }
       case VDevType.Log:

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -30,6 +30,7 @@ import {
 } from 'app/pages/storage/modules/pool-manager/utils/generate-vdevs/generate-vdevs.service';
 import {
   isDraidLayout,
+  nonDraidEquivalent,
   topologyCategoryToDisks,
   topologyToDisks,
 } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
@@ -204,13 +205,12 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
       case VDevType.Cache:
         return of([CreateVdevLayout.Stripe]);
       case VDevType.Dedup:
-        return this.select((state) => [state.topology[VDevType.Data].layout]);
+      case VDevType.Special:
+        return this.select((state) => [nonDraidEquivalent(state.topology[VDevType.Data].layout)]);
       case VDevType.Log:
         return of([CreateVdevLayout.Mirror, CreateVdevLayout.Stripe]);
       case VDevType.Spare:
         return of([CreateVdevLayout.Stripe]);
-      case VDevType.Special:
-        return this.select((state) => [state.topology[VDevType.Data].layout]);
       default:
         return of(Object.values(CreateVdevLayout));
     }

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -210,7 +210,7 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
       case VDevType.Special: {
         return this.select((state) => {
           const { layout } = state.topology[VDevType.Data];
-          return layout !== null ? [nonDraidEquivalent(layout)] : nonDraidLayouts as CreateVdevLayout[];
+          return layout !== null ? [nonDraidEquivalent(layout)] : [...nonDraidLayouts];
         });
       }
       case VDevType.Log:

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -210,7 +210,7 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
       case VDevType.Special: {
         return this.select((state) => {
           const { layout } = state.topology[VDevType.Data];
-          return layout !== null ? [nonDraidEquivalent(layout)] : [...nonDraidLayouts];
+          return layout !== null ? [nonDraidEquivalent(layout)] : nonDraidLayouts as CreateVdevLayout[];
         });
       }
       case VDevType.Log:

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -195,9 +195,8 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
   );
 
   isUsingDraidLayout(topology: PoolManagerTopology): boolean {
-    const dataCategory = topology[VDevType.Data];
-    return Boolean(dataCategory.layout
-      && [CreateVdevLayout.Draid1, CreateVdevLayout.Draid2, CreateVdevLayout.Draid3].includes(dataCategory.layout));
+    const { layout } = topology[VDevType.Data];
+    return layout !== null && isDraidLayout(layout);
   }
 
   getLayoutsForVdevType(vdevType: VDevType): Observable<CreateVdevLayout[]> {

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -204,8 +204,12 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
       case VDevType.Cache:
         return of([CreateVdevLayout.Stripe]);
       case VDevType.Dedup:
-      case VDevType.Special:
-        return this.select((state) => [nonDraidEquivalent(state.topology[VDevType.Data].layout)]);
+      case VDevType.Special: {
+        return this.select((state) => {
+          const { layout } = state.topology[VDevType.Data];
+          return layout !== null ? [nonDraidEquivalent(layout)] : [];
+        });
+      }
       case VDevType.Log:
         return of([CreateVdevLayout.Mirror, CreateVdevLayout.Stripe]);
       case VDevType.Spare:

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -204,11 +204,13 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
     switch (vdevType) {
       case VDevType.Cache:
         return of([CreateVdevLayout.Stripe]);
+      // Special (metadata) and dedup vdevs don't support dRAID but should match
+      // the redundancy level of the data vdevs for data safety.
       case VDevType.Dedup:
       case VDevType.Special: {
         return this.select((state) => {
           const { layout } = state.topology[VDevType.Data];
-          return layout !== null ? [nonDraidEquivalent(layout)] : nonDraidLayouts;
+          return layout !== null ? [nonDraidEquivalent(layout)] : [...nonDraidLayouts];
         });
       }
       case VDevType.Log:

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -95,8 +95,8 @@ const initialTopology = Object.values(VDevType).reduce((topology, value) => {
       vdevs: [] as DetailsDisk[][],
       hasCustomDiskSelection: false,
 
-      draidDataDisks: 0,
-      draidSpareDisks: 0,
+      draidDataDisks: null,
+      draidSpareDisks: null,
     } as PoolManagerTopologyCategory,
   };
 }, {} as PoolManagerTopology);

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -6,7 +6,6 @@ import {
   PoolManagerTopologyCategory,
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
 import {
-  existingVdevLayout,
   nonDraidEquivalent,
   parseDraidVdevName,
   resolveSpecialLayoutLock,
@@ -198,28 +197,6 @@ describe('resolveTopologyLayout', () => {
   it('returns null for unhandled topology types', () => {
     const items = [{ type: TopologyItemType.Replacing, children: [] }] as VDevItem[];
     expect(resolveTopologyLayout(items)).toBeNull();
-  });
-});
-
-describe('existingVdevLayout', () => {
-  it('returns null for empty or undefined items', () => {
-    expect(existingVdevLayout([])).toBeNull();
-    expect(existingVdevLayout(undefined)).toBeNull();
-  });
-
-  it('returns Stripe for a single disk with no children', () => {
-    const items = [{ type: TopologyItemType.Disk, children: [] }] as VDevItem[];
-    expect(existingVdevLayout(items)).toBe(CreateVdevLayout.Stripe);
-  });
-
-  it('returns Mirror for mirror vdevs', () => {
-    const items = [{ type: TopologyItemType.Mirror, children: [{}, {}] }] as VDevItem[];
-    expect(existingVdevLayout(items)).toBe(CreateVdevLayout.Mirror);
-  });
-
-  it('maps dRAID vdevs to equivalent RAIDZ layout', () => {
-    const items = [{ type: TopologyItemType.Draid, children: [], name: 'draid2:1d:6c:2s-0' }] as VDevItem[];
-    expect(existingVdevLayout(items)).toBe(CreateVdevLayout.Raidz2);
   });
 });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -8,7 +8,7 @@ import {
 import {
   nonDraidEquivalent,
   parseDraidVdevName,
-  resolveSpecialLayoutLock,
+  resolveParityLockedLayout,
   resolveTopologyLayout,
   topologyCategoryToDisks,
   topologyToDisks, topologyToPayload,
@@ -200,7 +200,7 @@ describe('resolveTopologyLayout', () => {
   });
 });
 
-describe('resolveSpecialLayoutLock', () => {
+describe('resolveParityLockedLayout', () => {
   const mirrorVdev = [{ type: TopologyItemType.Mirror, children: [{}, {}] }] as VDevItem[];
   const raidz2Vdev = [{ type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] }] as VDevItem[];
   const draid2Vdev = [{
@@ -209,37 +209,37 @@ describe('resolveSpecialLayoutLock', () => {
 
   it('prefers existing category layout over everything else', () => {
     expect(
-      resolveSpecialLayoutLock(mirrorVdev, raidz2Vdev, CreateVdevLayout.Raidz3),
+      resolveParityLockedLayout(mirrorVdev, raidz2Vdev, CreateVdevLayout.Raidz3),
     ).toBe(CreateVdevLayout.Mirror);
   });
 
   it('falls back to existing data layout when category is empty', () => {
     expect(
-      resolveSpecialLayoutLock(undefined, raidz2Vdev, CreateVdevLayout.Raidz1),
+      resolveParityLockedLayout(undefined, raidz2Vdev, CreateVdevLayout.Raidz1),
     ).toBe(CreateVdevLayout.Raidz2);
   });
 
   it('maps existing data dRAID layout to its non-dRAID equivalent', () => {
     expect(
-      resolveSpecialLayoutLock(undefined, draid2Vdev, null),
+      resolveParityLockedLayout(undefined, draid2Vdev, null),
     ).toBe(CreateVdevLayout.Raidz2);
   });
 
   it('uses wizard data layout when no existing topology is present', () => {
     expect(
-      resolveSpecialLayoutLock(undefined, undefined, CreateVdevLayout.Raidz2),
+      resolveParityLockedLayout(undefined, undefined, CreateVdevLayout.Raidz2),
     ).toBe(CreateVdevLayout.Raidz2);
   });
 
   it('maps wizard dRAID layout to its non-dRAID equivalent', () => {
     expect(
-      resolveSpecialLayoutLock(undefined, undefined, CreateVdevLayout.Draid3),
+      resolveParityLockedLayout(undefined, undefined, CreateVdevLayout.Draid3),
     ).toBe(CreateVdevLayout.Raidz3);
   });
 
   it('returns null when nothing is set', () => {
-    expect(resolveSpecialLayoutLock(undefined, undefined, null)).toBeNull();
-    expect(resolveSpecialLayoutLock([], [], null)).toBeNull();
+    expect(resolveParityLockedLayout(undefined, undefined, null)).toBeNull();
+    expect(resolveParityLockedLayout([], [], null)).toBeNull();
   });
 });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -7,9 +7,12 @@ import {
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
 import {
   existingVdevLayout,
+  layoutParity,
   nonDraidEquivalent,
+  nonDraidLayouts,
+  parityLockForMinParity,
   parseDraidVdevName,
-  resolveParityLockedLayout,
+  resolveParityLock,
   resolveTopologyLayout,
   topologyCategoryToDisks,
   topologyToDisks,
@@ -219,52 +222,144 @@ describe('existingVdevLayout', () => {
   });
 });
 
-describe('resolveParityLockedLayout', () => {
-  const mirrorVdev = [{ type: TopologyItemType.Mirror, children: [{}, {}] }] as VDevItem[];
+describe('layoutParity', () => {
+  it('returns 0 for Stripe regardless of width', () => {
+    expect(layoutParity(CreateVdevLayout.Stripe, 1)).toBe(0);
+    expect(layoutParity(CreateVdevLayout.Stripe, 5)).toBe(0);
+  });
+
+  it('returns width-1 for Mirror', () => {
+    expect(layoutParity(CreateVdevLayout.Mirror, 2)).toBe(1);
+    expect(layoutParity(CreateVdevLayout.Mirror, 3)).toBe(2);
+    expect(layoutParity(CreateVdevLayout.Mirror, 4)).toBe(3);
+  });
+
+  it('returns 1/2/3 for RAIDZ and dRAID variants', () => {
+    expect(layoutParity(CreateVdevLayout.Raidz1, 3)).toBe(1);
+    expect(layoutParity(CreateVdevLayout.Draid1, 3)).toBe(1);
+    expect(layoutParity(CreateVdevLayout.Raidz2, 4)).toBe(2);
+    expect(layoutParity(CreateVdevLayout.Draid2, 4)).toBe(2);
+    expect(layoutParity(CreateVdevLayout.Raidz3, 5)).toBe(3);
+    expect(layoutParity(CreateVdevLayout.Draid3, 5)).toBe(3);
+  });
+});
+
+describe('parityLockForMinParity', () => {
+  it('allows all non-dRAID layouts when minParity is 0', () => {
+    const lock = parityLockForMinParity(0);
+    expect(lock.allowedLayouts).toStrictEqual([...nonDraidLayouts]);
+    expect(lock.minMirrorWidth).toBe(2);
+  });
+
+  it('drops Stripe and keeps Mirror + RAIDZ1/2/3 at minParity 1', () => {
+    const lock = parityLockForMinParity(1);
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz1, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(2);
+  });
+
+  it('keeps Mirror + RAIDZ2/3 and raises minMirrorWidth at minParity 2', () => {
+    const lock = parityLockForMinParity(2);
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(3);
+  });
+
+  it('keeps only Mirror + RAIDZ3 and requires 4-wide mirror at minParity 3', () => {
+    const lock = parityLockForMinParity(3);
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(4);
+  });
+});
+
+describe('resolveParityLock', () => {
+  const mirror2Vdev = [{ type: TopologyItemType.Mirror, children: [{}, {}] }] as VDevItem[];
+  const mirror3Vdev = [{ type: TopologyItemType.Mirror, children: [{}, {}, {}] }] as VDevItem[];
   const raidz2Vdev = [{ type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] }] as VDevItem[];
   const draid2Vdev = [{
     type: TopologyItemType.Draid, children: [], name: 'draid2:1d:6c:2s-0',
   }] as VDevItem[];
 
-  it('prefers existing category layout over everything else', () => {
-    expect(
-      resolveParityLockedLayout(mirrorVdev, raidz2Vdev, CreateVdevLayout.Raidz3),
-    ).toBe(CreateVdevLayout.Mirror);
+  it('prefers existing category layout over everything else (strict single-layout match)', () => {
+    const lock = resolveParityLock(
+      mirror2Vdev,
+      raidz2Vdev,
+      { layout: CreateVdevLayout.Raidz3, width: 5 },
+    );
+    expect(lock.allowedLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
+    expect(lock.minMirrorWidth).toBe(2);
   });
 
-  it('falls back to existing data layout when category is empty', () => {
-    expect(
-      resolveParityLockedLayout(undefined, raidz2Vdev, CreateVdevLayout.Raidz1),
-    ).toBe(CreateVdevLayout.Raidz2);
+  it('falls back to existing data parity when category is empty', () => {
+    const lock = resolveParityLock(undefined, raidz2Vdev, { layout: CreateVdevLayout.Raidz1, width: 3 });
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(3);
   });
 
-  it('maps existing data dRAID layout to its non-dRAID equivalent', () => {
-    expect(
-      resolveParityLockedLayout(undefined, draid2Vdev, null),
-    ).toBe(CreateVdevLayout.Raidz2);
+  it('derives parity from existing data mirror width', () => {
+    const lock = resolveParityLock(undefined, mirror3Vdev, { layout: null, width: null });
+    // 3-way mirror tolerates 2 failures -> minParity 2
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(3);
   });
 
-  it('maps existing category dRAID layout to its non-dRAID equivalent', () => {
-    expect(
-      resolveParityLockedLayout(draid2Vdev, undefined, null),
-    ).toBe(CreateVdevLayout.Raidz2);
+  it('treats existing data dRAID as its raidz parity equivalent', () => {
+    const lock = resolveParityLock(undefined, draid2Vdev, { layout: null, width: null });
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(3);
   });
 
-  it('uses wizard data layout when no existing topology is present', () => {
-    expect(
-      resolveParityLockedLayout(undefined, undefined, CreateVdevLayout.Raidz2),
-    ).toBe(CreateVdevLayout.Raidz2);
+  it('locks to existing category dRAID as its non-dRAID equivalent', () => {
+    const lock = resolveParityLock(draid2Vdev, undefined, { layout: null, width: null });
+    expect(lock.allowedLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+    expect(lock.minMirrorWidth).toBe(2);
   });
 
-  it('maps wizard dRAID layout to its non-dRAID equivalent', () => {
-    expect(
-      resolveParityLockedLayout(undefined, undefined, CreateVdevLayout.Draid3),
-    ).toBe(CreateVdevLayout.Raidz3);
+  it('uses wizard layout and width when no existing topology is present', () => {
+    const lock = resolveParityLock(undefined, undefined, { layout: CreateVdevLayout.Raidz2, width: 4 });
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(3);
   });
 
-  it('returns null when nothing is set', () => {
-    expect(resolveParityLockedLayout(undefined, undefined, null)).toBeNull();
-    expect(resolveParityLockedLayout([], [], null)).toBeNull();
+  it('derives parity from wizard mirror width', () => {
+    const lock = resolveParityLock(undefined, undefined, { layout: CreateVdevLayout.Mirror, width: 4 });
+    // 4-way mirror tolerates 3 failures -> minParity 3
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(4);
+  });
+
+  it('leaves the lock unconstrained when wizard mirror width is not yet set', () => {
+    const lock = resolveParityLock(undefined, undefined, { layout: CreateVdevLayout.Mirror, width: null });
+    expect(lock.allowedLayouts).toStrictEqual([...nonDraidLayouts]);
+    expect(lock.minMirrorWidth).toBe(2);
+  });
+
+  it('maps wizard dRAID layout to its raidz parity equivalent', () => {
+    const lock = resolveParityLock(undefined, undefined, { layout: CreateVdevLayout.Draid3, width: 5 });
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(4);
+  });
+
+  it('returns a fully permissive lock when nothing is set', () => {
+    const lock = resolveParityLock(undefined, undefined, { layout: null, width: null });
+    expect(lock.allowedLayouts).toStrictEqual([...nonDraidLayouts]);
+    expect(lock.minMirrorWidth).toBe(2);
   });
 });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -103,6 +103,19 @@ describe('topologyToPayload', () => {
     });
   });
 
+  it('throws when a non-spare category has vdevs but layout is null', () => {
+    const topology = {
+      [VDevType.Data]: {
+        layout: null,
+        vdevs: [[{ devname: 'ada1' } as DetailsDisk]],
+      },
+    } as PoolManagerTopology;
+
+    expect(() => topologyToPayload(topology)).toThrow(
+      'topologyToPayload: category "data" has vdevs but no layout set.',
+    );
+  });
+
   it('converts dRAID layout to websocket payload', () => {
     const disk1 = { devname: 'ada1' } as DetailsDisk;
     const disk2 = { devname: 'ada2' } as DetailsDisk;

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -361,6 +361,15 @@ describe('resolveParityLock', () => {
     expect(lock.allowedLayouts).toStrictEqual([...nonDraidLayouts]);
     expect(lock.minMirrorWidth).toBe(2);
   });
+
+  it('ignores an existing Stripe category (misconfigured pool) and falls through to data parity', () => {
+    const stripeVdev = [{ type: TopologyItemType.Disk, children: [] }] as VDevItem[];
+    const lock = resolveParityLock(stripeVdev, raidz2Vdev, { layout: null, width: null });
+    expect(lock.allowedLayouts).toStrictEqual([
+      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+    ]);
+    expect(lock.minMirrorWidth).toBe(3);
+  });
 });
 
 describe('parseDraidVdevName', () => {

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -225,6 +225,12 @@ describe('resolveParityLockedLayout', () => {
     ).toBe(CreateVdevLayout.Raidz2);
   });
 
+  it('maps existing category dRAID layout to its non-dRAID equivalent', () => {
+    expect(
+      resolveParityLockedLayout(draid2Vdev, undefined, null),
+    ).toBe(CreateVdevLayout.Raidz2);
+  });
+
   it('uses wizard data layout when no existing topology is present', () => {
     expect(
       resolveParityLockedLayout(undefined, undefined, CreateVdevLayout.Raidz2),

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -5,6 +5,7 @@ import {
   PoolManagerTopologyCategory,
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
 import {
+  nonDraidEquivalent,
   parseDraidVdevName,
   topologyCategoryToDisks,
   topologyToDisks, topologyToPayload,
@@ -127,6 +128,22 @@ describe('topologyToPayload', () => {
         },
       ],
     });
+  });
+});
+
+describe('nonDraidEquivalent', () => {
+  it('maps DRAID layouts to equivalent RAIDZ layouts', () => {
+    expect(nonDraidEquivalent(CreateVdevLayout.Draid1)).toBe(CreateVdevLayout.Raidz1);
+    expect(nonDraidEquivalent(CreateVdevLayout.Draid2)).toBe(CreateVdevLayout.Raidz2);
+    expect(nonDraidEquivalent(CreateVdevLayout.Draid3)).toBe(CreateVdevLayout.Raidz3);
+  });
+
+  it('returns non-DRAID layouts unchanged', () => {
+    expect(nonDraidEquivalent(CreateVdevLayout.Mirror)).toBe(CreateVdevLayout.Mirror);
+    expect(nonDraidEquivalent(CreateVdevLayout.Stripe)).toBe(CreateVdevLayout.Stripe);
+    expect(nonDraidEquivalent(CreateVdevLayout.Raidz1)).toBe(CreateVdevLayout.Raidz1);
+    expect(nonDraidEquivalent(CreateVdevLayout.Raidz2)).toBe(CreateVdevLayout.Raidz2);
+    expect(nonDraidEquivalent(CreateVdevLayout.Raidz3)).toBe(CreateVdevLayout.Raidz3);
   });
 });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -1,10 +1,12 @@
-import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
 import { DetailsDisk } from 'app/interfaces/disk.interface';
+import { VDevItem } from 'app/interfaces/storage.interface';
 import {
   PoolManagerTopology,
   PoolManagerTopologyCategory,
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
 import {
+  existingVdevLayout,
   nonDraidEquivalent,
   parseDraidVdevName,
   topologyCategoryToDisks,
@@ -144,6 +146,28 @@ describe('nonDraidEquivalent', () => {
     expect(nonDraidEquivalent(CreateVdevLayout.Raidz1)).toBe(CreateVdevLayout.Raidz1);
     expect(nonDraidEquivalent(CreateVdevLayout.Raidz2)).toBe(CreateVdevLayout.Raidz2);
     expect(nonDraidEquivalent(CreateVdevLayout.Raidz3)).toBe(CreateVdevLayout.Raidz3);
+  });
+});
+
+describe('existingVdevLayout', () => {
+  it('returns null for empty or undefined items', () => {
+    expect(existingVdevLayout([])).toBeNull();
+    expect(existingVdevLayout(undefined)).toBeNull();
+  });
+
+  it('returns Stripe for a single disk with no children', () => {
+    const items = [{ type: TopologyItemType.Disk, children: [] }] as VDevItem[];
+    expect(existingVdevLayout(items)).toBe(CreateVdevLayout.Stripe);
+  });
+
+  it('returns Mirror for mirror vdevs', () => {
+    const items = [{ type: TopologyItemType.Mirror, children: [{}, {}] }] as VDevItem[];
+    expect(existingVdevLayout(items)).toBe(CreateVdevLayout.Mirror);
+  });
+
+  it('maps dRAID vdevs to equivalent RAIDZ layout', () => {
+    const items = [{ type: TopologyItemType.Draid, children: [], name: 'draid2:1d:6c:2s-0' }] as VDevItem[];
+    expect(existingVdevLayout(items)).toBe(CreateVdevLayout.Raidz2);
   });
 });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -175,6 +175,11 @@ describe('resolveTopologyLayout', () => {
     const items = [{ type: TopologyItemType.Raidz1, children: [{}, {}, {}] }] as VDevItem[];
     expect(resolveTopologyLayout(items)).toBe(CreateVdevLayout.Raidz1);
   });
+
+  it('returns null for unhandled topology types', () => {
+    const items = [{ type: TopologyItemType.Replacing, children: [] }] as VDevItem[];
+    expect(resolveTopologyLayout(items)).toBeNull();
+  });
 });
 
 describe('existingVdevLayout', () => {

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -9,6 +9,7 @@ import {
   existingVdevLayout,
   nonDraidEquivalent,
   parseDraidVdevName,
+  resolveSpecialLayoutLock,
   resolveTopologyLayout,
   topologyCategoryToDisks,
   topologyToDisks, topologyToPayload,
@@ -219,6 +220,49 @@ describe('existingVdevLayout', () => {
   it('maps dRAID vdevs to equivalent RAIDZ layout', () => {
     const items = [{ type: TopologyItemType.Draid, children: [], name: 'draid2:1d:6c:2s-0' }] as VDevItem[];
     expect(existingVdevLayout(items)).toBe(CreateVdevLayout.Raidz2);
+  });
+});
+
+describe('resolveSpecialLayoutLock', () => {
+  const mirrorVdev = [{ type: TopologyItemType.Mirror, children: [{}, {}] }] as VDevItem[];
+  const raidz2Vdev = [{ type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] }] as VDevItem[];
+  const draid2Vdev = [{
+    type: TopologyItemType.Draid, children: [], name: 'draid2:1d:6c:2s-0',
+  }] as VDevItem[];
+
+  it('prefers existing category layout over everything else', () => {
+    expect(
+      resolveSpecialLayoutLock(mirrorVdev, raidz2Vdev, CreateVdevLayout.Raidz3),
+    ).toBe(CreateVdevLayout.Mirror);
+  });
+
+  it('falls back to existing data layout when category is empty', () => {
+    expect(
+      resolveSpecialLayoutLock(undefined, raidz2Vdev, CreateVdevLayout.Raidz1),
+    ).toBe(CreateVdevLayout.Raidz2);
+  });
+
+  it('maps existing data dRAID layout to its non-dRAID equivalent', () => {
+    expect(
+      resolveSpecialLayoutLock(undefined, draid2Vdev, null),
+    ).toBe(CreateVdevLayout.Raidz2);
+  });
+
+  it('uses wizard data layout when no existing topology is present', () => {
+    expect(
+      resolveSpecialLayoutLock(undefined, undefined, CreateVdevLayout.Raidz2),
+    ).toBe(CreateVdevLayout.Raidz2);
+  });
+
+  it('maps wizard dRAID layout to its non-dRAID equivalent', () => {
+    expect(
+      resolveSpecialLayoutLock(undefined, undefined, CreateVdevLayout.Draid3),
+    ).toBe(CreateVdevLayout.Raidz3);
+  });
+
+  it('returns null when nothing is set', () => {
+    expect(resolveSpecialLayoutLock(undefined, undefined, null)).toBeNull();
+    expect(resolveSpecialLayoutLock([], [], null)).toBeNull();
   });
 });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -6,12 +6,14 @@ import {
   PoolManagerTopologyCategory,
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
 import {
+  existingVdevLayout,
   nonDraidEquivalent,
   parseDraidVdevName,
   resolveParityLockedLayout,
   resolveTopologyLayout,
   topologyCategoryToDisks,
-  topologyToDisks, topologyToPayload,
+  topologyToDisks,
+  topologyToPayload,
 } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 
 describe('topologyCategoryToDisks', () => {
@@ -197,6 +199,23 @@ describe('resolveTopologyLayout', () => {
   it('returns null for unhandled topology types', () => {
     const items = [{ type: TopologyItemType.Replacing, children: [] }] as VDevItem[];
     expect(resolveTopologyLayout(items)).toBeNull();
+  });
+});
+
+describe('existingVdevLayout', () => {
+  it('returns null for empty or undefined items', () => {
+    expect(existingVdevLayout(undefined)).toBeNull();
+    expect(existingVdevLayout([])).toBeNull();
+  });
+
+  it('passes non-dRAID layouts through unchanged', () => {
+    const items = [{ type: TopologyItemType.Mirror, children: [{}, {}] }] as VDevItem[];
+    expect(existingVdevLayout(items)).toBe(CreateVdevLayout.Mirror);
+  });
+
+  it('maps dRAID layouts to their non-dRAID equivalent', () => {
+    const items = [{ type: TopologyItemType.Draid, children: [], name: 'draid3:1d:6c:2s-0' }] as VDevItem[];
+    expect(existingVdevLayout(items)).toBe(CreateVdevLayout.Raidz3);
   });
 });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -184,6 +184,11 @@ describe('resolveTopologyLayout', () => {
     expect(resolveTopologyLayout(items)).toBe(CreateVdevLayout.Draid2);
   });
 
+  it('returns Raidz1 for bare RAIDZ vdevs', () => {
+    const items = [{ type: TopologyItemType.Raidz, children: [{}, {}, {}] }] as VDevItem[];
+    expect(resolveTopologyLayout(items)).toBe(CreateVdevLayout.Raidz1);
+  });
+
   it('returns Raidz1 for raidz1 vdevs', () => {
     const items = [{ type: TopologyItemType.Raidz1, children: [{}, {}, {}] }] as VDevItem[];
     expect(resolveTopologyLayout(items)).toBe(CreateVdevLayout.Raidz1);

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -9,6 +9,7 @@ import {
   existingVdevLayout,
   nonDraidEquivalent,
   parseDraidVdevName,
+  resolveTopologyLayout,
   topologyCategoryToDisks,
   topologyToDisks, topologyToPayload,
 } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
@@ -146,6 +147,33 @@ describe('nonDraidEquivalent', () => {
     expect(nonDraidEquivalent(CreateVdevLayout.Raidz1)).toBe(CreateVdevLayout.Raidz1);
     expect(nonDraidEquivalent(CreateVdevLayout.Raidz2)).toBe(CreateVdevLayout.Raidz2);
     expect(nonDraidEquivalent(CreateVdevLayout.Raidz3)).toBe(CreateVdevLayout.Raidz3);
+  });
+});
+
+describe('resolveTopologyLayout', () => {
+  it('returns null for empty or undefined items', () => {
+    expect(resolveTopologyLayout([])).toBeNull();
+    expect(resolveTopologyLayout(undefined)).toBeNull();
+  });
+
+  it('returns Stripe for a single disk with no children', () => {
+    const items = [{ type: TopologyItemType.Disk, children: [] }] as VDevItem[];
+    expect(resolveTopologyLayout(items)).toBe(CreateVdevLayout.Stripe);
+  });
+
+  it('returns Mirror for mirror vdevs', () => {
+    const items = [{ type: TopologyItemType.Mirror, children: [{}, {}] }] as VDevItem[];
+    expect(resolveTopologyLayout(items)).toBe(CreateVdevLayout.Mirror);
+  });
+
+  it('returns dRAID layout for dRAID vdevs', () => {
+    const items = [{ type: TopologyItemType.Draid, children: [], name: 'draid2:1d:6c:2s-0' }] as VDevItem[];
+    expect(resolveTopologyLayout(items)).toBe(CreateVdevLayout.Draid2);
+  });
+
+  it('returns Raidz1 for raidz1 vdevs', () => {
+    const items = [{ type: TopologyItemType.Raidz1, children: [{}, {}, {}] }] as VDevItem[];
+    expect(resolveTopologyLayout(items)).toBe(CreateVdevLayout.Raidz1);
   });
 });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -254,6 +254,11 @@ export function lockedParityLayout$(
   );
 }
 
+/**
+ * Order follows CreateVdevLayout declaration order, which also drives the
+ * ordering of options in the layout dropdown. Reordering enum members will
+ * change the visible option order.
+ */
 export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(CreateVdevLayout)
   .filter((layout) => !draidCreateLayouts.includes(layout));
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -71,13 +71,8 @@ export function poolTopologyToStoreTopology(topology: PoolTopology, disks: Detai
     if (!vdevs?.length) {
       continue;
     }
-    let layoutType: TopologyItemType = vdevs[0].type;
-    let width = vdevs[0].children.length;
-
-    if (!vdevs[0].children.length && layoutType === TopologyItemType.Disk) {
-      layoutType = TopologyItemType.Stripe;
-      width = 1;
-    }
+    const layout = resolveTopologyLayout(vdevs);
+    const width = vdevs[0].children.length || 1;
     const minSize = Math.min(...(disks.map((disk) => disk.size)));
 
     let draidDataDisks: number = null;
@@ -87,13 +82,12 @@ export function poolTopologyToStoreTopology(topology: PoolTopology, disks: Detai
       const parsedDraidInfo = parseDraidVdevName(vdevs[0].name);
       draidDataDisks = parsedDraidInfo.dataDisks;
       draidSpareDisks = parsedDraidInfo.spareDisks;
-      layoutType = parsedDraidInfo.layout as unknown as TopologyItemType;
     }
 
     poolManagerTopology[category as VDevType] = {
       diskType: disks[0].type,
       diskSize: minSize,
-      layout: layoutType as unknown as CreateVdevLayout,
+      layout,
       vdevsNumber: vdevs.length,
       width,
       hasCustomDiskSelection: vdevs.some((vdev) => vdevs[0].children.length !== vdev.children.length),
@@ -136,6 +130,7 @@ export function nonDraidEquivalent(layout: CreateVdevLayout): CreateVdevLayout {
   }
 }
 
+/** Used only via {@link resolveTopologyLayout}; Disk and Draid are handled before lookup. */
 const topologyTypeToLayout: Record<string, CreateVdevLayout> = {
   [TopologyItemType.Stripe]: CreateVdevLayout.Stripe,
   [TopologyItemType.Mirror]: CreateVdevLayout.Mirror,

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -32,6 +32,7 @@ export function topologyToPayload(topology: PoolManagerTopology): UpdatePoolTopo
     }
 
     if (category.layout === null) {
+      console.warn(`topologyToPayload: category "${vdevType}" has vdevs but no layout set — skipping.`);
       return;
     }
 
@@ -180,7 +181,7 @@ export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLay
   return layout !== null ? nonDraidEquivalent(layout) : null;
 }
 
-export const nonDraidLayouts: CreateVdevLayout[] = Object.values(CreateVdevLayout)
+export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(CreateVdevLayout)
   .filter((layout) => !isDraidLayout(layout));
 
 export function isDraidLayout(layout: CreateVdevLayout | TopologyItemType): boolean {

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -277,8 +277,11 @@ export function resolveParityLock(
   existingData: VDevItem[] | undefined,
   wizardData: { layout: CreateVdevLayout | null; width: number | null } | undefined,
 ): ParityLock {
+  // A Stripe special/dedup vdev would be a misconfigured pool (no redundancy
+  // where it's required). Ignore it and fall through to data-parity so we
+  // don't "lock" a new vdev into a no-redundancy layout.
   const categoryLayout = existingVdevLayout(existingCategory);
-  if (categoryLayout !== null) {
+  if (categoryLayout !== null && categoryLayout !== CreateVdevLayout.Stripe) {
     return { allowedLayouts: [categoryLayout], minMirrorWidth: 2 };
   }
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -2,6 +2,7 @@ import { DiskType } from 'app/enums/disk-type.enum';
 import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
 import { DetailsDisk } from 'app/interfaces/disk.interface';
 import { DataPoolTopologyUpdate, PoolTopology, UpdatePoolTopology } from 'app/interfaces/pool.interface';
+import { VDevItem } from 'app/interfaces/storage.interface';
 import {
   PoolManagerTopology,
   PoolManagerTopologyCategory,
@@ -135,13 +136,27 @@ export function nonDraidEquivalent(layout: CreateVdevLayout): CreateVdevLayout {
   }
 }
 
-export const nonDraidLayouts: CreateVdevLayout[] = [
-  CreateVdevLayout.Stripe,
-  CreateVdevLayout.Mirror,
-  CreateVdevLayout.Raidz1,
-  CreateVdevLayout.Raidz2,
-  CreateVdevLayout.Raidz3,
-];
+/**
+ * Resolves the layout of existing vdev items to a non-DRAID CreateVdevLayout.
+ * Returns null when there are no existing items.
+ */
+export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLayout | null {
+  if (!items?.length) {
+    return null;
+  }
+  // TODO: Similar code in poolTopologyToStoreTopology
+  let type = items[0].type;
+  if (type === TopologyItemType.Disk && !items[0].children.length) {
+    type = TopologyItemType.Stripe as TopologyItemType;
+  } else if (type === TopologyItemType.Draid) {
+    const parsedVdevName = parseDraidVdevName(items[0].name);
+    type = parsedVdevName.layout as unknown as TopologyItemType;
+  }
+  return nonDraidEquivalent(type as unknown as CreateVdevLayout);
+}
+
+export const nonDraidLayouts: CreateVdevLayout[] = Object.values(CreateVdevLayout)
+  .filter((layout) => !isDraidLayout(layout));
 
 export function isDraidLayout(layout: CreateVdevLayout | TopologyItemType): boolean {
   return [

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -201,57 +201,129 @@ export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLay
 }
 
 /**
- * Resolves the layout that a special or dedup vdev must be locked to.
- * These vdevs' failure destroys the whole pool, so their redundancy must match
- * the data vdev's. Preference order:
- *   1. Existing special/dedup layout (already in the pool).
- *   2. Existing data layout (pool already has data vdevs).
- *   3. Wizard-selected data layout (new pool being created).
- * Returns null when none are set (e.g. user jumps to this step before picking
- * a data layout); callers should allow the full non-dRAID list in that case.
- */
-export function resolveParityLockedLayout(
-  existingCategory: VDevItem[] | undefined,
-  existingData: VDevItem[] | undefined,
-  wizardDataLayout: CreateVdevLayout | null | undefined,
-): CreateVdevLayout | null {
-  const categoryLayout = existingVdevLayout(existingCategory);
-  if (categoryLayout !== null) {
-    return categoryLayout;
-  }
-  const dataLayout = existingVdevLayout(existingData);
-  if (dataLayout !== null) {
-    return dataLayout;
-  }
-  return wizardDataLayout ? nonDraidEquivalent(wizardDataLayout) : null;
-}
-
-/**
- * Emits the layout that the given special/dedup category must be locked to,
- * or null when no lock applies. Shared by the metadata and dedup wizard steps
- * so both react to the same set of inputs in the same way.
- */
-export function lockedParityLayout$(
-  pool$: Observable<Pool | null>,
-  topology$: Observable<PoolManagerTopology>,
-  vdevType: VDevType.Special | VDevType.Dedup,
-): Observable<CreateVdevLayout | null> {
-  return combineLatest([pool$, topology$]).pipe(
-    map(([pool, topology]) => resolveParityLockedLayout(
-      pool?.topology[vdevType],
-      pool?.topology[VDevType.Data],
-      topology[VDevType.Data].layout,
-    )),
-    distinctUntilChanged(),
-  );
-}
-
-/**
  * Every CreateVdevLayout value except the dRAID ones. Order is not semantic —
  * dropdown ordering is driven by {@link vdevLayoutOptions} in the component.
  */
 export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(CreateVdevLayout)
   .filter((layout) => !draidCreateLayouts.includes(layout));
+
+/**
+ * Constraint on the Layout + Width controls for a special/dedup vdev.
+ * Expressed as the set of layouts the user may pick plus a minimum Mirror
+ * width, rather than a single locked layout, so that any layout matching the
+ * data vdev's parity level is allowed (e.g. a 3-way mirror alongside RAIDZ2).
+ */
+export interface ParityLock {
+  allowedLayouts: readonly CreateVdevLayout[];
+  /** Applies only when Mirror is selected. `2` is the effective floor. */
+  minMirrorWidth: number;
+}
+
+const unconstrainedParityLock: ParityLock = {
+  allowedLayouts: nonDraidLayouts,
+  minMirrorWidth: 2,
+};
+
+/**
+ * Number of simultaneous drive failures `layout` at the given width can
+ * survive: Stripe = 0, Mirror = width-1, RaidzN/DraidN = N.
+ */
+export function layoutParity(layout: CreateVdevLayout, width: number): number {
+  switch (layout) {
+    case CreateVdevLayout.Stripe: return 0;
+    case CreateVdevLayout.Mirror: return Math.max(0, width - 1);
+    case CreateVdevLayout.Raidz1:
+    case CreateVdevLayout.Draid1: return 1;
+    case CreateVdevLayout.Raidz2:
+    case CreateVdevLayout.Draid2: return 2;
+    case CreateVdevLayout.Raidz3:
+    case CreateVdevLayout.Draid3: return 3;
+    default: return 0;
+  }
+}
+
+/**
+ * ParityLock admitting every non-dRAID layout that can tolerate at least
+ * `minParity` drive failures. Mirror is always in the set but gated by
+ * `minMirrorWidth` (width-1 >= minParity).
+ */
+export function parityLockForMinParity(minParity: number): ParityLock {
+  const allowedLayouts = nonDraidLayouts.filter((layout) => {
+    if (layout === CreateVdevLayout.Mirror) {
+      return true;
+    }
+    return layoutParity(layout, 0) >= minParity;
+  });
+  return {
+    allowedLayouts,
+    minMirrorWidth: Math.max(2, minParity + 1),
+  };
+}
+
+/**
+ * Resolves the parity lock for a special or dedup vdev. These vdevs' failure
+ * destroys the whole pool, so their redundancy must be at least the data
+ * vdev's. Preference order:
+ *   1. Existing special/dedup layout (pool already has vdevs in this category;
+ *      the new vdev must match exactly — pools don't mix layouts inside a
+ *      category).
+ *   2. Existing data layout (pool has data vdevs; match their parity level).
+ *   3. Wizard-selected data layout and width (new pool; match parity).
+ * Returns the fully permissive lock when none are set (e.g. user jumps to the
+ * step before picking a data layout).
+ */
+export function resolveParityLock(
+  existingCategory: VDevItem[] | undefined,
+  existingData: VDevItem[] | undefined,
+  wizardData: { layout: CreateVdevLayout | null; width: number | null } | undefined,
+): ParityLock {
+  const categoryLayout = existingVdevLayout(existingCategory);
+  if (categoryLayout !== null) {
+    return { allowedLayouts: [categoryLayout], minMirrorWidth: 2 };
+  }
+
+  if (existingData?.length) {
+    const layout = resolveTopologyLayout(existingData);
+    if (layout !== null) {
+      const width = existingData[0].children?.length ?? 2;
+      return parityLockForMinParity(layoutParity(layout, width));
+    }
+  }
+
+  if (wizardData?.layout) {
+    // Mirror parity depends on width; if width isn't picked yet, don't lock.
+    if (wizardData.layout === CreateVdevLayout.Mirror && !wizardData.width) {
+      return unconstrainedParityLock;
+    }
+    return parityLockForMinParity(layoutParity(wizardData.layout, wizardData.width ?? 2));
+  }
+
+  return unconstrainedParityLock;
+}
+
+/**
+ * Emits the parity lock for the given special/dedup category. Shared by the
+ * metadata and dedup wizard steps so both react to the same set of inputs
+ * (existing pool topology, wizard data layout + width) in the same way.
+ */
+export function parityLock$(
+  pool$: Observable<Pool | null>,
+  topology$: Observable<PoolManagerTopology>,
+  vdevType: VDevType.Special | VDevType.Dedup,
+): Observable<ParityLock> {
+  return combineLatest([pool$, topology$]).pipe(
+    map(([pool, topology]) => resolveParityLock(
+      pool?.topology[vdevType],
+      pool?.topology[VDevType.Data],
+      { layout: topology[VDevType.Data].layout, width: topology[VDevType.Data].width },
+    )),
+    distinctUntilChanged((a, b) => (
+      a.minMirrorWidth === b.minMirrorWidth
+      && a.allowedLayouts.length === b.allowedLayouts.length
+      && a.allowedLayouts.every((layout, i) => layout === b.allowedLayouts[i])
+    )),
+  );
+}
 
 export function isDraidLayout(layout: CreateVdevLayout | TopologyItemType | null | undefined): boolean {
   if (layout === TopologyItemType.Draid) {

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -32,8 +32,7 @@ export function topologyToPayload(topology: PoolManagerTopology): UpdatePoolTopo
     }
 
     if (category.layout === null) {
-      console.error(`topologyToPayload: category "${vdevType}" has vdevs but no layout set.`);
-      return;
+      throw new Error(`topologyToPayload: category "${vdevType}" has vdevs but no layout set.`);
     }
 
     const { layout } = category;
@@ -156,7 +155,8 @@ const topologyTypeToLayout: Record<string, CreateVdevLayout> = {
  * Resolves the layout of existing vdev items to a CreateVdevLayout.
  * All items in the array are assumed to share the same layout (ZFS guarantees
  * this per vdev category), so only the first item is inspected.
- * Returns null when there are no existing items.
+ * Returns null when there are no existing items or the type is unrecognised
+ * (e.g. transient states like Replacing / Spare).
  */
 export function resolveTopologyLayout(items: VDevItem[] | undefined): CreateVdevLayout | null {
   if (!items?.length) {

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -19,7 +19,11 @@ export function topologyCategoryToDisks(topologyCategory: PoolManagerTopologyCat
 export function topologyToPayload(topology: PoolManagerTopology): UpdatePoolTopology {
   const payload: UpdatePoolTopology = {};
 
-  Object.entries(topology).forEach(([vdevType, category]: [VDevType, PoolManagerTopologyCategory]) => {
+  (Object.entries(topology) as [VDevType, PoolManagerTopologyCategory][]).forEach(([vdevType, category]) => {
+    if (!category.vdevs.length) {
+      return;
+    }
+
     if (vdevType === VDevType.Spare) {
       payload.spares = category.vdevs.flatMap((vdev) => {
         return vdev.map((disk) => disk.devname);
@@ -27,13 +31,19 @@ export function topologyToPayload(topology: PoolManagerTopology): UpdatePoolTopo
       return;
     }
 
+    if (category.layout === null) {
+      return;
+    }
+
+    const { layout } = category;
+
     payload[vdevType] = category.vdevs.map((vdev) => {
       let typePayload = {
-        type: category.layout,
+        type: layout,
         disks: vdev.map((disk) => disk.devname),
       };
 
-      if (isDraidLayout(category.layout)) {
+      if (isDraidLayout(layout)) {
         typePayload = {
           ...typePayload,
           draid_data_disks: category.draidDataDisks,
@@ -55,6 +65,7 @@ export function poolTopologyToStoreTopology(topology: PoolTopology, disks: Detai
     return {
       ...topologySoFar,
       [value]: {
+        layout: null,
         width: null,
         diskSize: null,
         diskType: null,
@@ -62,6 +73,8 @@ export function poolTopologyToStoreTopology(topology: PoolTopology, disks: Detai
         treatDiskSizeAsMinimum: false,
         vdevs: [],
         hasCustomDiskSelection: false,
+        draidDataDisks: null,
+        draidSpareDisks: null,
       } as PoolManagerTopologyCategory,
     };
   }, {} as PoolManagerTopology);
@@ -75,8 +88,8 @@ export function poolTopologyToStoreTopology(topology: PoolTopology, disks: Detai
     const width = vdevs[0].children.length || 1;
     const minSize = Math.min(...(disks.map((disk) => disk.size)));
 
-    let draidDataDisks: number = null;
-    let draidSpareDisks: number = null;
+    let draidDataDisks: number | null = null;
+    let draidSpareDisks: number | null = null;
 
     if (vdevs[0].type === TopologyItemType.Draid) {
       const parsedDraidInfo = parseDraidVdevName(vdevs[0].name);
@@ -103,9 +116,8 @@ export function poolTopologyToStoreTopology(topology: PoolTopology, disks: Detai
               } as DetailsDisk),
             );
           }
-          return [
-            { ...disks.find((disk) => disk.devname === topologyItem.disk) },
-          ];
+          const matchedDisk = disks.find((disk) => disk.devname === topologyItem.disk);
+          return matchedDisk ? [{ ...matchedDisk }] : [];
         },
       ),
       treatDiskSizeAsMinimum: false,

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -168,7 +168,7 @@ export function resolveTopologyLayout(items: VDevItem[] | undefined): CreateVdev
   if (firstItem.type === TopologyItemType.Draid) {
     return parseDraidVdevName(firstItem.name).layout;
   }
-  return topologyTypeToLayout[firstItem.type];
+  return topologyTypeToLayout[firstItem.type] ?? null;
 }
 
 /**

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -206,7 +206,7 @@ function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLayout | n
  * Returns null when none are set (e.g. user jumps to this step before picking
  * a data layout); callers should allow the full non-dRAID list in that case.
  */
-export function resolveSpecialLayoutLock(
+export function resolveParityLockedLayout(
   existingCategory: VDevItem[] | undefined,
   existingData: VDevItem[] | undefined,
   wizardDataLayout: CreateVdevLayout | null | undefined,
@@ -222,23 +222,35 @@ export function resolveSpecialLayoutLock(
   return wizardDataLayout ? nonDraidEquivalent(wizardDataLayout) : null;
 }
 
+export interface ParityLayoutLockState {
+  lockedLayout: CreateVdevLayout | null;
+  currentLayout: CreateVdevLayout | null;
+}
+
 /**
- * Emits the layout that the given special/dedup category must lock to, or
- * null when no lock applies yet. Shared by the metadata and dedup wizard
- * steps so both react to the same set of inputs in the same way.
+ * Emits the lock state for the given special/dedup category: the layout the
+ * category must match (or null when no lock applies), plus the layout the
+ * store currently holds for that category so callers can detect and clear
+ * stale selections in a single subscription. Shared by the metadata and
+ * dedup wizard steps so both react to the same set of inputs in the same way.
  */
-export function lockedSpecialLayout$(
+export function lockedParityLayout$(
   pool$: Observable<Pool | null>,
   topology$: Observable<PoolManagerTopology>,
   vdevType: VDevType.Special | VDevType.Dedup,
-): Observable<CreateVdevLayout | null> {
+): Observable<ParityLayoutLockState> {
   return combineLatest([pool$, topology$]).pipe(
-    map(([pool, topology]) => resolveSpecialLayoutLock(
-      pool?.topology[vdevType],
-      pool?.topology[VDevType.Data],
-      topology[VDevType.Data]?.layout,
+    map(([pool, topology]): ParityLayoutLockState => ({
+      lockedLayout: resolveParityLockedLayout(
+        pool?.topology[vdevType],
+        pool?.topology[VDevType.Data],
+        topology[VDevType.Data]?.layout,
+      ),
+      currentLayout: topology[vdevType]?.layout ?? null,
+    })),
+    distinctUntilChanged((a, b) => (
+      a.lockedLayout === b.lockedLayout && a.currentLayout === b.currentLayout
     )),
-    distinctUntilChanged(),
   );
 }
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -143,7 +143,7 @@ export function nonDraidEquivalent(layout: CreateVdevLayout): CreateVdevLayout {
 }
 
 /** Used only via {@link resolveTopologyLayout}; Disk and Draid are handled before lookup. */
-const topologyTypeToLayout: Record<string, CreateVdevLayout> = {
+const topologyTypeToLayout: Partial<Record<TopologyItemType, CreateVdevLayout>> = {
   [TopologyItemType.Stripe]: CreateVdevLayout.Stripe,
   [TopologyItemType.Mirror]: CreateVdevLayout.Mirror,
   [TopologyItemType.Raidz]: CreateVdevLayout.Raidz1,
@@ -211,10 +211,11 @@ export function resolveSpecialLayoutLock(
 export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(CreateVdevLayout)
   .filter((layout) => !isDraidLayout(layout));
 
-export function isDraidLayout(layout: CreateVdevLayout | null): boolean {
+export function isDraidLayout(layout: CreateVdevLayout | TopologyItemType | null | undefined): boolean {
   return layout === CreateVdevLayout.Draid1
     || layout === CreateVdevLayout.Draid2
-    || layout === CreateVdevLayout.Draid3;
+    || layout === CreateVdevLayout.Draid3
+    || layout === TopologyItemType.Draid;
 }
 
 export function parseDraidVdevName(

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -121,6 +121,28 @@ export function poolTopologyToStoreTopology(topology: PoolTopology, disks: Detai
   return poolManagerTopology;
 }
 
+/**
+ * Non-data vdevs (special, dedup) don't support DRAID, but should match the
+ * redundancy level of the data vdevs. This maps any layout to its non-DRAID
+ * equivalent with the same parity level.
+ */
+export function nonDraidEquivalent(layout: CreateVdevLayout): CreateVdevLayout {
+  switch (layout) {
+    case CreateVdevLayout.Draid1: return CreateVdevLayout.Raidz1;
+    case CreateVdevLayout.Draid2: return CreateVdevLayout.Raidz2;
+    case CreateVdevLayout.Draid3: return CreateVdevLayout.Raidz3;
+    default: return layout;
+  }
+}
+
+export const nonDraidLayouts: CreateVdevLayout[] = [
+  CreateVdevLayout.Stripe,
+  CreateVdevLayout.Mirror,
+  CreateVdevLayout.Raidz1,
+  CreateVdevLayout.Raidz2,
+  CreateVdevLayout.Raidz3,
+];
+
 export function isDraidLayout(layout: CreateVdevLayout | TopologyItemType): boolean {
   return [
     CreateVdevLayout.Draid1,

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -182,6 +182,32 @@ export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLay
   return layout !== null ? nonDraidEquivalent(layout) : null;
 }
 
+/**
+ * Resolves the layout that a special or dedup vdev must be locked to.
+ * These vdevs' failure destroys the whole pool, so their redundancy must match
+ * the data vdev's. Preference order:
+ *   1. Existing special/dedup layout (already in the pool).
+ *   2. Existing data layout (pool already has data vdevs).
+ *   3. Wizard-selected data layout (new pool being created).
+ * Returns null when none are set (e.g. user jumps to this step before picking
+ * a data layout); callers should allow the full non-dRAID list in that case.
+ */
+export function resolveSpecialLayoutLock(
+  existingCategory: VDevItem[] | undefined,
+  existingData: VDevItem[] | undefined,
+  wizardDataLayout: CreateVdevLayout | null | undefined,
+): CreateVdevLayout | null {
+  const categoryLayout = existingVdevLayout(existingCategory);
+  if (categoryLayout) {
+    return categoryLayout;
+  }
+  const dataLayout = existingVdevLayout(existingData);
+  if (dataLayout) {
+    return dataLayout;
+  }
+  return wizardDataLayout ? nonDraidEquivalent(wizardDataLayout) : null;
+}
+
 export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(CreateVdevLayout)
   .filter((layout) => !isDraidLayout(layout));
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -32,8 +32,7 @@ export function topologyToPayload(topology: PoolManagerTopology): UpdatePoolTopo
     }
 
     if (category.layout === null) {
-      console.warn(`topologyToPayload: category "${vdevType}" has vdevs but no layout set — skipping.`);
-      return;
+      throw new Error(`topologyToPayload: category "${vdevType}" has vdevs but no layout set.`);
     }
 
     const { layout } = category;
@@ -184,7 +183,7 @@ export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLay
 export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(CreateVdevLayout)
   .filter((layout) => !isDraidLayout(layout));
 
-export function isDraidLayout(layout: CreateVdevLayout | TopologyItemType): boolean {
+export function isDraidLayout(layout: CreateVdevLayout | TopologyItemType | null): boolean {
   return [
     CreateVdevLayout.Draid1,
     CreateVdevLayout.Draid2,

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -32,7 +32,8 @@ export function topologyToPayload(topology: PoolManagerTopology): UpdatePoolTopo
     }
 
     if (category.layout === null) {
-      throw new Error(`topologyToPayload: category "${vdevType}" has vdevs but no layout set.`);
+      console.error(`topologyToPayload: category "${vdevType}" has vdevs but no layout set.`);
+      return;
     }
 
     const { layout } = category;
@@ -183,13 +184,10 @@ export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLay
 export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(CreateVdevLayout)
   .filter((layout) => !isDraidLayout(layout));
 
-export function isDraidLayout(layout: CreateVdevLayout | TopologyItemType | null): boolean {
-  return [
-    CreateVdevLayout.Draid1,
-    CreateVdevLayout.Draid2,
-    CreateVdevLayout.Draid3,
-    TopologyItemType.Draid,
-  ].includes(layout);
+export function isDraidLayout(layout: CreateVdevLayout | null): boolean {
+  return layout === CreateVdevLayout.Draid1
+    || layout === CreateVdevLayout.Draid2
+    || layout === CreateVdevLayout.Draid3;
 }
 
 export function parseDraidVdevName(

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -1,7 +1,10 @@
+import { combineLatest, distinctUntilChanged, map, Observable } from 'rxjs';
 import { DiskType } from 'app/enums/disk-type.enum';
 import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
 import { DetailsDisk } from 'app/interfaces/disk.interface';
-import { DataPoolTopologyUpdate, PoolTopology, UpdatePoolTopology } from 'app/interfaces/pool.interface';
+import {
+  DataPoolTopologyUpdate, Pool, PoolTopology, UpdatePoolTopology,
+} from 'app/interfaces/pool.interface';
 import { VDevItem } from 'app/interfaces/storage.interface';
 import {
   PoolManagerTopology,
@@ -129,6 +132,17 @@ export function poolTopologyToStoreTopology(topology: PoolTopology, disks: Detai
 }
 
 /**
+ * Single source of truth for which CreateVdevLayout values are dRAID.
+ * isDraidLayout and nonDraidLayouts both derive from this so a new DRAID
+ * enum member can't slip into nonDraidLayouts by accident.
+ */
+const draidCreateLayouts: readonly CreateVdevLayout[] = [
+  CreateVdevLayout.Draid1,
+  CreateVdevLayout.Draid2,
+  CreateVdevLayout.Draid3,
+];
+
+/**
  * Non-data vdevs (special, dedup) don't support DRAID, but should match the
  * redundancy level of the data vdevs. This maps any layout to its non-DRAID
  * equivalent with the same parity level.
@@ -177,7 +191,7 @@ export function resolveTopologyLayout(items: VDevItem[] | undefined): CreateVdev
  * Like resolveTopologyLayout, but maps dRAID layouts to their raidz equivalents.
  * Used for non-data vdevs (special, dedup) that don't support dRAID.
  */
-export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLayout | null {
+function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLayout | null {
   const layout = resolveTopologyLayout(items);
   return layout !== null ? nonDraidEquivalent(layout) : null;
 }
@@ -208,14 +222,34 @@ export function resolveSpecialLayoutLock(
   return wizardDataLayout ? nonDraidEquivalent(wizardDataLayout) : null;
 }
 
+/**
+ * Emits the layout that the given special/dedup category must lock to, or
+ * null when no lock applies yet. Shared by the metadata and dedup wizard
+ * steps so both react to the same set of inputs in the same way.
+ */
+export function lockedSpecialLayout$(
+  pool$: Observable<Pool | null>,
+  topology$: Observable<PoolManagerTopology>,
+  vdevType: VDevType.Special | VDevType.Dedup,
+): Observable<CreateVdevLayout | null> {
+  return combineLatest([pool$, topology$]).pipe(
+    map(([pool, topology]) => resolveSpecialLayoutLock(
+      pool?.topology[vdevType],
+      pool?.topology[VDevType.Data],
+      topology[VDevType.Data]?.layout,
+    )),
+    distinctUntilChanged(),
+  );
+}
+
 export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(CreateVdevLayout)
-  .filter((layout) => !isDraidLayout(layout));
+  .filter((layout) => !draidCreateLayouts.includes(layout));
 
 export function isDraidLayout(layout: CreateVdevLayout | TopologyItemType | null | undefined): boolean {
-  return layout === CreateVdevLayout.Draid1
-    || layout === CreateVdevLayout.Draid2
-    || layout === CreateVdevLayout.Draid3
-    || layout === TopologyItemType.Draid;
+  if (layout === TopologyItemType.Draid) {
+    return true;
+  }
+  return draidCreateLayouts.includes(layout as CreateVdevLayout);
 }
 
 export function parseDraidVdevName(

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -212,11 +212,11 @@ export function resolveSpecialLayoutLock(
   wizardDataLayout: CreateVdevLayout | null | undefined,
 ): CreateVdevLayout | null {
   const categoryLayout = existingVdevLayout(existingCategory);
-  if (categoryLayout) {
+  if (categoryLayout !== null) {
     return categoryLayout;
   }
   const dataLayout = existingVdevLayout(existingData);
-  if (dataLayout) {
+  if (dataLayout !== null) {
     return dataLayout;
   }
   return wizardDataLayout ? nonDraidEquivalent(wizardDataLayout) : null;

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -222,42 +222,29 @@ export function resolveParityLockedLayout(
   return wizardDataLayout ? nonDraidEquivalent(wizardDataLayout) : null;
 }
 
-export interface ParityLayoutLockState {
-  lockedLayout: CreateVdevLayout | null;
-  currentLayout: CreateVdevLayout | null;
-}
-
 /**
- * Emits the lock state for the given special/dedup category: the layout the
- * category must match (or null when no lock applies), plus the layout the
- * store currently holds for that category so callers can detect and clear
- * stale selections in a single subscription. Shared by the metadata and
- * dedup wizard steps so both react to the same set of inputs in the same way.
+ * Emits the layout that the given special/dedup category must be locked to,
+ * or null when no lock applies. Shared by the metadata and dedup wizard steps
+ * so both react to the same set of inputs in the same way.
  */
 export function lockedParityLayout$(
   pool$: Observable<Pool | null>,
   topology$: Observable<PoolManagerTopology>,
   vdevType: VDevType.Special | VDevType.Dedup,
-): Observable<ParityLayoutLockState> {
+): Observable<CreateVdevLayout | null> {
   return combineLatest([pool$, topology$]).pipe(
-    map(([pool, topology]): ParityLayoutLockState => ({
-      lockedLayout: resolveParityLockedLayout(
-        pool?.topology[vdevType],
-        pool?.topology[VDevType.Data],
-        topology[VDevType.Data]?.layout,
-      ),
-      currentLayout: topology[vdevType]?.layout ?? null,
-    })),
-    distinctUntilChanged((a, b) => (
-      a.lockedLayout === b.lockedLayout && a.currentLayout === b.currentLayout
+    map(([pool, topology]) => resolveParityLockedLayout(
+      pool?.topology[vdevType],
+      pool?.topology[VDevType.Data],
+      topology[VDevType.Data].layout,
     )),
+    distinctUntilChanged(),
   );
 }
 
 /**
- * Order follows CreateVdevLayout declaration order, which also drives the
- * ordering of options in the layout dropdown. Reordering enum members will
- * change the visible option order.
+ * Every CreateVdevLayout value except the dRAID ones. Order is not semantic —
+ * dropdown ordering is driven by {@link vdevLayoutOptions} in the component.
  */
 export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(CreateVdevLayout)
   .filter((layout) => !draidCreateLayouts.includes(layout));

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -35,6 +35,10 @@ export function topologyToPayload(topology: PoolManagerTopology): UpdatePoolTopo
     }
 
     if (category.layout === null) {
+      // Invariant assertion: by the time submit runs, every category with vdevs
+      // must have a layout. A silent skip here would drop the user's configured
+      // vdevs from the payload, so failing loud is preferable to a pool missing
+      // its special/dedup category.
       throw new Error(`topologyToPayload: category "${vdevType}" has vdevs but no layout set.`);
     }
 
@@ -191,7 +195,7 @@ export function resolveTopologyLayout(items: VDevItem[] | undefined): CreateVdev
  * Like resolveTopologyLayout, but maps dRAID layouts to their raidz equivalents.
  * Used for non-data vdevs (special, dedup) that don't support dRAID.
  */
-function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLayout | null {
+export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLayout | null {
   const layout = resolveTopologyLayout(items);
   return layout !== null ? nonDraidEquivalent(layout) : null;
 }

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -146,6 +146,7 @@ export function nonDraidEquivalent(layout: CreateVdevLayout): CreateVdevLayout {
 const topologyTypeToLayout: Record<string, CreateVdevLayout> = {
   [TopologyItemType.Stripe]: CreateVdevLayout.Stripe,
   [TopologyItemType.Mirror]: CreateVdevLayout.Mirror,
+  [TopologyItemType.Raidz]: CreateVdevLayout.Raidz1,
   [TopologyItemType.Raidz1]: CreateVdevLayout.Raidz1,
   [TopologyItemType.Raidz2]: CreateVdevLayout.Raidz2,
   [TopologyItemType.Raidz3]: CreateVdevLayout.Raidz3,

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -136,23 +136,41 @@ export function nonDraidEquivalent(layout: CreateVdevLayout): CreateVdevLayout {
   }
 }
 
+const topologyTypeToLayout: Record<string, CreateVdevLayout> = {
+  [TopologyItemType.Stripe]: CreateVdevLayout.Stripe,
+  [TopologyItemType.Mirror]: CreateVdevLayout.Mirror,
+  [TopologyItemType.Raidz1]: CreateVdevLayout.Raidz1,
+  [TopologyItemType.Raidz2]: CreateVdevLayout.Raidz2,
+  [TopologyItemType.Raidz3]: CreateVdevLayout.Raidz3,
+};
+
 /**
- * Resolves the layout of existing vdev items to a non-DRAID CreateVdevLayout.
+ * Resolves the layout of existing vdev items to a CreateVdevLayout.
+ * All items in the array are assumed to share the same layout (ZFS guarantees
+ * this per vdev category), so only the first item is inspected.
  * Returns null when there are no existing items.
  */
-export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLayout | null {
+export function resolveTopologyLayout(items: VDevItem[] | undefined): CreateVdevLayout | null {
   if (!items?.length) {
     return null;
   }
-  // TODO: Similar code in poolTopologyToStoreTopology
-  let type = items[0].type;
-  if (type === TopologyItemType.Disk && !items[0].children.length) {
-    type = TopologyItemType.Stripe as TopologyItemType;
-  } else if (type === TopologyItemType.Draid) {
-    const parsedVdevName = parseDraidVdevName(items[0].name);
-    type = parsedVdevName.layout as unknown as TopologyItemType;
+  const firstItem = items[0];
+  if (firstItem.type === TopologyItemType.Disk && !firstItem.children.length) {
+    return CreateVdevLayout.Stripe;
   }
-  return nonDraidEquivalent(type as unknown as CreateVdevLayout);
+  if (firstItem.type === TopologyItemType.Draid) {
+    return parseDraidVdevName(firstItem.name).layout;
+  }
+  return topologyTypeToLayout[firstItem.type];
+}
+
+/**
+ * Like resolveTopologyLayout, but maps dRAID layouts to their raidz equivalents.
+ * Used for non-data vdevs (special, dedup) that don't support dRAID.
+ */
+export function existingVdevLayout(items: VDevItem[] | undefined): CreateVdevLayout | null {
+  const layout = resolveTopologyLayout(items);
+  return layout !== null ? nonDraidEquivalent(layout) : null;
 }
 
 export const nonDraidLayouts: CreateVdevLayout[] = Object.values(CreateVdevLayout)


### PR DESCRIPTION
Testing: see ticket.

  ## Summary
  - Centralize vdev layout resolution into reusable resolveTopologyLayout() and existingVdevLayout() utilities, eliminating    duplicated topology-type-to-layout conversion logic across data/log/metadata/dedup wizard steps                          
  - Filter dRAID layouts from special (metadata) and dedup vdev steps — these vdev types don't support dRAID, so now they only show non-dRAID equivalents with matching parity                                                                             
  - Harden topologyToPayload() to skip empty categories and throw on missing layout, preventing invalid API payloads             
  - Add tests for existing-pool layout locking in metadata and dedup wizard steps                                   
  - Remove now-unused getLayoutsForVdevType() from pool manager store 
  
  ### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | New helper text added (  - Filter dRAID layouts from special (metadata) and dedup vdev steps — these vdev types don't support dRAID, so now they only show non-dRAID equivalents with matching parity                                                                             )
|Testing         | 
