### PR TITLE
NAS-128456 / 27.0.0-BETA.1 / Change in support down to bronze does not change state of proactive support

### DIFF
--- a/src/app/helptext/system/support.ts
+++ b/src/app/helptext/system/support.ts
@@ -12,6 +12,7 @@ export const helptextSystemSupport = {
     secondaryContact: T('Secondary Contact'),
 
     dialogMessage: T('Successfully saved proactive support settings.'),
+    unavailableMessage: T('Proactive support is not available on your license.'),
   },
 
   bug: {

--- a/src/app/helptext/system/support.ts
+++ b/src/app/helptext/system/support.ts
@@ -12,8 +12,6 @@ export const helptextSystemSupport = {
     secondaryContact: T('Secondary Contact'),
 
     dialogMessage: T('Successfully saved proactive support settings.'),
-    dialogUnavailableTitle: T('Warning'),
-    dialogUnavailableWarning: T('Proactive support settings are not available.'),
   },
 
   bug: {

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.html
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.html
@@ -14,7 +14,7 @@
     <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
       <div class="two-columns">
         <ix-fieldset
-          [class.form-disable]="isFormDisabled"
+          [class.form-disable]="isSupportUnavailable()"
           [title]="helptext.proactive.primaryContact | translate"
           [tooltip]="helptext.proactive.instructions | translate"
         >
@@ -49,7 +49,7 @@
         </ix-fieldset>
 
         <ix-fieldset
-          [class.form-disable]="isFormDisabled"
+          [class.form-disable]="isSupportUnavailable()"
           [title]="helptext.proactive.secondaryContact | translate"
         >
           <ix-input
@@ -84,7 +84,7 @@
           type="submit"
           color="primary"
           ixTest="save"
-          [disabled]="form.invalid || isLoading() || isFormDisabled"
+          [disabled]="form.invalid || isLoading() || isSupportUnavailable()"
         >
           {{ 'Save' | translate }}
         </button>

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.html
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.html
@@ -8,7 +8,7 @@
   <mat-card-content>
     @if (isSupportUnavailable()) {
       <ix-warning
-        [message]="'Proactive support is not available on your license.' | translate"
+        [message]="helptext.proactive.unavailableMessage | translate"
       ></ix-warning>
     }
     <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.html
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.html
@@ -6,6 +6,11 @@
 
 <mat-card>
   <mat-card-content>
+    @if (isSupportUnavailable()) {
+      <ix-warning
+        [message]="'Proactive support is not available on your license.' | translate"
+      ></ix-warning>
+    }
     <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
       <div class="two-columns">
         <ix-fieldset

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.html
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.html
@@ -7,9 +7,7 @@
 <mat-card>
   <mat-card-content>
     @if (isSupportUnavailable()) {
-      <ix-warning
-        [message]="helptext.proactive.unavailableMessage | translate"
-      ></ix-warning>
+      <ix-warning [message]="helptext.proactive.unavailableMessage"></ix-warning>
     }
     <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
       <div class="two-columns">

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.spec.ts
@@ -9,7 +9,6 @@ import {
 import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { DialogService } from 'app/modules/dialog/dialog.service';
 import { SupportConfig } from 'app/modules/feedback/interfaces/file-ticket.interface';
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
@@ -55,7 +54,6 @@ describe('ProactiveComponent', () => {
       ]),
       mockProvider(FormErrorHandlerService),
       mockProvider(SlideIn),
-      mockProvider(DialogService),
       mockProvider(SlideInRef, slideInRef),
     ],
   });
@@ -108,12 +106,11 @@ describe('ProactiveComponent', () => {
     expect(spectator.inject(SlideInRef).close).toHaveBeenCalled();
   });
 
