### PR TITLE
NAS-139220 / 26.0.0-BETA.2 / Improve chunk load error handling (by AlexKarpov98)

### DIFF
--- a/src/app/helpers/handle-chunk-load-error.spec.ts
+++ b/src/app/helpers/handle-chunk-load-error.spec.ts
@@ -1,4 +1,4 @@
-import { NavigationError, Event as RouterEvent } from '@angular/router';
+import { NavigationError } from '@angular/router';
 import { chunkReloadKey, handleChunkLoadError, resetReloadedFlag } from 'app/helpers/handle-chunk-load-error';
 
 describe('handleChunkLoadError', () => {
@@ -25,7 +25,6 @@ describe('handleChunkLoadError', () => {
       id: 1,
       url: '/test',
       error: new Error(message),
-      type: 2 as unknown as RouterEvent,
     } as unknown as NavigationError;
   }
 

--- a/src/app/helpers/handle-chunk-load-error.spec.ts
+++ b/src/app/helpers/handle-chunk-load-error.spec.ts
@@ -1,0 +1,77 @@
+import { NavigationError, Event as RouterEvent } from '@angular/router';
+import { chunkReloadKey, handleChunkLoadError } from 'app/helpers/handle-chunk-load-error';
+
+describe('handleChunkLoadError', () => {
+  let mockWindow: Window;
+
+  beforeEach(() => {
+    mockWindow = {
+      sessionStorage: {
+        getItem: jest.fn().mockReturnValue(null),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      },
+      location: { reload: jest.fn() },
+      document: { body: { innerHTML: '' } },
+    } as unknown as Window;
+  });
+
+  function makeNavigationError(message: string): NavigationError {
+    return {
+      id: 1,
+      url: '/test',
+      error: new Error(message),
+      type: 2 as unknown as RouterEvent,
+    } as unknown as NavigationError;
+  }
+
+  it('reloads on first chunk load failure', () => {
+    handleChunkLoadError(makeNavigationError('Loading chunk 123 failed'), mockWindow);
+
+    expect(mockWindow.sessionStorage.setItem).toHaveBeenCalledWith(chunkReloadKey, expect.any(String));
+    expect(mockWindow.location.reload).toHaveBeenCalled();
+  });
+
+  it('reloads on dynamic import failure', () => {
+    handleChunkLoadError(makeNavigationError('Failed to fetch dynamically imported module'), mockWindow);
+
+    expect(mockWindow.location.reload).toHaveBeenCalled();
+  });
+
+  it('shows fallback message when reload was recently attempted', () => {
+    (mockWindow.sessionStorage.getItem as jest.Mock).mockReturnValue(String(Date.now()));
+
+    handleChunkLoadError(makeNavigationError('Loading chunk 5 failed'), mockWindow);
+
+    expect(mockWindow.location.reload).not.toHaveBeenCalled();
+    expect(mockWindow.sessionStorage.removeItem).toHaveBeenCalledWith(chunkReloadKey);
+    expect(mockWindow.document.body.innerHTML).toContain('Click here to refresh');
+  });
+
+  it('retries reload when previous attempt was long ago', () => {
+    (mockWindow.sessionStorage.getItem as jest.Mock).mockReturnValue(String(Date.now() - 60_000));
+
+    handleChunkLoadError(makeNavigationError('Loading chunk 5 failed'), mockWindow);
+
+    expect(mockWindow.location.reload).toHaveBeenCalled();
+  });
+
+  it('falls back to reload when sessionStorage throws', () => {
+    (mockWindow.sessionStorage.getItem as jest.Mock).mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+
+    handleChunkLoadError(makeNavigationError('Loading chunk 5 failed'), mockWindow);
+
+    expect(mockWindow.location.reload).toHaveBeenCalled();
+  });
+
+  it('does not reload for non-chunk navigation errors', () => {
+    jest.spyOn(console, 'error').mockImplementation();
+
+    handleChunkLoadError(makeNavigationError('Cannot match route /foo'), mockWindow);
+
+    expect(mockWindow.location.reload).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/src/app/helpers/handle-chunk-load-error.spec.ts
+++ b/src/app/helpers/handle-chunk-load-error.spec.ts
@@ -1,11 +1,10 @@
 import { NavigationError } from '@angular/router';
-import { chunkReloadKey, handleChunkLoadError, resetReloadedFlag } from 'app/helpers/handle-chunk-load-error';
+import { chunkReloadKey, handleChunkLoadError } from 'app/helpers/handle-chunk-load-error';
 
 describe('handleChunkLoadError', () => {
   let mockWindow: Window;
 
   beforeEach(() => {
-    resetReloadedFlag();
     mockWindow = {
       sessionStorage: {
         getItem: jest.fn().mockReturnValue(null),
@@ -18,6 +17,10 @@ describe('handleChunkLoadError', () => {
         getElementById: jest.fn().mockReturnValue({ addEventListener: jest.fn() }),
       },
     } as unknown as Window;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   function makeNavigationError(message: string): NavigationError {

--- a/src/app/helpers/handle-chunk-load-error.spec.ts
+++ b/src/app/helpers/handle-chunk-load-error.spec.ts
@@ -1,10 +1,11 @@
 import { NavigationError, Event as RouterEvent } from '@angular/router';
-import { chunkReloadKey, handleChunkLoadError } from 'app/helpers/handle-chunk-load-error';
+import { chunkReloadKey, handleChunkLoadError, resetReloadedFlag } from 'app/helpers/handle-chunk-load-error';
 
 describe('handleChunkLoadError', () => {
   let mockWindow: Window;
 
   beforeEach(() => {
+    resetReloadedFlag();
     mockWindow = {
       sessionStorage: {
         getItem: jest.fn().mockReturnValue(null),
@@ -12,7 +13,10 @@ describe('handleChunkLoadError', () => {
         removeItem: jest.fn(),
       },
       location: { reload: jest.fn() },
-      document: { body: { innerHTML: '' } },
+      document: {
+        body: { innerHTML: '' },
+        getElementById: jest.fn().mockReturnValue({ addEventListener: jest.fn() }),
+      },
     } as unknown as Window;
   });
 
@@ -56,7 +60,7 @@ describe('handleChunkLoadError', () => {
     expect(mockWindow.location.reload).toHaveBeenCalled();
   });
 
-  it('falls back to reload when sessionStorage throws', () => {
+  it('falls back to reload when sessionStorage throws on first attempt', () => {
     (mockWindow.sessionStorage.getItem as jest.Mock).mockImplementation(() => {
       throw new Error('SecurityError');
     });
@@ -64,6 +68,17 @@ describe('handleChunkLoadError', () => {
     handleChunkLoadError(makeNavigationError('Loading chunk 5 failed'), mockWindow);
 
     expect(mockWindow.location.reload).toHaveBeenCalled();
+  });
+
+  it('shows fallback page when sessionStorage throws on repeated attempts', () => {
+    (mockWindow.sessionStorage.getItem as jest.Mock).mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+
+    handleChunkLoadError(makeNavigationError('Loading chunk 5 failed'), mockWindow);
+    handleChunkLoadError(makeNavigationError('Loading chunk 5 failed'), mockWindow);
+
+    expect(mockWindow.document.body.innerHTML).toContain('Click here to refresh');
   });
 
   it('does not reload for non-chunk navigation errors', () => {

--- a/src/app/helpers/handle-chunk-load-error.ts
+++ b/src/app/helpers/handle-chunk-load-error.ts
@@ -1,11 +1,14 @@
 import { NavigationError } from '@angular/router';
 
+// "error loading" variant is a defensive catch — not observed in a specific browser, but included
+// as a safeguard against future bundler/runtime error message changes.
 const chunkFailedPattern = /Loading chunk \d+ failed|(?:Failed to fetch|error loading) dynamically imported module/i;
 export const chunkReloadKey = 'chunk-reload-attempted';
 const reloadGuardMs = 30_000;
 
 let reloadedThisSession = false;
 
+/** @internal Exposed for testing only — not used at runtime. */
 export function resetReloadedFlag(): void {
   reloadedThisSession = false;
 }

--- a/src/app/helpers/handle-chunk-load-error.ts
+++ b/src/app/helpers/handle-chunk-load-error.ts
@@ -46,7 +46,7 @@ function showFallbackPage(window: Window): void {
       </div>
     </div>
   `;
-  window.document.getElementById('chunk-reload-btn').addEventListener('click', () => {
+  window.document.getElementById('chunk-reload-btn')?.addEventListener('click', () => {
     window.location.reload();
   });
 }

--- a/src/app/helpers/handle-chunk-load-error.ts
+++ b/src/app/helpers/handle-chunk-load-error.ts
@@ -6,12 +6,7 @@ const chunkFailedPattern = /Loading chunk \d+ failed|(?:Failed to fetch|error lo
 export const chunkReloadKey = 'chunk-reload-attempted';
 const reloadGuardMs = 30_000;
 
-let reloadedThisSession = false;
-
-/** @internal Exposed for testing only — not used at runtime. */
-export function resetReloadedFlag(): void {
-  reloadedThisSession = false;
-}
+const reloadedWindows = new WeakSet<Window>();
 
 export function handleChunkLoadError(error: NavigationError, window: Window): void {
   if (!chunkFailedPattern.test(String(error.error))) {
@@ -30,8 +25,8 @@ export function handleChunkLoadError(error: NavigationError, window: Window): vo
       showFallbackPage(window);
     }
   } catch {
-    if (!reloadedThisSession) {
-      reloadedThisSession = true;
+    if (!reloadedWindows.has(window)) {
+      reloadedWindows.add(window);
       window.location.reload();
     } else {
       showFallbackPage(window);
@@ -42,7 +37,7 @@ export function handleChunkLoadError(error: NavigationError, window: Window): vo
 function showFallbackPage(window: Window): void {
   // Outside Angular DI context — translations are unavailable at this point.
   window.document.body.innerHTML = `
-    <div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:sans-serif">
+    <div lang="en" style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:sans-serif">
       <div style="text-align:center">
         <p>The application has been updated.</p>
         <button id="chunk-reload-btn" style="background:none;border:none;color:blue;cursor:pointer;text-decoration:underline;font:inherit">
@@ -51,7 +46,7 @@ function showFallbackPage(window: Window): void {
       </div>
     </div>
   `;
-  window.document.getElementById('chunk-reload-btn')?.addEventListener('click', () => {
+  window.document.getElementById('chunk-reload-btn').addEventListener('click', () => {
     window.location.reload();
   });
 }

--- a/src/app/helpers/handle-chunk-load-error.ts
+++ b/src/app/helpers/handle-chunk-load-error.ts
@@ -1,0 +1,33 @@
+import { NavigationError } from '@angular/router';
+
+const chunkFailedPattern = /Loading chunk \d+ failed|(?:failed|error)\s.*dynamically imported module/i;
+export const chunkReloadKey = 'chunk-reload-attempted';
+const reloadGuardMs = 30_000;
+
+export function handleChunkLoadError(error: NavigationError, window: Window): void {
+  if (!chunkFailedPattern.test(String(error.error))) {
+    console.error(error);
+    return;
+  }
+
+  try {
+    const lastAttempt = Number(window.sessionStorage.getItem(chunkReloadKey));
+    const now = Date.now();
+    if (!lastAttempt || now - lastAttempt > reloadGuardMs) {
+      window.sessionStorage.setItem(chunkReloadKey, String(now));
+      window.location.reload();
+    } else {
+      window.sessionStorage.removeItem(chunkReloadKey);
+      window.document.body.innerHTML = `
+        <div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:sans-serif">
+          <div style="text-align:center">
+            <p>The application has been updated.</p>
+            <a href="javascript:location.reload()">Click here to refresh</a>
+          </div>
+        </div>
+      `;
+    }
+  } catch {
+    window.location.reload();
+  }
+}

--- a/src/app/helpers/handle-chunk-load-error.ts
+++ b/src/app/helpers/handle-chunk-load-error.ts
@@ -1,8 +1,14 @@
 import { NavigationError } from '@angular/router';
 
-const chunkFailedPattern = /Loading chunk \d+ failed|(?:failed|error)\s.*dynamically imported module/i;
+const chunkFailedPattern = /Loading chunk \d+ failed|(?:Failed to fetch|error loading) dynamically imported module/i;
 export const chunkReloadKey = 'chunk-reload-attempted';
 const reloadGuardMs = 30_000;
+
+let reloadedThisSession = false;
+
+export function resetReloadedFlag(): void {
+  reloadedThisSession = false;
+}
 
 export function handleChunkLoadError(error: NavigationError, window: Window): void {
   if (!chunkFailedPattern.test(String(error.error))) {
@@ -18,16 +24,31 @@ export function handleChunkLoadError(error: NavigationError, window: Window): vo
       window.location.reload();
     } else {
       window.sessionStorage.removeItem(chunkReloadKey);
-      window.document.body.innerHTML = `
-        <div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:sans-serif">
-          <div style="text-align:center">
-            <p>The application has been updated.</p>
-            <a href="javascript:location.reload()">Click here to refresh</a>
-          </div>
-        </div>
-      `;
+      showFallbackPage(window);
     }
   } catch {
-    window.location.reload();
+    if (!reloadedThisSession) {
+      reloadedThisSession = true;
+      window.location.reload();
+    } else {
+      showFallbackPage(window);
+    }
   }
+}
+
+function showFallbackPage(window: Window): void {
+  // Outside Angular DI context — translations are unavailable at this point.
+  window.document.body.innerHTML = `
+    <div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:sans-serif">
+      <div style="text-align:center">
+        <p>The application has been updated.</p>
+        <button id="chunk-reload-btn" style="background:none;border:none;color:blue;cursor:pointer;text-decoration:underline;font:inherit">
+          Click here to refresh
+        </button>
+      </div>
+    </div>
+  `;
+  window.document.getElementById('chunk-reload-btn')?.addEventListener('click', () => {
+    window.location.reload();
+  });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -136,14 +136,19 @@ bootstrapApplication(AppComponent, {
         const chunkFailedPattern = /Loading chunk \d+ failed|(?:failed|error)\s.*dynamically imported module/i;
         if (chunkFailedPattern.test(String(error.error))) {
           const window = inject<Window>(WINDOW);
-          const reloadKey = 'chunk-reload-attempted';
-          const lastAttempt = Number(window.sessionStorage.getItem(reloadKey));
-          const now = Date.now();
-          if (!lastAttempt || now - lastAttempt > 10_000) {
-            window.sessionStorage.setItem(reloadKey, String(now));
+          try {
+            const reloadKey = 'chunk-reload-attempted';
+            const lastAttempt = Number(window.sessionStorage.getItem(reloadKey));
+            const now = Date.now();
+            if (!lastAttempt || now - lastAttempt > 10_000) {
+              window.sessionStorage.setItem(reloadKey, String(now));
+              window.location.reload();
+            } else {
+              window.sessionStorage.removeItem(reloadKey);
+              window.document.body.innerText = 'The application has been updated. Please refresh the page.';
+            }
+          } catch {
             window.location.reload();
-          } else {
-            window.sessionStorage.removeItem(reloadKey);
           }
         }
         console.error(error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,9 +133,16 @@ bootstrapApplication(AppComponent, {
       withPreloading(PreloadAllModules),
       withComponentInputBinding(),
       withNavigationErrorHandler((error: NavigationError) => {
-        const chunkFailedMessage = /Loading chunk \d+ failed/;
+        const chunkFailedMessage = /Loading chunk \d+ failed|Failed to fetch dynamically imported module/;
         if (chunkFailedMessage.test(String(error.error))) {
-          inject<Window>(WINDOW).location.reload();
+          const window = inject<Window>(WINDOW);
+          const reloadKey = 'chunk-reload-attempted';
+          if (!window.sessionStorage.getItem(reloadKey)) {
+            window.sessionStorage.setItem(reloadKey, 'true');
+            window.location.reload();
+          } else {
+            window.sessionStorage.removeItem(reloadKey);
+          }
         }
         console.error(error);
       }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ import { NgxPopperjsModule } from 'ngx-popperjs';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { TranslateMessageFormatCompiler } from 'ngx-translate-messageformat-compiler';
 import { provideNgxWebstorage, withLocalStorage } from 'ngx-webstorage';
-import { filter, take } from 'rxjs';
+import { filter, firstValueFrom, take } from 'rxjs';
 import { AppComponent } from 'app/app.component';
 import { rootRoutes } from 'app/app.routes';
 import { defaultLanguage } from 'app/constants/languages.constant';
@@ -132,10 +132,10 @@ bootstrapApplication(AppComponent, {
     provideAppInitializer(() => {
       const router = inject(Router);
       const windowRef = inject<Window>(WINDOW);
-      router.events.pipe(
+      return firstValueFrom(router.events.pipe(
         filter((event) => event instanceof NavigationEnd),
         take(1),
-      ).subscribe(() => {
+      )).then(() => {
         try {
           windowRef.sessionStorage.removeItem(chunkReloadKey);
         } catch { /* sessionStorage may be unavailable */ }

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import { provideNgxWebstorage, withLocalStorage } from 'ngx-webstorage';
 import { AppComponent } from 'app/app.component';
 import { rootRoutes } from 'app/app.routes';
 import { defaultLanguage } from 'app/constants/languages.constant';
+import { chunkReloadKey, handleChunkLoadError } from 'app/helpers/handle-chunk-load-error';
 import { WINDOW, getWindow } from 'app/helpers/window.helper';
 import { IcuMissingTranslationHandler } from 'app/modules/language/translations/icu-missing-translation-handler';
 import { createTranslateLoader } from 'app/modules/language/translations/icu-translations-loader';
@@ -125,6 +126,11 @@ bootstrapApplication(AppComponent, {
       const spriteLoader = inject(TnSpriteLoaderService);
       return spriteLoader.ensureSpriteLoaded();
     }),
+    provideAppInitializer(() => {
+      try {
+        inject<Window>(WINDOW).sessionStorage.removeItem(chunkReloadKey);
+      } catch { /* sessionStorage may be unavailable */ }
+    }),
     ApiService,
     provideCharts(withDefaultRegisterables()),
     provideHttpClient(withInterceptorsFromDi()),
@@ -133,25 +139,7 @@ bootstrapApplication(AppComponent, {
       withPreloading(PreloadAllModules),
       withComponentInputBinding(),
       withNavigationErrorHandler((error: NavigationError) => {
-        const chunkFailedPattern = /Loading chunk \d+ failed|(?:failed|error)\s.*dynamically imported module/i;
-        if (chunkFailedPattern.test(String(error.error))) {
-          const window = inject<Window>(WINDOW);
-          try {
-            const reloadKey = 'chunk-reload-attempted';
-            const lastAttempt = Number(window.sessionStorage.getItem(reloadKey));
-            const now = Date.now();
-            if (!lastAttempt || now - lastAttempt > 10_000) {
-              window.sessionStorage.setItem(reloadKey, String(now));
-              window.location.reload();
-            } else {
-              window.sessionStorage.removeItem(reloadKey);
-              window.document.body.innerText = 'The application has been updated. Please refresh the page.';
-            }
-          } catch {
-            window.location.reload();
-          }
-        }
-        console.error(error);
+        handleChunkLoadError(error, inject<Window>(WINDOW));
       }),
     ),
   ],

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ import { NgxPopperjsModule } from 'ngx-popperjs';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { TranslateMessageFormatCompiler } from 'ngx-translate-messageformat-compiler';
 import { provideNgxWebstorage, withLocalStorage } from 'ngx-webstorage';
-import { filter, firstValueFrom, take } from 'rxjs';
+import { filter, take } from 'rxjs';
 import { AppComponent } from 'app/app.component';
 import { rootRoutes } from 'app/app.routes';
 import { defaultLanguage } from 'app/constants/languages.constant';
@@ -132,10 +132,10 @@ bootstrapApplication(AppComponent, {
     provideAppInitializer(() => {
       const router = inject(Router);
       const windowRef = inject<Window>(WINDOW);
-      return firstValueFrom(router.events.pipe(
+      router.events.pipe(
         filter((event) => event instanceof NavigationEnd),
         take(1),
-      )).then(() => {
+      ).subscribe(() => {
         try {
           windowRef.sessionStorage.removeItem(chunkReloadKey);
         } catch { /* sessionStorage may be unavailable */ }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,8 @@ import {
   withPreloading,
   provideRouter,
   PreloadAllModules,
+  Router,
+  NavigationEnd,
   withComponentInputBinding,
   withNavigationErrorHandler,
   NavigationError,
@@ -31,6 +33,7 @@ import { NgxPopperjsModule } from 'ngx-popperjs';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { TranslateMessageFormatCompiler } from 'ngx-translate-messageformat-compiler';
 import { provideNgxWebstorage, withLocalStorage } from 'ngx-webstorage';
+import { filter, take } from 'rxjs';
 import { AppComponent } from 'app/app.component';
 import { rootRoutes } from 'app/app.routes';
 import { defaultLanguage } from 'app/constants/languages.constant';
@@ -127,9 +130,16 @@ bootstrapApplication(AppComponent, {
       return spriteLoader.ensureSpriteLoaded();
     }),
     provideAppInitializer(() => {
-      try {
-        inject<Window>(WINDOW).sessionStorage.removeItem(chunkReloadKey);
-      } catch { /* sessionStorage may be unavailable */ }
+      const router = inject(Router);
+      const windowRef = inject<Window>(WINDOW);
+      router.events.pipe(
+        filter((event) => event instanceof NavigationEnd),
+        take(1),
+      ).subscribe(() => {
+        try {
+          windowRef.sessionStorage.removeItem(chunkReloadKey);
+        } catch { /* sessionStorage may be unavailable */ }
+      });
     }),
     ApiService,
     provideCharts(withDefaultRegisterables()),

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,12 +133,14 @@ bootstrapApplication(AppComponent, {
       withPreloading(PreloadAllModules),
       withComponentInputBinding(),
       withNavigationErrorHandler((error: NavigationError) => {
-        const chunkFailedMessage = /Loading chunk \d+ failed|Failed to fetch dynamically imported module/;
-        if (chunkFailedMessage.test(String(error.error))) {
+        const chunkFailedPattern = /Loading chunk \d+ failed|(?:failed|error)\s.*dynamically imported module/i;
+        if (chunkFailedPattern.test(String(error.error))) {
           const window = inject<Window>(WINDOW);
           const reloadKey = 'chunk-reload-attempted';
-          if (!window.sessionStorage.getItem(reloadKey)) {
-            window.sessionStorage.setItem(reloadKey, 'true');
+          const lastAttempt = Number(window.sessionStorage.getItem(reloadKey));
+          const now = Date.now();
+          if (!lastAttempt || now - lastAttempt > 10_000) {
+            window.sessionStorage.setItem(reloadKey, String(now));
             window.location.reload();
           } else {
             window.sessionStorage.removeItem(reloadKey);


### PR DESCRIPTION
Summary
                                                                                                                                 
  - Broadened chunk error detection to cover both Webpack (Loading chunk N failed) and esbuild/Vite (failed to fetch dynamically 
  imported module) error formats.
  - Added a reload guard using sessionStorage timestamps to prevent infinite reload loops — if a reload was already attempted    
  within 30 seconds, shows a user-facing fallback page instead of looping.                                                       
  - Wrapped logic in try/catch so restricted sessionStorage environments (e.g., some private browsing modes) fall back to a
  single reload.                                                                                                                 
  - Extracted handler into handle-chunk-load-error.ts for testability; added cleanup initializer to clear the guard on successful
   app boot.                                                                                                                     
                                                                                                                               
  Test plan                                                                                                                      
                                                                                                                               
  - Unit tests added (6 tests covering: first failure reload, dynamic import failure, recent-attempt fallback, expired-attempt   
  retry, sessionStorage exception, non-chunk error passthrough)
  - Verify on real hardware: update the server while a UI tab is open, navigate to a lazy route, confirm it reloads and recovers 
  - Verify fallback page appears if the reload doesn't fix it (e.g., disconnect network, navigate to a lazy route twice)  

Original PR: https://github.com/truenas/webui/pull/13482
