### PR TITLE
NAS-141008 / 27.0.0-BETA.1 / Set SMB purpose when creating dataset with Multiprotocol preset

### DIFF
--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.spec.ts
@@ -16,6 +16,7 @@ import { ServiceName } from 'app/enums/service-name.enum';
 import { helptextDatasetForm } from 'app/helptext/storage/volumes/datasets/dataset-form';
 import { Dataset } from 'app/interfaces/dataset.interface';
 import { FileSystemStat } from 'app/interfaces/filesystem-stat.interface';
+import { SmbSharePurpose } from 'app/interfaces/smb-share.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
@@ -48,11 +49,12 @@ describe('DatasetFormComponent', () => {
     smb_name: new FormControl('new_sbm_name', { nonNullable: true }),
   });
 
-  MockInstance(NameAndOptionsSectionComponent, 'form', new FormGroup({
+  const nameAndOptionsForm = new FormGroup({
     name: new FormControl('', { nonNullable: true }),
     parent: new FormControl('', { nonNullable: true }),
     share_type: new FormControl(DatasetPreset.Generic, { nonNullable: true }),
-  }));
+  });
+  MockInstance(NameAndOptionsSectionComponent, 'form', nameAndOptionsForm);
   MockInstance(NameAndOptionsSectionComponent, 'datasetPresetForm', datasetPresetForm);
   MockInstance(NameAndOptionsSectionComponent, 'canCreateSmb', true);
   MockInstance(NameAndOptionsSectionComponent, 'canCreateNfs', true);
@@ -194,6 +196,21 @@ describe('DatasetFormComponent', () => {
       expect(spectator.inject(Store).dispatch).toHaveBeenCalledWith(
         checkIfServiceIsEnabled({ serviceName: ServiceName.Nfs }),
       );
+    });
+
+    it('sets purpose to MultiProtocolShare on SMB create when Multiprotocol preset is selected', async () => {
+      nameAndOptionsForm.controls.share_type.setValue(DatasetPreset.Multiprotocol);
+
+      const submit = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await submit.click();
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('sharing.smb.create', [{
+        name: 'new_sbm_name',
+        path: '/mnt/saved-id',
+        purpose: SmbSharePurpose.MultiProtocolShare,
+      }]);
+
+      nameAndOptionsForm.controls.share_type.setValue(DatasetPreset.Generic);
     });
 
     it('skips creation new SMB and NFS when checkboxes are set to false', async () => {

--- a/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/dataset-form.component.ts
@@ -16,6 +16,7 @@ import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { helptextDatasetForm } from 'app/helptext/storage/volumes/datasets/dataset-form';
 import { Dataset, DatasetCreate, DatasetUpdate } from 'app/interfaces/dataset.interface';
+import { SmbSharePurpose } from 'app/interfaces/smb-share.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { ModalHeaderComponent } from 'app/modules/slide-ins/components/modal-header/modal-header.component';
@@ -308,9 +309,11 @@ export class DatasetFormComponent implements OnInit, AfterViewInit {
     if (!this.isNew || !datasetPresetFormValue.create_smb || !this.nameAndOptionsSection().canCreateSmb) {
       return of(dataset);
     }
+    const isMultiprotocol = this.nameAndOptionsSection().form.value.share_type === DatasetPreset.Multiprotocol;
     return this.api.call('sharing.smb.create', [{
       name: datasetPresetFormValue.smb_name,
       path: `${mntPath}/${dataset.id}`,
+      ...(isMultiprotocol ? { purpose: SmbSharePurpose.MultiProtocolShare } : {}),
     }]).pipe(
       switchMap(() => of(dataset)),
       catchError((error: unknown) => this.rollBack(dataset, error)),


### PR DESCRIPTION
**Changes:**

Use correct purpose for sharing.smb.create.

**Testing:**

Create a multipurpose dataset with smb and nfs, verify purpose of created SMB share is MULTIPURPOSE.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
