### PR TITLE
NAS-141002 / 27.0.0-BETA.1 / Cloud Sync tasks (and probably others) have the same color on 2 statuses

### DIFF
--- a/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-state-button/ix-cell-state-button.component.ts
+++ b/src/app/modules/ix-table/components/ix-table-body/cells/ix-cell-state-button/ix-cell-state-button.component.ts
@@ -184,6 +184,7 @@ export class IxCellStateButtonComponent<T> extends ColumnComponent<T> implements
         return 'fn-theme-orange';
       case JobState.Running:
       case TaskState.Running:
+        return 'fn-theme-blue';
       case TaskState.Finished:
       case JobState.Success:
         return 'fn-theme-green';


### PR DESCRIPTION
Testing: see ticket

Distinguishes the Running state from Finished/Success by giving it its own color (blue) — previously both states fell 
through to green, making it impossible to tell at a glance whether a task was still running or had completed.

<img width="750" height="255" alt="NAS-141002" src="https://github.com/user-attachments/assets/7c1b3446-0b1a-4ea7-aa3b-ada4e373df0c" />
