### PR TITLE
Update Snapshot Lifetime and Support localization (ES-ES)

### DIFF
--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1,9 +1,9 @@
 {
   "0": "0",
-  "How long snapshots created by the periodic snapshot task on the source system are kept before being deleted. Enter a number and choose a measure of time from the drop-down.": "",
-  "Not Available": "",
-  "Proactive support is not available on your license.": "",
-  "Source Snapshot Lifetime": "",
+  "How long snapshots created by the periodic snapshot task on the source system are kept before being deleted. Enter a number and choose a measure of time from the drop-down.": "Cuánto tiempo se conservan las instantáneas creadas por la tarea de instantáneas periódicas en el sistema de origen antes de ser eliminadas. Introduce un número y elige una medida de tiempo en el menú desplegable.",
+  "Not Available": "No disponible",
+  "Proactive support is not available on your license.": "El soporte proactivo no está disponible en tu licencia.",
+  "Source Snapshot Lifetime": "Tiempo de vida de la instantánea de origen",
   " as of {dateTime}": " a fecha de {dateTime}",
   " bytes.": " bytes.",
   " Est. Usable Raw Capacity": " Capacidad bruta utilizable estimada",


### PR DESCRIPTION
This PR updates the Spanish (Spain) translations for snapshot lifetime configurations and license support status.

Key changes and localization decisions:

ZFS Terminology: Consistently translated "snapshots" as instantáneas.

UI Elements: Translated "drop-down" to the standard UI term menú desplegable.

Tone: Maintained the direct, informal address (Introduce) to ensure consistency with the rest of the updated UI.

Phrasing: Localized "Source Snapshot Lifetime" as Tiempo de vida de la instantánea de origen.

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
