### PR TITLE
NAS-140864 / 26.0.0-BETA.2 / Revert / relax special-vdev validation introduced in NAS-140311 to unblock ER-72 testing (by AlexKarpov98) (by bugclerk)

### DIFF
--- a/src/app/helptext/storage/volumes/pool-creation/pool-creation.ts
+++ b/src/app/helptext/storage/volumes/pool-creation/pool-creation.ts
@@ -41,6 +41,11 @@ export const helptextPoolCreation = {
   addVdevStripeSpecialWarning: T('Adding a stripe metadata VDEV introduces a single point of failure to your pool.'),
   addVdevStripeDedupWarning: T('Adding a stripe dedup VDEV introduces a single point of failure to your pool.'),
 
+  specialRedundancyMismatchWarning: T('The metadata VDEV redundancy is lower than the data VDEV redundancy. Losing this VDEV will destroy the pool.'),
+  dedupRedundancyMismatchWarning: T('The dedup VDEV redundancy is lower than the data VDEV redundancy. Losing this VDEV will destroy the pool.'),
+  specialMixedLayoutWarning: T('Mixing layouts within the metadata class is not recommended.'),
+  dedupMixedLayoutWarning: T('Mixing layouts within the dedup class is not recommended.'),
+
   // SED Encryption
   sedInfoMessage: T('SED-capable (Self-Encrypting Drive) disks detected. Hardware-based encryption provides better performance and security.'),
   sedGlobalPasswordInfo: T('The Global SED Password is a system-wide setting that applies to all pools using SED encryption.'),

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -23,6 +23,10 @@ describe('MetadataWizardStepComponent', () => {
     { name: 'sdv', size: 12000138625024 },
   ] as DetailsDisk[];
 
+  const layoutsWithoutStripeOrDraid = [
+    CreateVdevLayout.Mirror, CreateVdevLayout.Raidz1, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+  ];
+
   const makeFactory = ({
     pool = null,
     dataLayout = null,
@@ -68,11 +72,9 @@ describe('MetadataWizardStepComponent', () => {
       expect(layoutComponent.type).toStrictEqual(VDevType.Special);
     });
 
-    it('allows any layout that tolerates at least 1 drive failure', () => {
+    it('exposes Mirror, RAIDZ1, RAIDZ2 and RAIDZ3 with a 2-way Mirror floor', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([
-        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz1, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-      ]);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
       expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
@@ -81,11 +83,11 @@ describe('MetadataWizardStepComponent', () => {
   describe('when creating a new pool without a data layout chosen yet', () => {
     const createComponent = makeFactory();
 
-    it('allows any non-dRAID layout', () => {
+    it('hides Stripe and dRAID until data is set', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.canChangeLayout).toBeTruthy();
-      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
       expect(layoutComponent.minMirrorWidth).toBe(2);
     });
   });
@@ -93,13 +95,11 @@ describe('MetadataWizardStepComponent', () => {
   describe('when creating a new pool with a DRAID2 data layout', () => {
     const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2, dataWidth: 4 });
 
-    it('matches dRAID2 parity: RAIDZ2, RAIDZ3, or a 3+-way mirror', () => {
+    it('still allows Mirror + RAIDZ1/2/3 (no parity gating, no dRAID exposure)', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([
-        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-      ]);
-      expect(layoutComponent.minMirrorWidth).toBe(3);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
@@ -107,13 +107,22 @@ describe('MetadataWizardStepComponent', () => {
   describe('when creating a new pool with a 3-way mirror data layout', () => {
     const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Mirror, dataWidth: 3 });
 
-    it('raises minMirrorWidth to match the data mirror width', () => {
+    it('keeps the Mirror floor at 2-way regardless of data mirror width', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([
-        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-      ]);
-      expect(layoutComponent.minMirrorWidth).toBe(3);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
+    });
+  });
+
+  describe('when creating a new pool with a Stripe data layout', () => {
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Stripe, dataWidth: 1 });
+
+    it('exposes Stripe alongside the redundant layouts', () => {
+      spectator = createComponent();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
     });
   });
 
@@ -129,35 +138,16 @@ describe('MetadataWizardStepComponent', () => {
       } as Pool,
     });
 
-    it('matches existing data parity: RAIDZ2, RAIDZ3, or 3+-way mirror', () => {
+    it('exposes Mirror + RAIDZ1/2/3 regardless of existing data parity', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([
-        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-      ]);
-      expect(layoutComponent.minMirrorWidth).toBe(3);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
-  describe('when the lock changes with a stale store selection', () => {
-    const createComponent = makeFactory({
-      dataLayout: CreateVdevLayout.Raidz2,
-      dataWidth: 4,
-      specialLayout: CreateVdevLayout.Stripe,
-    });
-
-    it('applies the new parity lock even while the store selection is stale', () => {
-      spectator = createComponent();
-      const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([
-        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-      ]);
-      expect(layoutComponent.minMirrorWidth).toBe(3);
-    });
-  });
-
-  describe('when pool has existing special vdevs', () => {
+  describe('when pool has existing special vdevs of a different layout', () => {
     const createComponent = makeFactory({
       pool: {
         topology: {
@@ -170,10 +160,10 @@ describe('MetadataWizardStepComponent', () => {
       dataWidth: 3,
     });
 
-    it('strict-locks to the existing category layout (no parity-level fan-out)', () => {
+    it('does not lock to the existing category layout (mixing now warned, not blocked)', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
       expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.spec.ts
@@ -30,12 +30,10 @@ describe('MetadataWizardStepComponent', () => {
   const makeFactory = ({
     pool = null,
     dataLayout = null,
-    dataWidth = null,
     specialLayout = null,
   }: {
     pool?: Partial<Pool> | null;
     dataLayout?: CreateVdevLayout | null;
-    dataWidth?: number | null;
     specialLayout?: CreateVdevLayout | null;
   } = {}): SpectatorFactory<MetadataWizardStepComponent> => createComponentFactory({
     component: MetadataWizardStepComponent,
@@ -50,7 +48,7 @@ describe('MetadataWizardStepComponent', () => {
       }),
       mockProvider(PoolManagerStore, {
         topology$: of({
-          [VDevType.Data]: { layout: dataLayout, width: dataWidth },
+          [VDevType.Data]: { layout: dataLayout },
           [VDevType.Special]: { layout: specialLayout },
         } as PoolManagerTopology),
         getInventoryForStep: jest.fn(() => of(fakeInventory)),
@@ -59,7 +57,7 @@ describe('MetadataWizardStepComponent', () => {
   });
 
   describe('when creating a new pool with a RAIDZ1 data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1, dataWidth: 3 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1 });
 
     beforeEach(() => {
       spectator = createComponent();
@@ -93,7 +91,7 @@ describe('MetadataWizardStepComponent', () => {
   });
 
   describe('when creating a new pool with a DRAID2 data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2, dataWidth: 4 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2 });
 
     it('still allows Mirror + RAIDZ1/2/3 (no parity gating, no dRAID exposure)', () => {
       spectator = createComponent();
@@ -105,7 +103,7 @@ describe('MetadataWizardStepComponent', () => {
   });
 
   describe('when creating a new pool with a 3-way mirror data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Mirror, dataWidth: 3 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Mirror });
 
     it('keeps the Mirror floor at 2-way regardless of data mirror width', () => {
       spectator = createComponent();
@@ -116,7 +114,7 @@ describe('MetadataWizardStepComponent', () => {
   });
 
   describe('when creating a new pool with a Stripe data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Stripe, dataWidth: 1 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Stripe });
 
     it('exposes Stripe alongside the redundant layouts', () => {
       spectator = createComponent();
@@ -157,7 +155,6 @@ describe('MetadataWizardStepComponent', () => {
         },
       } as Pool,
       dataLayout: CreateVdevLayout.Raidz1,
-      dataWidth: 3,
     });
 
     it('does not lock to the existing category layout (mixing now warned, not blocked)', () => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.ts
@@ -55,7 +55,7 @@ export class MetadataWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    parityLock$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Special)
+    parityLock$(this.addVdevsStore.pool$, this.store.topology$)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((lock) => {
         this.allowedLayouts = lock.allowedLayouts;

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -23,6 +23,10 @@ describe('DedupWizardStepComponent', () => {
     { name: 'sdv', size: 12000138625024 },
   ] as DetailsDisk[];
 
+  const layoutsWithoutStripeOrDraid = [
+    CreateVdevLayout.Mirror, CreateVdevLayout.Raidz1, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+  ];
+
   const makeFactory = ({
     pool = null,
     dataLayout = null,
@@ -68,11 +72,9 @@ describe('DedupWizardStepComponent', () => {
       expect(layoutComponent.type).toStrictEqual(VDevType.Dedup);
     });
 
-    it('allows any layout that tolerates at least 1 drive failure', () => {
+    it('exposes Mirror, RAIDZ1, RAIDZ2 and RAIDZ3 with a 2-way Mirror floor', () => {
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([
-        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz1, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-      ]);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
       expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
@@ -81,11 +83,11 @@ describe('DedupWizardStepComponent', () => {
   describe('when creating a new pool without a data layout chosen yet', () => {
     const createComponent = makeFactory();
 
-    it('allows any non-dRAID layout', () => {
+    it('hides Stripe and dRAID until data is set', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
       expect(layoutComponent.canChangeLayout).toBeTruthy();
-      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
       expect(layoutComponent.minMirrorWidth).toBe(2);
     });
   });
@@ -93,14 +95,23 @@ describe('DedupWizardStepComponent', () => {
   describe('when creating a new pool with a DRAID2 data layout', () => {
     const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2, dataWidth: 4 });
 
-    it('matches dRAID2 parity: RAIDZ2, RAIDZ3, or a 3+-way mirror', () => {
+    it('still allows Mirror + RAIDZ1/2/3 (no parity gating, no dRAID exposure)', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([
-        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-      ]);
-      expect(layoutComponent.minMirrorWidth).toBe(3);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
+    });
+  });
+
+  describe('when creating a new pool with a Stripe data layout', () => {
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Stripe, dataWidth: 1 });
+
+    it('exposes Stripe alongside the redundant layouts', () => {
+      spectator = createComponent();
+      const layoutComponent = spectator.query(LayoutStepComponent)!;
+      expect(layoutComponent.limitLayouts).toStrictEqual([...nonDraidLayouts]);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
     });
   });
 
@@ -116,35 +127,16 @@ describe('DedupWizardStepComponent', () => {
       } as Pool,
     });
 
-    it('matches existing data parity: RAIDZ2, RAIDZ3, or 3+-way mirror', () => {
+    it('exposes Mirror + RAIDZ1/2/3 regardless of existing data parity', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([
-        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-      ]);
-      expect(layoutComponent.minMirrorWidth).toBe(3);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
+      expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });
   });
 
-  describe('when the lock changes with a stale store selection', () => {
-    const createComponent = makeFactory({
-      dataLayout: CreateVdevLayout.Raidz2,
-      dataWidth: 4,
-      dedupLayout: CreateVdevLayout.Stripe,
-    });
-
-    it('applies the new parity lock even while the store selection is stale', () => {
-      spectator = createComponent();
-      const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([
-        CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-      ]);
-      expect(layoutComponent.minMirrorWidth).toBe(3);
-    });
-  });
-
-  describe('when pool has existing dedup vdevs', () => {
+  describe('when pool has existing dedup vdevs of a different layout', () => {
     const createComponent = makeFactory({
       pool: {
         topology: {
@@ -157,10 +149,10 @@ describe('DedupWizardStepComponent', () => {
       dataWidth: 3,
     });
 
-    it('strict-locks to the existing category layout (no parity-level fan-out)', () => {
+    it('does not lock to the existing category layout (mixing now warned, not blocked)', () => {
       spectator = createComponent();
       const layoutComponent = spectator.query(LayoutStepComponent)!;
-      expect(layoutComponent.limitLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
+      expect(layoutComponent.limitLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
       expect(layoutComponent.minMirrorWidth).toBe(2);
       expect(layoutComponent.canChangeLayout).toBeTruthy();
     });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.spec.ts
@@ -30,12 +30,10 @@ describe('DedupWizardStepComponent', () => {
   const makeFactory = ({
     pool = null,
     dataLayout = null,
-    dataWidth = null,
     dedupLayout = null,
   }: {
     pool?: Partial<Pool> | null;
     dataLayout?: CreateVdevLayout | null;
-    dataWidth?: number | null;
     dedupLayout?: CreateVdevLayout | null;
   } = {}): SpectatorFactory<DedupWizardStepComponent> => createComponentFactory({
     component: DedupWizardStepComponent,
@@ -50,7 +48,7 @@ describe('DedupWizardStepComponent', () => {
       }),
       mockProvider(PoolManagerStore, {
         topology$: of({
-          [VDevType.Data]: { layout: dataLayout, width: dataWidth },
+          [VDevType.Data]: { layout: dataLayout },
           [VDevType.Dedup]: { layout: dedupLayout },
         } as PoolManagerTopology),
         getInventoryForStep: jest.fn(() => of(fakeInventory)),
@@ -59,7 +57,7 @@ describe('DedupWizardStepComponent', () => {
   });
 
   describe('when creating a new pool with a RAIDZ1 data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1, dataWidth: 3 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Raidz1 });
 
     beforeEach(() => {
       spectator = createComponent();
@@ -93,7 +91,7 @@ describe('DedupWizardStepComponent', () => {
   });
 
   describe('when creating a new pool with a DRAID2 data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2, dataWidth: 4 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Draid2 });
 
     it('still allows Mirror + RAIDZ1/2/3 (no parity gating, no dRAID exposure)', () => {
       spectator = createComponent();
@@ -105,7 +103,7 @@ describe('DedupWizardStepComponent', () => {
   });
 
   describe('when creating a new pool with a Stripe data layout', () => {
-    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Stripe, dataWidth: 1 });
+    const createComponent = makeFactory({ dataLayout: CreateVdevLayout.Stripe });
 
     it('exposes Stripe alongside the redundant layouts', () => {
       spectator = createComponent();
@@ -146,7 +144,6 @@ describe('DedupWizardStepComponent', () => {
         },
       } as Pool,
       dataLayout: CreateVdevLayout.Raidz1,
-      dataWidth: 3,
     });
 
     it('does not lock to the existing category layout (mixing now warned, not blocked)', () => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.ts
@@ -57,7 +57,7 @@ export class DedupWizardStepComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    parityLock$(this.addVdevsStore.pool$, this.store.topology$, VDevType.Dedup)
+    parityLock$(this.addVdevsStore.pool$, this.store.topology$)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((lock) => {
         this.allowedLayouts = lock.allowedLayouts;

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -3,7 +3,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { firstValueFrom, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { getTestScheduler } from 'app/core/testing/utils/get-test-scheduler.utils';
-import { CreateVdevLayout, VDevType } from 'app/enums/v-dev-type.enum';
+import { CreateVdevLayout, TopologyItemType, VDevType } from 'app/enums/v-dev-type.enum';
 import { Pool } from 'app/interfaces/pool.interface';
 import {
   AddVdevsStore,
@@ -741,6 +741,313 @@ describe('PoolManagerValidationService', () => {
         const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
         const incompleteErrors = errors.filter((err) => err.text.includes('configuration is incomplete'));
         expect(incompleteErrors).toEqual([]);
+      });
+    });
+  });
+
+  describe('redundancy-mismatch warning (NAS-140839)', () => {
+    const sharedStoreMock = {
+      name$: of('Pool'),
+      nameErrors$: of(null),
+      enclosureSettings$: of({
+        limitToSingleEnclosure: null,
+        dispersalStrategy: DispersalStrategy.None,
+      }),
+      hasMultipleEnclosuresAfterFirstStep$: of(false),
+    };
+
+    describe('when special parity is lower than data parity (new pool)', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Raidz2,
+                width: 4,
+                vdevs: [[{ devname: 'sda' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: 2,
+                vdevs: [[{ devname: 'sdb' }, { devname: 'sdc' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('emits a non-blocking metadata redundancy warning', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Warning,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'The metadata VDEV redundancy is lower than the data VDEV redundancy. Losing this VDEV will destroy the pool.',
+        });
+      });
+    });
+
+    describe('when special parity matches data parity', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Raidz2,
+                width: 4,
+                vdevs: [[{ devname: 'sda' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Raidz2,
+                width: 4,
+                vdevs: [[{ devname: 'sdb' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('does not warn', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors.find((err) => err.text.includes('redundancy is lower'))).toBeUndefined();
+      });
+    });
+
+    describe('when adding dedup to a pool with higher-redundancy data', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Dedup]: {
+                layout: CreateVdevLayout.Mirror,
+                width: 2,
+                vdevs: [[{ devname: 'sdb' }, { devname: 'sdc' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, {
+            pool$: of({
+              name: 'pool',
+              topology: {
+                [VDevType.Data]: [
+                  { type: TopologyItemType.Raidz3, children: [{}, {}, {}, {}, {}] },
+                ],
+              },
+            } as Pool),
+          }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('emits a dedup redundancy warning', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Warning,
+          step: PoolCreationWizardStep.Dedup,
+          text: 'The dedup VDEV redundancy is lower than the data VDEV redundancy. Losing this VDEV will destroy the pool.',
+        });
+      });
+    });
+
+    describe('when both data and special are stripe', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Stripe,
+                width: 1,
+                vdevs: [[{ devname: 'sda' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Stripe,
+                width: 1,
+                vdevs: [[{ devname: 'sdb' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('does not double-warn (stripe warning handles the message)', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors.find((err) => err.text.includes('redundancy is lower'))).toBeUndefined();
+      });
+    });
+  });
+
+  describe('mixed-layout warning (NAS-140839)', () => {
+    const sharedStoreMock = {
+      name$: of('Pool'),
+      nameErrors$: of(null),
+      enclosureSettings$: of({
+        limitToSingleEnclosure: null,
+        dispersalStrategy: DispersalStrategy.None,
+      }),
+      hasMultipleEnclosuresAfterFirstStep$: of(false),
+    };
+
+    describe('when adding a special vdev with a layout different from existing pool special', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Raidz1,
+                width: 3,
+                vdevs: [[{ devname: 'sdb' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, {
+            pool$: of({
+              name: 'pool',
+              topology: {
+                [VDevType.Special]: [
+                  { type: TopologyItemType.Mirror, children: [{}, {}] },
+                ],
+              },
+            } as Pool),
+          }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('emits a non-blocking mixed-layout warning', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Warning,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'Mixing layouts within the metadata class is not recommended.',
+        });
+      });
+    });
+
+    describe('when creating a new pool (no existing pool to mix against)', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Mirror,
+                width: 2,
+                vdevs: [[{ devname: 'sda' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: 2,
+                vdevs: [[{ devname: 'sdb' }, { devname: 'sdc' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('does not warn', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors.find((err) => err.text.includes('Mixing layouts'))).toBeUndefined();
+      });
+    });
+
+    describe('when the new special layout matches the existing pool special layout', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: 2,
+                vdevs: [[{ devname: 'sdb' }, { devname: 'sdc' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, {
+            pool$: of({
+              name: 'pool',
+              topology: {
+                [VDevType.Special]: [
+                  { type: TopologyItemType.Mirror, children: [{}, {}] },
+                ],
+              },
+            } as Pool),
+          }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('does not warn', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors.find((err) => err.text.includes('Mixing layouts'))).toBeUndefined();
       });
     });
   });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -1141,5 +1141,46 @@ describe('PoolManagerValidationService', () => {
         expect(errors.find((err) => err.text.includes('Mixing layouts'))).toBeUndefined();
       });
     });
+
+    describe('when adding the first special vdev to a pool with no existing special class', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: 2,
+                vdevs: [[{ devname: 'sdb' }, { devname: 'sdc' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, {
+            pool$: of({
+              name: 'pool',
+              topology: {
+                [VDevType.Data]: [
+                  { type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] },
+                ],
+              },
+            } as Pool),
+          }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('does not emit a mixed-layout warning when the existing pool has no special class', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors.find((err) => err.text.includes('Mixing layouts'))).toBeUndefined();
+      });
+    });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -1010,6 +1010,97 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
+    describe('when adding a dedup vdev with a layout different from existing pool dedup', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Dedup]: {
+                layout: CreateVdevLayout.Raidz1,
+                width: 3,
+                vdevs: [[{ devname: 'sdb' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, {
+            pool$: of({
+              name: 'pool',
+              topology: {
+                [VDevType.Dedup]: [
+                  { type: TopologyItemType.Mirror, children: [{}, {}] },
+                ],
+              },
+            } as Pool),
+          }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('emits a non-blocking dedup mixed-layout warning', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Warning,
+          step: PoolCreationWizardStep.Dedup,
+          text: 'Mixing layouts within the dedup class is not recommended.',
+        });
+      });
+    });
+
+    describe('when adding a stripe special vdev on top of an existing mirror special', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Stripe,
+                width: 1,
+                vdevs: [[{ devname: 'sdb' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, {
+            pool$: of({
+              name: 'pool',
+              topology: {
+                [VDevType.Special]: [
+                  { type: TopologyItemType.Mirror, children: [{}, {}] },
+                ],
+              },
+            } as Pool),
+          }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('only surfaces the stripe single-point-of-failure warning, not the mixed-layout one', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors.find((err) => err.text.includes('Mixing layouts'))).toBeUndefined();
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.ErrorWarning,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'Adding a stripe metadata VDEV introduces a single point of failure to your pool.',
+        });
+      });
+    });
+
     describe('when the new special layout matches the existing pool special layout', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -27,7 +27,9 @@ import {
   PoolManagerTopologyCategory,
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
 import { hasExportedPool, hasNonUniqueSerial } from 'app/pages/storage/modules/pool-manager/utils/disk.utils';
-import { isDraidLayout } from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
+import {
+  existingVdevLayout, isDraidLayout, layoutParity, resolveTopologyLayout,
+} from 'app/pages/storage/modules/pool-manager/utils/topology.utils';
 import { AppState } from 'app/store';
 import { selectHasEnclosureSupport } from 'app/store/system-info/system-info.selectors';
 
@@ -71,6 +73,8 @@ export class PoolManagerValidationService {
         } else {
           errors.push(...this.validateAddVdevs(topology));
         }
+        errors.push(...this.validateRedundancyMismatch(topology, existingPool));
+        errors.push(...this.validateMixedSpecialLayout(topology, existingPool));
         errors.push(...this.validateIncompleteCategories(topology));
 
         return uniqBy(errors, 'text')
@@ -396,5 +400,118 @@ export class PoolManagerValidationService {
     }
 
     return errors;
+  }
+
+  /**
+   * NAS-140839 / ER-72 — special and dedup vdevs may now be created with any
+   * non-stripe redundancy regardless of the data vdev's parity. When the
+   * special/dedup parity is lower than data parity, surface a non-blocking
+   * warning so the user is aware that losing the metadata vdev would still
+   * destroy the pool.
+   */
+  private validateRedundancyMismatch(
+    topology: PoolManagerTopology,
+    existingPool: Pool | null,
+  ): PoolCreationError[] {
+    const errors: PoolCreationError[] = [];
+    const dataParity = this.resolveDataParity(topology, existingPool);
+    if (dataParity === null) {
+      return errors;
+    }
+
+    const ruleByType = {
+      [VDevType.Special]: {
+        text: helptextPoolCreation.specialRedundancyMismatchWarning,
+        step: PoolCreationWizardStep.Metadata,
+      },
+      [VDevType.Dedup]: {
+        text: helptextPoolCreation.dedupRedundancyMismatchWarning,
+        step: PoolCreationWizardStep.Dedup,
+      },
+    } as const;
+
+    ([VDevType.Special, VDevType.Dedup] as const).forEach((vdevType) => {
+      const category = topology[vdevType];
+      if (!category?.vdevs.length || !category.layout) {
+        return;
+      }
+      // Stripe is handled by validateStripeVdevsWarning / validateAddVdevRedundancy
+      // with its own dedicated message; don't double-warn here.
+      if (category.layout === CreateVdevLayout.Stripe) {
+        return;
+      }
+      const categoryParity = layoutParity(category.layout, category.width ?? 2);
+      if (categoryParity < dataParity) {
+        errors.push({
+          text: this.translate.instant(ruleByType[vdevType].text),
+          severity: PoolCreationSeverity.Warning,
+          step: ruleByType[vdevType].step,
+        });
+      }
+    });
+
+    return errors;
+  }
+
+  /**
+   * NAS-140839 / ER-72 — adding a special/dedup vdev whose layout differs from
+   * the existing pool's special/dedup layout is allowed but warned about. The
+   * topology category carries a single layout, so mixing can only arise in the
+   * add-vdev flow against an already-populated pool category.
+   */
+  private validateMixedSpecialLayout(
+    topology: PoolManagerTopology,
+    existingPool: Pool | null,
+  ): PoolCreationError[] {
+    const errors: PoolCreationError[] = [];
+    if (!existingPool) {
+      return errors;
+    }
+
+    const ruleByType = {
+      [VDevType.Special]: {
+        text: helptextPoolCreation.specialMixedLayoutWarning,
+        step: PoolCreationWizardStep.Metadata,
+      },
+      [VDevType.Dedup]: {
+        text: helptextPoolCreation.dedupMixedLayoutWarning,
+        step: PoolCreationWizardStep.Dedup,
+      },
+    } as const;
+
+    ([VDevType.Special, VDevType.Dedup] as const).forEach((vdevType) => {
+      const category = topology[vdevType];
+      if (!category?.vdevs.length || !category.layout) {
+        return;
+      }
+      const existingLayout = existingVdevLayout(existingPool.topology?.[vdevType]);
+      if (existingLayout !== null && existingLayout !== category.layout) {
+        errors.push({
+          text: this.translate.instant(ruleByType[vdevType].text),
+          severity: PoolCreationSeverity.Warning,
+          step: ruleByType[vdevType].step,
+        });
+      }
+    });
+
+    return errors;
+  }
+
+  private resolveDataParity(topology: PoolManagerTopology, existingPool: Pool | null): number | null {
+    const existingDataVdevs = existingPool?.topology?.[VDevType.Data];
+    if (existingDataVdevs?.length) {
+      const layout = resolveTopologyLayout(existingDataVdevs);
+      if (layout === null) {
+        return null;
+      }
+      const width = existingDataVdevs[0].children?.length ?? 2;
+      return layoutParity(layout, width);
+    }
+
+    const dataCategory = topology[VDevType.Data];
+    if (dataCategory?.layout) {
+      return layoutParity(dataCategory.layout, dataCategory.width ?? 2);
+    }
+    return null;
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -41,6 +41,38 @@ const incompleteCategoryRules: { vdevType: VDevType; step: PoolCreationWizardSte
   { vdevType: VDevType.Dedup, step: PoolCreationWizardStep.Dedup },
 ];
 
+type AllocClassVdev = VDevType.Special | VDevType.Dedup;
+const allocClassVdevs: readonly AllocClassVdev[] = [VDevType.Special, VDevType.Dedup];
+
+interface AllocClassRule {
+  step: PoolCreationWizardStep;
+  redundancyMismatchText: string;
+  mixedLayoutText: string;
+}
+
+const allocClassRules: Record<AllocClassVdev, AllocClassRule> = {
+  [VDevType.Special]: {
+    step: PoolCreationWizardStep.Metadata,
+    redundancyMismatchText: helptextPoolCreation.specialRedundancyMismatchWarning,
+    mixedLayoutText: helptextPoolCreation.specialMixedLayoutWarning,
+  },
+  [VDevType.Dedup]: {
+    step: PoolCreationWizardStep.Dedup,
+    redundancyMismatchText: helptextPoolCreation.dedupRedundancyMismatchWarning,
+    mixedLayoutText: helptextPoolCreation.dedupMixedLayoutWarning,
+  },
+};
+
+/**
+ * Mirror parity = width - 1, so width must be set before parity can be
+ * compared. Other layouts (Stripe, RAIDZN, dRAIDN) have layout-determined
+ * parity and can be compared eagerly. Returning false defers the warning
+ * until the user picks a width.
+ */
+function isMirrorParityKnown(layout: CreateVdevLayout, width: number | null | undefined): boolean {
+  return layout !== CreateVdevLayout.Mirror || width != null;
+}
+
 @Injectable()
 export class PoolManagerValidationService {
   protected store = inject(PoolManagerStore);
@@ -73,7 +105,7 @@ export class PoolManagerValidationService {
           errors.push(...this.validateAddVdevs(topology));
         }
         errors.push(...this.validateRedundancyMismatch(topology, existingPool));
-        errors.push(...this.validateMixedSpecialLayout(topology, existingPool));
+        errors.push(...this.validateMixedAllocClassLayout(topology, existingPool));
         errors.push(...this.validateIncompleteCategories(topology));
 
         return uniqBy(errors, 'text')
@@ -418,18 +450,7 @@ export class PoolManagerValidationService {
       return errors;
     }
 
-    const ruleByType = {
-      [VDevType.Special]: {
-        text: helptextPoolCreation.specialRedundancyMismatchWarning,
-        step: PoolCreationWizardStep.Metadata,
-      },
-      [VDevType.Dedup]: {
-        text: helptextPoolCreation.dedupRedundancyMismatchWarning,
-        step: PoolCreationWizardStep.Dedup,
-      },
-    } as const;
-
-    ([VDevType.Special, VDevType.Dedup] as const).forEach((vdevType) => {
+    allocClassVdevs.forEach((vdevType) => {
       const category = topology[vdevType];
       if (!category?.vdevs.length || !category.layout) {
         return;
@@ -439,17 +460,16 @@ export class PoolManagerValidationService {
       if (category.layout === CreateVdevLayout.Stripe) {
         return;
       }
-      // Mirror parity depends on width. Until the user has chosen one, defer
-      // the warning rather than fixing parity at the unconstrained floor of 2.
-      if (category.layout === CreateVdevLayout.Mirror && category.width == null) {
+      if (!isMirrorParityKnown(category.layout, category.width)) {
         return;
       }
       const categoryParity = layoutParity(category.layout, category.width ?? 2);
       if (categoryParity < dataParity) {
+        const rule = allocClassRules[vdevType];
         errors.push({
-          text: this.translate.instant(ruleByType[vdevType].text),
+          text: this.translate.instant(rule.redundancyMismatchText),
           severity: PoolCreationSeverity.Warning,
-          step: ruleByType[vdevType].step,
+          step: rule.step,
         });
       }
     });
@@ -463,7 +483,7 @@ export class PoolManagerValidationService {
    * topology category carries a single layout, so mixing can only arise in the
    * add-vdev flow against an already-populated pool category.
    */
-  private validateMixedSpecialLayout(
+  private validateMixedAllocClassLayout(
     topology: PoolManagerTopology,
     existingPool: Pool | null,
   ): PoolCreationError[] {
@@ -472,18 +492,7 @@ export class PoolManagerValidationService {
       return errors;
     }
 
-    const ruleByType = {
-      [VDevType.Special]: {
-        text: helptextPoolCreation.specialMixedLayoutWarning,
-        step: PoolCreationWizardStep.Metadata,
-      },
-      [VDevType.Dedup]: {
-        text: helptextPoolCreation.dedupMixedLayoutWarning,
-        step: PoolCreationWizardStep.Dedup,
-      },
-    } as const;
-
-    ([VDevType.Special, VDevType.Dedup] as const).forEach((vdevType) => {
+    allocClassVdevs.forEach((vdevType) => {
       const category = topology[vdevType];
       if (!category?.vdevs.length || !category.layout) {
         return;
@@ -495,10 +504,11 @@ export class PoolManagerValidationService {
       }
       const existingLayout = existingVdevLayout(existingPool.topology?.[vdevType]);
       if (existingLayout !== null && existingLayout !== category.layout) {
+        const rule = allocClassRules[vdevType];
         errors.push({
-          text: this.translate.instant(ruleByType[vdevType].text),
+          text: this.translate.instant(rule.mixedLayoutText),
           severity: PoolCreationSeverity.Warning,
-          step: ruleByType[vdevType].step,
+          step: rule.step,
         });
       }
     });
@@ -524,9 +534,7 @@ export class PoolManagerValidationService {
     if (!dataCategory?.layout) {
       return null;
     }
-    // Mirror parity depends on width; if the user hasn't picked one yet,
-    // defer parity resolution rather than locking it to the width-2 floor.
-    if (dataCategory.layout === CreateVdevLayout.Mirror && dataCategory.width == null) {
+    if (!isMirrorParityKnown(dataCategory.layout, dataCategory.width)) {
       return null;
     }
     return layoutParity(dataCategory.layout, dataCategory.width ?? 2);

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -64,13 +64,21 @@ const allocClassRules: Record<AllocClassVdev, AllocClassRule> = {
 };
 
 /**
- * Mirror parity = width - 1, so width must be set before parity can be
- * compared. Other layouts (Stripe, RAIDZN, dRAIDN) have layout-determined
- * parity and can be compared eagerly. Returning false defers the warning
- * until the user picks a width.
+ * Layout parity (drive failures the layout can survive) for the given width,
+ * or null when parity cannot yet be determined. Currently only Mirror without
+ * a chosen width yields null — Stripe, RAIDZN and dRAIDN are layout-determined
+ * and parity for them is independent of width. Sharing this between the data
+ * resolver and the per-category check keeps both deferring on identical
+ * conditions.
  */
-function isMirrorParityKnown(layout: CreateVdevLayout, width: number | null | undefined): boolean {
-  return layout !== CreateVdevLayout.Mirror || width != null;
+function parityFromLayoutWidth(
+  layout: CreateVdevLayout,
+  width: number | null | undefined,
+): number | null {
+  if (layout === CreateVdevLayout.Mirror && width == null) {
+    return null;
+  }
+  return layoutParity(layout, width ?? 0);
 }
 
 @Injectable()
@@ -446,7 +454,10 @@ export class PoolManagerValidationService {
   ): PoolCreationError[] {
     const errors: PoolCreationError[] = [];
     const dataParity = this.resolveDataParity(topology, existingPool);
-    if (dataParity === null) {
+    // dataParity === 0 means data is Stripe; nothing can be lower than 0, so
+    // skipping the loop is equivalent to running it but makes the intent
+    // explicit (and avoids implying Stripe data ever produces a mismatch).
+    if (dataParity === null || dataParity <= 0) {
       return errors;
     }
 
@@ -460,10 +471,10 @@ export class PoolManagerValidationService {
       if (category.layout === CreateVdevLayout.Stripe) {
         return;
       }
-      if (!isMirrorParityKnown(category.layout, category.width)) {
+      const categoryParity = parityFromLayoutWidth(category.layout, category.width);
+      if (categoryParity === null) {
         return;
       }
-      const categoryParity = layoutParity(category.layout, category.width ?? 2);
       if (categoryParity < dataParity) {
         const rule = allocClassRules[vdevType];
         errors.push({
@@ -497,8 +508,11 @@ export class PoolManagerValidationService {
       if (!category?.vdevs.length || !category.layout) {
         return;
       }
-      // Stripe is handled by validateAddVdevRedundancy with its own dedicated
-      // single-point-of-failure message; don't double-warn here.
+      // Asymmetric skip: only suppress when the *new* category is Stripe —
+      // that case already gets validateAddVdevRedundancy's dedicated SPOF
+      // message and we don't want to double-warn. If the existing pool's
+      // class is Stripe and the new vdev is non-stripe, mixing within an
+      // existing Stripe class is itself a real concern, so we still warn.
       if (category.layout === CreateVdevLayout.Stripe) {
         return;
       }
@@ -525,18 +539,20 @@ export class PoolManagerValidationService {
       }
       // Existing pool vdevs always carry a children list; the fallback only
       // guards against malformed payloads and is irrelevant for non-Mirror
-      // layouts where parity is layout-determined.
+      // layouts where parity is layout-determined. Note that a malformed
+      // payload could mask a backend bug as a 2-disk Mirror (parity 1).
       const width = existingDataVdevs[0].children?.length ?? 2;
       return layoutParity(layout, width);
     }
 
+    // Existing pool with an empty data array (or no existing pool) falls
+    // through to the wizard category. In add-vdev mode the wizard's data
+    // category is unset, so we return null and the mismatch warning is
+    // suppressed until parity can actually be resolved.
     const dataCategory = topology[VDevType.Data];
     if (!dataCategory?.layout) {
       return null;
     }
-    if (!isMirrorParityKnown(dataCategory.layout, dataCategory.width)) {
-      return null;
-    }
-    return layoutParity(dataCategory.layout, dataCategory.width ?? 2);
+    return parityFromLayoutWidth(dataCategory.layout, dataCategory.width);
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -48,7 +48,6 @@ export class PoolManagerValidationService {
   protected translate = inject(TranslateService);
   private addVdevsStore = inject(AddVdevsStore);
 
-
   exportedPoolsWarning = this.translate.instant(helptextPoolCreation.exportedSelectedDisksWarning);
 
   readonly poolCreationErrors$ = combineLatest([
@@ -440,6 +439,11 @@ export class PoolManagerValidationService {
       if (category.layout === CreateVdevLayout.Stripe) {
         return;
       }
+      // Mirror parity depends on width. Until the user has chosen one, defer
+      // the warning rather than fixing parity at the unconstrained floor of 2.
+      if (category.layout === CreateVdevLayout.Mirror && category.width == null) {
+        return;
+      }
       const categoryParity = layoutParity(category.layout, category.width ?? 2);
       if (categoryParity < dataParity) {
         errors.push({
@@ -484,6 +488,11 @@ export class PoolManagerValidationService {
       if (!category?.vdevs.length || !category.layout) {
         return;
       }
+      // Stripe is handled by validateAddVdevRedundancy with its own dedicated
+      // single-point-of-failure message; don't double-warn here.
+      if (category.layout === CreateVdevLayout.Stripe) {
+        return;
+      }
       const existingLayout = existingVdevLayout(existingPool.topology?.[vdevType]);
       if (existingLayout !== null && existingLayout !== category.layout) {
         errors.push({
@@ -504,14 +513,22 @@ export class PoolManagerValidationService {
       if (layout === null) {
         return null;
       }
+      // Existing pool vdevs always carry a children list; the fallback only
+      // guards against malformed payloads and is irrelevant for non-Mirror
+      // layouts where parity is layout-determined.
       const width = existingDataVdevs[0].children?.length ?? 2;
       return layoutParity(layout, width);
     }
 
     const dataCategory = topology[VDevType.Data];
-    if (dataCategory?.layout) {
-      return layoutParity(dataCategory.layout, dataCategory.width ?? 2);
+    if (!dataCategory?.layout) {
+      return null;
     }
-    return null;
+    // Mirror parity depends on width; if the user hasn't picked one yet,
+    // defer parity resolution rather than locking it to the width-2 floor.
+    if (dataCategory.layout === CreateVdevLayout.Mirror && dataCategory.width == null) {
+      return null;
+    }
+    return layoutParity(dataCategory.layout, dataCategory.width ?? 2);
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -10,7 +10,6 @@ import {
   layoutParity,
   nonDraidEquivalent,
   nonDraidLayouts,
-  parityLockForMinParity,
   parseDraidVdevName,
   resolveParityLock,
   resolveTopologyLayout,
@@ -244,131 +243,69 @@ describe('layoutParity', () => {
   });
 });
 
-describe('parityLockForMinParity', () => {
-  it('allows all non-dRAID layouts when minParity is 0', () => {
-    const lock = parityLockForMinParity(0);
-    expect(lock.allowedLayouts).toStrictEqual([...nonDraidLayouts]);
-    expect(lock.minMirrorWidth).toBe(2);
-  });
-
-  it('drops Stripe and keeps Mirror + RAIDZ1/2/3 at minParity 1', () => {
-    const lock = parityLockForMinParity(1);
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz1, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(2);
-  });
-
-  it('keeps Mirror + RAIDZ2/3 and raises minMirrorWidth at minParity 2', () => {
-    const lock = parityLockForMinParity(2);
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(3);
-  });
-
-  it('keeps only Mirror + RAIDZ3 and requires 4-wide mirror at minParity 3', () => {
-    const lock = parityLockForMinParity(3);
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(4);
-  });
-});
-
 describe('resolveParityLock', () => {
   const mirror2Vdev = [{ type: TopologyItemType.Mirror, children: [{}, {}] }] as VDevItem[];
-  const mirror3Vdev = [{ type: TopologyItemType.Mirror, children: [{}, {}, {}] }] as VDevItem[];
   const raidz2Vdev = [{ type: TopologyItemType.Raidz2, children: [{}, {}, {}, {}] }] as VDevItem[];
-  const draid2Vdev = [{
-    type: TopologyItemType.Draid, children: [], name: 'draid2:1d:6c:2s-0',
-  }] as VDevItem[];
+  const stripeVdev = [{ type: TopologyItemType.Disk, children: [] }] as VDevItem[];
+  const layoutsWithoutStripeOrDraid = [
+    CreateVdevLayout.Mirror, CreateVdevLayout.Raidz1, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
+  ];
 
-  it('prefers existing category layout over everything else (strict single-layout match)', () => {
-    const lock = resolveParityLock(
-      mirror2Vdev,
-      raidz2Vdev,
-      { layout: CreateVdevLayout.Raidz3, width: 5 },
-    );
-    expect(lock.allowedLayouts).toStrictEqual([CreateVdevLayout.Mirror]);
+  it('returns Mirror + RAIDZ1/2/3 (no Stripe, no dRAID) when data is non-stripe', () => {
+    const lock = resolveParityLock(raidz2Vdev, { layout: null, width: null });
+    expect(lock.allowedLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
     expect(lock.minMirrorWidth).toBe(2);
   });
 
-  it('falls back to existing data parity when category is empty', () => {
-    const lock = resolveParityLock(undefined, raidz2Vdev, { layout: CreateVdevLayout.Raidz1, width: 3 });
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(3);
-  });
-
-  it('derives parity from existing data mirror width', () => {
-    const lock = resolveParityLock(undefined, mirror3Vdev, { layout: null, width: null });
-    // 3-way mirror tolerates 2 failures -> minParity 2
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(3);
-  });
-
-  it('treats existing data dRAID as its raidz parity equivalent', () => {
-    const lock = resolveParityLock(undefined, draid2Vdev, { layout: null, width: null });
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(3);
-  });
-
-  it('locks to existing category dRAID as its non-dRAID equivalent', () => {
-    const lock = resolveParityLock(draid2Vdev, undefined, { layout: null, width: null });
-    expect(lock.allowedLayouts).toStrictEqual([CreateVdevLayout.Raidz2]);
+  it('keeps Mirror always at 2-way regardless of data mirror width', () => {
+    const mirror4Vdev = [{ type: TopologyItemType.Mirror, children: [{}, {}, {}, {}] }] as VDevItem[];
+    const lock = resolveParityLock(mirror4Vdev, { layout: null, width: null });
+    expect(lock.allowedLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
     expect(lock.minMirrorWidth).toBe(2);
   });
 
-  it('uses wizard layout and width when no existing topology is present', () => {
-    const lock = resolveParityLock(undefined, undefined, { layout: CreateVdevLayout.Raidz2, width: 4 });
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(3);
+  it('allows RAIDZ1 even when data is RAIDZ3', () => {
+    const raidz3Vdev = [{ type: TopologyItemType.Raidz3, children: [{}, {}, {}, {}, {}] }] as VDevItem[];
+    const lock = resolveParityLock(raidz3Vdev, { layout: null, width: null });
+    expect(lock.allowedLayouts).toContain(CreateVdevLayout.Raidz1);
+    expect(lock.allowedLayouts).toContain(CreateVdevLayout.Mirror);
+    expect(lock.minMirrorWidth).toBe(2);
   });
 
-  it('derives parity from wizard mirror width', () => {
-    const lock = resolveParityLock(undefined, undefined, { layout: CreateVdevLayout.Mirror, width: 4 });
-    // 4-way mirror tolerates 3 failures -> minParity 3
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(4);
+  it('falls back to wizard data layout when no existing data is present', () => {
+    const lock = resolveParityLock(undefined, { layout: CreateVdevLayout.Raidz2, width: 4 });
+    expect(lock.allowedLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
+    expect(lock.minMirrorWidth).toBe(2);
   });
 
-  it('leaves the lock unconstrained when wizard mirror width is not yet set', () => {
-    const lock = resolveParityLock(undefined, undefined, { layout: CreateVdevLayout.Mirror, width: null });
+  it('still hides dRAID layouts even when wizard data is dRAID', () => {
+    const lock = resolveParityLock(undefined, { layout: CreateVdevLayout.Draid3, width: 10 });
+    expect(lock.allowedLayouts).not.toContain(CreateVdevLayout.Draid1);
+    expect(lock.allowedLayouts).not.toContain(CreateVdevLayout.Draid2);
+    expect(lock.allowedLayouts).not.toContain(CreateVdevLayout.Draid3);
+  });
+
+  it('hides Stripe when neither existing nor wizard data is Stripe', () => {
+    const lock = resolveParityLock(mirror2Vdev, { layout: null, width: null });
+    expect(lock.allowedLayouts).not.toContain(CreateVdevLayout.Stripe);
+  });
+
+  it('hides Stripe when nothing is set yet', () => {
+    const lock = resolveParityLock(undefined, { layout: null, width: null });
+    expect(lock.allowedLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
+    expect(lock.minMirrorWidth).toBe(2);
+  });
+
+  it('exposes Stripe only when existing data is Stripe', () => {
+    const lock = resolveParityLock(stripeVdev, { layout: null, width: null });
     expect(lock.allowedLayouts).toStrictEqual([...nonDraidLayouts]);
     expect(lock.minMirrorWidth).toBe(2);
   });
 
-  it('maps wizard dRAID layout to its raidz parity equivalent', () => {
-    const lock = resolveParityLock(undefined, undefined, { layout: CreateVdevLayout.Draid3, width: 5 });
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(4);
-  });
-
-  it('returns a fully permissive lock when nothing is set', () => {
-    const lock = resolveParityLock(undefined, undefined, { layout: null, width: null });
+  it('exposes Stripe when wizard data is Stripe and no pool exists yet', () => {
+    const lock = resolveParityLock(undefined, { layout: CreateVdevLayout.Stripe, width: 1 });
     expect(lock.allowedLayouts).toStrictEqual([...nonDraidLayouts]);
     expect(lock.minMirrorWidth).toBe(2);
-  });
-
-  it('ignores an existing Stripe category (misconfigured pool) and falls through to data parity', () => {
-    const stripeVdev = [{ type: TopologyItemType.Disk, children: [] }] as VDevItem[];
-    const lock = resolveParityLock(stripeVdev, raidz2Vdev, { layout: null, width: null });
-    expect(lock.allowedLayouts).toStrictEqual([
-      CreateVdevLayout.Mirror, CreateVdevLayout.Raidz2, CreateVdevLayout.Raidz3,
-    ]);
-    expect(lock.minMirrorWidth).toBe(3);
   });
 });
 

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.spec.ts
@@ -252,58 +252,58 @@ describe('resolveParityLock', () => {
   ];
 
   it('returns Mirror + RAIDZ1/2/3 (no Stripe, no dRAID) when data is non-stripe', () => {
-    const lock = resolveParityLock(raidz2Vdev, { layout: null, width: null });
+    const lock = resolveParityLock(raidz2Vdev, { layout: null });
     expect(lock.allowedLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
     expect(lock.minMirrorWidth).toBe(2);
   });
 
   it('keeps Mirror always at 2-way regardless of data mirror width', () => {
     const mirror4Vdev = [{ type: TopologyItemType.Mirror, children: [{}, {}, {}, {}] }] as VDevItem[];
-    const lock = resolveParityLock(mirror4Vdev, { layout: null, width: null });
+    const lock = resolveParityLock(mirror4Vdev, { layout: null });
     expect(lock.allowedLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
     expect(lock.minMirrorWidth).toBe(2);
   });
 
   it('allows RAIDZ1 even when data is RAIDZ3', () => {
     const raidz3Vdev = [{ type: TopologyItemType.Raidz3, children: [{}, {}, {}, {}, {}] }] as VDevItem[];
-    const lock = resolveParityLock(raidz3Vdev, { layout: null, width: null });
+    const lock = resolveParityLock(raidz3Vdev, { layout: null });
     expect(lock.allowedLayouts).toContain(CreateVdevLayout.Raidz1);
     expect(lock.allowedLayouts).toContain(CreateVdevLayout.Mirror);
     expect(lock.minMirrorWidth).toBe(2);
   });
 
   it('falls back to wizard data layout when no existing data is present', () => {
-    const lock = resolveParityLock(undefined, { layout: CreateVdevLayout.Raidz2, width: 4 });
+    const lock = resolveParityLock(undefined, { layout: CreateVdevLayout.Raidz2 });
     expect(lock.allowedLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
     expect(lock.minMirrorWidth).toBe(2);
   });
 
   it('still hides dRAID layouts even when wizard data is dRAID', () => {
-    const lock = resolveParityLock(undefined, { layout: CreateVdevLayout.Draid3, width: 10 });
+    const lock = resolveParityLock(undefined, { layout: CreateVdevLayout.Draid3 });
     expect(lock.allowedLayouts).not.toContain(CreateVdevLayout.Draid1);
     expect(lock.allowedLayouts).not.toContain(CreateVdevLayout.Draid2);
     expect(lock.allowedLayouts).not.toContain(CreateVdevLayout.Draid3);
   });
 
   it('hides Stripe when neither existing nor wizard data is Stripe', () => {
-    const lock = resolveParityLock(mirror2Vdev, { layout: null, width: null });
+    const lock = resolveParityLock(mirror2Vdev, { layout: null });
     expect(lock.allowedLayouts).not.toContain(CreateVdevLayout.Stripe);
   });
 
   it('hides Stripe when nothing is set yet', () => {
-    const lock = resolveParityLock(undefined, { layout: null, width: null });
+    const lock = resolveParityLock(undefined, { layout: null });
     expect(lock.allowedLayouts).toStrictEqual(layoutsWithoutStripeOrDraid);
     expect(lock.minMirrorWidth).toBe(2);
   });
 
   it('exposes Stripe only when existing data is Stripe', () => {
-    const lock = resolveParityLock(stripeVdev, { layout: null, width: null });
+    const lock = resolveParityLock(stripeVdev, { layout: null });
     expect(lock.allowedLayouts).toStrictEqual([...nonDraidLayouts]);
     expect(lock.minMirrorWidth).toBe(2);
   });
 
   it('exposes Stripe when wizard data is Stripe and no pool exists yet', () => {
-    const lock = resolveParityLock(undefined, { layout: CreateVdevLayout.Stripe, width: 1 });
+    const lock = resolveParityLock(undefined, { layout: CreateVdevLayout.Stripe });
     expect(lock.allowedLayouts).toStrictEqual([...nonDraidLayouts]);
     expect(lock.minMirrorWidth).toBe(2);
   });

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -209,20 +209,16 @@ export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(Create
 
 /**
  * Constraint on the Layout + Width controls for a special/dedup vdev.
- * Expressed as the set of layouts the user may pick plus a minimum Mirror
- * width, rather than a single locked layout, so that any layout matching the
- * data vdev's parity level is allowed (e.g. a 3-way mirror alongside RAIDZ2).
+ * After NAS-140839 the lock is intentionally permissive: any non-dRAID layout
+ * is allowed regardless of the data vdev's redundancy, with Stripe gated only
+ * on the data vdev also being Stripe. Lower-redundancy choices surface as
+ * non-blocking warnings in PoolManagerValidationService.
  */
 export interface ParityLock {
   allowedLayouts: readonly CreateVdevLayout[];
   /** Applies only when Mirror is selected. `2` is the effective floor. */
   minMirrorWidth: number;
 }
-
-const unconstrainedParityLock: ParityLock = {
-  allowedLayouts: nonDraidLayouts,
-  minMirrorWidth: 2,
-};
 
 /**
  * Number of simultaneous drive failures `layout` at the given width can
@@ -243,80 +239,39 @@ export function layoutParity(layout: CreateVdevLayout, width: number): number {
 }
 
 /**
- * ParityLock admitting every non-dRAID layout that can tolerate at least
- * `minParity` drive failures. Mirror is always in the set but gated by
- * `minMirrorWidth` (width-1 >= minParity).
+ * Resolves the parity lock for a special or dedup vdev. ER-72 requires that
+ * Mirror, RAIDZ1, RAIDZ2 and RAIDZ3 are always selectable regardless of the
+ * data vdev's layout — the wizard no longer enforces parity matching at the
+ * dropdown level. Stripe remains gated on the data vdev also being Stripe so
+ * a no-redundancy metadata vdev can't be silently introduced. dRAID is never
+ * offered (ZFS doesn't support it for special/dedup).
  */
-export function parityLockForMinParity(minParity: number): ParityLock {
-  const allowedLayouts = nonDraidLayouts.filter((layout) => {
-    if (layout === CreateVdevLayout.Mirror) {
-      return true;
-    }
-    return layoutParity(layout, 0) >= minParity;
-  });
+export function resolveParityLock(
+  existingData: VDevItem[] | undefined,
+  wizardData: { layout: CreateVdevLayout | null; width: number | null } | undefined,
+): ParityLock {
+  const dataLayout = resolveTopologyLayout(existingData) ?? wizardData?.layout ?? null;
+  const allowStripe = dataLayout === CreateVdevLayout.Stripe;
+
+  const allowedLayouts = nonDraidLayouts.filter((layout) => allowStripe || layout !== CreateVdevLayout.Stripe);
+
   return {
     allowedLayouts,
-    minMirrorWidth: Math.max(2, minParity + 1),
+    minMirrorWidth: 2,
   };
 }
 
 /**
- * Resolves the parity lock for a special or dedup vdev. These vdevs' failure
- * destroys the whole pool, so their redundancy must be at least the data
- * vdev's. Preference order:
- *   1. Existing special/dedup layout (pool already has vdevs in this category;
- *      the new vdev must match exactly — pools don't mix layouts inside a
- *      category).
- *   2. Existing data layout (pool has data vdevs; match their parity level).
- *   3. Wizard-selected data layout and width (new pool; match parity).
- * Returns the fully permissive lock when none are set (e.g. user jumps to the
- * step before picking a data layout).
- */
-export function resolveParityLock(
-  existingCategory: VDevItem[] | undefined,
-  existingData: VDevItem[] | undefined,
-  wizardData: { layout: CreateVdevLayout | null; width: number | null } | undefined,
-): ParityLock {
-  // A Stripe special/dedup vdev would be a misconfigured pool (no redundancy
-  // where it's required). Ignore it and fall through to data-parity so we
-  // don't "lock" a new vdev into a no-redundancy layout.
-  const categoryLayout = existingVdevLayout(existingCategory);
-  if (categoryLayout !== null && categoryLayout !== CreateVdevLayout.Stripe) {
-    return { allowedLayouts: [categoryLayout], minMirrorWidth: 2 };
-  }
-
-  if (existingData?.length) {
-    const layout = resolveTopologyLayout(existingData);
-    if (layout !== null) {
-      const width = existingData[0].children?.length ?? 2;
-      return parityLockForMinParity(layoutParity(layout, width));
-    }
-  }
-
-  if (wizardData?.layout) {
-    // Mirror parity depends on width; if width isn't picked yet, don't lock.
-    if (wizardData.layout === CreateVdevLayout.Mirror && !wizardData.width) {
-      return unconstrainedParityLock;
-    }
-    return parityLockForMinParity(layoutParity(wizardData.layout, wizardData.width ?? 2));
-  }
-
-  return unconstrainedParityLock;
-}
-
-/**
- * Emits the parity lock for the given special/dedup category. Shared by the
- * metadata and dedup wizard steps so both react to the same set of inputs
- * (existing pool topology, wizard data layout + width) in the same way.
+ * Emits the parity lock for special/dedup categories. Shared by the metadata
+ * and dedup wizard steps so both react to the same set of inputs (existing
+ * pool data layout, wizard data layout) in the same way.
  */
 export function parityLock$(
   pool$: Observable<Pool | null>,
   topology$: Observable<PoolManagerTopology>,
-  vdevType: VDevType.Special | VDevType.Dedup,
 ): Observable<ParityLock> {
   return combineLatest([pool$, topology$]).pipe(
     map(([pool, topology]) => resolveParityLock(
-      pool?.topology[vdevType],
       pool?.topology[VDevType.Data],
       { layout: topology[VDevType.Data].layout, width: topology[VDevType.Data].width },
     )),

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -253,6 +253,10 @@ export function layoutParity(layout: CreateVdevLayout, width: number): number {
  * dropdown level. Stripe remains gated on the data vdev also being Stripe so
  * a no-redundancy metadata vdev can't be silently introduced. dRAID is never
  * offered (ZFS doesn't support it for special/dedup).
+ *
+ * Mirror data without a width still resolves to Mirror, which hides Stripe.
+ * Stripe special/dedup is a misconfiguration anyway, so concealing it during
+ * the transient pre-width state is preferable to briefly exposing it.
  */
 export function resolveParityLock(
   existingData: VDevItem[] | undefined,

--- a/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/topology.utils.ts
@@ -208,6 +208,14 @@ export const nonDraidLayouts: readonly CreateVdevLayout[] = Object.values(Create
   .filter((layout) => !draidCreateLayouts.includes(layout));
 
 /**
+ * Stable references for the two outcomes of {@link resolveParityLock} so that
+ * callers can compare allowedLayouts by reference (parityLock$'s
+ * distinctUntilChanged) without walking the array on every emission.
+ */
+const layoutsWithoutStripe: readonly CreateVdevLayout[] = nonDraidLayouts
+  .filter((layout) => layout !== CreateVdevLayout.Stripe);
+
+/**
  * Constraint on the Layout + Width controls for a special/dedup vdev.
  * After NAS-140839 the lock is intentionally permissive: any non-dRAID layout
  * is allowed regardless of the data vdev's redundancy, with Stripe gated only
@@ -248,15 +256,13 @@ export function layoutParity(layout: CreateVdevLayout, width: number): number {
  */
 export function resolveParityLock(
   existingData: VDevItem[] | undefined,
-  wizardData: { layout: CreateVdevLayout | null; width: number | null } | undefined,
+  wizardData: { layout: CreateVdevLayout | null } | undefined,
 ): ParityLock {
   const dataLayout = resolveTopologyLayout(existingData) ?? wizardData?.layout ?? null;
   const allowStripe = dataLayout === CreateVdevLayout.Stripe;
 
-  const allowedLayouts = nonDraidLayouts.filter((layout) => allowStripe || layout !== CreateVdevLayout.Stripe);
-
   return {
-    allowedLayouts,
+    allowedLayouts: allowStripe ? nonDraidLayouts : layoutsWithoutStripe,
     minMirrorWidth: 2,
   };
 }
@@ -273,12 +279,11 @@ export function parityLock$(
   return combineLatest([pool$, topology$]).pipe(
     map(([pool, topology]) => resolveParityLock(
       pool?.topology[VDevType.Data],
-      { layout: topology[VDevType.Data].layout, width: topology[VDevType.Data].width },
+      { layout: topology[VDevType.Data].layout },
     )),
     distinctUntilChanged((a, b) => (
       a.minMirrorWidth === b.minMirrorWidth
-      && a.allowedLayouts.length === b.allowedLayouts.length
-      && a.allowedLayouts.every((layout, i) => layout === b.allowedLayouts[i])
+      && a.allowedLayouts === b.allowedLayouts
     )),
   );
 }


### PR DESCRIPTION
## Summary                                                                                                                     
  - Replaces the strict redundancy lock on special/dedup vdev pickers with a permissive one: any non-dRAID layout is now
  selectable regardless of the data vdev's parity (Stripe still gated on data being Stripe).                                     
  - Surfaces non-blocking warnings in `PoolManagerValidationService` when (a) the special/dedup vdev's parity is lower than the
  data vdev's, or (b) a special/dedup vdev being added doesn't match the layout already present in that category on the existing 
  pool.                                                           
  - Simplifies `topology.utils.ts` accordingly: drops `parityLockForMinParity` and the existing-category branch in               
  `resolveParityLock`, and removes the now-unused `vdevType` arg from `parityLock$`.                                             
  
  ## Context                                                                                                                     
  Per ER-72 / NAS-140839, the wizard should no longer block users from picking a lower-redundancy metadata/dedup layout — it
  should warn instead. Pool integrity guidance (mirror of metadata vdev failure destroying the pool) is preserved as a warning   
  rather than a hard constraint.
                                                                                                                                 
  ## Test plan                                                    
  - [ ] Create a new pool with RAIDZ2 data + Mirror special — expect the metadata step to allow it and a redundancy-mismatch
  warning to appear in the review step.                                                                                          
  - [ ] Create a new pool with Stripe data — confirm Stripe is selectable for special/dedup; pick non-Stripe data and confirm
  Stripe disappears from the special/dedup layouts.                                                                              
  - [ ] Add a special vdev to a pool whose existing special class is Mirror, but pick RAIDZ1 — expect a mixed-layout warning, no
  block.                                                                                                                         
  - [ ] Add a dedup vdev with parity lower than data parity — expect dedup redundancy-mismatch warning.
  - [ ] dRAID is never offered for special/dedup.                                                                                
  - [ ] `yarn test src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts` and                 
  `…/utils/topology.utils.spec.ts` pass.                                                                                         
  - [ ] `yarn lint` clean on changed files.                  

Original PR: https://github.com/truenas/webui/pull/13553


Original PR: https://github.com/truenas/webui/pull/13573