-  it('shows a warning when support is not available', async () => {
+  it('disables form when support is not available', async () => {
     spectator.inject(MockApiService).mockCall('support.is_available', false);
     spectator.component.ngOnInit();
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
 
-    expect(spectator.inject(DialogService).warn).toHaveBeenCalled();
-    expect(saveButton.isDisabled()).toBeTruthy();
+    expect(await saveButton.isDisabled()).toBeTruthy();
   });
 });

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -59,7 +59,6 @@ export class ProactiveComponent implements OnInit {
 
   protected isLoading = signal(false);
   title = helptext.proactive.title;
-  protected isFormDisabled = false;
   protected isSupportUnavailable = signal(false);
   form = this.formBuilder.group({
     name: ['', [Validators.required]],
@@ -129,7 +128,6 @@ export class ProactiveComponent implements OnInit {
           this.patchFormValues(config, isEnabled);
         },
         error: (error: unknown) => {
-          this.isFormDisabled = true;
           this.form.disable();
           this.cdr.markForCheck();
           this.errorHandler.showErrorModal(error);
@@ -138,7 +136,6 @@ export class ProactiveComponent implements OnInit {
   }
 
   private supportUnavailable(): void {
-    this.isFormDisabled = true;
     this.isSupportUnavailable.set(true);
     this.form.disable();
     this.cdr.markForCheck();

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -10,7 +10,6 @@ import { forkJoin, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemSupport as helptext } from 'app/helptext/system/support';
-import { DialogService } from 'app/modules/dialog/dialog.service';
 import { SupportConfig, SupportConfigUpdate } from 'app/modules/feedback/interfaces/file-ticket.interface';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -48,7 +47,6 @@ export class ProactiveComponent implements OnInit {
   private errorHandler = inject(ErrorHandlerService);
   private api = inject(ApiService);
   private cdr = inject(ChangeDetectorRef);
-  private dialogService = inject(DialogService);
   private formErrorHandler = inject(FormErrorHandlerService);
   private translate = inject(TranslateService);
   private snackbar = inject(SnackbarService);
@@ -139,10 +137,7 @@ export class ProactiveComponent implements OnInit {
   private supportUnavailable(): void {
     this.isFormDisabled = true;
     this.form.disable();
-    this.dialogService.warn(
-      helptext.proactive.dialogUnavailableTitle,
-      helptext.proactive.dialogUnavailableWarning,
-    );
+    this.cdr.markForCheck();
   }
 
   private patchFormValues(config: Partial<SupportConfig>, isEnabled: boolean): void {

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -128,6 +128,7 @@ export class ProactiveComponent implements OnInit {
           this.patchFormValues(config, isEnabled);
         },
         error: (error: unknown) => {
+          this.isLoading.set(false);
           this.form.disable();
           this.cdr.markForCheck();
           this.errorHandler.showErrorModal(error);

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -14,6 +14,7 @@ import { SupportConfig, SupportConfigUpdate } from 'app/modules/feedback/interfa
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
+import { WarningComponent } from 'app/modules/forms/ix-forms/components/warning/warning.component';
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
 import { emailValidator } from 'app/modules/forms/ix-forms/validators/email-validation/email-validation';
 import { ModalHeaderComponent } from 'app/modules/slide-ins/components/modal-header/modal-header.component';
@@ -38,6 +39,7 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
     IxCheckboxComponent,
     RequiresRolesDirective,
     MatButton,
+    WarningComponent,
     TestDirective,
     TranslateModule,
   ],
@@ -57,7 +59,8 @@ export class ProactiveComponent implements OnInit {
 
   protected isLoading = signal(false);
   title = helptext.proactive.title;
-  isFormDisabled = false;
+  protected isFormDisabled = false;
+  protected isSupportUnavailable = signal(false);
   form = this.formBuilder.group({
     name: ['', [Validators.required]],
     title: ['', [Validators.required]],
@@ -136,6 +139,7 @@ export class ProactiveComponent implements OnInit {
 
   private supportUnavailable(): void {
     this.isFormDisabled = true;
+    this.isSupportUnavailable.set(true);
     this.form.disable();
     this.cdr.markForCheck();
   }

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -138,7 +138,6 @@ export class ProactiveComponent implements OnInit {
   private supportUnavailable(): void {
     this.isSupportUnavailable.set(true);
     this.form.disable();
-    this.cdr.markForCheck();
   }
 
   private patchFormValues(config: Partial<SupportConfig>, isEnabled: boolean): void {

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.html
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.html
@@ -118,6 +118,7 @@
         [systemInfo]="systemInfo"
         [licenseInfo]="licenseInfo"
         [productionControl]="hasLicense ? isProductionControl : null"
+        [isProactiveSupportAvailable]="isProactiveSupportAvailable()"
         [isProactiveSupportEnabled]="isProactiveSupportEnabled()"
         (editContacts)="openProactive()"
       ></ix-sys-info>

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
@@ -151,9 +151,9 @@ describe('SupportCardComponent', () => {
         expect(slideIn.open).toHaveBeenCalledWith(ProactiveComponent, { wide: true });
       });
 
-      it('re-checks proactive support availability after the slide-in closes', async () => {
+      it('re-checks proactive support availability after saving in the slide-in', async () => {
         const slideIn = spectator.inject(SlideIn);
-        jest.spyOn(slideIn, 'open').mockReturnValue(SlideInResult.cancel());
+        jest.spyOn(slideIn, 'open').mockReturnValue(SlideInResult.success(true));
 
         const api = spectator.inject(ApiService);
         const apiCallSpy = jest.spyOn(api, 'call');

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
@@ -151,9 +151,9 @@ describe('SupportCardComponent', () => {
         expect(slideIn.open).toHaveBeenCalledWith(ProactiveComponent, { wide: true });
       });
 
-      it('re-checks proactive support availability after saving in the slide-in', async () => {
+      it('re-checks proactive support availability after the slide-in closes', async () => {
         const slideIn = spectator.inject(SlideIn);
-        jest.spyOn(slideIn, 'open').mockReturnValue(SlideInResult.success(true));
+        jest.spyOn(slideIn, 'open').mockReturnValue(SlideInResult.cancel());
 
         const api = spectator.inject(ApiService);
         const apiCallSpy = jest.spyOn(api, 'call');

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
@@ -22,6 +22,7 @@ import {
 } from 'app/modules/forms/ix-forms/components/ix-slide-toggle/ix-slide-toggle.component';
 import { LocaleService } from 'app/modules/language/locale.service';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
+import { SlideInResult } from 'app/modules/slide-ins/slide-in-result';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { LicenseComponent } from 'app/pages/system/general-settings/support/license/license.component';
 import { ProactiveComponent } from 'app/pages/system/general-settings/support/proactive/proactive.component';
@@ -48,7 +49,9 @@ describe('SupportCardComponent', () => {
       mockProvider(MatDialog),
       mockProvider(DialogService),
       mockProvider(MatSnackBar),
-      mockProvider(SlideIn),
+      mockProvider(SlideIn, {
+        open: jest.fn(() => SlideInResult.empty()),
+      }),
       mockProvider(LocaleService, {
         getPreferredDateFormat: jest.fn(() => 'yyyy-MM-dd'),
       }),

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
@@ -151,6 +151,20 @@ describe('SupportCardComponent', () => {
         expect(slideIn.open).toHaveBeenCalledWith(ProactiveComponent, { wide: true });
       });
 
+      it('re-checks proactive support availability after the slide-in closes', async () => {
+        const slideIn = spectator.inject(SlideIn);
+        jest.spyOn(slideIn, 'open').mockReturnValue(SlideInResult.cancel());
+
+        const api = spectator.inject(ApiService);
+        const apiCallSpy = jest.spyOn(api, 'call');
+        apiCallSpy.mockClear();
+
+        const enableButton = await loader.getHarness(MatButtonHarness.with({ text: 'Enable' }));
+        await enableButton.click();
+
+        expect(apiCallSpy).toHaveBeenCalledWith('support.is_available');
+      });
+
       it('hides proactive support banner when enabled', () => {
         const api = spectator.inject(ApiService);
         jest.spyOn(api, 'call').mockImplementation((method: string) => {

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
@@ -164,7 +164,8 @@ export class SupportCardComponent implements OnInit {
   }
 
   openProactive(): void {
-    this.slideIn.open(ProactiveComponent, { wide: true });
+    this.slideIn.open(ProactiveComponent, { wide: true })
+      .onClose(() => this.checkProactiveSupportAvailability(), this.destroyRef);
   }
 
   private updateProductionStatus(newStatus: boolean): void {
@@ -228,11 +229,14 @@ export class SupportCardComponent implements OnInit {
       )
       .subscribe((isAvailable) => {
         this.isProactiveSupportAvailable.set(isAvailable);
-        this.cdr.markForCheck();
 
         if (isAvailable) {
           this.checkProactiveSupportEnabled();
+        } else {
+          this.isProactiveSupportEnabled.set(false);
         }
+
+        this.cdr.markForCheck();
       });
   }
 

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
@@ -165,7 +165,7 @@ export class SupportCardComponent implements OnInit {
 
   openProactive(): void {
     this.slideIn.open(ProactiveComponent, { wide: true })
-      .onSuccess(() => this.checkProactiveSupportAvailability(), this.destroyRef);
+      .onClose(() => this.checkProactiveSupportAvailability(), this.destroyRef);
   }
 
   private updateProductionStatus(newStatus: boolean): void {

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
@@ -165,7 +165,7 @@ export class SupportCardComponent implements OnInit {
 
   openProactive(): void {
     this.slideIn.open(ProactiveComponent, { wide: true })
-      .onClose(() => this.checkProactiveSupportAvailability(), this.destroyRef);
+      .onSuccess(() => this.checkProactiveSupportAvailability(), this.destroyRef);
   }
 
   private updateProductionStatus(newStatus: boolean): void {

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -31,8 +31,8 @@
           mat-button
           class="edit-contacts-btn"
           [disabled]="!isProactiveSupportAvailable()"
-          [matTooltip]="isProactiveSupportAvailable() ? '' : ('Proactive support is not available on your license.' | translate)"
-          (click)="isProactiveSupportAvailable() && editContacts.emit()"
+          [matTooltip]="isProactiveSupportAvailable() ? null : (helptext.proactive.unavailableMessage | translate)"
+          (click)="editContacts.emit()"
         >
           {{ 'Manage' | translate }}
         </button>

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -25,6 +25,8 @@
         <span class="label">{{ 'Proactive Support' | translate }}:</span>
         @if (isProactiveSupportEnabled()) {
           <span class="value">{{ 'Enabled' | translate }}</span>
+        } @else if (!isProactiveSupportAvailable()) {
+          <span class="value">{{ 'Not Available' | translate }}</span>
         }
         <button
           *ixRequiresRoles="requiredRoles"

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -20,28 +20,19 @@
         }
       </span>
     </mat-list-item>
-    @if (isProactiveSupportEnabled()) {
+    @if (isProactiveSupportEnabled() || !isProactiveSupportAvailable()) {
       <mat-list-item class="proactive-status">
         <span class="label">{{ 'Proactive Support' | translate }}:</span>
-        <span class="value">{{ 'Enabled' | translate }}</span>
+        @if (isProactiveSupportEnabled()) {
+          <span class="value">{{ 'Enabled' | translate }}</span>
+        }
         <button
           *ixRequiresRoles="requiredRoles"
           mat-button
           class="edit-contacts-btn"
+          [disabled]="!isProactiveSupportAvailable()"
+          [matTooltip]="isProactiveSupportAvailable() ? '' : ('Proactive support is not available on your license.' | translate)"
           (click)="editContacts.emit()"
-        >
-          {{ 'Manage' | translate }}
-        </button>
-      </mat-list-item>
-    } @else if (!isProactiveSupportAvailable()) {
-      <mat-list-item class="proactive-status">
-        <span class="label">{{ 'Proactive Support' | translate }}:</span>
-        <button
-          *ixRequiresRoles="requiredRoles"
-          mat-button
-          class="edit-contacts-btn"
-          disabled
-          [matTooltip]="'Proactive support is not available on your license.' | translate"
         >
           {{ 'Manage' | translate }}
         </button>

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -31,7 +31,7 @@
           mat-button
           class="edit-contacts-btn"
           [disabled]="!isProactiveSupportAvailable()"
-          [matTooltip]="isProactiveSupportAvailable() ? null : (helptext.proactive.unavailableMessage | translate)"
+          [matTooltip]="isProactiveSupportAvailable() ? '' : (helptext.proactive.unavailableMessage | translate)"
           (click)="editContacts.emit()"
         >
           {{ 'Manage' | translate }}

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -32,7 +32,7 @@
           class="edit-contacts-btn"
           [disabled]="!isProactiveSupportAvailable()"
           [matTooltip]="isProactiveSupportAvailable() ? '' : ('Proactive support is not available on your license.' | translate)"
-          (click)="editContacts.emit()"
+          (click)="isProactiveSupportAvailable() && editContacts.emit()"
         >
           {{ 'Manage' | translate }}
         </button>

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -29,11 +29,11 @@
           <span class="value">{{ 'Not Available' | translate }}</span>
         }
         <span
-          *ixRequiresRoles="requiredRoles"
           class="edit-contacts-wrapper"
           [matTooltip]="isProactiveSupportAvailable() ? '' : (helptext.proactive.unavailableMessage | translate)"
         >
           <button
+            *ixRequiresRoles="requiredRoles"
             mat-button
             class="edit-contacts-btn"
             [disabled]="!isProactiveSupportAvailable()"

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -37,6 +37,7 @@
       <mat-list-item class="proactive-status">
         <span class="label">{{ 'Proactive Support' | translate }}:</span>
         <button
+          *ixRequiresRoles="requiredRoles"
           mat-button
           class="edit-contacts-btn"
           disabled

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -33,7 +33,7 @@
           [matTooltip]="isProactiveSupportAvailable() ? '' : (helptext.proactive.unavailableMessage | translate)"
         >
           <button
-            *ixRequiresRoles="requiredRoles"
+            *ixRequiresRoles="manageProactiveRoles"
             mat-button
             class="edit-contacts-btn"
             [disabled]="!isProactiveSupportAvailable()"
@@ -49,7 +49,7 @@
       <span class="value">{{ license.model || systemInfo().model }}</span>
       @if (productionControl()) {
         <ix-slide-toggle
-          *ixRequiresRoles="requiredRoles"
+          *ixRequiresRoles="productionToggleRoles"
           class="production-toggle"
           color="primary"
           [formControl]="productionControl()"

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -33,6 +33,18 @@
           {{ 'Manage' | translate }}
         </button>
       </mat-list-item>
+    } @else if (!isProactiveSupportAvailable()) {
+      <mat-list-item class="proactive-status">
+        <span class="label">{{ 'Proactive Support' | translate }}:</span>
+        <button
+          mat-button
+          class="edit-contacts-btn"
+          disabled
+          [matTooltip]="'Proactive support is not available on your license.' | translate"
+        >
+          {{ 'Manage' | translate }}
+        </button>
+      </mat-list-item>
     }
     <mat-list-item class="model-row">
       <span class="label">{{ 'Model' | translate }}:</span>

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -25,19 +25,23 @@
         <span class="label">{{ 'Proactive Support' | translate }}:</span>
         @if (isProactiveSupportEnabled()) {
           <span class="value">{{ 'Enabled' | translate }}</span>
-        } @else if (!isProactiveSupportAvailable()) {
+        } @else {
           <span class="value">{{ 'Not Available' | translate }}</span>
         }
-        <button
+        <span
           *ixRequiresRoles="requiredRoles"
-          mat-button
-          class="edit-contacts-btn"
-          [disabled]="!isProactiveSupportAvailable()"
+          class="edit-contacts-wrapper"
           [matTooltip]="isProactiveSupportAvailable() ? '' : (helptext.proactive.unavailableMessage | translate)"
-          (click)="editContacts.emit()"
         >
-          {{ 'Manage' | translate }}
-        </button>
+          <button
+            mat-button
+            class="edit-contacts-btn"
+            [disabled]="!isProactiveSupportAvailable()"
+            (click)="editContacts.emit()"
+          >
+            {{ 'Manage' | translate }}
+          </button>
+        </span>
       </mat-list-item>
     }
     <mat-list-item class="model-row">

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.scss
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.scss
@@ -11,7 +11,7 @@
   display: flex;
   align-items: center;
 
-  .edit-contacts-btn {
+  .edit-contacts-wrapper {
     margin-left: auto;
   }
 }

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -134,9 +134,8 @@ describe('SysInfoComponent', () => {
     });
 
     it('shows proactive support row with disabled Manage button and Not Available value', async () => {
-      const proactiveRow = spectator.query('.proactive-status');
-      expect(proactiveRow).toExist();
-      expect(proactiveRow!.querySelector('.value')!.textContent!.trim()).toBe('Not Available');
+      expect(spectator.query('.proactive-status')).toExist();
+      expect(spectator.query('.proactive-status .value')?.textContent?.trim()).toBe('Not Available');
 
       const manageButton = await loader.getHarness(MatButtonHarness.with({ text: 'Manage' }));
       expect(await manageButton.isDisabled()).toBe(true);

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -133,9 +133,10 @@ describe('SysInfoComponent', () => {
       });
     });
 
-    it('shows proactive support row with disabled Manage button', async () => {
+    it('shows proactive support row with disabled Manage button and Not Available value', async () => {
       const proactiveRow = spectator.query('.proactive-status');
       expect(proactiveRow).toExist();
+      expect(proactiveRow!.querySelector('.value')!.textContent!.trim()).toBe('Not Available');
 
       const manageButton = await loader.getHarness(MatButtonHarness.with({ text: 'Manage' }));
       expect(await manageButton.isDisabled()).toBe(true);

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -69,6 +69,7 @@ describe('SysInfoComponent', () => {
     spectator.setInput({
       licenseInfo: licenseInfo as LicenseInfoInSupport,
       hasLicense: true,
+      isProactiveSupportAvailable: true,
     });
 
     const infoRows = getInfoRows();
@@ -89,6 +90,7 @@ describe('SysInfoComponent', () => {
       spectator.setInput({
         licenseInfo: licenseInfo as LicenseInfoInSupport,
         hasLicense: true,
+        isProactiveSupportAvailable: true,
         isProactiveSupportEnabled: true,
       });
     });
@@ -110,13 +112,33 @@ describe('SysInfoComponent', () => {
       expect(editContactsEmitted).toBe(true);
     });
 
-    it('does not show proactive support row when not enabled', () => {
+    it('does not show proactive support row when not enabled but available', () => {
       spectator.setInput({
+        isProactiveSupportAvailable: true,
         isProactiveSupportEnabled: false,
       });
 
       const proactiveRow = spectator.query('.proactive-status');
       expect(proactiveRow).not.toExist();
+    });
+  });
+
+  describe('Proactive support not available', () => {
+    beforeEach(() => {
+      spectator.setInput({
+        licenseInfo: licenseInfo as LicenseInfoInSupport,
+        hasLicense: true,
+        isProactiveSupportAvailable: false,
+        isProactiveSupportEnabled: false,
+      });
+    });
+
+    it('shows proactive support row with disabled Manage button', async () => {
+      const proactiveRow = spectator.query('.proactive-status');
+      expect(proactiveRow).toExist();
+
+      const manageButton = await loader.getHarness(MatButtonHarness.with({ text: 'Manage' }));
+      expect(await manageButton.isDisabled()).toBe(true);
     });
   });
 
@@ -126,6 +148,7 @@ describe('SysInfoComponent', () => {
       spectator.setInput({
         licenseInfo: licenseInfo as LicenseInfoInSupport,
         hasLicense: true,
+        isProactiveSupportAvailable: true,
         productionControl,
       });
 

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
@@ -41,7 +41,8 @@ export class SysInfoComponent {
 
   readonly editContacts = output();
 
-  protected readonly requiredRoles = [Role.FullAdmin];
+  protected readonly productionToggleRoles = [Role.FullAdmin];
+  protected readonly manageProactiveRoles = [Role.SupportWrite];
   protected readonly getLabelForContractType = getLabelForContractType;
   protected readonly helptext = helptextSystemSupport;
 }

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
@@ -8,6 +8,7 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
+import { helptextSystemSupport } from 'app/helptext/system/support';
 import { getLabelForContractType } from 'app/interfaces/system-info.interface';
 import {
   IxSlideToggleComponent,
@@ -42,4 +43,5 @@ export class SysInfoComponent {
 
   protected readonly requiredRoles = [Role.FullAdmin];
   protected readonly getLabelForContractType = getLabelForContractType;
+  protected readonly helptext = helptextSystemSupport;
 }

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
@@ -4,6 +4,7 @@ import {
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { MatListModule } from '@angular/material/list';
+import { MatTooltip } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
@@ -22,6 +23,7 @@ import { SystemInfoInSupport } from 'app/pages/system/general-settings/support/s
   imports: [
     MatButton,
     MatListModule,
+    MatTooltip,
     ReactiveFormsModule,
     IxSlideToggleComponent,
     RequiresRolesDirective,
@@ -33,6 +35,7 @@ export class SysInfoComponent {
   readonly licenseInfo = input<LicenseInfoInSupport>();
   readonly systemInfo = input.required<SystemInfoInSupport>();
   readonly productionControl = input<FormControl<boolean>>();
+  readonly isProactiveSupportAvailable = input<boolean>(false);
   readonly isProactiveSupportEnabled = input<boolean>(false);
 
   readonly editContacts = output();


### PR DESCRIPTION
**Changes:**                                                                                                                   
                                                                                                                                 
  - When proactive support is not available on the license, the "Manage" button in the sys-info section is now shown as disabled 
  with a tooltip ("Proactive support is not available on your license.") instead of being hidden.                                
  - Removed the warning dialog that popped up when opening the proactive support form with an unavailable license; the form now  
  simply disables itself silently.                                                                                               
  - Added `ixRequiresRoles` directive to the disabled proactive support button for proper role-based access control.
  - Re-check proactive support availability after closing the proactive slide-in.                                                
                               
<img width="789" height="613" alt="NAS-128456" src="https://github.com/user-attachments/assets/95af585e-460e-492a-ba42-f28e5d4f3f52" />
                                                                                                  
  **Testing:**                                                                                                                   
                                                                                                                                 
  Refer to ticket NAS-128456.             
  
I used that mock json:
                                    
[proactive-support.json](https://github.com/user-attachments/files/26826161/proactive-support.json)
                                                     
  
  ### Downstream                                                                                                                 
  <!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->
                                                                                                                                 
  |Affects         |Reasoning                                                                                                    
  |----------------|-------------------------------                                                                              
  |Documentation   | No                                                                                                          
  |Testing         | Yes — updated unit tests for `ProactiveComponent`, `SupportCardComponent`, and `SysInfoComponent` to cover
  the new disabled state and removed dialog behavior.  