### PR TITLE
Update Snapshot Lifetime and Support localization (GL)

### DIFF
--- a/src/assets/i18n/gl.json
+++ b/src/assets/i18n/gl.json
@@ -1,9 +1,9 @@
 {
   "0": "0",
-  "How long snapshots created by the periodic snapshot task on the source system are kept before being deleted. Enter a number and choose a measure of time from the drop-down.": "",
-  "Not Available": "",
-  "Proactive support is not available on your license.": "",
-  "Source Snapshot Lifetime": "",
+  "How long snapshots created by the periodic snapshot task on the source system are kept before being deleted. Enter a number and choose a measure of time from the drop-down.": "Canto tempo se conservan as instantáneas creadas pola tarefa de instantáneas periódicas no sistema de orixe antes de seren eliminadas. Introduce un número e elixe unha medida de tempo no menú despregable.",
+  "Not Available": "Non dispoñible",
+  "Proactive support is not available on your license.": "O soporte proactivo non está dispoñible na túa licenza.",
+  "Source Snapshot Lifetime": "Tempo de vida da instantánea de orixe",
   " as of {dateTime}": " a data de {dateTime}",
   " bytes.": " bytes.",
   " Est. Usable Raw Capacity": " Capacidade bruta utilizable estimada",


### PR DESCRIPTION
This PR updates the Galician translations for snapshot lifetime configurations and license support status.

Key changes and localization decisions:

ZFS Terminology: Consistently translated "snapshots" as instantáneas.

UI Elements: Translated "drop-down" to the standard UI term menú despregable.

Tone and Grammar: Maintained the direct, informal address (Introduce). Used the Galician conjugated infinitive (antes de seren eliminadas) for a more grammatically correct and natural flow.

Phrasing: Localized "Source Snapshot Lifetime" as Tempo de vida da instantánea de orixe.

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
