### PR TITLE
NAS-140973 / 27.0.0-BETA.1 / Type update endpoint bodies as Partial<XUpdate> to match API

### DIFF
--- a/src/app/interfaces/api-key.interface.ts
+++ b/src/app/interfaces/api-key.interface.ts
@@ -19,8 +19,10 @@ export interface CreateApiKeyRequest {
   expires_at: ApiTimestamp | null;
 }
 
-export type UpdateApiKeyRequest = [number, {
-  name: string;
+export interface UpdateApiKeyBody {
+  name?: string;
   reset?: boolean;
   expires_at?: ApiTimestamp | null;
-}];
+}
+
+export type UpdateApiKeyRequest = [number, UpdateApiKeyBody];

--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -731,7 +731,7 @@ export interface ApiCallDirectory {
   'pool.snapshottask.delete_will_change_retention_for': { params: [id: number]; response: Record<string, string[]> };
   'pool.snapshottask.query': { params: QueryParams<PeriodicSnapshotTask>; response: PeriodicSnapshotTask[] };
   'pool.snapshottask.update': { params: [id: number, update: Partial<PeriodicSnapshotTaskUpdate>]; response: PeriodicSnapshotTask };
-  'pool.snapshottask.update_will_change_retention_for': { params: [id: number, update: PeriodicSnapshotTaskUpdate]; response: Record<string, string[]> };
+  'pool.snapshottask.update_will_change_retention_for': { params: [id: number, update: Partial<PeriodicSnapshotTaskUpdate>]; response: Record<string, string[]> };
   'pool.upgrade': { params: [id: number]; response: boolean };
   'pool.validate_name': { params: string[]; response: boolean | { error: boolean } };
 

--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -576,7 +576,7 @@ export interface ApiCallDirectory {
   'iscsi.extent.delete': { params: [id: number, remove: boolean, force: boolean]; response: boolean };
   'iscsi.extent.disk_choices': { params: void; response: Choices };
   'iscsi.extent.query': { params: QueryParams<IscsiExtent>; response: IscsiExtent[] };
-  'iscsi.extent.update': { params: [id: number, update: Partial<IscsiExtentUpdate>]; response: IscsiExtentUpdate };
+  'iscsi.extent.update': { params: [id: number, update: Partial<IscsiExtentUpdate>]; response: IscsiExtent };
   'iscsi.global.config': { params: void; response: IscsiGlobalConfig };
   'iscsi.global.sessions': { params: QueryParams<IscsiGlobalSession>; response: IscsiGlobalSession[] };
   'iscsi.global.update': { params: [Partial<IscsiGlobalConfigUpdate>]; response: IscsiGlobalConfig };

--- a/src/app/interfaces/api/api-call-directory.interface.ts
+++ b/src/app/interfaces/api/api-call-directory.interface.ts
@@ -312,7 +312,7 @@ export interface ApiCallDirectory {
   'acme.dns.authenticator.create': { params: [CreateDnsAuthenticator]; response: DnsAuthenticator };
   'acme.dns.authenticator.delete': { params: [id: number]; response: boolean };
   'acme.dns.authenticator.query': { params: void; response: DnsAuthenticator[] };
-  'acme.dns.authenticator.update': { params: [number, UpdateDnsAuthenticator]; response: DnsAuthenticator };
+  'acme.dns.authenticator.update': { params: [number, Partial<UpdateDnsAuthenticator>]; response: DnsAuthenticator };
 
   // Alert
   'alert.dismiss': { params: string[]; response: void };
@@ -323,7 +323,7 @@ export interface ApiCallDirectory {
 
   // Alert Classes
   'alertclasses.config': { params: void; response: AlertClasses };
-  'alertclasses.update': { params: [AlertClassesUpdate]; response: AlertClasses };
+  'alertclasses.update': { params: [Partial<AlertClassesUpdate>]; response: AlertClasses };
   'alertservice.create': { params: [AlertServiceEdit]; response: AlertService };
   'alertservice.delete': { params: [number]; response: boolean };
   'alertservice.query': { params: QueryParams<AlertService>; response: AlertService[] };
@@ -350,7 +350,7 @@ export interface ApiCallDirectory {
   // App/Docker Registry
   'app.registry.create': { params: [DockerRegistryPayload]; response: DockerRegistry };
   'app.registry.delete': { params: [number]; response: null };
-  'app.registry.update': { params: [number, DockerRegistryPayload]; response: DockerRegistry };
+  'app.registry.update': { params: [number, Partial<DockerRegistryPayload>]; response: DockerRegistry };
   'app.registry.get_instance': { params: [number]; response: DockerRegistry };
   'app.registry.query': { params: QueryParams<DockerRegistryPayload>; response: DockerRegistry[] };
 
@@ -362,7 +362,7 @@ export interface ApiCallDirectory {
   // Audit
   'audit.config': { params: void; response: AuditConfig };
   'audit.query': { params: [AuditQueryParams]; response: AuditEntry[] };
-  'audit.update': { params: [AuditConfig]; response: AuditEntry[] };
+  'audit.update': { params: [Partial<AuditConfig>]; response: AuditEntry[] };
   'audit.download_report': { params: [{ report_name?: string }]; response: string[] };
 
   // Auth
@@ -377,7 +377,7 @@ export interface ApiCallDirectory {
   'auth.terminate_other_sessions': { params: void; response: void };
   'auth.terminate_session': { params: [id: string]; response: void };
   'auth.twofactor.config': { params: void; response: GlobalTwoFactorConfig };
-  'auth.twofactor.update': { params: [GlobalTwoFactorConfigUpdate]; response: GlobalTwoFactorConfig };
+  'auth.twofactor.update': { params: [Partial<GlobalTwoFactorConfigUpdate>]; response: GlobalTwoFactorConfig };
 
   // Boot
   'boot.detach': { params: [disk: string]; response: void };
@@ -394,7 +394,7 @@ export interface ApiCallDirectory {
   // Catalog
   'catalog.get_app_details': { params: [name: string, params: GetItemDetailsParams]; response: CatalogApp };
   'catalog.trains': { params: void; response: string[] };
-  'catalog.update': { params: [CatalogUpdate]; response: CatalogConfig };
+  'catalog.update': { params: [Partial<CatalogUpdate>]; response: CatalogConfig };
   'catalog.config': { params: void; response: CatalogConfig };
 
   // Certificate
@@ -411,7 +411,7 @@ export interface ApiCallDirectory {
   'cloud_backup.list_snapshot_directory': { params: CloudBackupSnapshotDirectoryParams; response: CloudBackupSnapshotDirectoryListing[] };
   'cloud_backup.transfer_setting_choices': { params: void; response: CloudsyncTransferSetting[] };
   'cloud_backup.query': { params: [id?: QueryParams<CloudBackup>]; response: CloudBackup[] };
-  'cloud_backup.update': { params: [id: number, update: CloudBackupUpdate]; response: CloudBackup };
+  'cloud_backup.update': { params: [id: number, update: Partial<CloudBackupUpdate>]; response: CloudBackup };
 
   // CloudSync
   'cloudsync.abort': { params: [id: number]; response: boolean };
@@ -429,7 +429,7 @@ export interface ApiCallDirectory {
   'cloudsync.providers': { params: void; response: CloudSyncProvider[] };
   'cloudsync.query': { params: QueryParams<CloudSyncTask>; response: CloudSyncTask[] };
   'cloudsync.restore': { params: CloudSyncRestoreParams; response: void };
-  'cloudsync.update': { params: [id: number, task: CloudSyncTaskUpdate]; response: CloudSyncTask };
+  'cloudsync.update': { params: [id: number, task: Partial<CloudSyncTaskUpdate>]; response: CloudSyncTask };
 
   // Core
   'core.ping': { params: void; response: 'pong' };
@@ -447,7 +447,7 @@ export interface ApiCallDirectory {
   'cronjob.delete': { params: [id: number]; response: boolean };
   'cronjob.query': { params: QueryParams<Cronjob>; response: Cronjob[] };
   'cronjob.run': { params: [id: number]; response: void };
-  'cronjob.update': { params: [id: number, update: CronjobUpdate]; response: Cronjob };
+  'cronjob.update': { params: [id: number, update: Partial<CronjobUpdate>]; response: Cronjob };
 
   // Device
   'device.get_info': { params: [{ type: DeviceType }]; response: Device[] };
@@ -472,7 +472,7 @@ export interface ApiCallDirectory {
   'disk.temperature_alerts': { params: [disks: string[]]; response: Alert[] };
   'disk.temperatures': { params: [disks: string[]]; response: DiskTemperatures };
   'disk.unlock_sed': { params: [params: { name: string; password: string }]; response: void };
-  'disk.update': { params: [id: string, update: DiskUpdate]; response: Disk };
+  'disk.update': { params: [id: string, update: Partial<DiskUpdate>]; response: Disk };
 
   // Enclosure
   'enclosure2.query': { params: void; response: Enclosure[] };
@@ -491,7 +491,7 @@ export interface ApiCallDirectory {
   'failover.status': { params: void; response: FailoverStatus };
   'failover.sync_from_peer': { params: void; response: void };
   'failover.sync_to_peer': { params: [{ reboot?: boolean }]; response: void };
-  'failover.update': { params: [FailoverUpdate]; response: FailoverConfig };
+  'failover.update': { params: [Partial<FailoverUpdate>]; response: FailoverConfig };
 
   // Fibre Channel
   'fc.capable': { params: []; response: boolean };
@@ -502,7 +502,7 @@ export interface ApiCallDirectory {
 
   // Fibre Channel Port
   'fcport.create': { params: [FibreChannelPortUpdate]; response: FibreChannelPort };
-  'fcport.update': { params: [id: number, update: FibreChannelPortUpdate]; response: FibreChannelPort };
+  'fcport.update': { params: [id: number, update: Partial<FibreChannelPortUpdate>]; response: FibreChannelPort };
   'fcport.delete': { params: [id: number]; response: true };
   'fcport.port_choices': { params: [include_used?: boolean]; response: FibreChannelPortChoices };
   'fcport.query': { params: QueryParams<FibreChannelPort>; response: FibreChannelPort[] };
@@ -519,7 +519,7 @@ export interface ApiCallDirectory {
 
   // FTP
   'ftp.config': { params: void; response: FtpConfig };
-  'ftp.update': { params: [FtpConfigUpdate]; response: FtpConfig };
+  'ftp.update': { params: [Partial<FtpConfigUpdate>]; response: FtpConfig };
 
   // Group
   'group.create': { params: [CreateGroup]; response: number };
@@ -527,7 +527,7 @@ export interface ApiCallDirectory {
   'group.get_group_obj': { params: [{ groupname?: string; gid?: number }]; response: DsUncachedGroup };
   'group.get_next_gid': { params: void; response: number };
   'group.query': { params: QueryParams<Group>; response: Group[] };
-  'group.update': { params: [number, UpdateGroup]; response: number };
+  'group.update': { params: [number, Partial<UpdateGroup>]; response: number };
 
   // Initshutdownscript
   'initshutdownscript.create': { params: [CreateInitShutdownScript]; response: InitShutdownScript };
@@ -555,7 +555,7 @@ export interface ApiCallDirectory {
   'interface.save_default_route': { params: string[]; response: void };
   'interface.save_network_config': { params: [{ ipv4gateway: string; nameserver1?: string; nameserver2?: string; nameserver3?: string }]; response: void };
   'interface.services_restarted_on_sync': { params: void; response: ServiceRestartedOnNetworkSync[] };
-  'interface.update': { params: [id: string, update: NetworkInterfaceUpdate]; response: NetworkInterface };
+  'interface.update': { params: [id: string, update: Partial<NetworkInterfaceUpdate>]; response: NetworkInterface };
   'interface.vlan_parent_interface_choices': { params: void; response: Choices };
   'interface.websocket_local_ip': { params: void; response: string };
   'interface.xmit_hash_policy_choices': { params: void; response: Choices };
@@ -571,39 +571,39 @@ export interface ApiCallDirectory {
   'iscsi.auth.create': { params: [IscsiAuthAccessUpdate]; response: IscsiAuthAccess };
   'iscsi.auth.delete': { params: [id: number]; response: boolean };
   'iscsi.auth.query': { params: QueryParams<IscsiAuthAccess>; response: IscsiAuthAccess[] };
-  'iscsi.auth.update': { params: [id: number, auth: IscsiAuthAccessUpdate]; response: IscsiAuthAccess };
+  'iscsi.auth.update': { params: [id: number, auth: Partial<IscsiAuthAccessUpdate>]; response: IscsiAuthAccess };
   'iscsi.extent.create': { params: [IscsiExtentUpdate]; response: IscsiExtent };
   'iscsi.extent.delete': { params: [id: number, remove: boolean, force: boolean]; response: boolean };
   'iscsi.extent.disk_choices': { params: void; response: Choices };
   'iscsi.extent.query': { params: QueryParams<IscsiExtent>; response: IscsiExtent[] };
-  'iscsi.extent.update': { params: [id: number, update: IscsiExtentUpdate]; response: IscsiExtentUpdate };
+  'iscsi.extent.update': { params: [id: number, update: Partial<IscsiExtentUpdate>]; response: IscsiExtentUpdate };
   'iscsi.global.config': { params: void; response: IscsiGlobalConfig };
   'iscsi.global.sessions': { params: QueryParams<IscsiGlobalSession>; response: IscsiGlobalSession[] };
-  'iscsi.global.update': { params: [IscsiGlobalConfigUpdate]; response: IscsiGlobalConfig };
+  'iscsi.global.update': { params: [Partial<IscsiGlobalConfigUpdate>]; response: IscsiGlobalConfig };
   'iscsi.initiator.create': { params: [IscsiInitiatorGroupUpdate]; response: IscsiInitiatorGroup };
   'iscsi.initiator.delete': { params: [id: number]; response: boolean };
   'iscsi.initiator.query': { params: QueryParams<IscsiInitiatorGroup>; response: IscsiInitiatorGroup[] };
-  'iscsi.initiator.update': { params: [id: number, initiator: IscsiInitiatorGroupUpdate]; response: IscsiInitiatorGroup };
+  'iscsi.initiator.update': { params: [id: number, initiator: Partial<IscsiInitiatorGroupUpdate>]; response: IscsiInitiatorGroup };
   'iscsi.portal.create': { params: [IscsiPortalUpdate]; response: IscsiPortal };
   'iscsi.portal.delete': { params: [number]; response: boolean };
   'iscsi.portal.listen_ip_choices': { params: void; response: Choices };
   'iscsi.portal.query': { params: QueryParams<IscsiPortal>; response: IscsiPortal[] };
-  'iscsi.portal.update': { params: [id: number, target: IscsiPortalUpdate]; response: IscsiPortal };
+  'iscsi.portal.update': { params: [id: number, target: Partial<IscsiPortalUpdate>]; response: IscsiPortal };
   'iscsi.target.create': { params: [IscsiTargetUpdate]; response: IscsiTarget };
   'iscsi.target.delete': { params: [id: number, force?: boolean, delete_extents?: boolean]; response: boolean };
   'iscsi.target.query': { params: QueryParams<IscsiTarget>; response: IscsiTarget[] };
-  'iscsi.target.update': { params: [id: number, target: IscsiTargetUpdate]; response: IscsiTarget };
+  'iscsi.target.update': { params: [id: number, target: Partial<IscsiTargetUpdate>]; response: IscsiTarget };
   'iscsi.targetextent.create': { params: [IscsiTargetExtentUpdate]; response: IscsiTargetExtent };
   'iscsi.targetextent.delete': { params: [id: number, force?: boolean]; response: boolean };
   'iscsi.targetextent.query': { params: QueryParams<IscsiTargetExtent>; response: IscsiTargetExtent[] };
-  'iscsi.targetextent.update': { params: [id: number, extent: IscsiTargetExtentUpdate]; response: IscsiTargetExtent };
+  'iscsi.targetextent.update': { params: [id: number, extent: Partial<IscsiTargetExtentUpdate>]; response: IscsiTargetExtent };
   'iscsi.target.validate_name': { params: string[]; response: null | string };
 
   // Jbof
   'jbof.licensed': { params: void; response: number };
   'jbof.query': { params: [QueryParams<Jbof>]; response: Jbof[] };
   'jbof.create': { params: [JbofUpdate]; response: Jbof };
-  'jbof.update': { params: [id: number, update: JbofUpdate]; response: Jbof };
+  'jbof.update': { params: [id: number, update: Partial<JbofUpdate>]; response: Jbof };
   'jbof.delete': { params: [id: number, force?: boolean]; response: boolean };
 
   // Kerberos
@@ -612,12 +612,12 @@ export interface ApiCallDirectory {
   'kerberos.keytab.delete': { params: [id: number]; response: boolean };
   'kerberos.keytab.kerberos_principal_choices': { params: void; response: string[] };
   'kerberos.keytab.query': { params: QueryParams<KerberosKeytab>; response: KerberosKeytab[] };
-  'kerberos.keytab.update': { params: [id: number, update: KerberosKeytabUpdate]; response: KerberosKeytab };
+  'kerberos.keytab.update': { params: [id: number, update: Partial<KerberosKeytabUpdate>]; response: KerberosKeytab };
   'kerberos.realm.create': { params: [KerberosRealmUpdate]; response: KerberosRealm };
   'kerberos.realm.delete': { params: [id: number]; response: boolean };
   'kerberos.realm.query': { params: QueryParams<KerberosRealm>; response: KerberosRealm[] };
-  'kerberos.realm.update': { params: [id: number, update: KerberosRealmUpdate]; response: KerberosRealm };
-  'kerberos.update': { params: [KerberosConfigUpdate]; response: KerberosConfig };
+  'kerberos.realm.update': { params: [id: number, update: Partial<KerberosRealmUpdate>]; response: KerberosRealm };
+  'kerberos.update': { params: [Partial<KerberosConfigUpdate>]; response: KerberosConfig };
 
   // Keychain credential
   'keychaincredential.create': { params: [KeychainCredentialCreate]; response: KeychainCredential };
@@ -626,7 +626,7 @@ export interface ApiCallDirectory {
   'keychaincredential.query': { params: QueryParams<KeychainCredential>; response: KeychainCredential[] };
   'keychaincredential.remote_ssh_host_key_scan': { params: [RemoteSshScanParams]; response: string };
   'keychaincredential.setup_ssh_connection': { params: [SshConnectionSetup]; response: KeychainSshCredentials };
-  'keychaincredential.update': { params: [id: number, credential: KeychainCredentialUpdate]; response: KeychainCredential };
+  'keychaincredential.update': { params: [id: number, credential: Partial<KeychainCredentialUpdate>]; response: KeychainCredential };
   'keychaincredential.used_by': { params: [id: number]; response: KeychainCredentialUsedBy[] };
 
   // KMIP
@@ -642,12 +642,12 @@ export interface ApiCallDirectory {
   // Mail
   'mail.config': { params: void; response: MailConfig };
   'mail.local_administrator_email': { params: void; response: string | null };
-  'mail.update': { params: [MailConfigUpdate]; response: MailConfig };
+  'mail.update': { params: [Partial<MailConfigUpdate>]; response: MailConfig };
 
   // Network configuration
   'network.configuration.activity_choices': { params: void; response: MapOption[] };
   'network.configuration.config': { params: void; response: NetworkConfiguration };
-  'network.configuration.update': { params: [NetworkConfigurationUpdate]; response: NetworkConfiguration };
+  'network.configuration.update': { params: [Partial<NetworkConfigurationUpdate>]; response: NetworkConfiguration };
   'network.general.summary': { params: void; response: NetworkSummary };
 
   // NFS
@@ -656,20 +656,20 @@ export interface ApiCallDirectory {
   'nfs.config': { params: void; response: NfsConfig };
   'nfs.get_nfs3_clients': { params: [params?: QueryParams<Nfs3Session>]; response: Nfs3Session[] };
   'nfs.get_nfs4_clients': { params: [params?: QueryParams<Nfs4Session>]; response: Nfs4Session[] };
-  'nfs.update': { params: [NfsConfigUpdate]; response: NfsConfig };
+  'nfs.update': { params: [Partial<NfsConfigUpdate>]; response: NfsConfig };
 
   // NVMe-oF
   'nvmet.global.config': { params: void; response: NvmeOfGlobalConfig };
-  'nvmet.global.update': { params: [NvmeOfGlobalConfigUpdate]; response: NvmeOfGlobalConfig };
+  'nvmet.global.update': { params: [Partial<NvmeOfGlobalConfigUpdate>]; response: NvmeOfGlobalConfig };
 
   'nvmet.subsys.query': { params: QueryParams<NvmeOfSubsystem, { extra: { verbose: boolean } }>; response: NvmeOfSubsystem[] };
   'nvmet.subsys.create': { params: [CreateNvmeOfSubsystem]; response: NvmeOfSubsystem };
-  'nvmet.subsys.update': { params: [id: number, update: UpdateNvmeOfSubsystem]; response: NvmeOfSubsystem };
+  'nvmet.subsys.update': { params: [id: number, update: Partial<UpdateNvmeOfSubsystem>]; response: NvmeOfSubsystem };
   'nvmet.subsys.delete': { params: [id: number, { force: boolean }?]; response: void };
 
   'nvmet.port.query': { params: QueryParams<NvmeOfPort>; response: NvmeOfPort[] };
   'nvmet.port.create': { params: [CreateNvmeOfPort]; response: NvmeOfPort };
-  'nvmet.port.update': { params: [id: number, update: UpdateNvmeOfPort]; response: NvmeOfPort };
+  'nvmet.port.update': { params: [id: number, update: Partial<UpdateNvmeOfPort>]; response: NvmeOfPort };
   'nvmet.port.delete': { params: [id: number, { force: boolean }?]; response: void };
 
   'nvmet.port_subsys.query': { params: QueryParams<SubsystemPortAssociation>; response: SubsystemPortAssociation[] };
@@ -678,7 +678,7 @@ export interface ApiCallDirectory {
 
   'nvmet.host.query': { params: QueryParams<NvmeOfHost>; response: NvmeOfHost[] };
   'nvmet.host.create': { params: [CreateNvmeOfHost]; response: NvmeOfHost };
-  'nvmet.host.update': { params: [id: number, update: UpdateNvmeOfHost]; response: NvmeOfHost };
+  'nvmet.host.update': { params: [id: number, update: Partial<UpdateNvmeOfHost>]; response: NvmeOfHost };
   'nvmet.host.delete': { params: [id: number, { force: boolean }?]; response: void };
   'nvmet.host.generate_key': { params: GenerateNvmeHostParams; response: string };
   'nvmet.host.dhchap_dhgroup_choices': { params: void; response: string[] };
@@ -690,7 +690,7 @@ export interface ApiCallDirectory {
 
   'nvmet.namespace.query': { params: QueryParams<NvmeOfNamespace>; response: NvmeOfNamespace[] };
   'nvmet.namespace.create': { params: [CreateNvmeOfNamespace]; response: NvmeOfNamespace };
-  'nvmet.namespace.update': { params: [id: number, update: UpdateNvmeOfNamespace]; response: NvmeOfNamespace };
+  'nvmet.namespace.update': { params: [id: number, update: Partial<UpdateNvmeOfNamespace>]; response: NvmeOfNamespace };
   'nvmet.namespace.delete': { params: DeleteNamespaceParams; response: void };
 
   'nvmet.port.transport_address_choices': { params: NvmeOfTransportParams; response: Choices };
@@ -713,7 +713,7 @@ export interface ApiCallDirectory {
   'pool.dataset.recommended_zvol_blocksize': { params: [pool: string]; response: DatasetRecordSize };
   'pool.dataset.recordsize_choices': { params: void; response: string[] };
   'pool.dataset.set_quota': { params: [dataset: string, quotas: SetDatasetQuota[]]; response: void };
-  'pool.dataset.update': { params: [id: string, update: DatasetUpdate]; response: Dataset };
+  'pool.dataset.update': { params: [id: string, update: Partial<DatasetUpdate>]; response: Dataset };
   'pool.detach': { params: [id: number, params: { label: string }]; response: boolean };
   'pool.filesystem_choices': { params: [DatasetType[]?]; response: string[] };
   'pool.offline': { params: [id: number, params: { label: string }]; response: boolean };
@@ -721,16 +721,16 @@ export interface ApiCallDirectory {
   'pool.processes': { params: [id: number]; response: Process[] };
   'pool.query': { params: QueryParams<Pool>; response: Pool[] };
   'pool.resilver.config': { params: void; response: ResilverConfig };
-  'pool.resilver.update': { params: [ResilverConfigUpdate]; response: ResilverConfig };
+  'pool.resilver.update': { params: [Partial<ResilverConfigUpdate>]; response: ResilverConfig };
   'pool.scrub.create': { params: [CreateScrubTask]; response: ScrubTask };
   'pool.scrub.delete': { params: [id: number]; response: boolean };
   'pool.scrub.query': { params: QueryParams<ScrubTask>; response: ScrubTask[] };
-  'pool.scrub.update': { params: [id: number, params: CreateScrubTask]; response: ScrubTask };
+  'pool.scrub.update': { params: [id: number, params: Partial<CreateScrubTask>]; response: ScrubTask };
   'pool.snapshottask.create': { params: [PeriodicSnapshotTaskCreate]; response: PeriodicSnapshotTask };
   'pool.snapshottask.delete': { params: [id: number, options?: { fixate_removal_date: boolean }]; response: boolean };
   'pool.snapshottask.delete_will_change_retention_for': { params: [id: number]; response: Record<string, string[]> };
   'pool.snapshottask.query': { params: QueryParams<PeriodicSnapshotTask>; response: PeriodicSnapshotTask[] };
-  'pool.snapshottask.update': { params: [id: number, update: PeriodicSnapshotTaskUpdate]; response: PeriodicSnapshotTask };
+  'pool.snapshottask.update': { params: [id: number, update: Partial<PeriodicSnapshotTaskUpdate>]; response: PeriodicSnapshotTask };
   'pool.snapshottask.update_will_change_retention_for': { params: [id: number, update: PeriodicSnapshotTaskUpdate]; response: Record<string, string[]> };
   'pool.upgrade': { params: [id: number]; response: boolean };
   'pool.validate_name': { params: string[]; response: boolean | { error: boolean } };
@@ -740,14 +740,14 @@ export interface ApiCallDirectory {
   'privilege.delete': { params: [id: number]; response: boolean };
   'privilege.query': { params: QueryParams<Privilege>; response: Privilege[] };
   'privilege.roles': { params: QueryParams<PrivilegeRole>; response: PrivilegeRole[] };
-  'privilege.update': { params: [id: number, update: PrivilegeUpdate]; response: Privilege };
+  'privilege.update': { params: [id: number, update: Partial<PrivilegeUpdate>]; response: Privilege };
 
   // RDMA
   'rdma.capable_protocols': { params: []; response: RdmaProtocolName[] };
 
   // Replication
   'replication.config.config': { params: void; response: ReplicationConfig };
-  'replication.config.update': { params: [ReplicationConfigUpdate]; response: ReplicationConfig };
+  'replication.config.update': { params: [Partial<ReplicationConfigUpdate>]; response: ReplicationConfig };
   'replication.count_eligible_manual_snapshots': { params: [CountManualSnapshotsParams]; response: EligibleManualSnapshotsCount };
   'replication.create': { params: [ReplicationCreate]; response: ReplicationTask };
   'replication.delete': { params: [id: number]; response: boolean };
@@ -763,7 +763,7 @@ export interface ApiCallDirectory {
   'reporting.exporters.delete': { params: [id: number]; response: boolean };
   'reporting.exporters.exporter_schemas': { params: void; response: ReportingExporterSchema[] };
   'reporting.exporters.query': { params: QueryParams<ReportingExporter>; response: ReportingExporter[] };
-  'reporting.exporters.update': { params: [number, UpdateReportingExporter]; response: ReportingExporter };
+  'reporting.exporters.update': { params: [number, Partial<UpdateReportingExporter>]; response: ReportingExporter };
   'reporting.netdata_get_data': { params: ReportingQueryParams; response: ReportingData[] };
   'reporting.netdata_graphs': { params: QueryParams<ReportingGraph>; response: ReportingGraph[] };
 
@@ -771,7 +771,7 @@ export interface ApiCallDirectory {
   'rsynctask.create': { params: [RsyncTaskUpdate]; response: RsyncTask };
   'rsynctask.delete': { params: [id: number]; response: boolean };
   'rsynctask.query': { params: QueryParams<RsyncTask>; response: RsyncTask[] };
-  'rsynctask.update': { params: [id: number, params: RsyncTaskUpdate]; response: RsyncTask };
+  'rsynctask.update': { params: [id: number, params: Partial<RsyncTaskUpdate>]; response: RsyncTask };
 
   // Service
   'service.query': { params: QueryParams<Service>; response: Service[] };
@@ -781,7 +781,7 @@ export interface ApiCallDirectory {
   'sharing.nfs.create': { params: [NfsShareUpdate]; response: NfsShare };
   'sharing.nfs.delete': { params: [id: number]; response: boolean };
   'sharing.nfs.query': { params: QueryParams<NfsShare>; response: NfsShare[] };
-  'sharing.nfs.update': { params: [id: number, update: NfsShareUpdate]; response: NfsShare };
+  'sharing.nfs.update': { params: [id: number, update: Partial<NfsShareUpdate>]; response: NfsShare };
   'sharing.smb.create': { params: [Partial<SmbShare>]; response: SmbShare };
   'sharing.smb.delete': { params: [id: number]; response: boolean };
   'sharing.smb.getacl': { params: [{ share_name: string }]; response: SmbSharesec };
@@ -792,35 +792,35 @@ export interface ApiCallDirectory {
   'sharing.webshare.create': { params: [WebShareUpdate]; response: WebShare };
   'sharing.webshare.delete': { params: [id: number]; response: boolean };
   'sharing.webshare.query': { params: QueryParams<WebShare>; response: WebShare[] };
-  'sharing.webshare.update': { params: [id: number, update: WebShareUpdate]; response: WebShare };
+  'sharing.webshare.update': { params: [id: number, update: Partial<WebShareUpdate>]; response: WebShare };
 
   // SMB
   'smb.bindip_choices': { params: void; response: Choices };
   'smb.config': { params: void; response: SmbConfig };
   'smb.status': { params: [level: SmbInfoLevel, params?: QueryParams<SmbStatus>]; response: SmbStatus[] };
   'smb.unixcharset_choices': { params: void; response: Choices };
-  'smb.update': { params: [SmbConfigUpdate]; response: SmbConfig };
+  'smb.update': { params: [Partial<SmbConfigUpdate>]; response: SmbConfig };
 
   // SNMP
   'snmp.config': { params: void; response: SnmpConfig };
-  'snmp.update': { params: [SnmpConfigUpdate]; response: SnmpConfig };
+  'snmp.update': { params: [Partial<SnmpConfigUpdate>]; response: SnmpConfig };
 
   // SSH
   'ssh.bindiface_choices': { params: void; response: Choices };
   'ssh.config': { params: void; response: SshConfig };
-  'ssh.update': { params: [SshConfigUpdate]; response: SshConfig };
+  'ssh.update': { params: [Partial<SshConfigUpdate>]; response: SshConfig };
 
   // Static route
   'staticroute.create': { params: [UpdateStaticRoute]; response: StaticRoute };
   'staticroute.delete': { params: [id: number]; response: boolean };
   'staticroute.query': { params: QueryParams<StaticRoute>; response: StaticRoute[] };
-  'staticroute.update': { params: [id: number, update: UpdateStaticRoute]; response: StaticRoute };
+  'staticroute.update': { params: [id: number, update: Partial<UpdateStaticRoute>]; response: StaticRoute };
 
   // Support
   'support.config': { params: void; response: SupportConfig };
   'support.is_available': { params: void; response: boolean };
   'support.is_available_and_enabled': { params: void; response: boolean };
-  'support.update': { params: [SupportConfigUpdate]; response: SupportConfig };
+  'support.update': { params: [Partial<SupportConfigUpdate>]; response: SupportConfig };
   'support.similar_issues': { params: SimilarIssuesParams; response: SimilarIssue[] };
   'support.attach_ticket_max_size': { params: void; response: number };
 
@@ -844,13 +844,13 @@ export interface ApiCallDirectory {
   'system.general.ui_httpsprotocols_choices': { params: void; response: Choices };
   'system.general.ui_restart': { params: void; response: void };
   'system.general.ui_v6address_choices': { params: void; response: Choices };
-  'system.general.update': { params: [SystemGeneralConfigUpdate]; response: SystemGeneralConfig };
+  'system.general.update': { params: [Partial<SystemGeneralConfigUpdate>]; response: SystemGeneralConfig };
   'system.host_id': { params: void; response: string };
   'system.info': { params: void; response: SystemInfo };
   'system.ntpserver.create': { params: [CreateNtpServer]; response: NtpServer };
   'system.ntpserver.delete': { params: [id: number]; response: boolean };
   'system.ntpserver.query': { params: QueryParams<NtpServer>; response: NtpServer[] };
-  'system.ntpserver.update': { params: [id: number, params: CreateNtpServer]; response: NtpServer };
+  'system.ntpserver.update': { params: [id: number, params: Partial<CreateNtpServer>]; response: NtpServer };
   'system.product_type': { params: void; response: ProductType };
   'system.security.config': { params: void; response: SystemSecurityConfig };
   'system.security.info.fips_available': { params: void; response: boolean };
@@ -862,11 +862,11 @@ export interface ApiCallDirectory {
 
   // Truecommand
   'truecommand.config': { params: void; response: TrueCommandConfig };
-  'truecommand.update': { params: [UpdateTrueCommand]; response: TrueCommandUpdateResponse };
+  'truecommand.update': { params: [Partial<UpdateTrueCommand>]; response: TrueCommandUpdateResponse };
 
   // Truenas Connect
   'tn_connect.config': { params: void; response: TruenasConnectConfig };
-  'tn_connect.update': { params: [TruenasConnectUpdate]; response: TruenasConnectConfig };
+  'tn_connect.update': { params: [Partial<TruenasConnectUpdate>]; response: TruenasConnectConfig };
   'tn_connect.generate_claim_token': { params: void; response: string };
   'tn_connect.get_registration_uri': { params: void; response: string };
   'tn_connect.ips_with_hostnames': { params: void; response: Record<string, string> };
@@ -899,11 +899,11 @@ export interface ApiCallDirectory {
   'ups.config': { params: void; response: UpsConfig };
   'ups.driver_choices': { params: void; response: Choices };
   'ups.port_choices': { params: void; response: string[] };
-  'ups.update': { params: [UpsConfigUpdate]; response: UpsConfig };
+  'ups.update': { params: [Partial<UpsConfigUpdate>]; response: UpsConfig };
 
   // User
   'user.create': { params: [UserUpdate]; response: User };
-  'user.update': { params: [id: number, update: UserUpdate]; response: User };
+  'user.update': { params: [id: number, update: Partial<UserUpdate>]; response: User };
   'user.delete': { params: DeleteUserParams; response: number };
   'user.get_next_uid': { params: void; response: number };
   'user.get_user_obj': { params: [{ username?: string; uid?: number }]; response: DsUncachedUser };
@@ -919,7 +919,7 @@ export interface ApiCallDirectory {
   'container.device.create': { params: [ContainerDevicePayload]; response: ContainerDeviceEntry };
   'container.device.delete': { params: [id: number, options?: ContainerDeviceDelete]; response: boolean };
   'container.device.query': { params: QueryParams<ContainerDeviceEntry>; response: ContainerDeviceEntry[] };
-  'container.device.update': { params: [id: number, update: ContainerDevicePayload]; response: ContainerDeviceEntry };
+  'container.device.update': { params: [id: number, update: Partial<ContainerDevicePayload>]; response: ContainerDeviceEntry };
   'container.device.disk_choices': { params: []; response: Record<string, string> };
   'container.device.gpu_choices': { params: []; response: Record<string, string> };
   'container.device.nic_attach_choices': { params: []; response: Record<string, string[]> };
@@ -932,12 +932,12 @@ export interface ApiCallDirectory {
   'container.pool_choices': { params: []; response: Choices };
   'container.query': { params: QueryParams<Container>; response: Container[] };
   'container.start': { params: [containerId: number]; response: void };
-  'container.update': { params: [containerId: number, update: UpdateContainer]; response: Container };
+  'container.update': { params: [containerId: number, update: Partial<UpdateContainer>]; response: Container };
 
   // LXC (actual available endpoints only)
   'lxc.bridge_choices': { params: []; response: Choices };
   'lxc.config': { params: []; response: ContainerGlobalConfig };
-  'lxc.update': { params: [ContainerGlobalConfig]; response: ContainerGlobalConfig };
+  'lxc.update': { params: [Partial<ContainerGlobalConfig>]; response: ContainerGlobalConfig };
 
   // VM
   'vm.bootloader_options': { params: void; response: Choices };
@@ -954,7 +954,7 @@ export interface ApiCallDirectory {
   'vm.device.nic_attach_choices': { params: void; response: Record<string, string[]> };
   'vm.device.passthrough_device_choices': { params: void; response: Record<string, VmPassthroughDeviceChoice> };
   'vm.device.query': { params: QueryParams<VmDevice>; response: VmDevice[] };
-  'vm.device.update': { params: [id: number, update: VmDeviceUpdate]; response: VmDevice };
+  'vm.device.update': { params: [id: number, update: Partial<VmDeviceUpdate>]; response: VmDevice };
   'vm.device.usb_controller_choices': { params: void; response: Choices };
   'vm.device.usb_passthrough_choices': { params: void; response: Record<string, VmUsbPassthroughDeviceChoice> };
   'vm.device.virtual_size': { params: [{ path: string }]; response: number };
@@ -968,7 +968,7 @@ export interface ApiCallDirectory {
   'vm.random_mac': { params: void; response: string };
   'vm.resolution_choices': { params: void; response: Choices };
   'vm.start': { params: [id: number, params?: { overcommit?: boolean }]; response: void };
-  'vm.update': { params: [id: number, update: VirtualMachineUpdate]; response: VirtualMachine };
+  'vm.update': { params: [id: number, update: Partial<VirtualMachineUpdate>]; response: VirtualMachine };
   'vm.virtualization_details': { params: void; response: VirtualizationDetails };
   'vm.resume': { params: [id: number]; response: void };
 
@@ -978,7 +978,7 @@ export interface ApiCallDirectory {
   'vmware.delete': { params: [id: number]; response: boolean };
   'vmware.match_datastores_with_datasets': { params: [MatchDatastoresWithDatasetsParams]; response: MatchDatastoresWithDatasets };
   'vmware.query': { params: QueryParams<VmwareSnapshot>; response: VmwareSnapshot[] };
-  'vmware.update': { params: [id: number, update: VmwareSnapshotUpdate]; response: VmwareSnapshot };
+  'vmware.update': { params: [id: number, update: Partial<VmwareSnapshotUpdate>]; response: VmwareSnapshot };
 
   // WebUI main
   // TODO: Incorrect response definition here or for system.info.
@@ -990,7 +990,7 @@ export interface ApiCallDirectory {
 
   // WebShare
   'webshare.config': { params: void; response: WebShareConfig };
-  'webshare.update': { params: [WebShareConfigUpdate]; response: WebShareConfig };
+  'webshare.update': { params: [Partial<WebShareConfigUpdate>]; response: WebShareConfig };
 
   // ZFS
   'pool.snapshot.clone': { params: [CloneZfsSnapshot]; response: boolean };

--- a/src/app/interfaces/api/api-job-directory.interface.ts
+++ b/src/app/interfaces/api/api-job-directory.interface.ts
@@ -71,11 +71,11 @@ export interface ApiJobDirectory {
   // Certificate
   'certificate.create': { params: [CertificateCreate]; response: Certificate };
   'certificate.delete': { params: [id: number, force?: boolean]; response: boolean };
-  'certificate.update': { params: [id: number, update: CertificateUpdate]; response: Certificate };
+  'certificate.update': { params: [id: number, update: Partial<CertificateUpdate>]; response: Certificate };
 
   // App
   'app.create': { params: [AppCreate]; response: App };
-  'app.update': { params: [string, AppUpdate]; response: App };
+  'app.update': { params: [string, Partial<AppUpdate>]; response: App };
   'app.start': { params: AppStartQueryParams; response: void };
   'app.stop': { params: AppStartQueryParams; response: void };
   'app.redeploy': { params: AppStartQueryParams; response: void };
@@ -127,10 +127,10 @@ export interface ApiJobDirectory {
   'ipmi.sel.elist': { params: void; response: IpmiEvent[] };
 
   // KMIP
-  'kmip.update': { params: [KmipConfigUpdate]; response: KmipConfig };
+  'kmip.update': { params: [Partial<KmipConfigUpdate>]; response: KmipConfig };
 
   // Docker
-  'docker.update': { params: [DockerConfigUpdate]; response: DockerConfig };
+  'docker.update': { params: [Partial<DockerConfigUpdate>]; response: DockerConfig };
 
   // Mail
   'mail.send': { params: [SendMailParams, MailConfigUpdate]; response: boolean };
@@ -146,7 +146,7 @@ export interface ApiJobDirectory {
   'pool.remove': { params: PoolRemoveParams; response: void };
   'pool.replace': { params: [id: number, params: PoolReplaceParams]; response: boolean };
   'pool.scrub': { params: PoolScrubTaskParams; response: void };
-  'pool.update': { params: [id: number, update: UpdatePool]; response: Pool };
+  'pool.update': { params: [id: number, update: Partial<UpdatePool>]; response: Pool };
   'pool.dataset.change_key': { params: [id: string, params: DatasetChangeKeyParams]; response: void };
   'pool.dataset.encryption_summary': {
     params: [path: string, params?: DatasetEncryptionSummaryQueryParams];
@@ -176,10 +176,10 @@ export interface ApiJobDirectory {
   // System
   'system.reboot': { params: RebootParams; response: void };
   'system.shutdown': { params: ShutdownParams; response: void };
-  'system.security.update': { params: [SystemSecurityConfig]; response: void };
+  'system.security.update': { params: [Partial<SystemSecurityConfig>]; response: void };
 
   // SystemDataset
-  'systemdataset.update': { params: [SystemDatasetUpdate]; response: SystemDatasetConfig };
+  'systemdataset.update': { params: [Partial<SystemDatasetUpdate>]; response: SystemDatasetConfig };
 
   // TrueNAS
   'truenas.set_production': {
@@ -190,7 +190,7 @@ export interface ApiJobDirectory {
   // Tunable
   'tunable.create': { params: [TunableCreate]; response: Tunable };
   'tunable.delete': { params: [id: number]; response: true };
-  'tunable.update': { params: [id: number, update: TunableUpdate]; response: Tunable };
+  'tunable.update': { params: [id: number, update: Partial<TunableUpdate>]; response: Tunable };
 
   // Update
   'update.file': { params: [{ resume: boolean }?]; response: void };

--- a/src/app/interfaces/init-shutdown-script.interface.ts
+++ b/src/app/interfaces/init-shutdown-script.interface.ts
@@ -25,5 +25,5 @@ export interface CreateInitShutdownScript {
 
 export type UpdateInitShutdownScriptParams = [
   id: number,
-  params: CreateInitShutdownScript,
+  params: Partial<CreateInitShutdownScript>,
 ];

--- a/src/app/interfaces/vmware.interface.ts
+++ b/src/app/interfaces/vmware.interface.ts
@@ -34,4 +34,4 @@ export interface VmwareSnapshot {
   state: VmwareState;
 }
 
-export type VmwareSnapshotUpdate = Omit<VmwareSnapshot, 'id'>;
+export type VmwareSnapshotUpdate = Omit<VmwareSnapshot, 'id' | 'state'>;

--- a/src/app/pages/apps/components/catalog-settings/apps-settings.component.ts
+++ b/src/app/pages/apps/components/catalog-settings/apps-settings.component.ts
@@ -20,7 +20,6 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { Role } from 'app/enums/role.enum';
 import { singleArrayToOptions } from 'app/helpers/operators/options.operators';
 import { helptextApps } from 'app/helptext/apps/apps';
-import { CatalogUpdate } from 'app/interfaces/catalog.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxCheckboxListComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox-list/ix-checkbox-list.component';
@@ -189,7 +188,7 @@ export class AppsSettingsComponent implements OnInit {
 
     this.isFormLoading.set(true);
     forkJoin([
-      this.api.call('catalog.update', [{ preferred_trains: values.preferred_trains } as CatalogUpdate]),
+      this.api.call('catalog.update', [{ preferred_trains: values.preferred_trains }]),
       this.api.job('docker.update', [{
         enable_image_updates: values.enable_image_updates,
         address_pools: values.address_pools,

--- a/src/app/pages/credentials/kmip/kmip.component.ts
+++ b/src/app/pages/credentials/kmip/kmip.component.ts
@@ -13,7 +13,6 @@ import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { Role } from 'app/enums/role.enum';
 import { idNameArrayToOptions } from 'app/helpers/operators/options.operators';
 import { helptextSystemKmip } from 'app/helptext/system/kmip';
-import { KmipConfigUpdate } from 'app/interfaces/kmip-config.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -129,7 +128,7 @@ export class KmipComponent implements OnInit {
 
   protected onSubmit(): void {
     this.dialogService.jobDialog(
-      this.api.job('kmip.update', [this.form.value as KmipConfigUpdate]),
+      this.api.job('kmip.update', [this.form.value]),
       { title: this.translate.instant(helptextSystemKmip.jobDialog.title) },
     )
       .afterClosed()

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-card/cloud-backup-card.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-card/cloud-backup-card.component.ts
@@ -17,7 +17,7 @@ import { JobState } from 'app/enums/job-state.enum';
 import { Role } from 'app/enums/role.enum';
 import { tapOnce } from 'app/helpers/operators/tap-once.operator';
 import { WINDOW } from 'app/helpers/window.helper';
-import { CloudBackup, CloudBackupUpdate } from 'app/interfaces/cloud-backup.interface';
+import { CloudBackup } from 'app/interfaces/cloud-backup.interface';
 import { Job } from 'app/interfaces/job.interface';
 import { CardAlertBadgeComponent } from 'app/modules/alerts/components/card-alert-badge/card-alert-badge.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -218,7 +218,7 @@ export class CloudBackupCardComponent implements OnInit {
   private onChangeEnabledState(cloudBackup: CloudBackup): void {
     this.updatedCount.update((count) => count + 1);
     this.api
-      .call('cloud_backup.update', [cloudBackup.id, { enabled: !cloudBackup.enabled } as CloudBackupUpdate])
+      .call('cloud_backup.update', [cloudBackup.id, { enabled: !cloudBackup.enabled }])
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-list/cloud-backup-list.component.ts
@@ -11,7 +11,7 @@ import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { JobState } from 'app/enums/job-state.enum';
 import { Role } from 'app/enums/role.enum';
 import { tapOnce } from 'app/helpers/operators/tap-once.operator';
-import { CloudBackup, CloudBackupUpdate } from 'app/interfaces/cloud-backup.interface';
+import { CloudBackup } from 'app/interfaces/cloud-backup.interface';
 import { EmptyConfig } from 'app/interfaces/empty-config.interface';
 import { Job } from 'app/interfaces/job.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -214,7 +214,7 @@ export class CloudBackupListComponent {
 
   private onChangeEnabledState(cloudBackup: CloudBackup): void {
     this.api
-      .call('cloud_backup.update', [cloudBackup.id, { enabled: !cloudBackup.enabled } as CloudBackupUpdate])
+      .call('cloud_backup.update', [cloudBackup.id, { enabled: !cloudBackup.enabled }])
       .pipe(this.loader.withLoader(), takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => this.dataProvider().load(),

--- a/src/app/pages/data-protection/cloudsync/cloudsync-task-card/cloudsync-task-card.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-task-card/cloudsync-task-card.component.ts
@@ -19,7 +19,7 @@ import { JobState } from 'app/enums/job-state.enum';
 import { Role } from 'app/enums/role.enum';
 import { tapOnce } from 'app/helpers/operators/tap-once.operator';
 import { helptextCloudSync } from 'app/helptext/data-protection/cloudsync/cloudsync';
-import { CloudSyncTaskUi, CloudSyncTaskUpdate } from 'app/interfaces/cloud-sync-task.interface';
+import { CloudSyncTaskUi } from 'app/interfaces/cloud-sync-task.interface';
 import { Job } from 'app/interfaces/job.interface';
 import { CardAlertBadgeComponent } from 'app/modules/alerts/components/card-alert-badge/card-alert-badge.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -336,7 +336,7 @@ export class CloudSyncTaskCardComponent implements OnInit {
 
   private onChangeEnabledState(cloudsyncTask: CloudSyncTaskUi): void {
     this.api
-      .call('cloudsync.update', [cloudsyncTask.id, { enabled: !cloudsyncTask.enabled } as CloudSyncTaskUpdate])
+      .call('cloudsync.update', [cloudsyncTask.id, { enabled: !cloudsyncTask.enabled }])
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {

--- a/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-card/rsync-task-card.component.ts
@@ -19,7 +19,7 @@ import { Role } from 'app/enums/role.enum';
 import { TaskState } from 'app/enums/task-state.enum';
 import { tapOnce } from 'app/helpers/operators/tap-once.operator';
 import { Job } from 'app/interfaces/job.interface';
-import { RsyncTask, RsyncTaskUi, RsyncTaskUpdate } from 'app/interfaces/rsync-task.interface';
+import { RsyncTask, RsyncTaskUi } from 'app/interfaces/rsync-task.interface';
 import { CardAlertBadgeComponent } from 'app/modules/alerts/components/card-alert-badge/card-alert-badge.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EmptyComponent } from 'app/modules/empty/empty.component';
@@ -248,7 +248,7 @@ export class RsyncTaskCardComponent implements OnInit {
 
   private onChangeEnabledState(rsyncTask: RsyncTaskUi): void {
     this.api
-      .call('rsynctask.update', [rsyncTask.id, { enabled: !rsyncTask.enabled } as RsyncTaskUpdate])
+      .call('rsynctask.update', [rsyncTask.id, { enabled: !rsyncTask.enabled }])
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {

--- a/src/app/pages/data-protection/snapshot-task/snapshot-task-card/snapshot-task-card.component.ts
+++ b/src/app/pages/data-protection/snapshot-task/snapshot-task-card/snapshot-task-card.component.ts
@@ -214,7 +214,7 @@ export class SnapshotTaskCardComponent implements OnInit {
 
   protected onChangeEnabledState(snapshotTask: PeriodicSnapshotTaskUi): void {
     this.api
-      .call('pool.snapshottask.update', [snapshotTask.id, { enabled: !snapshotTask.enabled } as PeriodicSnapshotTaskUi])
+      .call('pool.snapshottask.update', [snapshotTask.id, { enabled: !snapshotTask.enabled }])
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         error: (error: unknown) => {

--- a/src/app/pages/data-protection/snapshot-task/snapshot-task-form/snapshot-task-form.component.ts
+++ b/src/app/pages/data-protection/snapshot-task/snapshot-task-form/snapshot-task-form.component.ts
@@ -247,7 +247,7 @@ export class SnapshotTaskFormComponent implements OnInit {
       // cspell:ignore snapshottask
       request$ = this.api.call('pool.snapshottask.update', [
         this.editingTask.id,
-        params as PeriodicSnapshotTaskUpdate,
+        params,
       ]);
     } else {
       // cspell:ignore snapshottask

--- a/src/app/pages/data-protection/snapshot-task/snapshot-task-form/snapshot-task-form.component.ts
+++ b/src/app/pages/data-protection/snapshot-task/snapshot-task-form/snapshot-task-form.component.ts
@@ -14,7 +14,6 @@ import { helptextSnapshotForm } from 'app/helptext/data-protection/snapshot/snap
 import {
   PeriodicSnapshotTask,
   PeriodicSnapshotTaskCreate,
-  PeriodicSnapshotTaskUpdate,
 } from 'app/interfaces/periodic-snapshot-task.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -190,7 +189,7 @@ export class SnapshotTaskFormComponent implements OnInit {
 
         return this.snapshotTaskService.checkUpdateWillChangeRetention(
           this.editingTask.id,
-          params as PeriodicSnapshotTaskUpdate,
+          params,
         );
       }),
       takeUntilDestroyed(this.destroyRef),

--- a/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-form/vmware-snapshot-form.component.ts
+++ b/src/app/pages/data-protection/vmware-snapshot/vmware-snapshot-form/vmware-snapshot-form.component.ts
@@ -12,7 +12,7 @@ import { extractApiErrorDetails } from 'app/helpers/api.helper';
 import { helptextVmwareSnapshot } from 'app/helptext/storage/vmware-snapshot/vmware-snapshot';
 import { Option } from 'app/interfaces/option.interface';
 import {
-  MatchDatastoresWithDatasets, VmwareDatastore, VmwareFilesystem, VmwareSnapshot, VmwareSnapshotUpdate,
+  MatchDatastoresWithDatasets, VmwareDatastore, VmwareFilesystem, VmwareSnapshot,
 } from 'app/interfaces/vmware.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -67,7 +67,7 @@ export class VmwareSnapshotFormComponent implements OnInit {
       : this.translate.instant('Edit VM Snapshot');
   }
 
-  form = this.fb.group({
+  form = this.fb.nonNullable.group({
     hostname: ['', Validators.required],
     username: ['', Validators.required],
     password: ['', Validators.required],
@@ -186,7 +186,7 @@ export class VmwareSnapshotFormComponent implements OnInit {
   }
 
   onSubmit(): void {
-    const values = this.form.value as VmwareSnapshotUpdate;
+    const values = this.form.getRawValue();
 
     this.isLoading = true;
     let request$: Observable<unknown>;

--- a/src/app/pages/services/components/service-ftp/service-ftp.component.ts
+++ b/src/app/pages/services/components/service-ftp/service-ftp.component.ts
@@ -12,7 +12,6 @@ import { Role } from 'app/enums/role.enum';
 import { invertUmask } from 'app/helpers/mode.helper';
 import { idNameArrayToOptions } from 'app/helpers/operators/options.operators';
 import { helptextServiceFtp } from 'app/helptext/services/components/service-ftp';
-import { FtpConfigUpdate } from 'app/interfaces/ftp-config.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import {
@@ -160,7 +159,7 @@ export class ServiceFtpComponent implements OnInit {
       localuserdlbw: this.convertByteToKbyte(Number(this.form.value.localuserdlbw)),
       anonuserbw: this.convertByteToKbyte(Number(this.form.value.anonuserbw)),
       anonuserdlbw: this.convertByteToKbyte(Number(this.form.value.anonuserdlbw)),
-    } as FtpConfigUpdate;
+    };
 
     this.isFormLoading.set(true);
     this.api.call('ftp.update', [values])

--- a/src/app/pages/services/components/service-snmp/service-snmp.component.ts
+++ b/src/app/pages/services/components/service-snmp/service-snmp.component.ts
@@ -8,7 +8,6 @@ import { of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { helptextServiceSnmp } from 'app/helptext/services/components/service-snmp';
-import { SnmpConfigUpdate } from 'app/interfaces/snmp-config.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -128,7 +127,7 @@ export class ServiceSnmpComponent implements OnInit {
       values.v3_privpassphrase = '';
     }
 
-    this.api.call('snmp.update', [values as SnmpConfigUpdate]).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+    this.api.call('snmp.update', [values]).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: () => {
         this.isFormLoading.set(false);
         this.snackbar.success(this.translate.instant('Service configuration saved'));

--- a/src/app/pages/services/components/service-ssh/service-ssh.component.ts
+++ b/src/app/pages/services/components/service-ssh/service-ssh.component.ts
@@ -10,7 +10,6 @@ import { Role } from 'app/enums/role.enum';
 import { SshSftpLogFacility, SshSftpLogLevel, SshWeakCipher } from 'app/enums/ssh.enum';
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { helptextServiceSsh } from 'app/helptext/services/components/service-ssh';
-import { SshConfigUpdate } from 'app/interfaces/ssh-config.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -125,7 +124,7 @@ export class ServiceSshComponent implements OnInit {
     const values = this.form.value;
 
     this.isFormLoading.set(true);
-    this.api.call('ssh.update', [values as SshConfigUpdate])
+    this.api.call('ssh.update', [values])
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {

--- a/src/app/pages/sharing/iscsi/authorized-access/authorized-access-form/authorized-access-form.component.ts
+++ b/src/app/pages/sharing/iscsi/authorized-access/authorized-access-form/authorized-access-form.component.ts
@@ -11,7 +11,7 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { IscsiAuthMethod } from 'app/enums/iscsi.enum';
 import { Role } from 'app/enums/role.enum';
 import { helptextIscsi } from 'app/helptext/sharing';
-import { IscsiAuthAccess, IscsiAuthAccessUpdate } from 'app/interfaces/iscsi.interface';
+import { IscsiAuthAccess } from 'app/interfaces/iscsi.interface';
 import { Option } from 'app/interfaces/option.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -201,7 +201,7 @@ export class AuthorizedAccessFormComponent implements OnInit {
       peeruser: values.peeruser,
       peersecret: values.peersecret,
       discovery_auth: values.discovery_auth,
-    } as IscsiAuthAccessUpdate;
+    };
 
     this.isLoading.set(true);
     const request$ = this.editingAccess

--- a/src/app/pages/sharing/iscsi/global-target-configuration/global-target-configuration.component.ts
+++ b/src/app/pages/sharing/iscsi/global-target-configuration/global-target-configuration.component.ts
@@ -14,7 +14,6 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { Role } from 'app/enums/role.enum';
 import { RdmaProtocolName, ServiceName } from 'app/enums/service-name.enum';
 import { helptextIscsi } from 'app/helptext/sharing';
-import { IscsiGlobalConfigUpdate } from 'app/interfaces/iscsi-global-config.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxChipsComponent } from 'app/modules/forms/ix-forms/components/ix-chips/ix-chips.component';
@@ -111,7 +110,7 @@ export class GlobalTargetConfigurationComponent implements OnInit {
 
   onSubmit(): void {
     this.isLoading.set(true);
-    const values = { ...this.form.value } as IscsiGlobalConfigUpdate;
+    const values = { ...this.form.value };
 
     this.api.call('iscsi.global.update', [values])
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
@@ -17,7 +17,7 @@ import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { helptextSharingNfs } from 'app/helptext/sharing';
 import { DatasetCreate } from 'app/interfaces/dataset.interface';
-import { NfsShare, NfsShareUpdate } from 'app/interfaces/nfs-share.interface';
+import { NfsShare } from 'app/interfaces/nfs-share.interface';
 import { Option } from 'app/interfaces/option.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -201,7 +201,7 @@ export class NfsFormComponent implements OnInit {
   }
 
   protected onSubmit(): void {
-    const nfsShare = { ...this.form.value } as NfsShareUpdate;
+    const nfsShare = { ...this.form.value };
 
     if (!this.isEnterprise()) {
       delete nfsShare.expose_snapshots;

--- a/src/app/pages/system/advanced/audit/audit-form/audit-form.component.ts
+++ b/src/app/pages/system/advanced/audit/audit-form/audit-form.component.ts
@@ -15,7 +15,6 @@ import {
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemAdvanced as helptext } from 'app/helptext/system/advanced';
-import { AuditConfig } from 'app/interfaces/audit/audit.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
@@ -98,7 +97,7 @@ export class AuditFormComponent implements OnInit {
   }
 
   protected onSubmit(): void {
-    const configUpdate = this.form.value as AuditConfig;
+    const configUpdate = this.form.value;
     this.isFormLoading.set(true);
     this.api.call('audit.update', [configUpdate]).pipe(
       tap(() => {

--- a/src/app/pages/system/advanced/cron/cron-form/cron-form.component.ts
+++ b/src/app/pages/system/advanced/cron/cron-form/cron-form.component.ts
@@ -8,7 +8,7 @@ import { Observable, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { helptextCron } from 'app/helptext/system/cron-form';
-import { Cronjob, CronjobUpdate } from 'app/interfaces/cronjob.interface';
+import { Cronjob } from 'app/interfaces/cronjob.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
@@ -109,7 +109,7 @@ export class CronFormComponent implements OnInit {
     const values = {
       ...this.form.getRawValue(),
       schedule: crontabToSchedule(this.form.getRawValue().schedule),
-    } as CronjobUpdate;
+    };
 
     this.isLoading.set(true);
     let request$: Observable<unknown>;

--- a/src/app/pages/system/enclosure/components/jbof-list/jbof-form/jbof-form.component.ts
+++ b/src/app/pages/system/enclosure/components/jbof-list/jbof-form/jbof-form.component.ts
@@ -7,7 +7,7 @@ import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { Observable, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
-import { Jbof, JbofUpdate } from 'app/interfaces/jbof.interface';
+import { Jbof } from 'app/interfaces/jbof.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
@@ -50,7 +50,7 @@ export class JbofFormComponent implements OnInit {
   protected isFormLoading = signal(false);
   protected editingJbof: Jbof | undefined;
 
-  form = this.fb.group({
+  form = this.fb.nonNullable.group({
     description: ['', [Validators.required]],
     mgmt_ip1: ['', [Validators.required, ipv4Validator()]],
     mgmt_ip2: ['', [ipv4Validator()]],
@@ -82,7 +82,7 @@ export class JbofFormComponent implements OnInit {
   }
 
   onSubmit(): void {
-    const values = this.form.value as JbofUpdate;
+    const values = this.form.getRawValue();
 
     this.isFormLoading.set(true);
     let request$: Observable<unknown>;

--- a/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.ts
+++ b/src/app/pages/system/general-settings/gui/gui-form/gui-form.component.ts
@@ -163,13 +163,13 @@ export class GuiFormComponent implements OnInit {
       }),
       switchMap(() => {
         this.isFormLoading.set(true);
-        return this.api.call('system.general.update', [params as SystemGeneralConfigUpdate]);
+        return this.api.call('system.general.update', [params]);
       }),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe({
       next: () => {
         this.isFormLoading.set(false);
-        this.handleServiceRestart(params as SystemGeneralConfigUpdate);
+        this.handleServiceRestart(params);
       },
       error: (error: unknown) => {
         this.isFormLoading.set(false);

--- a/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
+++ b/src/app/pages/system/general-settings/support/proactive/proactive.component.ts
@@ -10,7 +10,7 @@ import { forkJoin, of } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemSupport as helptext } from 'app/helptext/system/support';
-import { SupportConfig, SupportConfigUpdate } from 'app/modules/feedback/interfaces/file-ticket.interface';
+import { SupportConfig } from 'app/modules/feedback/interfaces/file-ticket.interface';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
@@ -85,7 +85,7 @@ export class ProactiveComponent implements OnInit {
   }
 
   protected onSubmit(): void {
-    const values = this.form.value as SupportConfigUpdate;
+    const values = this.form.value;
     this.isLoading.set(true);
 
     this.api.call('support.update', [values])

--- a/src/app/pages/system/network/components/network-configuration/network-configuration.component.ts
+++ b/src/app/pages/system/network/components/network-configuration/network-configuration.component.ts
@@ -14,7 +14,6 @@ import { helptextNetworkConfiguration } from 'app/helptext/network/configuration
 import {
   NetworkConfiguration,
   NetworkConfigurationActivity,
-  NetworkConfigurationUpdate,
 } from 'app/interfaces/network-configuration.interface';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxChipsComponent } from 'app/modules/forms/ix-forms/components/ix-chips/ix-chips.component';
@@ -364,7 +363,7 @@ export class NetworkConfigurationComponent implements OnInit {
     };
 
     this.isFormLoading.set(true);
-    this.api.call('network.configuration.update', [params] as [NetworkConfigurationUpdate])
+    this.api.call('network.configuration.update', [params])
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {

--- a/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
+++ b/src/app/pages/vm/vm-edit-form/vm-edit-form.component.ts
@@ -191,7 +191,7 @@ export class VmEditFormComponent implements OnInit {
     const gpusIds = this.form.getRawValue().gpus;
     this.gpuService.addIsolatedGpuPciIds(gpusIds).pipe(
       switchMap(() => forkJoin([
-        this.api.call('vm.update', [this.existingVm.id, vmPayload as VirtualMachineUpdate]),
+        this.api.call('vm.update', [this.existingVm.id, vmPayload]),
         this.vmGpuService.updateVmGpus(this.existingVm, gpusIds),
       ])),
       takeUntilDestroyed(this.destroyRef),

--- a/src/app/services/snapshot-task.service.ts
+++ b/src/app/services/snapshot-task.service.ts
@@ -33,7 +33,7 @@ export class SnapshotTaskService {
    */
   checkUpdateWillChangeRetention(
     taskId: number,
-    update: PeriodicSnapshotTaskUpdate,
+    update: Partial<PeriodicSnapshotTaskUpdate>,
   ): Observable<string[]> {
     // cspell:ignore snapshottask
     return this.api.call('pool.snapshottask.update_will_change_retention_for', [taskId, update]).pipe(

--- a/src/app/services/vm.service.ts
+++ b/src/app/services/vm.service.ts
@@ -14,7 +14,6 @@ import { ApiCallParams } from 'app/interfaces/api/api-call-directory.interface';
 import {
   VirtualizationDetails,
   VirtualMachine,
-  VirtualMachineUpdate,
   VmDisplayWebUriParams,
   VmDisplayWebUriParamsOptions,
 } from 'app/interfaces/virtual-machine.interface';
@@ -178,7 +177,7 @@ export class VmService {
   }
 
   toggleVmAutostart(vm: VirtualMachine): Observable<boolean> {
-    return this.api.call('vm.update', [vm.id, { autostart: !vm.autostart } as VirtualMachineUpdate])
+    return this.api.call('vm.update', [vm.id, { autostart: !vm.autostart }])
       .pipe(
         this.loader.withLoader(),
         take(1),


### PR DESCRIPTION
Testing: see ticket.

**Summary**

  - Type *.update endpoint bodies as Partial<XxxUpdate> in api-call-directory.interface.ts / api-job-directory.interface.ts to
  match what the backend actually accepts
  - Drop the now-redundant as XxxUpdate casts across ~25 components and services so TypeScript can verify field names instead of   being silenced
  - Minor correctness fixes pulled in along the way: VmwareSnapshotUpdate now excludes server-derived state; a couple of forms   switch to fb.nonNullable.group() + getRawValue()

  **Test plan**

  - yarn lint passes
  - yarn build:prod passes
  - Spot-check edit flows for representative forms: cron, NFS share, SSH service, VMware snapshot, snapshot task, cloud backup   toggle