### PR TITLE
NAS-140723 / 26.0.0-BETA.2 / Dashboard widget trims letter underside (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-table/components/ix-table/ix-table.component.scss
+++ b/src/app/modules/ix-table/components/ix-table/ix-table.component.scss
@@ -19,6 +19,6 @@ table {
   tr > td span.mat-mdc-tooltip-trigger,
   tr > td div.mat-mdc-tooltip-trigger span {
     @include line-clamp(2);
-    margin: 0 0 -5px;
+    margin: 0 0 -3px;
   }
 }

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -872,6 +872,8 @@ table {
 }
 
 mat-list-item {
+  --mat-list-list-item-label-text-line-height: 14px;
+
   height: inherit;
   min-height: 48px;
 


### PR DESCRIPTION
Before: 
<img width="559" height="425" alt="Screenshot 2026-04-21 at 12 53 31" src="https://github.com/user-attachments/assets/c32f11d0-bac4-4503-96f0-796ac16f8ddd" />


After:
<img width="551" height="417" alt="Screenshot 2026-04-21 at 12 53 39" src="https://github.com/user-attachments/assets/7f6ba1b1-ca67-4eac-9d06-1817caf87b7b" />


Original PR: https://github.com/truenas/webui/pull/13507
