### PR TITLE
NAS-140860 / 27.0.0-BETA.1 / Add license fingerprint dialog to Support Card

### DIFF
--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -877,6 +877,7 @@ export interface ApiCallDirectory {
   'truenas.is_eula_accepted': { params: void; response: boolean };
   'truenas.is_production': { params: void; response: boolean };
   'truenas.is_ix_hardware': { params: void; response: boolean };
+  'truenas.license.fingerprint': { params: void; response: string };
   'truenas.license.info': { params: void; response: License | null };
   'truenas.license.upload': {
     params: [license: string, options?: { ha_propagate?: boolean }];

--- a/src/app/interfaces/system-info.interface.ts
+++ b/src/app/interfaces/system-info.interface.ts
@@ -58,6 +58,16 @@ export interface License {
   enclosures: Record<string, number>;
 }
 
+/**
+ * Decoded shape of `truenas.license.fingerprint`.
+ *
+ * Middleware returns the fingerprint as a base64-encoded JSON object. The
+ * payload is intentionally a flat key/value map so middleware can add or
+ * remove fields without coupled UI changes — the support card displays it
+ * as pretty-printed JSON.
+ */
+export type LicenseFingerprint = Record<string, string | number | null>;
+
 export enum ContractType {
   Gold = 'GOLD',
   SilverInternational = 'SILVERINTERNATIONAL',

--- a/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.html
+++ b/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.html
@@ -1,0 +1,34 @@
+<h1 matDialogTitle>{{ 'License Fingerprint' | translate }}</h1>
+
+<div mat-dialog-content class="dialog-content">
+  @if (isLoading()) {
+    <div class="loading">
+      <mat-spinner [diameter]="36"></mat-spinner>
+      <span>{{ 'Loading fingerprint…' | translate }}</span>
+    </div>
+  } @else if (fingerprintDecoded()) {
+    <p class="hint">
+      {{ 'This identifies your system to the licensing service. Share it with iX support to request or update a license.' | translate }}
+    </p>
+    <pre class="fingerprint-decoded">{{ fingerprintDecoded() }}</pre>
+  }
+</div>
+
+<div mat-dialog-actions class="dialog-actions">
+  <button
+    mat-icon-button
+    type="button"
+    ixTest="copy-fingerprint"
+    [disabled]="isLoading() || !fingerprintRaw()"
+    [matTooltip]="'Copy raw fingerprint to clipboard' | translate"
+    (click)="copyToClipboard()"
+  >
+    <tn-icon name="content-copy" library="mdi" size="md"></tn-icon>
+  </button>
+
+  <span class="spacer"></span>
+
+  <button mat-button type="button" ixTest="close" [matDialogClose]="true">
+    {{ 'Close' | translate }}
+  </button>
+</div>

--- a/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.html
+++ b/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.html
@@ -1,10 +1,10 @@
-<h1 matDialogTitle>{{ 'License Fingerprint' | translate }}</h1>
+<h1 matDialogTitle>{{ 'System Thumbprint' | translate }}</h1>
 
 <div mat-dialog-content class="dialog-content">
   @if (isLoading()) {
     <div class="loading">
       <mat-spinner [diameter]="36"></mat-spinner>
-      <span>{{ 'Loading fingerprint…' | translate }}</span>
+      <span>{{ 'Loading thumbprint…' | translate }}</span>
     </div>
   } @else if (fingerprintDecoded()) {
     <p class="hint">
@@ -20,7 +20,7 @@
     type="button"
     ixTest="copy-fingerprint"
     [disabled]="isLoading() || !fingerprintRaw()"
-    [matTooltip]="'Copy raw fingerprint to clipboard' | translate"
+    [matTooltip]="'Copy raw thumbprint to clipboard' | translate"
     (click)="copyToClipboard()"
   >
     <tn-icon name="content-copy" library="mdi" size="md"></tn-icon>

--- a/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.scss
+++ b/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.scss
@@ -1,0 +1,37 @@
+.dialog-content {
+  min-width: 480px;
+}
+
+.hint {
+  color: var(--fg2);
+  font-size: 13px;
+  margin: 0 0 12px;
+}
+
+.loading {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  padding: 16px 0;
+}
+
+.fingerprint-decoded {
+  background: var(--alt-bg2);
+  border-radius: 4px;
+  font-size: 13px;
+  margin: 0;
+  max-height: 360px;
+  overflow: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.dialog-actions {
+  align-items: center;
+  display: flex;
+}
+
+.spacer {
+  flex: 1;
+}

--- a/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.spec.ts
@@ -1,0 +1,56 @@
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
+import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { ApiService } from 'app/modules/websocket/api.service';
+import {
+  LicenseFingerprintDialog,
+} from 'app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component';
+
+describe('LicenseFingerprintDialog', () => {
+  const payload = { system_serial: 'A1', hardware_model: 'M60', customer_id: 42 };
+  const base64 = btoa(JSON.stringify(payload));
+
+  let spectator: Spectator<LicenseFingerprintDialog>;
+  let loader: HarnessLoader;
+
+  const createComponent = createComponentFactory({
+    component: LicenseFingerprintDialog,
+    providers: [
+      mockAuth(),
+      mockApi([mockCall('truenas.license.fingerprint', base64)]),
+      mockProvider(MatDialogRef),
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createComponent();
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+  });
+
+  it('fetches the fingerprint on init and renders pretty-printed JSON', () => {
+    expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('truenas.license.fingerprint');
+
+    const decoded = spectator.query('.fingerprint-decoded');
+    expect(decoded).toExist();
+    expect(JSON.parse(decoded!.textContent!.trim())).toEqual(payload);
+  });
+
+  it('copies the raw base64 string when the copy button is clicked', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const copyButton = await loader.getHarness(
+      MatButtonHarness.with({ selector: '[ixTest="copy-fingerprint"]' }),
+    );
+    await copyButton.click();
+
+    expect(writeText).toHaveBeenCalledWith(base64);
+  });
+});

--- a/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.ts
+++ b/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.ts
@@ -1,0 +1,83 @@
+import {
+  ChangeDetectionStrategy, Component, computed, DestroyRef, inject, OnInit, signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButton, MatIconButton } from '@angular/material/button';
+import {
+  MatDialogActions, MatDialogClose, MatDialogContent, MatDialogTitle,
+} from '@angular/material/dialog';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatTooltip } from '@angular/material/tooltip';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TnIconComponent } from '@truenas/ui-components';
+import { LicenseFingerprint } from 'app/interfaces/system-info.interface';
+import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
+import { TestDirective } from 'app/modules/test-id/test.directive';
+import { ApiService } from 'app/modules/websocket/api.service';
+import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+
+@Component({
+  selector: 'ix-license-fingerprint-dialog',
+  templateUrl: './license-fingerprint-dialog.component.html',
+  styleUrls: ['./license-fingerprint-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatButton,
+    MatIconButton,
+    MatDialogActions,
+    MatDialogClose,
+    MatDialogContent,
+    MatDialogTitle,
+    MatProgressSpinner,
+    MatTooltip,
+    TestDirective,
+    TnIconComponent,
+    TranslateModule,
+  ],
+})
+export class LicenseFingerprintDialog implements OnInit {
+  private api = inject(ApiService);
+  private errorHandler = inject(ErrorHandlerService);
+  private snackbar = inject(SnackbarService);
+  private translate = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
+
+  protected readonly isLoading = signal(true);
+  protected readonly fingerprintRaw = signal<string | null>(null);
+
+  protected readonly fingerprintDecoded = computed(() => {
+    const raw = this.fingerprintRaw();
+    if (!raw) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(atob(raw)) as LicenseFingerprint;
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return raw;
+    }
+  });
+
+  ngOnInit(): void {
+    this.api.call('truenas.license.fingerprint').pipe(
+      this.errorHandler.withErrorHandler(),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
+      next: (value) => {
+        this.fingerprintRaw.set(value);
+        this.isLoading.set(false);
+      },
+      error: () => this.isLoading.set(false),
+    });
+  }
+
+  protected copyToClipboard(): void {
+    const raw = this.fingerprintRaw();
+    if (!raw) {
+      return;
+    }
+    navigator.clipboard.writeText(raw).then(() => {
+      this.snackbar.success(this.translate.instant('Copied to clipboard'));
+    });
+  }
+}

--- a/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.ts
+++ b/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.ts
@@ -76,8 +76,9 @@ export class LicenseFingerprintDialog implements OnInit {
     if (!raw) {
       return;
     }
-    navigator.clipboard.writeText(raw).then(() => {
-      this.snackbar.success(this.translate.instant('Copied to clipboard'));
-    });
+    navigator.clipboard.writeText(raw).then(
+      () => this.snackbar.success(this.translate.instant('Copied to clipboard')),
+      () => this.snackbar.error(this.translate.instant('Failed to copy to clipboard')),
+    );
   }
 }

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -1,6 +1,6 @@
 @let license = licenseInfo();
