### PR TITLE
NAS-140844 / 27.0.0-BETA.1 / UI hides input field for pool name when trying to destroy pool (MacOS Safari)

### DIFF
--- a/src/app/pages/storage/components/dashboard-pool/export-disconnect-modal/export-disconnect-modal.component.scss
+++ b/src/app/pages/storage/components/dashboard-pool/export-disconnect-modal/export-disconnect-modal.component.scss
@@ -2,11 +2,8 @@
 
 :host {
   display: block;
-  width: 650px;
-
-  @media (max-width: $breakpoint-tablet) {
-    width: inherit;
-  }
+  max-width: 800px;
+  width: 100%;
 
   &::ng-deep {
     .mat-expanded .mat-expansion-panel-header span.mat-expansion-indicator {
@@ -20,6 +17,7 @@
 }
 
 .export-disconnect-modal-content {
+  max-height: 83vh !important;
   overflow: auto !important;
 }
 

--- a/src/app/pages/storage/components/dashboard-pool/export-disconnect-modal/export-disconnect-modal.component.scss
+++ b/src/app/pages/storage/components/dashboard-pool/export-disconnect-modal/export-disconnect-modal.component.scss
@@ -16,6 +16,8 @@
   }
 }
 
+// Override global .mat-mdc-dialog-content { max-height: 50vh } so the pool name
+// input below the warning panels stays reachable without aggressive scrolling.
 .export-disconnect-modal-content {
   max-height: 83vh !important;
   overflow: auto !important;

--- a/src/assets/styles/other/_fn-styles.scss
+++ b/src/assets/styles/other/_fn-styles.scss
@@ -211,7 +211,7 @@ body .mat-mdc-select-trigger {
 
 /*-------- Scrollbar ---------*/
 body * {
-  scrollbar-color: rgba(127, 127, 127, 60%) var(--contrast-lightest);
+  scrollbar-color: var(--scrollbar-thumb) var(--contrast-lightest);
   scrollbar-width: auto;
 }
 
@@ -220,13 +220,13 @@ body * {
   width: 8px;
 }
 
-::-webkit-scrollbar-thumb:hover {
-  box-shadow: inset 0 0 0 10px rgba(127, 127, 127, 0.85), inset 1px 0 0 0 rgba(250, 250, 250, 0.05);
-}
-
 ::-webkit-scrollbar-thumb {
   border-radius: 8px;
-  box-shadow: inset 0 0 0 10px rgba(127, 127, 127, 0.6), inset 1px 0 0 0 rgba(250, 250, 250, 0.05);
+  box-shadow: inset 0 0 0 10px var(--scrollbar-thumb), inset 1px 0 0 0 rgba(250, 250, 250, 0.05);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  box-shadow: inset 0 0 0 10px var(--scrollbar-thumb-hover), inset 1px 0 0 0 rgba(250, 250, 250, 0.05);
 }
 
 ::-webkit-scrollbar-track:hover,

--- a/src/assets/styles/other/_fn-styles.scss
+++ b/src/assets/styles/other/_fn-styles.scss
@@ -211,7 +211,7 @@ body .mat-mdc-select-trigger {
 
 /*-------- Scrollbar ---------*/
 body * {
-  scrollbar-color: rgba(0, 0, 0, 28%) var(--contrast-lightest);
+  scrollbar-color: rgba(127, 127, 127, 60%) var(--contrast-lightest);
   scrollbar-width: auto;
 }
 
@@ -220,10 +220,13 @@ body * {
   width: 8px;
 }
 
-::-webkit-scrollbar-thumb:hover,
+::-webkit-scrollbar-thumb:hover {
+  box-shadow: inset 0 0 0 10px rgba(127, 127, 127, 0.85), inset 1px 0 0 0 rgba(250, 250, 250, 0.05);
+}
+
 ::-webkit-scrollbar-thumb {
   border-radius: 8px;
-  box-shadow: inset 0 0 0 10px rgba(0, 0, 0, 0.28), inset 1px 0 0 0 rgba(250, 250, 250, 0.03);
+  box-shadow: inset 0 0 0 10px rgba(127, 127, 127, 0.6), inset 1px 0 0 0 rgba(250, 250, 250, 0.05);
 }
 
 ::-webkit-scrollbar-track:hover,

--- a/src/assets/styles/other/_root-variables.scss
+++ b/src/assets/styles/other/_root-variables.scss
@@ -4,6 +4,8 @@
   --contrast-darkest: hsl(0, 0%, 5.7%); // default theme fallback
   --contrast-lighter: hsl(0, 0%, 20.7%); // default theme fallback
   --contrast-lightest: hsl(0, 0%, 25.7%); // default theme fallback
+  --scrollbar-thumb: rgba(127, 127, 127, 0.6);
+  --scrollbar-thumb-hover: rgba(127, 127, 127, 0.85);
   --light-theme-lines: var(--contrast-darkest);
   --dark-theme-lines: var(--contrast-lighter);
   --disabled-opacity: 0.5;


### PR DESCRIPTION
Testing: see ticket.

Preview:

<img width="1728" height="918" alt="Screenshot 2026-04-30 at 13 43 43" src="https://github.com/user-attachments/assets/33558a95-943c-43f2-8724-cf0cc1803f54" />
