### PR TITLE
NAS-140791 / 26.0.0-RC.1 / Unable to modify Device Order in VM using 26.0.0-BETA.1

### DIFF
--- a/src/app/pages/vm/devices/device-form/device-form.component.html
+++ b/src/app/pages/vm/devices/device-form/device-form.component.html
@@ -262,7 +262,7 @@
           mat-button
           color="primary"
           ixTest="save"
-          [disabled]="typeSpecificForm.invalid || (!isNew && typeSpecificForm.pristine) || isLoading"
+          [disabled]="typeSpecificForm.invalid || isLoading"
         >
           {{ 'Save' | translate }}
         </button>

--- a/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
+++ b/src/app/pages/vm/devices/device-form/device-form.component.spec.ts
@@ -209,6 +209,25 @@ describe('DeviceFormComponent', () => {
           vm: 45,
         }]);
       });
+
+      it('enables Save when only Device Order is changed', async () => {
+        await form.fillForm({
+          'Device Order': 10,
+        });
+
+        expect(await saveButton.isDisabled()).toBe(false);
+
+        await saveButton.click();
+
+        expect(api.call).toHaveBeenLastCalledWith('vm.device.update', [5, {
+          attributes: {
+            path: '/mnt/bassein/cdrom',
+            dtype: VmDeviceType.Cdrom,
+          },
+          order: 10,
+          vm: 45,
+        }]);
+      });
     });
   });
 


### PR DESCRIPTION
The issue is already fixed for v27 (master) here as a part of this ticket (so no need to backport to master): https://github.com/truenas/webui/commit/066733e710198e60a084f470d2b55551c57991cb

Preview:

https://github.com/user-attachments/assets/06ece3bd-bd86-4658-9096-20fb4a425f44