-@if (hasLicense() && license) {
-  <mat-list>
+<mat-list>
+  @if (hasLicense() && license) {
     @if (license.contractType) {
       <mat-list-item>
         <span class="label">{{ 'Contract Type' | translate }}:</span>
@@ -91,9 +91,7 @@
         <span class="value">{{ license.additionalHardware }}</span>
       </mat-list-item>
     }
-  </mat-list>
-} @else {
-  <mat-list>
+  } @else {
     <mat-list-item>
       <span class="label">{{ 'OS Version' | translate }}:</span>
       <span class="value">{{ systemInfo().version }}</span>
@@ -120,5 +118,32 @@
         <span class="value">{{ systemInfo().system_serial }}</span>
       </mat-list-item>
     }
-  </mat-list>
-}
+  }
+
+  <mat-list-item class="fingerprint-row">
+    <span class="label">{{ 'License Fingerprint' | translate }}:</span>
+    <span class="value fingerprint-actions">
+      <button
+        mat-icon-button
+        type="button"
+        ixTest="view-fingerprint"
+        [attr.aria-label]="'View License Fingerprint' | translate"
+        [matTooltip]="'View Fingerprint' | translate"
+        (click)="openFingerprintDialog()"
+      >
+        <tn-icon name="eye" library="mdi" size="md"></tn-icon>
+      </button>
+      <button
+        mat-icon-button
+        type="button"
+        ixTest="copy-fingerprint"
+        [attr.aria-label]="'Copy License Fingerprint' | translate"
+        [disabled]="isFingerprintBusy()"
+        [matTooltip]="'Copy to Clipboard' | translate"
+        (click)="copyFingerprint()"
+      >
+        <tn-icon name="content-copy" library="mdi" size="md"></tn-icon>
+      </button>
+    </span>
+  </mat-list-item>
+</mat-list>

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -121,14 +121,14 @@
   }
 
   <mat-list-item class="fingerprint-row">
