### PR TITLE
NAS-140803 / 27.0.0-BETA.1 / Some action buttons don’t have a border on focus

### DIFF
--- a/src/app/modules/forms/ix-forms/components/form-actions/form-actions.component.scss
+++ b/src/app/modules/forms/ix-forms/components/form-actions/form-actions.component.scss
@@ -12,18 +12,21 @@
 .submit-button-wrapper {
   position: relative;
   display: inline-block;
-  overflow: hidden;
 
-  &.validating::before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 1;
-    width: 30%;
-    height: 3px;
-    background: var(--primary);
-    content: '';
-    animation: loading-bar 1s ease-in-out infinite;
+  &.validating {
+    overflow: hidden;
+
+    &::before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: 1;
+      width: 30%;
+      height: 3px;
+      background: var(--primary);
+      content: '';
+      animation: loading-bar 1s ease-in-out infinite;
+    }
   }
 }
 


### PR DESCRIPTION

<img width="366" height="283" alt="Screenshot 2026-04-29 at 18 56 43" src="https://github.com/user-attachments/assets/ab846820-15a7-4dc5-9640-7dcb3bc5898d" />
