### PR TITLE
NAS-140762 / 26.0.0-BETA.2 / Switch to truenas.license.* API and normalized license shape (by aervin)

### DIFF
--- a/src/app/enums/license-feature.enum.ts
+++ b/src/app/enums/license-feature.enum.ts
@@ -18,10 +18,10 @@ export function getLabelForLicenseFeature(feature: LicenseFeature | string): str
     [LicenseFeature.Containers]: 'Containers',
     [LicenseFeature.Dedup]: 'Deduplication',
     [LicenseFeature.FibreChannel]: 'Fibre Channel',
-    [LicenseFeature.Lts]: 'Long-Term Support',
+    [LicenseFeature.Lts]: 'LTS',
     [LicenseFeature.Sed]: 'Self-Encrypting Drives',
     [LicenseFeature.Support]: 'Support',
-    [LicenseFeature.Vms]: 'Virtual Machines',
+    [LicenseFeature.Vms]: 'VMs',
     [LicenseFeature.ZfsTier]: 'ZFS Tiering',
   };
   return labels[feature as LicenseFeature] ?? feature;

--- a/src/app/enums/license-feature.enum.ts
+++ b/src/app/enums/license-feature.enum.ts
@@ -8,3 +8,15 @@ export enum LicenseFeature {
   Sed = 'SED',
   Support = 'SUPPORT',
 }
+
+export function getLabelForLicenseFeature(feature: LicenseFeature | string): string {
+  const labels: Record<LicenseFeature, string> = {
+    [LicenseFeature.Apps]: 'Apps',
+    [LicenseFeature.FibreChannel]: 'Fibre Channel',
+    [LicenseFeature.Dedup]: 'Deduplication',
+    [LicenseFeature.Vm]: 'Virtualization',
+    [LicenseFeature.Sed]: 'Self-Encrypting Drives',
+    [LicenseFeature.Support]: 'Support',
+  };
+  return labels[feature as LicenseFeature] ?? feature;
+}

--- a/src/app/enums/license-feature.enum.ts
+++ b/src/app/enums/license-feature.enum.ts
@@ -2,21 +2,27 @@ export enum LicenseFeature {
   // The middleware truenas.license.info endpoint normalizes legacy `JAILS` → `APPS`
   // before returning, so the UI only ever sees `APPS`.
   Apps = 'APPS',
-  FibreChannel = 'FIBRECHANNEL',
+  Containers = 'CONTAINERS',
   Dedup = 'DEDUP',
-  Vm = 'VM',
+  FibreChannel = 'FIBRECHANNEL',
+  Lts = 'LTS',
   Sed = 'SED',
   Support = 'SUPPORT',
+  Vms = 'VMS',
+  ZfsTier = 'ZFSTIER',
 }
 
 export function getLabelForLicenseFeature(feature: LicenseFeature | string): string {
   const labels: Record<LicenseFeature, string> = {
     [LicenseFeature.Apps]: 'Apps',
-    [LicenseFeature.FibreChannel]: 'Fibre Channel',
+    [LicenseFeature.Containers]: 'Containers',
     [LicenseFeature.Dedup]: 'Deduplication',
-    [LicenseFeature.Vm]: 'Virtualization',
+    [LicenseFeature.FibreChannel]: 'Fibre Channel',
+    [LicenseFeature.Lts]: 'Long-Term Support',
     [LicenseFeature.Sed]: 'Self-Encrypting Drives',
     [LicenseFeature.Support]: 'Support',
+    [LicenseFeature.Vms]: 'Virtual Machines',
+    [LicenseFeature.ZfsTier]: 'ZFS Tiering',
   };
   return labels[feature as LicenseFeature] ?? feature;
 }

--- a/src/app/enums/license-feature.enum.ts
+++ b/src/app/enums/license-feature.enum.ts
@@ -1,7 +1,10 @@
 export enum LicenseFeature {
-  Jails = 'JAILS', // Jails are used for apps as well
+  // The middleware truenas.license.info endpoint normalizes legacy `JAILS` → `APPS`
+  // before returning, so the UI only ever sees `APPS`.
+  Apps = 'APPS',
   FibreChannel = 'FIBRECHANNEL',
   Dedup = 'DEDUP',
   Vm = 'VM',
   Sed = 'SED',
+  Support = 'SUPPORT',
 }

--- a/src/app/enums/license-type.enum.ts
+++ b/src/app/enums/license-type.enum.ts
@@ -1,0 +1,4 @@
+export enum LicenseType {
+  EnterpriseHa = 'ENTERPRISE_HA',
+  EnterpriseSingle = 'ENTERPRISE_SINGLE',
+}