-    <span class="label">{{ 'License Fingerprint' | translate }}:</span>
+    <span class="label">{{ 'System Thumbprint' | translate }}:</span>
     <span class="value fingerprint-actions">
       <button
         mat-icon-button
         type="button"
         ixTest="view-fingerprint"
-        [attr.aria-label]="'View License Fingerprint' | translate"
-        [matTooltip]="'View Fingerprint' | translate"
+        [attr.aria-label]="'View System Thumbprint' | translate"
+        [matTooltip]="'View Thumbprint' | translate"
         (click)="openFingerprintDialog()"
       >
         <tn-icon name="eye" library="mdi" size="md"></tn-icon>
@@ -137,7 +137,7 @@
         mat-icon-button
         type="button"
         ixTest="copy-fingerprint"
-        [attr.aria-label]="'Copy License Fingerprint' | translate"
+        [attr.aria-label]="'Copy System Thumbprint' | translate"
         [disabled]="isFingerprintBusy()"
         [matTooltip]="'Copy to Clipboard' | translate"
         (click)="copyFingerprint()"

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.scss
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.scss
@@ -15,3 +15,13 @@
     margin-left: auto;
   }
 }
+
+.fingerprint-row {
+  align-items: center;
+
+  .fingerprint-actions {
+    align-items: center;
+    display: flex;
+    gap: 4px;
+  }
+}

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -2,9 +2,15 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { FormControl } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { MatDialog } from '@angular/material/dialog';
+import { createComponentFactory, Spectator, mockProvider } from '@ngneat/spectator/jest';
+import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { ContractType } from 'app/interfaces/system-info.interface';
+import { ApiService } from 'app/modules/websocket/api.service';
+import {
+  LicenseFingerprintDialog,
+} from 'app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component';
 import { LicenseInfoInSupport } from 'app/pages/system/general-settings/support/license-info-in-support.interface';
 import { SysInfoComponent } from 'app/pages/system/general-settings/support/sys-info/sys-info.component';
 import { SystemInfoInSupport } from 'app/pages/system/general-settings/support/system-info-in-support.interface';
