### PR TITLE
Update Hardware Device availability localization (GL)

### DIFF
--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1,8 +1,8 @@
 {
   "0": "0",
-  "No GPU devices available": "",
-  "No NIC devices available": "",
-  "No USB devices available": "",
+  "No GPU devices available": "Non hai dispositivos GPU dispoñibles",
+  "No NIC devices available": "Non hai dispositivos NIC dispoñibles",
+  "No USB devices available": "Non hai dispositivos USB dispoñibles",
   " as of {dateTime}": " a data de {dateTime}",
   " bytes.": " bytes.",
   " Est. Usable Raw Capacity": " Capacidade bruta utilizable estimada",


### PR DESCRIPTION
This PR updates the Galician translations for hardware device availability states (GPU, NIC, USB).

Key changes and localization decisions:

Hardware Terminology: Kept standard technical acronyms (GPU, NIC, USB) intact.

Grammar: Localized "No [X] devices available" using the natural Galician construction Non hai dispositivos [X] dispoñibles.

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
