### PR TITLE
NAS-140713 / 27.0.0-BETA.1 / Prevent empty /system/support page

### DIFF
--- a/src/app/pages/system/system.routes.ts
+++ b/src/app/pages/system/system.routes.ts
@@ -119,8 +119,13 @@ export const systemRoutes: Routes = [
       },
       {
         path: 'support',
-        data: { title: T('Support'), breadcrumb: T('Support') },
+        data: { title: T('Support'), breadcrumb: null },
         children: [
+          {
+            path: '',
+            pathMatch: 'full',
+            redirectTo: '/system/general',
+          },
           {
             path: 'eula',
             component: EulaComponent,


### PR DESCRIPTION
 **Summary**            
                                                                                                                                 
  - Redirect /system/support to /system/general to prevent rendering an empty page when navigated to directly.                   
  - Drop the Support breadcrumb on the parent route since it no longer has a landing view.
                                                                                                                                 
  **Test plan**                                                       
                                                                                                                                 
  - Navigate directly to /system/support and confirm redirect to /system/general.                                                
  - Verify child routes (/system/support/eula, etc.) still load normally.
  - Check breadcrumbs on child pages render correctly without a Support crumb.  