### PR TITLE
NAS-140443 / 26.0.0-BETA.2 / M-Series Rear NVMe Enclosure Management is wrong (UI) (by AlexKarpov98)

### DIFF
--- a/src/assets/images/new-hardware/m-series/m-series-rear.svg
+++ b/src/assets/images/new-hardware/m-series/m-series-rear.svg
@@ -974,7 +974,7 @@
     </g>
   </g>
   <g id="M-Series_Caches">
-    <g id="DRIVE_CAGE_25">
+    <g id="DRIVE_CAGE_28">
       <g>
         <g>
           <rect class="st2" x="37.2" y="189.9" width="207.1" height="6.9"/>
@@ -1013,7 +1013,7 @@
         <rect class="st15" x="228.7" y="224.8" width="9.4" height="3.8" transform="translate(460.2 -6.7) rotate(90)"/>
       </g>
     </g>
-    <g id="DRIVE_CAGE_26">
+    <g id="DRIVE_CAGE_27">
       <g>
         <g>
           <rect class="st2" x="37.2" y="131" width="207.1" height="6.9"/>
@@ -1052,7 +1052,7 @@
         <rect class="st15" x="228.7" y="165.9" width="9.4" height="3.8" transform="translate(401.2 -65.7) rotate(90)"/>
       </g>
     </g>
-    <g id="DRIVE_CAGE_27">
+    <g id="DRIVE_CAGE_26">
       <g>
         <g>
           <rect class="st2" x="37.2" y="72" width="207.1" height="6.9"/>
@@ -1091,7 +1091,7 @@
         <rect class="st15" x="228.7" y="106.9" width="9.4" height="3.8" transform="translate(342.2 -124.7) rotate(90)"/>
       </g>
     </g>
-    <g id="DRIVE_CAGE_28">
+    <g id="DRIVE_CAGE_25">
       <g>
         <g>
           <rect class="st2" x="37.2" y="13" width="207.1" height="6.9"/>


### PR DESCRIPTION
Testing: see ticket.

Preview:

https://github.com/user-attachments/assets/ba5a9d21-914e-415e-823c-ea115da874e6




Original PR: https://github.com/truenas/webui/pull/13462
