### PR TITLE
NAS-140660 / 26.0.0-BETA.2 / Snapshot created by a Replication Task defaults to a 2 week Lifetime (by AlexKarpov98)

### DIFF
--- a/src/app/helptext/data-protection/replication/replication-wizard.ts
+++ b/src/app/helptext/data-protection/replication/replication-wizard.ts
@@ -127,6 +127,7 @@ If not checked, <i>zfs allow</i> must be used to grant non-user permissions to p
   sourceLifetimeTooltip: T('How long snapshots created by the periodic\
  snapshot task on the source system are kept before being deleted.\
  Enter a number and choose a measure of time from the drop-down.'),
+  sourceLifetimeUnitLabel: T('Unit'),
 
   retentionPolicyLabel: T('Destination Snapshot Lifetime'),
   retentionPolicyTooltip: T('When replicated snapshots are deleted \

--- a/src/app/helptext/data-protection/replication/replication-wizard.ts
+++ b/src/app/helptext/data-protection/replication/replication-wizard.ts
@@ -127,7 +127,6 @@ If not checked, <i>zfs allow</i> must be used to grant non-user permissions to p
   sourceLifetimeTooltip: T('How long snapshots created by the periodic\
  snapshot task on the source system are kept before being deleted.\
  Enter a number and choose a measure of time from the drop-down.'),
-  sourceLifetimeUnitLabel: T('Unit'),
 
   retentionPolicyLabel: T('Destination Snapshot Lifetime'),
   retentionPolicyTooltip: T('When replicated snapshots are deleted \

--- a/src/app/helptext/data-protection/replication/replication-wizard.ts
+++ b/src/app/helptext/data-protection/replication/replication-wizard.ts
@@ -123,6 +123,11 @@ If not checked, <i>zfs allow</i> must be used to grant non-user permissions to p
   readonlyTooltip: T('Setting this option changes the destination dataset to be read-only.\
  To continue using the default or existing dataset read permissions, leave this option unset.'),
 
+  sourceLifetimeLabel: T('Source Snapshot Lifetime'),
+  sourceLifetimeTooltip: T('How long snapshots created by the periodic\
+ snapshot task on the source system are kept before being deleted.\
+ Enter a number and choose a measure of time from the drop-down.'),
+
   retentionPolicyLabel: T('Destination Snapshot Lifetime'),
   retentionPolicyTooltip: T('When replicated snapshots are deleted \
  from the destination system: <br> \

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard-data.interface.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard-data.interface.ts
@@ -35,8 +35,8 @@ export interface ReplicationWizardData {
   retention_policy: RetentionPolicy;
   lifetime_value: number;
   lifetime_unit: LifetimeUnit;
-  source_lifetime_value: number;
-  source_lifetime_unit: LifetimeUnit;
+  source_lifetime_value?: number;
+  source_lifetime_unit?: LifetimeUnit;
   periodic_snapshot_tasks?: number[];
   sudo: boolean;
 }

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard-data.interface.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard-data.interface.ts
@@ -35,6 +35,8 @@ export interface ReplicationWizardData {
   retention_policy: RetentionPolicy;
   lifetime_value: number;
   lifetime_unit: LifetimeUnit;
+  source_lifetime_value: number;
+  source_lifetime_unit: LifetimeUnit;
   periodic_snapshot_tasks?: number[];
   sudo: boolean;
 }

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.html
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.html
@@ -11,13 +11,17 @@
 
       <mat-step [stepControl]="whatAndWhere().form">
         <ng-template matStepLabel>{{ 'What and Where' | translate }}</ng-template>
-        <ix-replication-what-and-where (customRetentionVisibleChange)="isCustomRetentionVisible = $event"></ix-replication-what-and-where>
+        <ix-replication-what-and-where
+          (customRetentionVisibleChange)="isCustomRetentionVisible = $event"
+          (sourceLocalChange)="isSourceLocal = $event"
+        ></ix-replication-what-and-where>
       </mat-step>
 
       <mat-step [stepControl]="when().form">
         <ng-template matStepLabel>{{ 'When' | translate }}</ng-template>
         <ix-replication-when
           [isCustomRetentionVisible]="isCustomRetentionVisible"
+          [isSourceLocal]="isSourceLocal"
           [isLoading]="isLoading"
           (save)="onSubmit()"
         ></ix-replication-when>

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.spec.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.spec.ts
@@ -221,7 +221,9 @@ describe('ReplicationWizardComponent', () => {
 
     await goToNextStep();
 
-    const sourceLifetimeInput = await loader.getHarness(IxInputHarness.with({ label: 'Source Snapshot Lifetime' }));
+    const sourceLifetimeInput = await loader.getHarness(
+      IxInputHarness.with({ selector: '[formControlName="source_lifetime_value"]' }),
+    );
     await sourceLifetimeInput.setValue('3');
 
     const sourceLifetimeUnit = await loader.getHarness(

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.spec.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.spec.ts
@@ -18,7 +18,9 @@ import { ScheduleMethod } from 'app/enums/schedule-method.enum';
 import { TransportMode } from 'app/enums/transport-mode.enum';
 import { PeriodicSnapshotTask } from 'app/interfaces/periodic-snapshot-task.interface';
 import { ReplicationTask } from 'app/interfaces/replication-task.interface';
+import { IxInputHarness } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.harness';
 import { IxRadioGroupHarness } from 'app/modules/forms/ix-forms/components/ix-radio-group/ix-radio-group.harness';
+import { IxSelectHarness } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.harness';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { LocaleService } from 'app/modules/language/locale.service';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
@@ -219,10 +221,13 @@ describe('ReplicationWizardComponent', () => {
 
     await goToNextStep();
 
-    await form!.fillForm({
-      'Source Snapshot Lifetime': 3,
-      Unit: 'Hours',
-    });
+    const sourceLifetimeInput = await loader.getHarness(IxInputHarness.with({ label: 'Source Snapshot Lifetime' }));
+    await sourceLifetimeInput.setValue('3');
+
+    const sourceLifetimeUnit = await loader.getHarness(
+      IxSelectHarness.with({ selector: '[formControlName="source_lifetime_unit"]' }),
+    );
+    await sourceLifetimeUnit.setValue('Hours');
 
     const lifeTimeRadioGroup = await loader.getHarness(
       IxRadioGroupHarness.with({ label: 'Destination Snapshot Lifetime' }),

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.spec.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.spec.ts
@@ -222,12 +222,12 @@ describe('ReplicationWizardComponent', () => {
     await goToNextStep();
 
     const sourceLifetimeInput = await loader.getHarness(
-      IxInputHarness.with({ selector: '[formControlName="source_lifetime_value"]' }),
+      IxInputHarness.with({ label: 'Source Snapshot Lifetime' }),
     );
     await sourceLifetimeInput.setValue('3');
 
     const sourceLifetimeUnit = await loader.getHarness(
-      IxSelectHarness.with({ selector: '[formControlName="source_lifetime_unit"]' }),
+      IxSelectHarness.with({ label: 'Unit' }),
     );
     await sourceLifetimeUnit.setValue('Hours');
 

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.spec.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.spec.ts
@@ -203,4 +203,45 @@ describe('ReplicationWizardComponent', () => {
     expect(spectator.inject(SnackbarService).success).toHaveBeenCalledWith('Replication task created.');
     expect(slideInRef.close).toHaveBeenCalledWith({ response: existingTask });
   });
+
+  it('uses custom source snapshot lifetime for periodic snapshot tasks', async () => {
+    await form!.fillForm(
+      {
+        'Source Location': 'On this System',
+        'Destination Location': 'On this System',
+        Recursive: false,
+        'Replicate Custom Snapshots': true,
+        'Snapshot Name Regular Expression': '.*',
+        Source: ['pool1/'],
+        Destination: 'pool3/',
+      },
+    );
+
+    await goToNextStep();
+
+    await form!.fillForm({
+      'Source Snapshot Lifetime': 3,
+      Unit: 'Hours',
+    });
+
+    const lifeTimeRadioGroup = await loader.getHarness(
+      IxRadioGroupHarness.with({ label: 'Destination Snapshot Lifetime' }),
+    );
+    await lifeTimeRadioGroup.setValue('Custom');
+
+    const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+    await saveButton.click();
+
+    expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('pool.snapshottask.create', [{
+      dataset: 'pool1/',
+      enabled: true,
+      lifetime_unit: LifetimeUnit.Hour,
+      lifetime_value: 3,
+      naming_schema: 'auto-%Y-%m-%d_%H-%M',
+      recursive: false,
+      schedule: {
+        dom: '*', dow: '*', hour: '0', minute: '0', month: '*',
+      },
+    }]);
+  });
 });

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
@@ -11,6 +11,7 @@ import { truenasDbKeyLocation } from 'app/constants/truenas-db-key-location.cons
 import { DatasetSource } from 'app/enums/dataset.enum';
 import { Direction } from 'app/enums/direction.enum';
 import { EncryptionKeyFormat } from 'app/enums/encryption-key-format.enum';
+import { LifetimeUnit } from 'app/enums/lifetime-unit.enum';
 import { mntPath } from 'app/enums/mnt-path.enum';
 import { NetcatMode } from 'app/enums/netcat-mode.enum';
 import { ReadOnlyMode } from 'app/enums/readonly-mode.enum';
@@ -264,8 +265,8 @@ export class ReplicationWizardComponent {
         dataset,
         recursive: data.recursive,
         schedule: crontabToSchedule(data.schedule_picker),
-        lifetime_value: data.source_lifetime_value,
-        lifetime_unit: data.source_lifetime_unit,
+        lifetime_value: data.source_lifetime_value ?? 2,
+        lifetime_unit: data.source_lifetime_unit ?? LifetimeUnit.Week,
         naming_schema: data.naming_schema ? data.naming_schema : this.defaultNamingSchema,
         enabled: true,
       });

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
@@ -11,7 +11,6 @@ import { truenasDbKeyLocation } from 'app/constants/truenas-db-key-location.cons
 import { DatasetSource } from 'app/enums/dataset.enum';
 import { Direction } from 'app/enums/direction.enum';
 import { EncryptionKeyFormat } from 'app/enums/encryption-key-format.enum';
-import { LifetimeUnit } from 'app/enums/lifetime-unit.enum';
 import { mntPath } from 'app/enums/mnt-path.enum';
 import { NetcatMode } from 'app/enums/netcat-mode.enum';
 import { ReadOnlyMode } from 'app/enums/readonly-mode.enum';
@@ -264,8 +263,8 @@ export class ReplicationWizardComponent {
         dataset,
         recursive: data.recursive,
         schedule: crontabToSchedule(data.schedule_picker),
-        lifetime_value: 2,
-        lifetime_unit: LifetimeUnit.Week,
+        lifetime_value: data.source_lifetime_value,
+        lifetime_unit: data.source_lifetime_unit,
         naming_schema: data.naming_schema ? data.naming_schema : this.defaultNamingSchema,
         enabled: true,
       });

--- a/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/replication-wizard.component.ts
@@ -82,6 +82,7 @@ export class ReplicationWizardComponent {
   isLoading = false;
   defaultNamingSchema = 'auto-%Y-%m-%d_%H-%M';
   isCustomRetentionVisible = true;
+  isSourceLocal = false;
 
   eligibleSnapshots = 0;
   existSnapshotTasks: number[] = [];

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
@@ -89,6 +89,7 @@ export class ReplicationWhatAndWhereComponent implements OnInit, SummaryProvider
   private destroyRef = inject(DestroyRef);
 
   readonly customRetentionVisibleChange = output<boolean>();
+  readonly sourceLocalChange = output<boolean>();
 
   protected sourceNodeProvider: TreeNodeProvider;
   protected targetNodeProvider: TreeNodeProvider;
@@ -210,6 +211,7 @@ export class ReplicationWhatAndWhereComponent implements OnInit, SummaryProvider
         this.disableSource();
       }
       this.checkCustomVisible();
+      this.sourceLocalChange.emit(value === DatasetSource.Local);
     });
 
     this.form.controls.custom_snapshots.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
@@ -213,6 +213,7 @@ export class ReplicationWhatAndWhereComponent implements OnInit, SummaryProvider
       this.checkCustomVisible();
       this.sourceLocalChange.emit(value === DatasetSource.Local);
     });
+    this.sourceLocalChange.emit(this.form.controls.source_datasets_from.value === DatasetSource.Local);
 
     this.form.controls.custom_snapshots.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {
       if (this.form.controls.custom_snapshots.enabled) {

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
@@ -213,7 +213,6 @@ export class ReplicationWhatAndWhereComponent implements OnInit, SummaryProvider
       this.checkCustomVisible();
       this.sourceLocalChange.emit(value === DatasetSource.Local);
     });
-    this.sourceLocalChange.emit(this.form.controls.source_datasets_from.value === DatasetSource.Local);
 
     this.form.controls.custom_snapshots.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {
       if (this.form.controls.custom_snapshots.enabled) {

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
@@ -34,6 +34,7 @@
       <ix-select
         class="unit"
         formControlName="source_lifetime_unit"
+        [label]="helptext.sourceLifetimeUnitLabel | translate"
         [options]="lifetimeUnitOptions$"
         [required]="true"
       ></ix-select>

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
@@ -22,21 +22,19 @@
     ></ix-checkbox>
   }
   @if (form.controls.source_lifetime_value.enabled) {
-    <ix-label
-      [label]="helptext.sourceLifetimeLabel | translate"
-      [tooltip]="helptext.sourceLifetimeTooltip | translate"
-      [required]="true"
-    ></ix-label>
     <div class="lifetime">
       <ix-input
         class="value"
         formControlName="source_lifetime_value"
         type="number"
+        [label]="helptext.sourceLifetimeLabel | translate"
+        [tooltip]="helptext.sourceLifetimeTooltip | translate"
         [required]="true"
       ></ix-input>
       <ix-select
         class="unit"
         formControlName="source_lifetime_unit"
+        [label]="'Unit' | translate"
         [options]="lifetimeUnitOptions$"
         [required]="true"
       ></ix-select>

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
@@ -34,7 +34,6 @@
       <ix-select
         class="unit"
         formControlName="source_lifetime_unit"
-        [label]="helptext.sourceLifetimeUnitLabel | translate"
         [options]="lifetimeUnitOptions$"
         [required]="true"
       ></ix-select>

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
@@ -22,13 +22,16 @@
     ></ix-checkbox>
   }
   @if (form.controls.source_lifetime_value.enabled) {
+    <ix-label
+      [label]="helptext.sourceLifetimeLabel | translate"
+      [tooltip]="helptext.sourceLifetimeTooltip | translate"
+      [required]="true"
+    ></ix-label>
     <div class="lifetime">
       <ix-input
         class="value"
         formControlName="source_lifetime_value"
         type="number"
-        [label]="helptext.sourceLifetimeLabel | translate"
-        [tooltip]="helptext.sourceLifetimeTooltip | translate"
         [required]="true"
       ></ix-input>
       <ix-select

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.html
@@ -21,6 +21,24 @@
       [tooltip]="helptext.readonlyTooltip | translate"
     ></ix-checkbox>
   }
+  @if (form.controls.source_lifetime_value.enabled) {
+    <div class="lifetime">
+      <ix-input
+        class="value"
+        formControlName="source_lifetime_value"
+        type="number"
+        [label]="helptext.sourceLifetimeLabel | translate"
+        [tooltip]="helptext.sourceLifetimeTooltip | translate"
+        [required]="true"
+      ></ix-input>
+      <ix-select
+        class="unit"
+        formControlName="source_lifetime_unit"
+        [options]="lifetimeUnitOptions$"
+        [required]="true"
+      ></ix-select>
+    </div>
+  }
   <ix-radio-group
     formControlName="retention_policy"
     [label]="helptext.retentionPolicyLabel | translate"

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.spec.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.spec.ts
@@ -43,6 +43,8 @@ describe('ReplicationWhenComponent', () => {
     expect(spectator.component.getPayload()).toEqual({
       schedule_method: ScheduleMethod.Cron,
       schedule_picker: '0 0 * * *',
+      source_lifetime_value: 2,
+      source_lifetime_unit: LifetimeUnit.Week,
       retention_policy: RetentionPolicy.Custom,
       lifetime_value: 2,
       lifetime_unit: LifetimeUnit.Week,

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.spec.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.spec.ts
@@ -31,6 +31,7 @@ describe('ReplicationWhenComponent', () => {
 
   beforeEach(async () => {
     spectator = createComponent();
+    spectator.setInput('isSourceLocal', true);
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     form = await loader.getHarness(IxFormHarness);
 
@@ -55,6 +56,24 @@ describe('ReplicationWhenComponent', () => {
     expect(spectator.component.getSummary()).toEqual([
       { label: 'Replication Schedule', value: 'Run On a Schedule' },
     ]);
+  });
+
+  it('excludes source lifetime fields from payload when Run Once is selected', async () => {
+    await form.fillForm({
+      'Replication Schedule': 'Run Once',
+    });
+
+    const payload = spectator.component.getPayload();
+    expect(payload.source_lifetime_value).toBeUndefined();
+    expect(payload.source_lifetime_unit).toBeUndefined();
+  });
+
+  it('excludes source lifetime fields from payload when source is not local', () => {
+    spectator.setInput('isSourceLocal', false);
+
+    const payload = spectator.component.getPayload();
+    expect(payload.source_lifetime_value).toBeUndefined();
+    expect(payload.source_lifetime_unit).toBeUndefined();
   });
 
   it('emits (save) when Save is selected', async () => {

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.spec.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.spec.ts
@@ -55,6 +55,7 @@ describe('ReplicationWhenComponent', () => {
   it('returns summary when getSummary() is called', () => {
     expect(spectator.component.getSummary()).toEqual([
       { label: 'Replication Schedule', value: 'Run On a Schedule' },
+      { label: 'Source Snapshot Lifetime', value: '2 Week(s)' },
     ]);
   });
 

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
@@ -49,6 +49,7 @@ export class ReplicationWhenComponent implements OnInit, OnChanges, SummaryProvi
   private destroyRef = inject(DestroyRef);
 
   readonly isCustomRetentionVisible = input(true);
+  readonly isSourceLocal = input(false);
   readonly isLoading = input(false);
 
   readonly save = output();
@@ -98,24 +99,26 @@ export class ReplicationWhenComponent implements OnInit, OnChanges, SummaryProvi
     if (changes.isCustomRetentionVisible && !changes.isCustomRetentionVisible.currentValue) {
       this.form.controls.retention_policy.setValue(RetentionPolicy.Source);
     }
+    if (changes.isSourceLocal) {
+      this.updateSourceLifetimeState();
+    }
   }
 
   ngOnInit(): void {
     this.form.controls.readonly.disable();
     this.form.controls.lifetime_value.disable();
     this.form.controls.lifetime_unit.disable();
+    this.form.controls.source_lifetime_value.disable();
+    this.form.controls.source_lifetime_unit.disable();
     this.form.controls.schedule_method.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((method) => {
       if (method === ScheduleMethod.Cron) {
         this.form.controls.schedule_picker.enable();
         this.form.controls.readonly.disable();
-        this.form.controls.source_lifetime_value.enable();
-        this.form.controls.source_lifetime_unit.enable();
       } else {
         this.form.controls.schedule_picker.disable();
         this.form.controls.readonly.enable();
-        this.form.controls.source_lifetime_value.disable();
-        this.form.controls.source_lifetime_unit.disable();
       }
+      this.updateSourceLifetimeState();
     });
     this.form.controls.retention_policy.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((policy) => {
       if (policy === RetentionPolicy.Custom) {
@@ -126,6 +129,18 @@ export class ReplicationWhenComponent implements OnInit, OnChanges, SummaryProvi
         this.form.controls.lifetime_unit.disable();
       }
     });
+  }
+
+  private updateSourceLifetimeState(): void {
+    const showSourceLifetime = this.isSourceLocal()
+      && this.form.controls.schedule_method.value === ScheduleMethod.Cron;
+    if (showSourceLifetime) {
+      this.form.controls.source_lifetime_value.enable();
+      this.form.controls.source_lifetime_unit.enable();
+    } else {
+      this.form.controls.source_lifetime_value.disable();
+      this.form.controls.source_lifetime_unit.disable();
+    }
   }
 
   getSummary(): SummarySection {

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
@@ -16,7 +16,6 @@ import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
-import { IxLabelComponent } from 'app/modules/forms/ix-forms/components/ix-label/ix-label.component';
 import { IxRadioGroupComponent } from 'app/modules/forms/ix-forms/components/ix-radio-group/ix-radio-group.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import { SchedulerComponent } from 'app/modules/scheduler/components/scheduler/scheduler.component';
@@ -35,7 +34,6 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
     SchedulerComponent,
     IxCheckboxComponent,
     IxInputComponent,
-    IxLabelComponent,
     IxSelectComponent,
     FormActionsComponent,
     MatButton,

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
@@ -6,7 +6,7 @@ import { MatStepperPrevious } from '@angular/material/stepper';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { Observable, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
-import { LifetimeUnit } from 'app/enums/lifetime-unit.enum';
+import { LifetimeUnit, lifetimeUnitNames } from 'app/enums/lifetime-unit.enum';
 import { RetentionPolicy } from 'app/enums/retention-policy.enum';
 import { Role } from 'app/enums/role.enum';
 import { ScheduleMethod } from 'app/enums/schedule-method.enum';
@@ -61,7 +61,7 @@ export class ReplicationWhenComponent implements OnInit, OnChanges, SummaryProvi
     source_lifetime_value: [2, [Validators.required, Validators.min(1)]],
     source_lifetime_unit: [LifetimeUnit.Week, [Validators.required]],
     retention_policy: [RetentionPolicy.Source, [Validators.required]],
-    lifetime_value: [2, [Validators.required]],
+    lifetime_value: [2, [Validators.required, Validators.min(1)]],
     lifetime_unit: [LifetimeUnit.Week, [Validators.required]],
   });
 
@@ -157,6 +157,16 @@ export class ReplicationWhenComponent implements OnInit, OnChanges, SummaryProvi
         label: this.translate.instant(helptextReplicationWizard.scheduleMethodLabel),
         value: this.translate.instant('Run Once'),
       });
+    }
+
+    if (values.source_lifetime_value != null && values.source_lifetime_unit != null) {
+      const unitName = lifetimeUnitNames.get(values.source_lifetime_unit);
+      if (unitName) {
+        summary.push({
+          label: this.translate.instant(helptextReplicationWizard.sourceLifetimeLabel),
+          value: `${values.source_lifetime_value} ${this.translate.instant(unitName)}`,
+        });
+      }
     }
 
     return summary;

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
@@ -16,6 +16,7 @@ import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
+import { IxLabelComponent } from 'app/modules/forms/ix-forms/components/ix-label/ix-label.component';
 import { IxRadioGroupComponent } from 'app/modules/forms/ix-forms/components/ix-radio-group/ix-radio-group.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import { SchedulerComponent } from 'app/modules/scheduler/components/scheduler/scheduler.component';
@@ -34,6 +35,7 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
     SchedulerComponent,
     IxCheckboxComponent,
     IxInputComponent,
+    IxLabelComponent,
     IxSelectComponent,
     FormActionsComponent,
     MatButton,

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
@@ -58,7 +58,7 @@ export class ReplicationWhenComponent implements OnInit, OnChanges, SummaryProvi
     schedule_method: [ScheduleMethod.Cron, [Validators.required]],
     schedule_picker: [CronPresetValue.Daily, [Validators.required]],
     readonly: [true],
-    source_lifetime_value: [2, [Validators.required]],
+    source_lifetime_value: [2, [Validators.required, Validators.min(1)]],
     source_lifetime_unit: [LifetimeUnit.Week, [Validators.required]],
     retention_policy: [RetentionPolicy.Source, [Validators.required]],
     lifetime_value: [2, [Validators.required]],

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-when/replication-when.component.ts
@@ -57,6 +57,8 @@ export class ReplicationWhenComponent implements OnInit, OnChanges, SummaryProvi
     schedule_method: [ScheduleMethod.Cron, [Validators.required]],
     schedule_picker: [CronPresetValue.Daily, [Validators.required]],
     readonly: [true],
+    source_lifetime_value: [2, [Validators.required]],
+    source_lifetime_unit: [LifetimeUnit.Week, [Validators.required]],
     retention_policy: [RetentionPolicy.Source, [Validators.required]],
     lifetime_value: [2, [Validators.required]],
     lifetime_unit: [LifetimeUnit.Week, [Validators.required]],
@@ -106,9 +108,13 @@ export class ReplicationWhenComponent implements OnInit, OnChanges, SummaryProvi
       if (method === ScheduleMethod.Cron) {
         this.form.controls.schedule_picker.enable();
         this.form.controls.readonly.disable();
+        this.form.controls.source_lifetime_value.enable();
+        this.form.controls.source_lifetime_unit.enable();
       } else {
         this.form.controls.schedule_picker.disable();
         this.form.controls.readonly.enable();
+        this.form.controls.source_lifetime_value.disable();
+        this.form.controls.source_lifetime_unit.disable();
       }
     });
     this.form.controls.retention_policy.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((policy) => {


### PR DESCRIPTION
Testing: see ticket.

Preview:


https://github.com/user-attachments/assets/73a253f5-29e0-441f-b236-0cd2e22451a6

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Yes - new "Source Snapshot Lifetime" field added to the Replication Wizard's "When" step; user-facing  help text and tooltip need to be documented 
|Testing         |  Yes - unit tests added for the new source snapshot lifetime controls in both ReplicationWhenComponent and  ReplicationWizardComponent; QA should verify the field appears only when source is local and schedule is cron, and that the lifetime value is passed to pool.snapshottask.create   

Original PR: https://github.com/truenas/webui/pull/13485