@@ -26,20 +32,25 @@ describe('SysInfoComponent', () => {
     additionalHardware: null,
     serials: ['abcdefgh12345678'],
   };
+  const fingerprintBase64 = btoa(JSON.stringify({ system_serial: 'A1' }));
+
   let spectator: Spectator<SysInfoComponent>;
   let loader: HarnessLoader;
   const createComponent = createComponentFactory({
     component: SysInfoComponent,
     providers: [
       mockAuth(),
+      mockProvider(MatDialog, { open: jest.fn() }),
+      mockApi([mockCall('truenas.license.fingerprint', fingerprintBase64)]),
     ],
   });
 
   function getInfoRows(): Record<string, string> {
-    const values = spectator.queryAll('mat-list-item .value');
-    const labels = spectator.queryAll('mat-list-item .label');
-    return values.reduce((acc, item, i) => {
-      return { ...acc, [labels[i].textContent!]: item.textContent!.replace(/\s{2,}/g, ' ').trim() };
+    const rows = spectator.queryAll('mat-list-item:not(.fingerprint-row)');
+    return rows.reduce((acc, row) => {
+      const label = row.querySelector('.label')?.textContent ?? '';
+      const value = row.querySelector('.value')?.textContent?.replace(/\s{2,}/g, ' ').trim() ?? '';
+      return { ...acc, [label]: value };
     }, {} as Record<string, string>);
   }
 
@@ -156,6 +167,78 @@ describe('SysInfoComponent', () => {
 
       const toggle = spectator.query('.model-row ix-slide-toggle');
       expect(toggle).toExist();
+    });
+  });
+
+  describe('License fingerprint', () => {
+    it('renders a View Fingerprint button regardless of license state', async () => {
+      spectator.setInput({ hasLicense: false, licenseInfo: undefined });
+      expect(spectator.query('.fingerprint-row')).toExist();
+      const viewWithoutLicense = await loader.getHarness(
+        MatButtonHarness.with({ selector: '[ixTest="view-fingerprint"]' }),
+      );
+      expect(viewWithoutLicense).toBeTruthy();
+
+      spectator.setInput({ hasLicense: true, licenseInfo, isProactiveSupportAvailable: true });
+      const viewWithLicense = await loader.getHarness(
+        MatButtonHarness.with({ selector: '[ixTest="view-fingerprint"]' }),
+      );
+      expect(viewWithLicense).toBeTruthy();
+    });
+
+    it('opens the LicenseFingerprintDialog when the eye icon is clicked, with no fetch from sys-info', async () => {
+      spectator.setInput({ hasLicense: true, licenseInfo, isProactiveSupportAvailable: true });
+
+      const viewButton = await loader.getHarness(
+        MatButtonHarness.with({ selector: '[ixTest="view-fingerprint"]' }),
+      );
+      await viewButton.click();
+
+      expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(
+        LicenseFingerprintDialog,
+        expect.any(Object),
+      );
+      expect(spectator.inject(ApiService).call).not.toHaveBeenCalledWith('truenas.license.fingerprint');
+    });
+
+    it('copies the raw base64 string when the copy icon is clicked, fetching if needed', async () => {
+      spectator.setInput({ hasLicense: true, licenseInfo, isProactiveSupportAvailable: true });
+
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+
+      const copyButton = await loader.getHarness(
+        MatButtonHarness.with({ selector: '[ixTest="copy-fingerprint"]' }),
+      );
+      await copyButton.click();
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('truenas.license.fingerprint');
+      expect(writeText).toHaveBeenCalledWith(fingerprintBase64);
+      expect(spectator.inject(MatDialog).open).not.toHaveBeenCalled();
+    });
+
+    it('caches the fingerprint after the first copy and does not refetch', async () => {
+      spectator.setInput({ hasLicense: true, licenseInfo, isProactiveSupportAvailable: true });
+
+      const writeText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+
+      const copyButton = await loader.getHarness(
+        MatButtonHarness.with({ selector: '[ixTest="copy-fingerprint"]' }),
+      );
+      await copyButton.click();
+      await copyButton.click();
+
+      const fingerprintCalls = (spectator.inject(ApiService).call as jest.Mock).mock.calls
+        .filter((args) => args[0] === 'truenas.license.fingerprint');
+      expect(fingerprintCalls).toHaveLength(1);
+      expect(writeText).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
@@ -1,11 +1,15 @@
 import {
-  ChangeDetectionStrategy, Component, input, output,
+  ChangeDetectionStrategy, Component, DestroyRef, inject, input, output, signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { MatButton } from '@angular/material/button';
+import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
 import { MatListModule } from '@angular/material/list';
 import { MatTooltip } from '@angular/material/tooltip';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TnIconComponent } from '@truenas/ui-components';
+import { Observable, of, tap } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemSupport } from 'app/helptext/system/support';
@@ -13,8 +17,15 @@ import { getLabelForContractType } from 'app/interfaces/system-info.interface';
 import {
   IxSlideToggleComponent,
 } from 'app/modules/forms/ix-forms/components/ix-slide-toggle/ix-slide-toggle.component';
+import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
+import { TestDirective } from 'app/modules/test-id/test.directive';
+import { ApiService } from 'app/modules/websocket/api.service';
+import {
+  LicenseFingerprintDialog,
+} from 'app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component';
 import { LicenseInfoInSupport } from 'app/pages/system/general-settings/support/license-info-in-support.interface';
 import { SystemInfoInSupport } from 'app/pages/system/general-settings/support/system-info-in-support.interface';
+import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 
 @Component({
   selector: 'ix-sys-info',
@@ -23,15 +34,25 @@ import { SystemInfoInSupport } from 'app/pages/system/general-settings/support/s
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     MatButton,
+    MatIconButton,
     MatListModule,
     MatTooltip,
     ReactiveFormsModule,
     IxSlideToggleComponent,
     RequiresRolesDirective,
+    TestDirective,
+    TnIconComponent,
     TranslateModule,
   ],
 })
 export class SysInfoComponent {
+  private api = inject(ApiService);
+  private errorHandler = inject(ErrorHandlerService);
+  private snackbar = inject(SnackbarService);
+  private translate = inject(TranslateService);
+  private matDialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
+
   readonly hasLicense = input<boolean>();
   readonly licenseInfo = input<LicenseInfoInSupport>();
   readonly systemInfo = input.required<SystemInfoInSupport>();
@@ -45,4 +66,39 @@ export class SysInfoComponent {
   protected readonly manageProactiveRoles = [Role.SupportWrite];
   protected readonly getLabelForContractType = getLabelForContractType;
   protected readonly helptext = helptextSystemSupport;
+
+  protected readonly isFingerprintBusy = signal(false);
+  private fingerprintRaw: string | null = null;
+
+  protected openFingerprintDialog(): void {
+    this.matDialog.open(LicenseFingerprintDialog, { autoFocus: false });
+  }
+
+  protected copyFingerprint(): void {
+    this.loadFingerprint().subscribe({
+      next: (raw) => {
+        navigator.clipboard.writeText(raw).then(() => {
+          this.snackbar.success(this.translate.instant('Copied to clipboard'));
+        });
+      },
+    });
+  }
+
+  private loadFingerprint(): Observable<string> {
+    if (this.fingerprintRaw) {
+      return of(this.fingerprintRaw);
+    }
+    this.isFingerprintBusy.set(true);
+    return this.api.call('truenas.license.fingerprint').pipe(
+      tap({
+        next: (value) => {
+          this.fingerprintRaw = value;
+          this.isFingerprintBusy.set(false);
+        },
+        error: () => this.isFingerprintBusy.set(false),
+      }),
+      this.errorHandler.withErrorHandler(),
+      takeUntilDestroyed(this.destroyRef),
+    );
+  }
 }

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
@@ -77,9 +77,10 @@ export class SysInfoComponent {
   protected copyFingerprint(): void {
     this.loadFingerprint().subscribe({
       next: (raw) => {
-        navigator.clipboard.writeText(raw).then(() => {
-          this.snackbar.success(this.translate.instant('Copied to clipboard'));
-        });
+        navigator.clipboard.writeText(raw).then(
+          () => this.snackbar.success(this.translate.instant('Copied to clipboard')),
+          () => this.snackbar.error(this.translate.instant('Failed to copy to clipboard')),
+        );
       },
     });
   }


### PR DESCRIPTION
**Changes:**
Exposes the new system "fingerprint" in the System -> General Settings UI, specifically the Support card. Users can view their fingerprint details as well as copy the fingerprint to clipboard.

**Testing:**
View your system fingerprint and verify it copies to clipboard.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | We may want to document what the fingerprint is and what it is used for
|Testing         |