--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -255,7 +255,7 @@ import {
 import { StaticRoute, UpdateStaticRoute } from 'app/interfaces/static-route.interface';
 import { SystemGeneralConfig, SystemGeneralConfigUpdate } from 'app/interfaces/system-config.interface';
 import { SystemDatasetConfig } from 'app/interfaces/system-dataset-config.interface';
-import { SystemInfo } from 'app/interfaces/system-info.interface';
+import { License, SystemInfo } from 'app/interfaces/system-info.interface';
 import { SystemSecurityConfig } from 'app/interfaces/system-security-config.interface';
 import {
   UpdateConfig,
@@ -847,7 +847,6 @@ export interface ApiCallDirectory {
   'system.general.update': { params: [SystemGeneralConfigUpdate]; response: SystemGeneralConfig };
   'system.host_id': { params: void; response: string };
   'system.info': { params: void; response: SystemInfo };
-  'system.license_update': { params: [license: string]; response: void };
   'system.ntpserver.create': { params: [CreateNtpServer]; response: NtpServer };
   'system.ntpserver.delete': { params: [id: number]; response: boolean };
   'system.ntpserver.query': { params: QueryParams<NtpServer>; response: NtpServer[] };
@@ -878,6 +877,11 @@ export interface ApiCallDirectory {
   'truenas.is_eula_accepted': { params: void; response: boolean };
   'truenas.is_production': { params: void; response: boolean };
   'truenas.is_ix_hardware': { params: void; response: boolean };
+  'truenas.license.info': { params: void; response: License | null };
+  'truenas.license.upload': {
+    params: [license: string, options?: { ha_propagate?: boolean }];
+    response: void;
+  };
   'truenas.managed_by_truecommand': { params: void; response: boolean };
 
   // Tunable

--- a/src/app/interfaces/system-info.interface.spec.ts
+++ b/src/app/interfaces/system-info.interface.spec.ts
@@ -1,0 +1,28 @@
+import { ContractType, getLabelForContractType } from './system-info.interface';
+
+describe('getLabelForContractType', () => {
+  it('returns the human-readable label for a known contract type', () => {
+    expect(getLabelForContractType(ContractType.Gold)).toBe('Gold');
+    expect(getLabelForContractType(ContractType.SilverInternational)).toBe('Silver International');
+    expect(getLabelForContractType(ContractType.FreeNasMini)).toBe('Free NAS Mini');
+  });
+
+  it('returns an empty string when contract type is null', () => {
+    expect(getLabelForContractType(null)).toBe('');
+  });
+
+  it('returns an empty string when contract type is undefined', () => {
+    expect(getLabelForContractType(undefined)).toBe('');
+  });
+
+  it('returns an empty string when contract type is an empty string', () => {
+    expect(getLabelForContractType('')).toBe('');
+  });
+
+  it('falls back to the raw value for unknown contract types', () => {
+    // Future-proofing: middleware may emit values not yet in the enum (e.g. PLATINUM).
+    // The effect uppercases unknowns rather than dropping them, so the label helper
+    // surfaces the raw string instead of an empty cell.
+    expect(getLabelForContractType('PLATINUM')).toBe('PLATINUM');
+  });
+});

--- a/src/app/interfaces/system-info.interface.ts
+++ b/src/app/interfaces/system-info.interface.ts
@@ -1,6 +1,6 @@
 import { LicenseFeature } from 'app/enums/license-feature.enum';
 import { LicenseType } from 'app/enums/license-type.enum';
-import { ApiTimestamp } from 'app/interfaces/api-date.interface';
+import { ApiDate, ApiTimestamp } from 'app/interfaces/api-date.interface';
 
 // TODO: Split mixed interface for system.info and webui.main.dashboard.sys_info
 export interface SystemInfo {
@@ -30,14 +30,14 @@ export interface SystemInfo {
 /**
  * Per-feature license entry.
  *
- * `start_date` and `expires_at` are ISO date strings (`YYYY-MM-DD`) or null.
- * The `Support` entry, when present, carries the contract dates surfaced on
+ * Dates are wrapped in the `ApiDate` envelope (`{ $type: 'date', $value: 'YYYY-MM-DD' }`)
+ * or null. The `Support` entry, when present, carries the contract dates surfaced on
  * the support card; other features may have null dates.
  */
 export interface LicenseFeatureInfo {
   name: LicenseFeature;
-  start_date: string | null;
-  expires_at: string | null;
+  start_date: ApiDate | null;
+  expires_at: ApiDate | null;
 }
 
 /**
@@ -52,7 +52,7 @@ export interface License {
   type: LicenseType;
   contract_type: ContractType | null;
   model: string | null;
-  expires_at: string | null;
+  expires_at: ApiDate | null;
   features: LicenseFeatureInfo[];
   serials: string[];
   enclosures: Record<string, number>;

--- a/src/app/interfaces/system-info.interface.ts
+++ b/src/app/interfaces/system-info.interface.ts
@@ -1,5 +1,6 @@
 import { LicenseFeature } from 'app/enums/license-feature.enum';
-import { ApiDate, ApiTimestamp } from 'app/interfaces/api-date.interface';
+import { LicenseType } from 'app/enums/license-type.enum';
+import { ApiTimestamp } from 'app/interfaces/api-date.interface';
 
 // TODO: Split mixed interface for system.info and webui.main.dashboard.sys_info
 export interface SystemInfo {
@@ -10,7 +11,7 @@ export interface SystemInfo {
   datetime: ApiTimestamp;
   ecc_memory: boolean;
   hostname: string;
-  license: SystemLicense;
+  license: License | null;
   loadavg: [number, number, number];
   model: string;
   physical_cores: number;
@@ -26,20 +27,35 @@ export interface SystemInfo {
   remote_info: SystemInfo | null;
 }
 
-export interface SystemLicense {
-  addhw: unknown[];
-  addhw_detail: unknown[];
-  contract_end: ApiDate;
-  contract_start: ApiDate;
-  contract_type: ContractType;
-  customer_name: string;
-  expired: boolean;
-  features: LicenseFeature[];
-  legacy_contract_hardware: unknown;
-  legacy_contract_software: unknown;
-  model: string;
-  system_serial: string;
-  system_serial_ha: string;
+/**
+ * Per-feature license entry.
+ *
+ * `start_date` and `expires_at` are ISO date strings (`YYYY-MM-DD`) or null.
+ * The `Support` entry, when present, carries the contract dates surfaced on
+ * the support card; other features may have null dates.
+ */
+export interface LicenseFeatureInfo {
+  name: LicenseFeature;
+  start_date: string | null;
+  expires_at: string | null;
+}
+
+/**
+ * Normalized license payload returned by `truenas.license.info`.
+ *
+ * Middleware always returns this shape (legacy on-disk licenses are
+ * pre-normalized; their `id` is prefixed with `legacy_`). The UI does not
+ * need to handle the historical `system.license` shape.
+ */
+export interface License {
+  id: string;
+  type: LicenseType;
+  contract_type: ContractType | null;
+  model: string | null;
+  expires_at: string | null;
+  features: LicenseFeatureInfo[];
+  serials: string[];
+  enclosures: Record<string, number>;
 }
 
 export enum ContractType {
@@ -53,7 +69,11 @@ export enum ContractType {
   FreeNasMini = 'FREENASMINI',
 }
 
-export function getLabelForContractType(contractType: ContractType): string {
+export function getLabelForContractType(contractType: ContractType | null | undefined): string {
+  if (!contractType) {
+    return '';
+  }
+
   const contractTypeToLabelsMap: Record<ContractType, string> = {
     [ContractType.Gold]: 'Gold',
     [ContractType.Legacy]: 'Legacy',

--- a/src/app/interfaces/system-info.interface.ts
+++ b/src/app/interfaces/system-info.interface.ts
@@ -69,7 +69,7 @@ export enum ContractType {
   FreeNasMini = 'FREENASMINI',
 }
 
-export function getLabelForContractType(contractType: ContractType | null | undefined): string {
+export function getLabelForContractType(contractType: ContractType | string | null | undefined): string {
   if (!contractType) {
     return '';
   }
@@ -84,5 +84,7 @@ export function getLabelForContractType(contractType: ContractType | null | unde
     [ContractType.FreeNasMini]: 'Free NAS Mini',
     [ContractType.SilverInternational]: 'Silver International',
   };
-  return contractTypeToLabelsMap[contractType] || contractType;
+  // For values not in the known set (e.g. a future PLATINUM tier), fall back
+  // to the raw string so we surface something useful instead of an empty cell.
+  return contractTypeToLabelsMap[contractType as ContractType] ?? contractType;
 }

--- a/src/app/pages/dashboard/widgets/system/common/widget-sys-info.utils.ts
+++ b/src/app/pages/dashboard/widgets/system/common/widget-sys-info.utils.ts
@@ -1,5 +1,8 @@
+import { formatInTimeZone } from 'date-fns-tz';
 import { miniSeries, serverSeries } from 'app/constants/server-series.constant';
 import { ProductEnclosure } from 'app/enums/product-enclosure.enum';
+import { ApiDate } from 'app/interfaces/api-date.interface';
+import { LocaleService } from 'app/modules/language/locale.service';
 
 export function getServerProduct(systemProduct: string): string | undefined {
   return serverSeries.find((series) => systemProduct?.includes(series));
@@ -22,6 +25,23 @@ export function getProductImageSrc(systemProduct: string): string | null {
     return null;
   }
   return 'assets/images' + (imgName.startsWith('/') ? imgName : ('/' + imgName));
+}
+
+/**
+ * Format a license expiration `ApiDate` for display in the user's preferred date
+ * format. The wire value is a calendar date (`YYYY-MM-DD`) parsed as UTC midnight,
+ * so we format in UTC to keep the displayed date stable regardless of the user's
+ * local time zone.
+ */
+export function formatLicenseExpiration(
+  expiresAt: ApiDate | null | undefined,
+  localeService: LocaleService,
+): string | null {
+  const value = expiresAt?.$value;
+  if (!value) {
+    return null;
+  }
+  return formatInTimeZone(new Date(value), 'UTC', localeService.getPreferredDateFormat());
 }
 
 export function getProductEnclosure(systemProduct: string): ProductEnclosure | null {

--- a/src/app/pages/dashboard/widgets/system/common/widget-sys-info.utils.ts
+++ b/src/app/pages/dashboard/widgets/system/common/widget-sys-info.utils.ts
@@ -2,6 +2,7 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { miniSeries, serverSeries } from 'app/constants/server-series.constant';
 import { ProductEnclosure } from 'app/enums/product-enclosure.enum';
 import { ApiDate } from 'app/interfaces/api-date.interface';
+import { License } from 'app/interfaces/system-info.interface';
 import { LocaleService } from 'app/modules/language/locale.service';
 
 export function getServerProduct(systemProduct: string): string | undefined {
@@ -42,6 +43,22 @@ export function formatLicenseExpiration(
     return null;
   }
   return formatInTimeZone(new Date(value), 'UTC', localeService.getPreferredDateFormat());
+}
+
+/**
+ * Pick the license expiration date, tolerating the legacy `contract_end` field
+ * still emitted by `webui.main.dashboard.sys_info` (which the dashboard widgets
+ * consume). The new `truenas.license.info` endpoint surfaces `expires_at`.
+ *
+ * Remove the `contract_end` fallback once the dashboard endpoint is migrated
+ * to the new shape.
+ */
+export function getLicenseExpiration(license: License | null | undefined): ApiDate | null | undefined {
+  if (!license) {
+    return null;
+  }
+  const legacyContractEnd = (license as License & { contract_end?: ApiDate | null }).contract_end;
+  return license.expires_at ?? legacyContractEnd ?? null;
 }
 
 export function getProductEnclosure(systemProduct: string): ProductEnclosure | null {

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -127,10 +127,10 @@
                       }
                     }}
                   </div>
-                  @if (systemInfo().license.expires_at) {
+                  @if (licenseExpirationDate()) {
                     <div>
                       {{
-                        'Expires on {date}' | translate: { date: systemInfo().license.expires_at }
+                        'Expires on {date}' | translate: { date: licenseExpirationDate() }
                       }}
                     </div>
                   }

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -122,7 +122,7 @@
                   @if (systemInfo()?.license?.contract_type) {
                     <div>
                       {{
-                        '{license} Contract,' | translate:
+                        '{license} Contract' | translate:
                         {
                           license: getLabelForContractType(systemInfo()?.license?.contract_type),
                         }

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -127,11 +127,13 @@
                       }
                     }}
                   </div>
-                  <div>
-                    {{
-                      'Expires on {date}' | translate: { date: systemInfo().license.contract_end.$value }
-                    }}
-                  </div>
+                  @if (systemInfo().license.expires_at) {
+                    <div>
+                      {{
+                        'Expires on {date}' | translate: { date: systemInfo().license.expires_at }
+                      }}
+                    </div>
+                  }
                 </div>
               </div>
             </mat-list-item>

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -119,14 +119,16 @@
               <div class="license-info">
                 <div class="title">{{ 'Support License' | translate }}:</div>
                 <div class="info">
-                  <div>
-                    {{
-                      '{license} Contract,' | translate:
-                      {
-                        license: getLabelForContractType(systemInfo().license.contract_type),
-                      }
-                    }}
-                  </div>
+                  @if (systemInfo().license.contract_type) {
+                    <div>
+                      {{
+                        '{license} Contract,' | translate:
+                        {
+                          license: getLabelForContractType(systemInfo().license.contract_type),
+                        }
+                      }}
+                    </div>
+                  }
                   @if (licenseExpirationDate()) {
                     <div>
                       {{

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -119,12 +119,12 @@
               <div class="license-info">
                 <div class="title">{{ 'Support License' | translate }}:</div>
                 <div class="info">
-                  @if (systemInfo().license.contract_type) {
+                  @if (systemInfo()?.license?.contract_type) {
                     <div>
                       {{
                         '{license} Contract,' | translate:
                         {
-                          license: getLabelForContractType(systemInfo().license.contract_type),
+                          license: getLabelForContractType(systemInfo()?.license?.contract_type),
                         }
                       }}
                     </div>

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
@@ -31,7 +31,7 @@ describe('WidgetSysInfoActiveComponent', () => {
     version: '25.10.0-MASTER-20250126-184805',
     license: {
       contract_type: ContractType.Gold,
-      expires_at: '2025-01-01',
+      expires_at: { $type: 'date', $value: '2025-01-01' },
     } as License,
     system_serial: 'AA-00001',
     hostname: 'test-hostname-a',

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
@@ -61,6 +61,7 @@ describe('WidgetSysInfoActiveComponent', () => {
       mockProvider(LocaleService, {
         getDateAndTime: () => ['2024-03-15', '10:34:11'],
         getDateFromString: (date: string) => new Date(date),
+        getPreferredDateFormat: () => 'yyyy-MM-dd',
       }),
       provideMockStore({
         selectors: [

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
@@ -114,7 +114,7 @@ describe('WidgetSysInfoActiveComponent', () => {
       'Platform: TRUENAS-M40-HA',
       'Edition: Enterprise',
       'Version: 25.10.0-MASTER-20250126-184805',
-      'Support License: Gold Contract,  Expires on 2025-01-01',
+      'Support License: Gold Contract  Expires on 2025-01-01',
       'System Serial: AA-00001',
       'Uptime: 23 hours 12 minutes as of 10:34',
     ]);

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
@@ -9,7 +9,7 @@ import { BehaviorSubject } from 'rxjs';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { ProductType } from 'app/enums/product-type.enum';
 import { LoadingState } from 'app/helpers/operators/to-loading-state.helper';
-import { SystemLicense, SystemInfo, ContractType } from 'app/interfaces/system-info.interface';
+import { License, SystemInfo, ContractType } from 'app/interfaces/system-info.interface';
 import { selectUpdateJobForActiveNode } from 'app/modules/jobs/store/job.selectors';
 import { LocaleService } from 'app/modules/language/locale.service';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
@@ -31,11 +31,8 @@ describe('WidgetSysInfoActiveComponent', () => {
     version: '25.10.0-MASTER-20250126-184805',
     license: {
       contract_type: ContractType.Gold,
-      contract_end: {
-        $type: 'date',
-        $value: '2025-01-01',
-      },
-    } as SystemLicense,
+      expires_at: '2025-01-01',
+    } as License,
     system_serial: 'AA-00001',
     hostname: 'test-hostname-a',
     uptime_seconds: 83532.938532175,

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
@@ -9,6 +9,7 @@ import { RouterLink } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { tnIconMarker, TnIconComponent, TnTooltipDirective } from '@truenas/ui-components';
+import { format } from 'date-fns-tz';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { filter, map } from 'rxjs';
 import { getLabelForContractType } from 'app/interfaces/system-info.interface';
@@ -87,6 +88,14 @@ export class WidgetSysInfoActiveComponent {
     this.realElapsedSeconds();
     const [, timeValue] = this.localeService.getDateAndTime();
     return `${timeValue.split(':')[0]}:${timeValue.split(':')[1]}`;
+  });
+
+  licenseExpirationDate = computed(() => {
+    const expiresAt = this.systemInfo()?.license?.expires_at;
+    if (!expiresAt) {
+      return null;
+    }
+    return format(new Date(expiresAt), this.localeService.getPreferredDateFormat());
   });
 
   isLoaded = computed(() => this.systemInfo());

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
@@ -9,7 +9,6 @@ import { RouterLink } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { tnIconMarker, TnIconComponent, TnTooltipDirective } from '@truenas/ui-components';
-import { formatInTimeZone } from 'date-fns-tz';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { filter, map } from 'rxjs';
 import { getLabelForContractType } from 'app/interfaces/system-info.interface';
@@ -22,6 +21,7 @@ import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-reso
 import { SlotSize } from 'app/pages/dashboard/types/widget.interface';
 import { ProductImageComponent } from 'app/pages/dashboard/widgets/system/common/product-image/product-image.component';
 import { UptimePipe } from 'app/pages/dashboard/widgets/system/common/uptime.pipe';
+import { formatLicenseExpiration } from 'app/pages/dashboard/widgets/system/common/widget-sys-info.utils';
 import { AppState } from 'app/store';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
@@ -90,15 +90,9 @@ export class WidgetSysInfoActiveComponent {
     return `${timeValue.split(':')[0]}:${timeValue.split(':')[1]}`;
   });
 
-  licenseExpirationDate = computed(() => {
-    const expiresAt = this.systemInfo()?.license?.expires_at?.$value;
-    if (!expiresAt) {
-      return null;
-    }
-    // expires_at is a calendar date (YYYY-MM-DD) parsed as UTC midnight; format
-    // in UTC so the displayed date matches the API regardless of the user's zone.
-    return formatInTimeZone(new Date(expiresAt), 'UTC', this.localeService.getPreferredDateFormat());
-  });
+  licenseExpirationDate = computed(
+    () => formatLicenseExpiration(this.systemInfo()?.license?.expires_at, this.localeService),
+  );
 
   isLoaded = computed(() => this.systemInfo());
 

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
@@ -9,7 +9,7 @@ import { RouterLink } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateModule } from '@ngx-translate/core';
 import { tnIconMarker, TnIconComponent, TnTooltipDirective } from '@truenas/ui-components';
-import { format } from 'date-fns-tz';
+import { formatInTimeZone } from 'date-fns-tz';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { filter, map } from 'rxjs';
 import { getLabelForContractType } from 'app/interfaces/system-info.interface';
@@ -91,11 +91,13 @@ export class WidgetSysInfoActiveComponent {
   });
 
   licenseExpirationDate = computed(() => {
-    const expiresAt = this.systemInfo()?.license?.expires_at;
+    const expiresAt = this.systemInfo()?.license?.expires_at?.$value;
     if (!expiresAt) {
       return null;
     }
-    return format(new Date(expiresAt), this.localeService.getPreferredDateFormat());
+    // expires_at is a calendar date (YYYY-MM-DD) parsed as UTC midnight; format
+    // in UTC so the displayed date matches the API regardless of the user's zone.
+    return formatInTimeZone(new Date(expiresAt), 'UTC', this.localeService.getPreferredDateFormat());
   });
 
   isLoaded = computed(() => this.systemInfo());

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
@@ -21,7 +21,10 @@ import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-reso
 import { SlotSize } from 'app/pages/dashboard/types/widget.interface';
 import { ProductImageComponent } from 'app/pages/dashboard/widgets/system/common/product-image/product-image.component';
 import { UptimePipe } from 'app/pages/dashboard/widgets/system/common/uptime.pipe';
-import { formatLicenseExpiration } from 'app/pages/dashboard/widgets/system/common/widget-sys-info.utils';
+import {
+  formatLicenseExpiration,
+  getLicenseExpiration,
+} from 'app/pages/dashboard/widgets/system/common/widget-sys-info.utils';
 import { AppState } from 'app/store';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
@@ -91,7 +94,7 @@ export class WidgetSysInfoActiveComponent {
   });
 
   licenseExpirationDate = computed(
-    () => formatLicenseExpiration(this.systemInfo()?.license?.expires_at, this.localeService),
+    () => formatLicenseExpiration(getLicenseExpiration(this.systemInfo()?.license), this.localeService),
   );
 
   isLoaded = computed(() => this.systemInfo());

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -119,7 +119,7 @@
                   @if (systemInfo()?.license?.contract_type) {
                     <div>
                       {{
-                        '{license} Contract,' | translate:
+                        '{license} Contract' | translate:
                         {
                           license: getLabelForContractType(systemInfo()?.license?.contract_type),
                         }

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -116,14 +116,16 @@
               <div class="license-info">
                 <div class="title">{{ 'Support License' | translate }}:</div>
                 <div class="info">
-                  <div>
-                    {{
-                      '{license} Contract,' | translate:
-                      {
-                        license: getLabelForContractType(systemInfo().license.contract_type),
-                      }
-                    }}
-                  </div>
+                  @if (systemInfo().license.contract_type) {
+                    <div>
+                      {{
+                        '{license} Contract,' | translate:
+                        {
+                          license: getLabelForContractType(systemInfo().license.contract_type),
+                        }
+                      }}
+                    </div>
+                  }
                   @if (licenseExpirationDate()) {
                     <div>
                       {{

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -116,12 +116,12 @@
               <div class="license-info">
                 <div class="title">{{ 'Support License' | translate }}:</div>
                 <div class="info">
-                  @if (systemInfo().license.contract_type) {
+                  @if (systemInfo()?.license?.contract_type) {
                     <div>
                       {{
                         '{license} Contract,' | translate:
                         {
-                          license: getLabelForContractType(systemInfo().license.contract_type),
+                          license: getLabelForContractType(systemInfo()?.license?.contract_type),
                         }
                       }}
                     </div>

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -124,10 +124,10 @@
                       }
                     }}
                   </div>
-                  @if (systemInfo().license.expires_at) {
+                  @if (licenseExpirationDate()) {
                     <div>
                       {{
-                        'Expires on {date}' | translate: { date: systemInfo().license.expires_at }
+                        'Expires on {date}' | translate: { date: licenseExpirationDate() }
                       }}
                     </div>
                   }

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -124,11 +124,13 @@
                       }
                     }}
                   </div>
-                  <div>
-                    {{
-                      'Expires on {date}' | translate: { date: systemInfo().license.contract_end.$value }
-                    }}
-                  </div>
+                  @if (systemInfo().license.expires_at) {
+                    <div>
+                      {{
+                        'Expires on {date}' | translate: { date: systemInfo().license.expires_at }
+                      }}
+                    </div>
+                  }
                 </div>
               </div>
             </mat-list-item>

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
@@ -125,7 +125,7 @@ describe('WidgetSysInfoPassiveComponent', () => {
         'Platform: TRUENAS-M40-HA',
         'Edition: Enterprise',
         'Version: 25.10.0-MASTER-20250126-184805',
-        'Support License: Gold Contract,  Expires on 2025-01-01',
+        'Support License: Gold Contract  Expires on 2025-01-01',
         'System Serial: AA-00002',
         'Uptime: 1 minute 17 seconds as of 10:34',
       ]);

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
@@ -9,7 +9,7 @@ import { BehaviorSubject, of } from 'rxjs';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { ProductType } from 'app/enums/product-type.enum';
 import { LoadingState } from 'app/helpers/operators/to-loading-state.helper';
-import { SystemLicense, SystemInfo, ContractType } from 'app/interfaces/system-info.interface';
+import { License, SystemInfo, ContractType } from 'app/interfaces/system-info.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { selectUpdateJobForPassiveNode } from 'app/modules/jobs/store/job.selectors';
 import { LocaleService } from 'app/modules/language/locale.service';
@@ -35,11 +35,8 @@ describe('WidgetSysInfoPassiveComponent', () => {
       version: '25.10.0-MASTER-20250126-184805',
       license: {
         contract_type: ContractType.Gold,
-        contract_end: {
-          $type: 'date',
-          $value: '2025-01-01',
-        },
-      } as SystemLicense,
+        expires_at: '2025-01-01',
+      } as License,
       system_serial: 'AA-00002',
       hostname: 'test-hostname-b',
       uptime_seconds: 77.915545062,

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
@@ -55,6 +55,7 @@ describe('WidgetSysInfoPassiveComponent', () => {
       mockProvider(LocaleService, {
         getDateAndTime: () => ['2024-03-15', '10:34:11'],
         getDateFromString: (date: string) => new Date(date),
+        getPreferredDateFormat: () => 'yyyy-MM-dd',
       }),
       provideMockStore({
         selectors: [

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
@@ -35,7 +35,7 @@ describe('WidgetSysInfoPassiveComponent', () => {
       version: '25.10.0-MASTER-20250126-184805',
       license: {
         contract_type: ContractType.Gold,
-        expires_at: '2025-01-01',
+        expires_at: { $type: 'date', $value: '2025-01-01' },
       } as License,
       system_serial: 'AA-00002',
       hostname: 'test-hostname-b',

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
@@ -9,7 +9,7 @@ import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { tnIconMarker, TnIconComponent } from '@truenas/ui-components';
-import { format } from 'date-fns-tz';
+import { formatInTimeZone } from 'date-fns-tz';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import {
   filter, map,
@@ -102,11 +102,13 @@ export class WidgetSysInfoPassiveComponent {
   });
 
   licenseExpirationDate = computed(() => {
-    const expiresAt = this.systemInfo()?.license?.expires_at;
+    const expiresAt = this.systemInfo()?.license?.expires_at?.$value;
     if (!expiresAt) {
       return null;
     }
-    return format(new Date(expiresAt), this.localeService.getPreferredDateFormat());
+    // expires_at is a calendar date (YYYY-MM-DD) parsed as UTC midnight; format
+    // in UTC so the displayed date matches the API regardless of the user's zone.
+    return formatInTimeZone(new Date(expiresAt), 'UTC', this.localeService.getPreferredDateFormat());
   });
 
   isLoaded = computed(() => this.systemInfo());

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
@@ -9,6 +9,7 @@ import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { tnIconMarker, TnIconComponent } from '@truenas/ui-components';
+import { format } from 'date-fns-tz';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import {
   filter, map,
@@ -98,6 +99,14 @@ export class WidgetSysInfoPassiveComponent {
     this.realElapsedSeconds();
     const [, timeValue] = this.localeService.getDateAndTime();
     return `${timeValue.split(':')[0]}:${timeValue.split(':')[1]}`;
+  });
+
+  licenseExpirationDate = computed(() => {
+    const expiresAt = this.systemInfo()?.license?.expires_at;
+    if (!expiresAt) {
+      return null;
+    }
+    return format(new Date(expiresAt), this.localeService.getPreferredDateFormat());
   });
 
   isLoaded = computed(() => this.systemInfo());

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
@@ -9,7 +9,6 @@ import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { tnIconMarker, TnIconComponent } from '@truenas/ui-components';
-import { formatInTimeZone } from 'date-fns-tz';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import {
   filter, map,
@@ -27,6 +26,7 @@ import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-reso
 import { SlotSize } from 'app/pages/dashboard/types/widget.interface';
 import { ProductImageComponent } from 'app/pages/dashboard/widgets/system/common/product-image/product-image.component';
 import { UptimePipe } from 'app/pages/dashboard/widgets/system/common/uptime.pipe';
+import { formatLicenseExpiration } from 'app/pages/dashboard/widgets/system/common/widget-sys-info.utils';
 import { AppState } from 'app/store';
 import { selectCanFailover, selectIsHaEnabled, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
@@ -101,15 +101,9 @@ export class WidgetSysInfoPassiveComponent {
     return `${timeValue.split(':')[0]}:${timeValue.split(':')[1]}`;
   });
 
-  licenseExpirationDate = computed(() => {
-    const expiresAt = this.systemInfo()?.license?.expires_at?.$value;
-    if (!expiresAt) {
-      return null;
-    }
-    // expires_at is a calendar date (YYYY-MM-DD) parsed as UTC midnight; format
-    // in UTC so the displayed date matches the API regardless of the user's zone.
-    return formatInTimeZone(new Date(expiresAt), 'UTC', this.localeService.getPreferredDateFormat());
-  });
+  licenseExpirationDate = computed(
+    () => formatLicenseExpiration(this.systemInfo()?.license?.expires_at, this.localeService),
+  );
 
   isLoaded = computed(() => this.systemInfo());
 

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
@@ -26,7 +26,10 @@ import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-reso
 import { SlotSize } from 'app/pages/dashboard/types/widget.interface';
 import { ProductImageComponent } from 'app/pages/dashboard/widgets/system/common/product-image/product-image.component';
 import { UptimePipe } from 'app/pages/dashboard/widgets/system/common/uptime.pipe';
-import { formatLicenseExpiration } from 'app/pages/dashboard/widgets/system/common/widget-sys-info.utils';
+import {
+  formatLicenseExpiration,
+  getLicenseExpiration,
+} from 'app/pages/dashboard/widgets/system/common/widget-sys-info.utils';
 import { AppState } from 'app/store';
 import { selectCanFailover, selectIsHaEnabled, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
@@ -102,7 +105,7 @@ export class WidgetSysInfoPassiveComponent {
   });
 
   licenseExpirationDate = computed(
-    () => formatLicenseExpiration(this.systemInfo()?.license?.expires_at, this.localeService),
+    () => formatLicenseExpiration(getLicenseExpiration(this.systemInfo()?.license), this.localeService),
   );
 
   isLoaded = computed(() => this.systemInfo());

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
@@ -531,7 +531,7 @@ describe('OtherOptionsSectionComponent', () => {
       store$.overrideSelector(selectSystemInfo, {
         productType: ProductType.Enterprise,
         license: {
-          features: [LicenseFeature.Dedup],
+          features: [{ name: LicenseFeature.Dedup, start_date: null, expires_at: null }],
         },
       } as unknown as SystemInfo);
       store$.refreshState();

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
@@ -263,8 +263,7 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
         return;
       }
 
-      // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
-      if (systemInfo.license && systemInfo.license.features.includes(LicenseFeature.Dedup)) {
+      if (systemInfo.license?.features.some((feature) => feature.name === LicenseFeature.Dedup)) {
         this.hasDeduplication = true;
         this.cdr.markForCheck();
       }

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.spec.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.spec.ts
@@ -122,7 +122,7 @@ describe('IscsiWizardComponent', () => {
             value: {
               version: 'TrueNAS-SCALE-22.12',
               license: {
-                features: [LicenseFeature.FibreChannel],
+                features: [{ name: LicenseFeature.FibreChannel, start_date: null, expires_at: null }],
               },
             } as SystemInfo,
           },

--- a/src/app/pages/sharing/iscsi/target/target-form/target-form.component.spec.ts
+++ b/src/app/pages/sharing/iscsi/target/target-form/target-form.component.spec.ts
@@ -78,7 +78,7 @@ describe('TargetFormComponent', () => {
             value: {
               version: 'TrueNAS-SCALE-22.12',
               license: {
-                features: [LicenseFeature.FibreChannel],
+                features: [{ name: LicenseFeature.FibreChannel, start_date: null, expires_at: null }],
               },
             } as SystemInfo,
           },

--- a/src/app/pages/system/general-settings/support/license-info-in-support.interface.ts
+++ b/src/app/pages/system/general-settings/support/license-info-in-support.interface.ts
@@ -1,8 +1,24 @@
-import { SystemLicense } from 'app/interfaces/system-info.interface';
+import { ContractType } from 'app/interfaces/system-info.interface';
 
-export interface LicenseInfoInSupport extends SystemLicense {
-  featuresString?: string;
-  expiration_date?: string;
-  add_hardware?: string;
-  daysLeftinContract?: number;
+/**
+ * Support-card view-model derived from a normalized `License`. Built once in
+ * the support-card component and consumed by `ix-sys-info` for display.
+ *
+ * Fields with no equivalent on the new license shape (e.g. `customer_name`)
+ * are intentionally omitted — the rows that depended on them are removed from
+ * the template.
+ */
+export interface LicenseInfoInSupport {
+  contractType: ContractType | null;
+  model: string | null;
+  /** Pre-formatted expiration date for display, or null when unavailable. */
+  expirationDate: string | null;
+  /** Days until contract end. Negative when expired. */
+  daysLeftInContract: number | null;
+  /** Comma-joined feature list, or 'NONE'. SUPPORT is omitted (surfaced via contract type). */
+  featuresString: string;
+  /** Comma-joined list of `count× model` pairs from `enclosures`, or null. */
+  additionalHardware: string | null;
+  /** All system serials from the license payload. */
+  serials: string[];
 }

--- a/src/app/pages/system/general-settings/support/license-info-in-support.interface.ts
+++ b/src/app/pages/system/general-settings/support/license-info-in-support.interface.ts
@@ -15,8 +15,12 @@ export interface LicenseInfoInSupport {
   expirationDate: string | null;
   /** Days until contract end. Negative when expired. */
   daysLeftInContract: number | null;
-  /** Comma-joined feature list, or 'NONE'. SUPPORT is omitted (surfaced via contract type). */
-  featuresString: string;
+  /**
+   * Feature names with `Support` filtered out (it is surfaced via the contract
+   * type row instead). The template renders the comma-joined list or a
+   * translated `'NONE'` placeholder.
+   */
+  featureNames: string[];
   /** Comma-joined list of `count× model` pairs from `enclosures`, or null. */
   additionalHardware: string | null;
   /** All system serials from the license payload. */

--- a/src/app/pages/system/general-settings/support/license-info-in-support.interface.ts
+++ b/src/app/pages/system/general-settings/support/license-info-in-support.interface.ts
@@ -11,8 +11,12 @@ import { ContractType } from 'app/interfaces/system-info.interface';
 export interface LicenseInfoInSupport {
   contractType: ContractType | null;
   model: string | null;
-  /** Pre-formatted expiration date for display, or null when unavailable. */
-  expirationDate: string | null;
+  /**
+   * Pre-formatted expiration date string for display (already run through the
+   * user's preferred date format and the UTC-stable formatter). `null` when no
+   * expiration is set on either the SUPPORT feature or the top-level license.
+   */
+  expirationDateDisplay: string | null;
   /** Days until contract end. Negative when expired. */
   daysLeftInContract: number | null;
   /**

--- a/src/app/pages/system/general-settings/support/license/license.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/license/license.component.spec.ts
@@ -38,7 +38,7 @@ describe('LicenseComponent', () => {
     ],
     providers: [
       mockApi([
-        mockCall('system.license_update'),
+        mockCall('truenas.license.upload'),
       ]),
       mockProvider(SlideIn),
       mockProvider(DialogService, {
@@ -70,7 +70,7 @@ describe('LicenseComponent', () => {
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
     await saveButton.click();
 
-    expect(api.call).toHaveBeenCalledWith('system.license_update', ['test-license']);
+    expect(api.call).toHaveBeenCalledWith('truenas.license.upload', ['test-license']);
   });
 
   it('shows a warning that UI needs to be reloaded and reloads it after dialog is closed', async () => {

--- a/src/app/pages/system/general-settings/support/license/license.component.ts
+++ b/src/app/pages/system/general-settings/support/license/license.component.ts
@@ -72,7 +72,7 @@ export class LicenseComponent {
     this.isFormLoading = true;
 
     const { license } = this.form.getRawValue();
-    this.api.call('system.license_update', [license]).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+    this.api.call('truenas.license.upload', [license]).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => {
         this.isFormLoading = false;
         this.slideInRef.close({ response: true });

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.html
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.html
@@ -45,7 +45,7 @@
         <div class="support-banner warning">
           <div class="banner-text">
             <strong class="banner-heading">{{ 'Your support contract expires in {n, plural, one {# day} other {# days}}' | translate: { n: licenseInfo.daysLeftInContract } }}</strong>
-            <span class="banner-subheading">{{ 'You will be unable to contact support after {date}. Contact your account team to renew.' | translate: { date: licenseInfo.expirationDate } }}</span>
+            <span class="banner-subheading">{{ 'You will be unable to contact support after {date}. Contact your account team to renew.' | translate: { date: licenseInfo.expirationDateDisplay } }}</span>
           </div>
           <a
             href="https://www.truenas.com/contact-us/"

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.html
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.html
@@ -44,8 +44,8 @@
       @if (hasLicense && isContractExpiringSoon()) {
         <div class="support-banner warning">
           <div class="banner-text">
-            <strong class="banner-heading">{{ 'Your support contract expires in {n, plural, one {# day} other {# days}}' | translate: { n: licenseInfo.daysLeftinContract } }}</strong>
-            <span class="banner-subheading">{{ 'You will be unable to contact support after {date}. Contact your account team to renew.' | translate: { date: licenseInfo.expiration_date } }}</span>
+            <strong class="banner-heading">{{ 'Your support contract expires in {n, plural, one {# day} other {# days}}' | translate: { n: licenseInfo.daysLeftInContract } }}</strong>
+            <span class="banner-subheading">{{ 'You will be unable to contact support after {date}. Contact your account team to renew.' | translate: { date: licenseInfo.expirationDate } }}</span>
           </div>
           <a
             href="https://www.truenas.com/contact-us/"

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
@@ -97,16 +97,24 @@ describe('SupportCardComponent', () => {
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   });
 
-  describe('System with a license', () => {
-    beforeEach(() => {
-      const store$ = spectator.inject(MockStore);
-      store$.overrideSelector(selectSystemInfo, {
-        ...systemInfo,
-        license: makeLicense('2027-09-29'),
-      });
-      store$.refreshState();
-      spectator.detectChanges();
+  /**
+   * Push a fresh systemInfo through the store and let the support-card
+   * subscription re-fire (NgRx select uses identity-based distinctUntilChanged,
+   * so we always pass a new reference).
+   */
+  function emitSystemInfo(overrides: Partial<SystemInfo> = {}): void {
+    const store$ = spectator.inject(MockStore);
+    store$.overrideSelector(selectSystemInfo, {
+      ...systemInfo,
+      license: makeLicense('2027-09-29'),
+      ...overrides,
     });
+    store$.refreshState();
+    spectator.detectChanges();
+  }
+
+  describe('System with a license', () => {
+    beforeEach(() => emitSystemInfo());
 
     describe('Proactive support availability', () => {
       it('checks if proactive support is available when license is present', () => {
@@ -121,15 +129,7 @@ describe('SupportCardComponent', () => {
         const api = spectator.inject(ApiService);
         jest.spyOn(api, 'call').mockReturnValue(of(false));
 
-        // Re-emit systemInfo with a fresh reference so the subscription re-fires
-        // (NgRx select uses distinctUntilChanged on object identity).
-        const store$ = spectator.inject(MockStore);
-        store$.overrideSelector(selectSystemInfo, {
-          ...systemInfo,
-          license: makeLicense('2027-09-29'),
-        });
-        store$.refreshState();
-        spectator.detectChanges();
+        emitSystemInfo();
 
         expect(spectator.component.isProactiveSupportAvailable()).toBe(false);
       });
@@ -177,14 +177,7 @@ describe('SupportCardComponent', () => {
           return of(true);
         });
 
-        // Re-emit systemInfo with a fresh reference so the subscription re-fires.
-        const store$ = spectator.inject(MockStore);
-        store$.overrideSelector(selectSystemInfo, {
-          ...systemInfo,
-          license: makeLicense('2027-09-29'),
-        });
-        store$.refreshState();
-        spectator.detectChanges();
+        emitSystemInfo();
 
         const banner = spectator.query('.support-banner.proactive');
         expect(banner).not.toExist();
@@ -193,14 +186,10 @@ describe('SupportCardComponent', () => {
 
     describe('Contract expiration warning banner', () => {
       beforeEach(() => {
-        const store$ = spectator.inject(MockStore);
-        store$.overrideSelector(selectSystemInfo, {
-          ...systemInfo,
-          datetime: { $date: 1767830400000 }, // 2026-01-08
+        emitSystemInfo({
+          datetime: { $date: 1767830400000 } as SystemInfo['datetime'], // 2026-01-08
           license: makeLicense('2026-01-11'),
         });
-        store$.refreshState();
-        spectator.detectChanges();
       });
 
       it('shows warning banner when contract expires within 14 days', () => {
@@ -215,14 +204,10 @@ describe('SupportCardComponent', () => {
       });
 
       it('does not show warning banner when contract expires in more than 14 days', () => {
-        const store$ = spectator.inject(MockStore);
-        store$.overrideSelector(selectSystemInfo, {
-          ...systemInfo,
-          datetime: { $date: 1767830400000 }, // 2026-01-08
+        emitSystemInfo({
+          datetime: { $date: 1767830400000 } as SystemInfo['datetime'], // 2026-01-08
           license: makeLicense('2026-02-01'), // 24 days away
         });
-        store$.refreshState();
-        spectator.detectChanges();
 
         const banner = spectator.query('.support-banner.warning');
         expect(banner).not.toExist();
@@ -284,13 +269,7 @@ describe('SupportCardComponent', () => {
         return of(null);
       });
 
-      const store$ = spectator.inject(MockStore);
-      store$.overrideSelector(selectSystemInfo, {
-        ...systemInfo,
-        license: makeLicense('2027-09-29'),
-      });
-      store$.refreshState();
-      spectator.detectChanges();
+      emitSystemInfo();
     });
 
     it('shows upsell banner for support options', () => {

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
@@ -121,7 +121,15 @@ describe('SupportCardComponent', () => {
         const api = spectator.inject(ApiService);
         jest.spyOn(api, 'call').mockReturnValue(of(false));
 
-        spectator.component.ngOnInit();
+        // Re-emit systemInfo with a fresh reference so the subscription re-fires
+        // (NgRx select uses distinctUntilChanged on object identity).
+        const store$ = spectator.inject(MockStore);
+        store$.overrideSelector(selectSystemInfo, {
+          ...systemInfo,
+          license: makeLicense('2027-09-29'),
+        });
+        store$.refreshState();
+        spectator.detectChanges();
 
         expect(spectator.component.isProactiveSupportAvailable()).toBe(false);
       });
@@ -169,7 +177,13 @@ describe('SupportCardComponent', () => {
           return of(true);
         });
 
-        spectator.component.ngOnInit();
+        // Re-emit systemInfo with a fresh reference so the subscription re-fires.
+        const store$ = spectator.inject(MockStore);
+        store$.overrideSelector(selectSystemInfo, {
+          ...systemInfo,
+          license: makeLicense('2027-09-29'),
+        });
+        store$.refreshState();
         spectator.detectChanges();
 
         const banner = spectator.query('.support-banner.proactive');

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
@@ -12,8 +12,9 @@ import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
 import { mockCall, mockJob, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { LicenseFeature } from 'app/enums/license-feature.enum';
+import { LicenseType } from 'app/enums/license-type.enum';
 import { ProductType } from 'app/enums/product-type.enum';
-import { SystemInfo, SystemLicense } from 'app/interfaces/system-info.interface';
+import { ContractType, License, SystemInfo } from 'app/interfaces/system-info.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FeedbackDialog } from 'app/modules/feedback/components/feedback-dialog/feedback-dialog.component';
 import { FeedbackType } from 'app/modules/feedback/interfaces/feedback.interface';
@@ -33,6 +34,24 @@ const systemInfo = {
   system_product: 'N7',
   datetime: { $date: 1666376171107 },
 } as SystemInfo;
+
+function makeLicense(supportExpiresAt: string | null): License {
+  return {
+    id: 'test-license-id',
+    type: LicenseType.EnterpriseSingle,
+    contract_type: ContractType.Gold,
+    model: 'M40',
+    expires_at: supportExpiresAt,
+    features: [
+      { name: LicenseFeature.Apps, start_date: null, expires_at: null },
+      ...(supportExpiresAt
+        ? [{ name: LicenseFeature.Support, start_date: null, expires_at: supportExpiresAt }]
+        : []),
+    ],
+    serials: ['AA-00001'],
+    enclosures: {},
+  };
+}
 
 describe('SupportCardComponent', () => {
   let spectator: Spectator<SupportCardComponent>;
@@ -83,14 +102,7 @@ describe('SupportCardComponent', () => {
       const store$ = spectator.inject(MockStore);
       store$.overrideSelector(selectSystemInfo, {
         ...systemInfo,
-        license: {
-          features: [LicenseFeature.Jails],
-          contract_end: {
-            $type: 'date',
-            $value: '2027-09-29',
-          },
-          addhw_detail: [] as unknown[],
-        } as SystemLicense,
+        license: makeLicense('2027-09-29'),
       });
       store$.refreshState();
       spectator.detectChanges();
@@ -171,14 +183,7 @@ describe('SupportCardComponent', () => {
         store$.overrideSelector(selectSystemInfo, {
           ...systemInfo,
           datetime: { $date: 1767830400000 }, // 2026-01-08
-          license: {
-            features: [LicenseFeature.Jails],
-            contract_end: {
-              $type: 'date',
-              $value: '2026-01-11',
-            },
-            addhw_detail: [] as unknown[],
-          } as SystemLicense,
+          license: makeLicense('2026-01-11'),
         });
         store$.refreshState();
         spectator.detectChanges();
@@ -200,14 +205,7 @@ describe('SupportCardComponent', () => {
         store$.overrideSelector(selectSystemInfo, {
           ...systemInfo,
           datetime: { $date: 1767830400000 }, // 2026-01-08
-          license: {
-            features: [LicenseFeature.Jails],
-            contract_end: {
-              $type: 'date',
-              $value: '2026-02-01', // 24 days away
-            },
-            addhw_detail: [] as unknown[],
-          } as SystemLicense,
+          license: makeLicense('2026-02-01'), // 24 days away
         });
         store$.refreshState();
         spectator.detectChanges();
@@ -275,14 +273,7 @@ describe('SupportCardComponent', () => {
       const store$ = spectator.inject(MockStore);
       store$.overrideSelector(selectSystemInfo, {
         ...systemInfo,
-        license: {
-          features: [LicenseFeature.Jails],
-          contract_end: {
-            $type: 'date',
-            $value: '2027-09-29',
-          },
-          addhw_detail: [] as unknown[],
-        } as SystemLicense,
+        license: makeLicense('2027-09-29'),
       });
       store$.refreshState();
       spectator.detectChanges();

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.spec.ts
@@ -36,16 +36,17 @@ const systemInfo = {
 } as SystemInfo;
 
 function makeLicense(supportExpiresAt: string | null): License {
+  const expiresAtDate = supportExpiresAt ? { $type: 'date' as const, $value: supportExpiresAt } : null;
   return {
     id: 'test-license-id',
     type: LicenseType.EnterpriseSingle,
     contract_type: ContractType.Gold,
     model: 'M40',
-    expires_at: supportExpiresAt,
+    expires_at: expiresAtDate,
     features: [
       { name: LicenseFeature.Apps, start_date: null, expires_at: null },
-      ...(supportExpiresAt
-        ? [{ name: LicenseFeature.Support, start_date: null, expires_at: supportExpiresAt }]
+      ...(expiresAtDate
+        ? [{ name: LicenseFeature.Support, start_date: null, expires_at: expiresAtDate }]
         : []),
     ],
     serials: ['AA-00001'],

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
@@ -10,8 +10,6 @@ import { MatToolbarRow } from '@angular/material/toolbar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { formatInTimeZone } from 'date-fns-tz';
-import { isObject } from 'lodash-es';
 import { Observable, of, switchMap } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 import { GiB } from 'app/constants/bytes.constant';
@@ -30,7 +28,10 @@ import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
-import { getProductImageSrc } from 'app/pages/dashboard/widgets/system/common/widget-sys-info.utils';
+import {
+  formatLicenseExpiration,
+  getProductImageSrc,
+} from 'app/pages/dashboard/widgets/system/common/widget-sys-info.utils';
 import { LicenseComponent } from 'app/pages/system/general-settings/support/license/license.component';
 import { LicenseInfoInSupport } from 'app/pages/system/general-settings/support/license-info-in-support.interface';
 import { ProactiveComponent } from 'app/pages/system/general-settings/support/proactive/proactive.component';
@@ -136,22 +137,17 @@ export class SupportCardComponent implements OnInit {
     // Support contract dates live on the SUPPORT feature entry; fall back to the
     // top-level expiration if the SUPPORT entry is absent.
     const supportFeature = license.features.find((feature) => feature.name === LicenseFeature.Support);
-    const expirationIso = supportFeature?.expires_at?.$value ?? license.expires_at?.$value ?? null;
+    const expiresAt = supportFeature?.expires_at ?? license.expires_at ?? null;
 
-    let expirationDate: string | null = null;
+    const expirationDateDisplay = formatLicenseExpiration(expiresAt, this.localeService);
     let daysLeftInContract: number | null = null;
-    if (expirationIso) {
-      // expirationIso is a calendar date (YYYY-MM-DD) parsed as UTC midnight; format
-      // in UTC so the displayed date matches the API regardless of the user's zone.
-      const expDate = new Date(expirationIso);
-      expirationDate = formatInTimeZone(expDate, 'UTC', this.localeService.getPreferredDateFormat());
-      daysLeftInContract = Math.round((expDate.getTime() - nowMs) / oneDayMillis);
+    if (expiresAt?.$value) {
+      daysLeftInContract = Math.round((new Date(expiresAt.$value).getTime() - nowMs) / oneDayMillis);
     }
 
     const featureNames = license.features
-      .map((feature) => feature.name)
-      .filter((name) => name !== LicenseFeature.Support)
-      .map((name) => getLabelForLicenseFeature(name));
+      .filter((feature) => feature.name !== LicenseFeature.Support)
+      .map((feature) => getLabelForLicenseFeature(feature.name));
 
     const additionalHardware = Object.entries(license.enclosures)
       .map(([model, count]) => this.translate.instant('{count}× {model}', { count, model }))
@@ -160,7 +156,7 @@ export class SupportCardComponent implements OnInit {
     return {
       contractType: license.contract_type,
       model: license.model,
-      expirationDate,
+      expirationDateDisplay,
       daysLeftInContract,
       featureNames,
       additionalHardware,
@@ -205,7 +201,7 @@ export class SupportCardComponent implements OnInit {
 
     request$.pipe(
       switchMap((result) => {
-        const attachDebug = (isObject(result) && result.sendInitialDebug) || false;
+        const attachDebug = (typeof result === 'object' && result?.sendInitialDebug) || false;
 
         return this.api.job('truenas.set_production', [newStatus, attachDebug]).pipe(
           this.loader.withLoader(),

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
@@ -18,7 +18,7 @@ import { GiB } from 'app/constants/bytes.constant';
 import { oneDayMillis } from 'app/constants/time.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
-import { LicenseFeature } from 'app/enums/license-feature.enum';
+import { LicenseFeature, getLabelForLicenseFeature } from 'app/enums/license-feature.enum';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemSupport as helptext } from 'app/helptext/system/support';
 import { License, SystemInfo } from 'app/interfaces/system-info.interface';
@@ -148,10 +148,11 @@ export class SupportCardComponent implements OnInit {
 
     const featureNames = license.features
       .map((feature) => feature.name)
-      .filter((name) => name !== LicenseFeature.Support);
+      .filter((name) => name !== LicenseFeature.Support)
+      .map((name) => getLabelForLicenseFeature(name));
 
     const additionalHardware = Object.entries(license.enclosures)
-      .map(([model, count]) => `${count}× ${model}`)
+      .map(([model, count]) => this.translate.instant('{count}× {model}', { count, model }))
       .join(', ') || null;
 
     return {

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
@@ -111,7 +111,8 @@ export class SupportCardComponent implements OnInit {
 
       if (systemInfo.license) {
         this.hasLicense = true;
-        this.licenseInfo = this.buildLicenseInfo(systemInfo.license);
+        this.licenseInfo = this.buildLicenseInfo(systemInfo.license, systemInfo.datetime.$date);
+        this.isContractExpiringSoon.set(this.computeExpiringSoon(this.licenseInfo.daysLeftInContract));
         this.checkProactiveSupportAvailability();
         this.setupProductImage(systemInfo);
       } else {
@@ -131,7 +132,7 @@ export class SupportCardComponent implements OnInit {
     this.productImageSrc.set(productImageUrl);
   }
 
-  private buildLicenseInfo(license: License): LicenseInfoInSupport {
+  private buildLicenseInfo(license: License, nowMs: number): LicenseInfoInSupport {
     // Support contract dates live on the SUPPORT feature entry; fall back to the
     // top-level expiration if the SUPPORT entry is absent.
     const supportFeature = license.features.find((feature) => feature.name === LicenseFeature.Support);
@@ -142,20 +143,12 @@ export class SupportCardComponent implements OnInit {
     if (expirationIso) {
       const expDate = new Date(expirationIso);
       expirationDate = format(expDate, this.localeService.getPreferredDateFormat());
-      const now = new Date(this.systemInfo.datetime.$date);
-      daysLeftInContract = Math.round((expDate.getTime() - now.getTime()) / oneDayMillis);
+      daysLeftInContract = Math.round((expDate.getTime() - nowMs) / oneDayMillis);
     }
-
-    this.isContractExpiringSoon.set(
-      daysLeftInContract !== null
-      && daysLeftInContract >= 0
-      && daysLeftInContract <= this.expirationWarningDays,
-    );
 
     const featureNames = license.features
       .map((feature) => feature.name)
       .filter((name) => name !== LicenseFeature.Support);
-    const featuresString = featureNames.length ? featureNames.join(', ') : 'NONE';
 
     const additionalHardware = Object.entries(license.enclosures)
       .map(([model, count]) => `${count}× ${model}`)
@@ -166,10 +159,16 @@ export class SupportCardComponent implements OnInit {
       model: license.model,
       expirationDate,
       daysLeftInContract,
-      featuresString,
+      featureNames,
       additionalHardware,
       serials: license.serials,
     };
+  }
+
+  private computeExpiringSoon(daysLeft: number | null): boolean {
+    return daysLeft !== null
+      && daysLeft >= 0
+      && daysLeft <= this.expirationWarningDays;
   }
 
   updateLicense(): void {

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
@@ -18,9 +18,10 @@ import { GiB } from 'app/constants/bytes.constant';
 import { oneDayMillis } from 'app/constants/time.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
+import { LicenseFeature } from 'app/enums/license-feature.enum';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemSupport as helptext } from 'app/helptext/system/support';
-import { SystemInfo } from 'app/interfaces/system-info.interface';
+import { License, SystemInfo } from 'app/interfaces/system-info.interface';
 import { FeedbackDialog } from 'app/modules/feedback/components/feedback-dialog/feedback-dialog.component';
 import { FeedbackType } from 'app/modules/feedback/interfaces/feedback.interface';
 import { LocaleService } from 'app/modules/language/locale.service';
@@ -110,10 +111,13 @@ export class SupportCardComponent implements OnInit {
 
       if (systemInfo.license) {
         this.hasLicense = true;
-        this.licenseInfo = { ...systemInfo.license };
-        this.parseLicenseInfo(this.licenseInfo);
+        this.licenseInfo = this.buildLicenseInfo(systemInfo.license);
         this.checkProactiveSupportAvailability();
         this.setupProductImage(systemInfo);
+      } else {
+        this.hasLicense = false;
+        this.licenseInfo = null;
+        this.isContractExpiringSoon.set(false);
       }
       this.cdr.markForCheck();
     });
@@ -127,32 +131,45 @@ export class SupportCardComponent implements OnInit {
     this.productImageSrc.set(productImageUrl);
   }
 
-  private parseLicenseInfo(licenseInfo: LicenseInfoInSupport): void {
-    if (licenseInfo.features.length === 0) {
-      licenseInfo.featuresString = 'NONE';
-    } else {
-      licenseInfo.featuresString = licenseInfo.features.join(', ');
-    }
-    const expDateConverted = new Date(licenseInfo.contract_end.$value);
-    const userDateFormat = this.localeService.getPreferredDateFormat();
-    licenseInfo.expiration_date = format(expDateConverted, userDateFormat);
+  private buildLicenseInfo(license: License): LicenseInfoInSupport {
+    // Support contract dates live on the SUPPORT feature entry; fall back to the
+    // top-level expiration if the SUPPORT entry is absent.
+    const supportFeature = license.features.find((feature) => feature.name === LicenseFeature.Support);
+    const expirationIso = supportFeature?.expires_at ?? license.expires_at ?? null;
 
-    if (licenseInfo.addhw_detail.length === 0) {
-      licenseInfo.add_hardware = 'NONE';
-    } else {
-      licenseInfo.add_hardware = licenseInfo.addhw_detail.join(', ');
+    let expirationDate: string | null = null;
+    let daysLeftInContract: number | null = null;
+    if (expirationIso) {
+      const expDate = new Date(expirationIso);
+      expirationDate = format(expDate, this.localeService.getPreferredDateFormat());
+      const now = new Date(this.systemInfo.datetime.$date);
+      daysLeftInContract = Math.round((expDate.getTime() - now.getTime()) / oneDayMillis);
     }
-    const now = new Date(this.systemInfo.datetime.$date);
-    const then = expDateConverted;
-    licenseInfo.daysLeftinContract = this.daysTillExpiration(now, then);
 
     this.isContractExpiringSoon.set(
-      licenseInfo.daysLeftinContract >= 0 && licenseInfo.daysLeftinContract <= this.expirationWarningDays,
+      daysLeftInContract !== null
+      && daysLeftInContract >= 0
+      && daysLeftInContract <= this.expirationWarningDays,
     );
-  }
 
-  private daysTillExpiration(now: Date, then: Date): number {
-    return Math.round((then.getTime() - now.getTime()) / oneDayMillis);
+    const featureNames = license.features
+      .map((feature) => feature.name)
+      .filter((name) => name !== LicenseFeature.Support);
+    const featuresString = featureNames.length ? featureNames.join(', ') : 'NONE';
+
+    const additionalHardware = Object.entries(license.enclosures)
+      .map(([model, count]) => `${count}× ${model}`)
+      .join(', ') || null;
+
+    return {
+      contractType: license.contract_type,
+      model: license.model,
+      expirationDate,
+      daysLeftInContract,
+      featuresString,
+      additionalHardware,
+      serials: license.serials,
+    };
   }
 
   updateLicense(): void {

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.ts
@@ -10,7 +10,7 @@ import { MatToolbarRow } from '@angular/material/toolbar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { format } from 'date-fns-tz';
+import { formatInTimeZone } from 'date-fns-tz';
 import { isObject } from 'lodash-es';
 import { Observable, of, switchMap } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
@@ -136,13 +136,15 @@ export class SupportCardComponent implements OnInit {
     // Support contract dates live on the SUPPORT feature entry; fall back to the
     // top-level expiration if the SUPPORT entry is absent.
     const supportFeature = license.features.find((feature) => feature.name === LicenseFeature.Support);
-    const expirationIso = supportFeature?.expires_at ?? license.expires_at ?? null;
+    const expirationIso = supportFeature?.expires_at?.$value ?? license.expires_at?.$value ?? null;
 
     let expirationDate: string | null = null;
     let daysLeftInContract: number | null = null;
     if (expirationIso) {
+      // expirationIso is a calendar date (YYYY-MM-DD) parsed as UTC midnight; format
+      // in UTC so the displayed date matches the API regardless of the user's zone.
       const expDate = new Date(expirationIso);
-      expirationDate = format(expDate, this.localeService.getPreferredDateFormat());
+      expirationDate = formatInTimeZone(expDate, 'UTC', this.localeService.getPreferredDateFormat());
       daysLeftInContract = Math.round((expDate.getTime() - nowMs) / oneDayMillis);
     }
 

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -7,11 +7,11 @@
         <span class="value">{{ getLabelForContractType(license.contractType) }}</span>
       </mat-list-item>
     }
-    @if (license.expirationDate) {
+    @if (license.expirationDateDisplay) {
       <mat-list-item>
         <span class="label">{{ 'Expiration Date' | translate }}:</span>
         <span class="value">
-          {{ license.expirationDate }}
+          {{ license.expirationDateDisplay }}
           @if (license.daysLeftInContract !== null) {
             @if (license.daysLeftInContract > 0) {
               ({{ 'expires in {n, plural, one {# day} other {# days} }' | translate: { n: license.daysLeftInContract } }})

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -77,7 +77,13 @@
     }
     <mat-list-item>
       <span class="label">{{ 'Features' | translate }}:</span>
-      <span class="value">{{ license.featuresString }}</span>
+      <span class="value">
+        @if (license.featureNames.length) {
+          {{ license.featureNames.join(', ') }}
+        } @else {
+          {{ 'NONE' | translate }}
+        }
+      </span>
     </mat-list-item>
     @if (license.additionalHardware) {
       <mat-list-item>

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -1,25 +1,31 @@
 @let license = licenseInfo();
 @if (hasLicense() && license) {
   <mat-list>
-    <mat-list-item>
-      <span class="label">{{ 'Contract Type' | translate }}:</span>
-      <span class="value">{{ getLabelForContractType(license.contract_type) }}</span>
-    </mat-list-item>
-    <mat-list-item>
-      <span class="label">{{ 'Expiration Date' | translate }}:</span>
-      <span class="value">
-        {{ license.expiration_date }}
-        @if (license.daysLeftinContract > 0) {
-          ({{ 'expires in {n, plural, one {# day} other {# days} }' | translate: { n: license.daysLeftinContract } }})
-        }
-        @if (license.daysLeftinContract === 0) {
-          ({{ 'EXPIRES TODAY' | translate }})
-        }
-        @if (license.daysLeftinContract < 0) {
-          ({{ 'EXPIRED' | translate }})
-        }
-      </span>
-    </mat-list-item>
+    @if (license.contractType) {
+      <mat-list-item>
+        <span class="label">{{ 'Contract Type' | translate }}:</span>
+        <span class="value">{{ getLabelForContractType(license.contractType) }}</span>
+      </mat-list-item>
+    }
+    @if (license.expirationDate) {
+      <mat-list-item>
+        <span class="label">{{ 'Expiration Date' | translate }}:</span>
+        <span class="value">
+          {{ license.expirationDate }}
+          @if (license.daysLeftInContract !== null) {
+            @if (license.daysLeftInContract > 0) {
+              ({{ 'expires in {n, plural, one {# day} other {# days} }' | translate: { n: license.daysLeftInContract } }})
+            }
+            @if (license.daysLeftInContract === 0) {
+              ({{ 'EXPIRES TODAY' | translate }})
+            }
+            @if (license.daysLeftInContract < 0) {
+              ({{ 'EXPIRED' | translate }})
+            }
+          }
+        </span>
+      </mat-list-item>
+    }
     @if (isProactiveSupportEnabled() || !isProactiveSupportAvailable()) {
       <mat-list-item class="proactive-status">
         <span class="label">{{ 'Proactive Support' | translate }}:</span>
@@ -63,30 +69,20 @@
         <span class="value">{{ systemInfo().system_serial }}</span>
       </mat-list-item>
     }
-    @if (license.system_serial || license.system_serial_ha) {
+    @if (license.serials.length) {
       <mat-list-item>
         <span class="label">{{ 'Licensed Serials' | translate }}:</span>
-        <span class="value">
-          @if (license.system_serial) {
-            <span>{{ license.system_serial }}</span>
-          }
-          @if (license.system_serial && license.system_serial_ha) {
-            <span> / </span>
-          }
-          @if (license.system_serial_ha) {
-            <span>{{ license.system_serial_ha }}</span>
-          }
-        </span>
+        <span class="value">{{ license.serials.join(' / ') }}</span>
       </mat-list-item>
     }
     <mat-list-item>
       <span class="label">{{ 'Features' | translate }}:</span>
-      <span class="value">{{ license.features.length ? license.features.join(', ') : 'NONE' }}</span>
+      <span class="value">{{ license.featuresString }}</span>
     </mat-list-item>
-    @if (license.add_hardware) {
+    @if (license.additionalHardware) {
       <mat-list-item>
         <span class="label">{{ 'Additional Hardware' | translate }}:</span>
-        <span class="value">{{ license.add_hardware }}</span>
+        <span class="value">{{ license.additionalHardware }}</span>
       </mat-list-item>
     }
   </mat-list>

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -22,7 +22,7 @@ describe('SysInfoComponent', () => {
     model: 'M60',
     expirationDate: '2022-06-10',
     daysLeftInContract: -4,
-    featuresString: 'DEDUP, FIBRECHANNEL, VM',
+    featureNames: ['DEDUP', 'FIBRECHANNEL', 'VM'],
     additionalHardware: null,
     serials: ['abcdefgh12345678'],
   };
@@ -78,7 +78,7 @@ describe('SysInfoComponent', () => {
       'Model:': licenseInfo.model,
       'Licensed Serials:': licenseInfo.serials.join(' / '),
       'System Serial:': systemInfo.system_serial,
-      'Features:': licenseInfo.featuresString,
+      'Features:': licenseInfo.featureNames.join(', '),
       'Contract Type:': 'Gold',
       'Expiration Date:': `${licenseInfo.expirationDate} (EXPIRED)`,
     });

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -20,7 +20,7 @@ describe('SysInfoComponent', () => {
   const licenseInfo: LicenseInfoInSupport = {
     contractType: ContractType.Gold,
     model: 'M60',
-    expirationDate: '2022-06-10',
+    expirationDateDisplay: '2022-06-10',
     daysLeftInContract: -4,
     featureNames: ['DEDUP', 'FIBRECHANNEL', 'VM'],
     additionalHardware: null,
@@ -80,7 +80,7 @@ describe('SysInfoComponent', () => {
       'System Serial:': systemInfo.system_serial,
       'Features:': licenseInfo.featureNames.join(', '),
       'Contract Type:': 'Gold',
-      'Expiration Date:': `${licenseInfo.expirationDate} (EXPIRED)`,
+      'Expiration Date:': `${licenseInfo.expirationDateDisplay} (EXPIRED)`,
     });
   });
 

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -4,6 +4,7 @@ import { FormControl } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { ContractType } from 'app/interfaces/system-info.interface';
 import { LicenseInfoInSupport } from 'app/pages/system/general-settings/support/license-info-in-support.interface';
 import { SysInfoComponent } from 'app/pages/system/general-settings/support/sys-info/sys-info.component';
 import { SystemInfoInSupport } from 'app/pages/system/general-settings/support/system-info-in-support.interface';
@@ -16,15 +17,14 @@ describe('SysInfoComponent', () => {
     memory: '5 GiB',
     system_serial: 'ffbb355c',
   };
-  const licenseInfo = {
-    customer_name: 'TrueNAS',
-    features: ['DEDUP', 'FIBRECHANNEL', 'VM'],
+  const licenseInfo: LicenseInfoInSupport = {
+    contractType: ContractType.Gold,
     model: 'M60',
-    contract_type: 'GOLD',
-    expiration_date: '2022-06-10',
-    daysLeftinContract: -4,
-    add_hardware: 'NONE',
-    system_serial: 'abcdefgh12345678',
+    expirationDate: '2022-06-10',
+    daysLeftInContract: -4,
+    featuresString: 'DEDUP, FIBRECHANNEL, VM',
+    additionalHardware: null,
+    serials: ['abcdefgh12345678'],
   };
   let spectator: Spectator<SysInfoComponent>;
   let loader: HarnessLoader;
@@ -67,7 +67,7 @@ describe('SysInfoComponent', () => {
 
   it('shows a block with license info', () => {
     spectator.setInput({
-      licenseInfo: licenseInfo as LicenseInfoInSupport,
+      licenseInfo,
       hasLicense: true,
       isProactiveSupportAvailable: true,
     });
@@ -76,19 +76,18 @@ describe('SysInfoComponent', () => {
 
     expect(infoRows).toEqual({
       'Model:': licenseInfo.model,
-      'Licensed Serials:': licenseInfo.system_serial,
+      'Licensed Serials:': licenseInfo.serials.join(' / '),
       'System Serial:': systemInfo.system_serial,
-      'Features:': licenseInfo.features.join(', '),
+      'Features:': licenseInfo.featuresString,
       'Contract Type:': 'Gold',
-      'Expiration Date:': `${licenseInfo.expiration_date} (EXPIRED)`,
-      'Additional Hardware:': licenseInfo.add_hardware,
+      'Expiration Date:': `${licenseInfo.expirationDate} (EXPIRED)`,
     });
   });
 
   describe('Proactive support status', () => {
     beforeEach(() => {
       spectator.setInput({
-        licenseInfo: licenseInfo as LicenseInfoInSupport,
+        licenseInfo,
         hasLicense: true,
         isProactiveSupportAvailable: true,
         isProactiveSupportEnabled: true,
@@ -126,7 +125,7 @@ describe('SysInfoComponent', () => {
   describe('Proactive support not available', () => {
     beforeEach(() => {
       spectator.setInput({
-        licenseInfo: licenseInfo as LicenseInfoInSupport,
+        licenseInfo,
         hasLicense: true,
         isProactiveSupportAvailable: false,
         isProactiveSupportEnabled: false,
@@ -146,7 +145,7 @@ describe('SysInfoComponent', () => {
     it('shows production toggle in Model row when productionControl is provided', () => {
       const productionControl = new FormControl(false);
       spectator.setInput({
-        licenseInfo: licenseInfo as LicenseInfoInSupport,
+        licenseInfo,
         hasLicense: true,
         isProactiveSupportAvailable: true,
         productionControl,

--- a/src/app/pages/system/general-settings/support/system-info-in-support.interface.ts
+++ b/src/app/pages/system/general-settings/support/system-info-in-support.interface.ts
@@ -2,6 +2,4 @@ import { SystemInfo } from 'app/interfaces/system-info.interface';
 
 export interface SystemInfoInSupport extends SystemInfo {
   memory?: string;
-  system_serial_ha?: string;
-  serial?: string;
 }

--- a/src/app/services/license.service.ts
+++ b/src/app/services/license.service.ts
@@ -17,7 +17,7 @@ import {
 // Hoist parameterized selector instances so consumers share memoization across
 // subscriptions (each call to `selectHasLicenseFeature` builds a new selector).
 const selectHasAppsFeature = selectHasLicenseFeature(LicenseFeature.Apps);
-const selectHasVmFeature = selectHasLicenseFeature(LicenseFeature.Vm);
+const selectHasVmsFeature = selectHasLicenseFeature(LicenseFeature.Vms);
 const selectHasSedFeature = selectHasLicenseFeature(LicenseFeature.Sed);
 const selectHasFibreChannelFeature = selectHasLicenseFeature(LicenseFeature.FibreChannel);
 
@@ -41,10 +41,10 @@ export class LicenseService {
   );
 
   hasVms$ = combineLatest([
-    this.store$.select(selectHasVmFeature),
+    this.store$.select(selectHasVmsFeature),
     this.store$.select(selectIsEnterprise),
   ]).pipe(
-    map(([hasVm, isEnterprise]) => !isEnterprise || hasVm),
+    map(([hasVms, isEnterprise]) => !isEnterprise || hasVms),
   );
 
   hasApps$ = combineLatest([

--- a/src/app/services/license.service.ts
+++ b/src/app/services/license.service.ts
@@ -14,6 +14,13 @@ import {
   selectIsEnterprise,
 } from 'app/store/system-info/system-info.selectors';
 
+// Hoist parameterized selector instances so consumers share memoization across
+// subscriptions (each call to `selectHasLicenseFeature` builds a new selector).
+const selectHasAppsFeature = selectHasLicenseFeature(LicenseFeature.Apps);
+const selectHasVmFeature = selectHasLicenseFeature(LicenseFeature.Vm);
+const selectHasSedFeature = selectHasLicenseFeature(LicenseFeature.Sed);
+const selectHasFibreChannelFeature = selectHasLicenseFeature(LicenseFeature.FibreChannel);
+
 @Injectable({
   providedIn: 'root',
 })
@@ -26,7 +33,7 @@ export class LicenseService {
   hasEnclosure$ = this.store$.select(selectHasEnclosureSupport);
 
   hasFibreChannel$ = combineLatest([
-    this.store$.select(selectHasLicenseFeature(LicenseFeature.FibreChannel)),
+    this.store$.select(selectHasFibreChannelFeature),
     this.api.call('fc.capable'),
   ]).pipe(
     map(([hasFibreChannel, isFcCapable]) => hasFibreChannel && isFcCapable),
@@ -34,14 +41,14 @@ export class LicenseService {
   );
 
   hasVms$ = combineLatest([
-    this.store$.select(selectHasLicenseFeature(LicenseFeature.Vm)),
+    this.store$.select(selectHasVmFeature),
     this.store$.select(selectIsEnterprise),
   ]).pipe(
     map(([hasVm, isEnterprise]) => !isEnterprise || hasVm),
   );
 
   hasApps$ = combineLatest([
-    this.store$.select(selectHasLicenseFeature(LicenseFeature.Apps)),
+    this.store$.select(selectHasAppsFeature),
     this.store$.select(selectIsEnterprise),
   ]).pipe(
     map(([hasApps, isEnterprise]) => !isEnterprise || hasApps),
@@ -49,11 +56,11 @@ export class LicenseService {
 
   readonly hasKmip$ = this.store$.select(selectIsEnterprise);
 
-  readonly hasSed$ = this.store$.select(selectHasLicenseFeature(LicenseFeature.Sed));
+  readonly hasSed$ = this.store$.select(selectHasSedFeature);
 
   readonly shouldShowContainers$ = combineLatest([
     this.store$.select(selectIsEnterprise),
-    this.store$.select(selectHasLicenseFeature(LicenseFeature.Apps)),
+    this.store$.select(selectHasAppsFeature),
   ]).pipe(
     map(([isEnterprise, hasApps]) => !isEnterprise || hasApps),
   );

--- a/src/app/services/license.service.ts
+++ b/src/app/services/license.service.ts
@@ -4,6 +4,7 @@ import { combineLatest, shareReplay } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { LicenseFeature } from 'app/enums/license-feature.enum';
 import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
+import { License } from 'app/interfaces/system-info.interface';
 import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { AppState } from 'app/store';
@@ -11,10 +12,12 @@ import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
   selectHasEnclosureSupport,
   selectIsEnterprise,
-  selectLicenseFeatures,
-  selectSystemInfo,
-  waitForSystemInfo,
+  selectLicense,
 } from 'app/store/system-info/system-info.selectors';
+
+function licenseHasFeature(license: License | null | undefined, feature: LicenseFeature): boolean {
+  return license?.features.some((entry) => entry.name === feature) ?? false;
+}
 
 @Injectable({
   providedIn: 'root',
@@ -26,10 +29,10 @@ export class LicenseService {
 
   hasFailover$ = this.store$.select(selectIsHaLicensed);
   hasEnclosure$ = this.store$.select(selectHasEnclosureSupport);
+
   hasFibreChannel$ = combineLatest([
-    this.store$.pipe(
-      waitForSystemInfo,
-      map((systemInfo) => systemInfo.license?.features?.includes(LicenseFeature.FibreChannel)),
+    this.store$.select(selectLicense).pipe(
+      map((license) => licenseHasFeature(license, LicenseFeature.FibreChannel)),
     ),
     this.api.call('fc.capable'),
   ]).pipe(
@@ -38,43 +41,31 @@ export class LicenseService {
   );
 
   hasVms$ = combineLatest([
-    this.store$.select(selectSystemInfo),
+    this.store$.select(selectLicense),
     this.store$.select(selectIsEnterprise),
   ]).pipe(
-    map(([systemInfo, isEnterprise]) => {
-      if (!isEnterprise) {
-        return true;
-      }
-
-      return Boolean(systemInfo?.license?.features?.includes(LicenseFeature.Vm));
-    }),
+    map(([license, isEnterprise]) => !isEnterprise || licenseHasFeature(license, LicenseFeature.Vm)),
   );
 
   hasApps$ = combineLatest([
-    this.store$.select(selectSystemInfo),
+    this.store$.select(selectLicense),
     this.store$.select(selectIsEnterprise),
   ]).pipe(
-    map(([systemInfo, isEnterprise]) => {
-      if (!isEnterprise) {
-        return true;
-      }
-
-      return Boolean(systemInfo?.license?.features?.includes(LicenseFeature.Jails));
-    }),
+    map(([license, isEnterprise]) => !isEnterprise || licenseHasFeature(license, LicenseFeature.Apps)),
   );
 
   readonly hasKmip$ = this.store$.select(selectIsEnterprise);
 
-  readonly hasSed$ = this.store$.select(selectLicenseFeatures).pipe(
-    map((licenseFeatures) => licenseFeatures?.includes(LicenseFeature.Sed) ?? false),
+  readonly hasSed$ = this.store$.select(selectLicense).pipe(
+    map((license) => licenseHasFeature(license, LicenseFeature.Sed)),
   );
 
   readonly shouldShowContainers$ = combineLatest([
     this.store$.select(selectIsEnterprise),
-    this.store$.select(selectLicenseFeatures),
-  ]).pipe(map((
-    [isEnterprise, licenseFeatures],
-  ) => !isEnterprise || licenseFeatures?.includes(LicenseFeature.Jails)));
+    this.store$.select(selectLicense),
+  ]).pipe(
+    map(([isEnterprise, license]) => !isEnterprise || licenseHasFeature(license, LicenseFeature.Apps)),
+  );
 
   /**
    * Check if the system is configured with TrueNAS Connect.

--- a/src/app/services/license.service.ts
+++ b/src/app/services/license.service.ts
@@ -4,20 +4,15 @@ import { combineLatest, shareReplay } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { LicenseFeature } from 'app/enums/license-feature.enum';
 import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
-import { License } from 'app/interfaces/system-info.interface';
 import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { AppState } from 'app/store';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
   selectHasEnclosureSupport,
+  selectHasLicenseFeature,
   selectIsEnterprise,
-  selectLicense,
 } from 'app/store/system-info/system-info.selectors';
-
-function licenseHasFeature(license: License | null | undefined, feature: LicenseFeature): boolean {
-  return license?.features.some((entry) => entry.name === feature) ?? false;
-}
 
 @Injectable({
   providedIn: 'root',
@@ -31,9 +26,7 @@ export class LicenseService {
   hasEnclosure$ = this.store$.select(selectHasEnclosureSupport);
 
   hasFibreChannel$ = combineLatest([
-    this.store$.select(selectLicense).pipe(
-      map((license) => licenseHasFeature(license, LicenseFeature.FibreChannel)),
-    ),
+    this.store$.select(selectHasLicenseFeature(LicenseFeature.FibreChannel)),
     this.api.call('fc.capable'),
   ]).pipe(
     map(([hasFibreChannel, isFcCapable]) => hasFibreChannel && isFcCapable),
@@ -41,30 +34,28 @@ export class LicenseService {
   );
 
   hasVms$ = combineLatest([
-    this.store$.select(selectLicense),
+    this.store$.select(selectHasLicenseFeature(LicenseFeature.Vm)),
     this.store$.select(selectIsEnterprise),
   ]).pipe(
-    map(([license, isEnterprise]) => !isEnterprise || licenseHasFeature(license, LicenseFeature.Vm)),
+    map(([hasVm, isEnterprise]) => !isEnterprise || hasVm),
   );
 
   hasApps$ = combineLatest([
-    this.store$.select(selectLicense),
+    this.store$.select(selectHasLicenseFeature(LicenseFeature.Apps)),
     this.store$.select(selectIsEnterprise),
   ]).pipe(
-    map(([license, isEnterprise]) => !isEnterprise || licenseHasFeature(license, LicenseFeature.Apps)),
+    map(([hasApps, isEnterprise]) => !isEnterprise || hasApps),
   );
 
   readonly hasKmip$ = this.store$.select(selectIsEnterprise);
 
-  readonly hasSed$ = this.store$.select(selectLicense).pipe(
-    map((license) => licenseHasFeature(license, LicenseFeature.Sed)),
-  );
+  readonly hasSed$ = this.store$.select(selectHasLicenseFeature(LicenseFeature.Sed));
 
   readonly shouldShowContainers$ = combineLatest([
     this.store$.select(selectIsEnterprise),
-    this.store$.select(selectLicense),
+    this.store$.select(selectHasLicenseFeature(LicenseFeature.Apps)),
   ]).pipe(
-    map(([isEnterprise, license]) => !isEnterprise || licenseHasFeature(license, LicenseFeature.Apps)),
+    map(([isEnterprise, hasApps]) => !isEnterprise || hasApps),
   );
 
   /**

--- a/src/app/store/system-info/system-info.effects.spec.ts
+++ b/src/app/store/system-info/system-info.effects.spec.ts
@@ -1,0 +1,119 @@
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { firstValueFrom, ReplaySubject, of, throwError } from 'rxjs';
+import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
+import { LicenseFeature } from 'app/enums/license-feature.enum';
+import { LicenseType } from 'app/enums/license-type.enum';
+import { ProductType } from 'app/enums/product-type.enum';
+import { ContractType, License, SystemInfo } from 'app/interfaces/system-info.interface';
+import { ApiService } from 'app/modules/websocket/api.service';
+import { adminUiInitialized } from 'app/store/admin-panel/admin.actions';
+import { systemInfoLoaded } from 'app/store/system-info/system-info.actions';
+import { SystemInfoEffects } from 'app/store/system-info/system-info.effects';
+
+describe('SystemInfoEffects', () => {
+  let spectator: SpectatorService<SystemInfoEffects>;
+  let api: ApiService;
+  let actions$: ReplaySubject<unknown>;
+
+  const baseSystemInfo = { hostname: 'test-host', license: null } as unknown as SystemInfo;
+
+  const baseLicense: License = {
+    id: 'test-id',
+    type: LicenseType.EnterpriseSingle,
+    contract_type: ContractType.Gold,
+    model: 'M40',
+    expires_at: null,
+    features: [{ name: LicenseFeature.Apps, start_date: null, expires_at: null }],
+    serials: ['CI-1'],
+    enclosures: {},
+  };
+
+  const createService = createServiceFactory({
+    service: SystemInfoEffects,
+    providers: [
+      provideMockActions(() => actions$),
+      provideMockStore(),
+      mockApi([
+        mockCall('system.info', baseSystemInfo),
+        mockCall('truenas.license.info', baseLicense),
+        mockCall('truenas.is_ix_hardware', true),
+        mockCall('system.product_type', ProductType.Enterprise),
+      ]),
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+    api = spectator.inject(ApiService);
+    actions$ = new ReplaySubject(1);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * The effect's forkJoin issues two API calls per dispatch — stub both with
+   * one switch so each test can pin precise responses without touching the
+   * default mockApi setup.
+   */
+  function stubLoadCalls(license: License | null, licenseError?: Error): void {
+    jest.spyOn(api, 'call').mockImplementation((method: string) => {
+      if (method === 'system.info') {
+        return of(baseSystemInfo) as never;
+      }
+      if (method === 'truenas.license.info') {
+        return licenseError ? throwError(() => licenseError) : of(license) as never;
+      }
+      return of(null) as never;
+    });
+  }
+
+  describe('loadSystemInfo', () => {
+    it('merges truenas.license.info into systemInfo before dispatching', async () => {
+      actions$.next(adminUiInitialized());
+
+      const action = await firstValueFrom(spectator.service.loadSystemInfo);
+
+      expect(api.call).toHaveBeenCalledWith('system.info');
+      expect(api.call).toHaveBeenCalledWith('truenas.license.info');
+      expect(action).toEqual(systemInfoLoaded({
+        systemInfo: { ...baseSystemInfo, license: baseLicense },
+      }));
+    });
+
+    it('emits systemInfoLoaded with license: null when truenas.license.info errors', async () => {
+      jest.spyOn(console, 'error').mockImplementation();
+      stubLoadCalls(null, new Error('license fetch failed'));
+
+      actions$.next(adminUiInitialized());
+      const action = await firstValueFrom(spectator.service.loadSystemInfo);
+
+      expect(action).toEqual(systemInfoLoaded({
+        systemInfo: { ...baseSystemInfo, license: null },
+      }));
+    });
+
+    it('uppercases lower-cased contract_type', async () => {
+      stubLoadCalls({ ...baseLicense, contract_type: 'gold' as ContractType });
+
+      actions$.next(adminUiInitialized());
+      const action = await firstValueFrom(spectator.service.loadSystemInfo);
+
+      expect(action.systemInfo.license?.contract_type).toBe(ContractType.Gold);
+    });
+
+    it('preserves unknown contract_type values and warns', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      stubLoadCalls({ ...baseLicense, contract_type: 'platinum' as unknown as ContractType });
+
+      actions$.next(adminUiInitialized());
+      const action = await firstValueFrom(spectator.service.loadSystemInfo);
+
+      expect(action.systemInfo.license?.contract_type).toBe('PLATINUM');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('platinum'));
+    });
+  });
+});

--- a/src/app/store/system-info/system-info.effects.ts
+++ b/src/app/store/system-info/system-info.effects.ts
@@ -29,7 +29,7 @@ function normalizeLicense(license: License | null): License | null {
 
   let contractType: ContractType | null = null;
   if (license.contract_type) {
-    const upper = license.contract_type.toString().toUpperCase();
+    const upper = license.contract_type.toUpperCase();
     contractType = validContractTypes.has(upper) ? (upper as ContractType) : null;
   }
 
@@ -46,7 +46,14 @@ export class SystemInfoEffects {
     mergeMap(() => {
       return forkJoin({
         systemInfo: this.api.call('system.info'),
-        license: this.api.call('truenas.license.info'),
+        // A license fetch failure must not take the dashboard down. Recover to
+        // null so `systemInfoLoaded` still fires with the rest of the payload.
+        license: this.api.call('truenas.license.info').pipe(
+          catchError((error: unknown) => {
+            console.error(error);
+            return of(null);
+          }),
+        ),
       }).pipe(
         map(({ systemInfo, license }) => systemInfoLoaded({
           systemInfo: { ...systemInfo, license: normalizeLicense(license) },

--- a/src/app/store/system-info/system-info.effects.ts
+++ b/src/app/store/system-info/system-info.effects.ts
@@ -1,10 +1,11 @@
 import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { EMPTY, of } from 'rxjs';
+import { EMPTY, forkJoin, of } from 'rxjs';
 import {
   catchError, map, mergeMap,
 } from 'rxjs/operators';
 import { ProductType } from 'app/enums/product-type.enum';
+import { ContractType, License } from 'app/interfaces/system-info.interface';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { adminUiInitialized } from 'app/store/admin-panel/admin.actions';
 import {
@@ -12,6 +13,28 @@ import {
   productTypeLoaded,
   systemInfoLoaded, systemInfoUpdated,
 } from 'app/store/system-info/system-info.actions';
+
+const validContractTypes: ReadonlySet<string> = new Set(Object.values(ContractType));
+
+/**
+ * The middleware response casing for `contract_type` is not 100% certain at the
+ * time of writing — uppercasing here means downstream code can rely on the
+ * `ContractType` enum without scattering normalization through the UI. Unknown
+ * values fall through to `null`.
+ */
+function normalizeLicense(license: License | null): License | null {
+  if (!license) {
+    return null;
+  }
+
+  let contractType: ContractType | null = null;
+  if (license.contract_type) {
+    const upper = license.contract_type.toString().toUpperCase();
+    contractType = validContractTypes.has(upper) ? (upper as ContractType) : null;
+  }
+
+  return { ...license, contract_type: contractType };
+}
 
 @Injectable()
 export class SystemInfoEffects {
@@ -21,8 +44,13 @@ export class SystemInfoEffects {
   loadSystemInfo = createEffect(() => this.actions$.pipe(
     ofType(adminUiInitialized, systemInfoUpdated),
     mergeMap(() => {
-      return this.api.call('system.info').pipe(
-        map((systemInfo) => systemInfoLoaded({ systemInfo })),
+      return forkJoin({
+        systemInfo: this.api.call('system.info'),
+        license: this.api.call('truenas.license.info'),
+      }).pipe(
+        map(({ systemInfo, license }) => systemInfoLoaded({
+          systemInfo: { ...systemInfo, license: normalizeLicense(license) },
+        })),
         catchError((error: unknown) => {
           // TODO: Basically a fatal error. Handle it.
           console.error(error);

--- a/src/app/store/system-info/system-info.effects.ts
+++ b/src/app/store/system-info/system-info.effects.ts
@@ -14,26 +14,26 @@ import {
   systemInfoLoaded, systemInfoUpdated,
 } from 'app/store/system-info/system-info.actions';
 
-const validContractTypes: ReadonlySet<string> = new Set(Object.values(ContractType));
+const knownContractTypes: ReadonlySet<string> = new Set(Object.values(ContractType));
 
 /**
- * The middleware response casing for `contract_type` is not 100% certain at the
- * time of writing — uppercasing here means downstream code can rely on the
- * `ContractType` enum without scattering normalization through the UI. Unknown
- * values fall through to `null`.
+ * Defensively uppercase `contract_type` so downstream `getLabelForContractType`
+ * lookups hit the `ContractType` enum keys regardless of how middleware emits
+ * the casing. Unknown values are passed through as the uppercased string and a
+ * warning is logged so they surface during testing — the label helper has its
+ * own raw-string fallback for display.
  */
 function normalizeLicense(license: License | null): License | null {
-  if (!license) {
-    return null;
+  if (!license?.contract_type) {
+    return license;
   }
 
-  let contractType: ContractType | null = null;
-  if (license.contract_type) {
-    const upper = license.contract_type.toUpperCase();
-    contractType = validContractTypes.has(upper) ? (upper as ContractType) : null;
+  const upper = license.contract_type.toUpperCase();
+  if (!knownContractTypes.has(upper)) {
+    console.warn(`Unknown license.contract_type "${license.contract_type}" — falling back to raw value.`);
   }
 
-  return { ...license, contract_type: contractType };
+  return { ...license, contract_type: upper as ContractType };
 }
 
 @Injectable()

--- a/src/app/store/system-info/system-info.selectors.ts
+++ b/src/app/store/system-info/system-info.selectors.ts
@@ -43,9 +43,14 @@ export const selectCopyrightHtml = createSelector(
   (productType) => getCopyrightHtml(productType || undefined),
 );
 
-export const selectLicenseFeatures = createSelector(
+export const selectLicense = createSelector(
   selectSystemInfoState,
-  (state) => state?.systemInfo?.license?.features,
+  (state) => state?.systemInfo?.license ?? null,
+);
+
+export const selectLicenseFeatures = createSelector(
+  selectLicense,
+  (license) => license?.features.map((feature) => feature.name),
 );
 
 export const waitForSystemInfo = selectNotNull(selectSystemInfo);

--- a/src/app/store/system-info/system-info.selectors.ts
+++ b/src/app/store/system-info/system-info.selectors.ts
@@ -1,4 +1,5 @@
-import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { createFeatureSelector, createSelector, MemoizedSelector } from '@ngrx/store';
+import { LicenseFeature } from 'app/enums/license-feature.enum';
 import { ProductType } from 'app/enums/product-type.enum';
 import { getCopyrightHtml } from 'app/helpers/copyright-text.helper';
 import { selectNotNull } from 'app/helpers/operators/select-not-null.helper';
@@ -51,6 +52,18 @@ export const selectLicense = createSelector(
 export const selectLicenseFeatures = createSelector(
   selectLicense,
   (license) => license?.features.map((feature) => feature.name),
+);
+
+/**
+ * Selector factory: emits true when the license carries the given feature.
+ * Used by `LicenseService.has*$` observables and any component that needs to
+ * gate behavior on a specific license feature.
+ */
+export const selectHasLicenseFeature = (
+  feature: LicenseFeature,
+): MemoizedSelector<object, boolean> => createSelector(
+  selectLicense,
+  (license) => license?.features.some((entry) => entry.name === feature) ?? false,
 );
 
 export const waitForSystemInfo = selectNotNull(selectSystemInfo);

--- a/src/app/store/system-info/system-info.selectors.ts
+++ b/src/app/store/system-info/system-info.selectors.ts
@@ -49,11 +49,6 @@ export const selectLicense = createSelector(
   (systemInfo) => systemInfo?.license ?? null,
 );
 
-export const selectLicenseFeatures = createSelector(
-  selectLicense,
-  (license) => license?.features.map((feature) => feature.name),
-);
-
 /**
  * Selector factory: emits true when the license carries the given feature.
  * Used by `LicenseService.has*$` observables and any component that needs to

--- a/src/app/store/system-info/system-info.selectors.ts
+++ b/src/app/store/system-info/system-info.selectors.ts
@@ -44,8 +44,8 @@ export const selectCopyrightHtml = createSelector(
 );
 
 export const selectLicense = createSelector(
-  selectSystemInfoState,
-  (state) => state?.systemInfo?.license ?? null,
+  selectSystemInfo,
+  (systemInfo) => systemInfo?.license ?? null,
 );
 
 export const selectLicenseFeatures = createSelector(


### PR DESCRIPTION
Starting with 26 BETA2, the legacy license structure is being normalized to the new structure that was defined by the ER-11 team. The legacy license endpoints are being deprecated. This PR updates the UI to use the new endpoints.

There should be no visual changes here. License upload should work the same as well. To test, you'll need a license that follows the new format. DM me and I can provide one.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/13531
