### PR TITLE
Update Hardware Device availability localization (ES-ES)

### DIFF
--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1,8 +1,8 @@
 {
   "0": "0",
-  "No GPU devices available": "",
-  "No NIC devices available": "",
-  "No USB devices available": "",
+  "No GPU devices available": "No hay dispositivos GPU disponibles",
+  "No NIC devices available": "No hay dispositivos NIC disponibles",
+  "No USB devices available": "No hay dispositivos USB disponibles",
   " as of {dateTime}": " a fecha de {dateTime}",
   " bytes.": " bytes.",
   " Est. Usable Raw Capacity": " Capacidad bruta utilizable estimada",


### PR DESCRIPTION
This PR updates the Spanish (Spain) translations for hardware device availability states (GPU, NIC, USB).

Key changes and localization decisions:

Hardware Terminology: Kept standard technical acronyms (GPU, NIC, USB) intact as they are universally used in Spanish IT environments.

Grammar: Localized "No [X] devices available" using the natural Spanish construction No hay dispositivos [X] disponibles.

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
