### PR TITLE
NAS-140990 / 26.0.0-BETA.2 / Metadata redundancy warning missing when metadata vdev is configured with manual selection (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/custom-layout-applied/custom-layout-applied.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/layout-step/custom-layout-applied/custom-layout-applied.component.html
@@ -20,9 +20,6 @@
       <li class="vdevs-length">
         <strong>{{ 'VDEVs' | translate }}: </strong>{{ vdevs().length }}
       </li>
-      <li>
-        <strong>{{ 'No warnings' | translate }}</strong>
-      </li>
     </ul>
   </div>
 </div>

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -879,6 +879,46 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
+    describe('when special has only empty vdevs (unreachable in practice)', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Raidz2,
+                width: 4,
+                vdevs: [[{ devname: 'sda' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: null,
+                vdevs: [[]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('suppresses the redundancy warning rather than treating Infinity as a width', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).not.toContainEqual(expect.objectContaining({
+          step: PoolCreationWizardStep.Metadata,
+          severity: PoolCreationSeverity.Warning,
+        }));
+      });
+    });
+
     describe('when special parity matches data parity', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -915,6 +915,7 @@ describe('PoolManagerValidationService', () => {
         expect(errors).not.toContainEqual(expect.objectContaining({
           step: PoolCreationWizardStep.Metadata,
           severity: PoolCreationSeverity.Warning,
+          text: expect.stringContaining('redundancy is lower'),
         }));
       });
     });
@@ -1004,7 +1005,7 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
-    describe('when special has only empty vdevs (unreachable in practice)', () => {
+    describe('when special has only empty vdev arrays', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({
         service: PoolManagerValidationService,
@@ -1035,11 +1036,12 @@ describe('PoolManagerValidationService', () => {
         spectator = createService();
       });
 
-      it('suppresses the redundancy warning rather than treating Infinity as a width', async () => {
+      it('suppresses the redundancy warning when no real vdev disks are present', async () => {
         const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
         expect(errors).not.toContainEqual(expect.objectContaining({
           step: PoolCreationWizardStep.Metadata,
           severity: PoolCreationSeverity.Warning,
+          text: expect.stringContaining('redundancy is lower'),
         }));
       });
     });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -838,6 +838,47 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
+    describe('when data is manually selected Mirror (no width set on category)', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Mirror,
+                width: null,
+                vdevs: [[{ devname: 'sda' }, { devname: 'sdb' }, { devname: 'sdc' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: 2,
+                vdevs: [[{ devname: 'sdd' }, { devname: 'sde' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('emits the metadata redundancy warning using the manual data vdev disk count', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Warning,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'The metadata VDEV redundancy is lower than the data VDEV redundancy. Losing this VDEV will destroy the pool.',
+        });
+      });
+    });
+
     describe('when special parity matches data parity', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -919,6 +919,91 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
+    describe('when special width is stale after manual selection removed a disk', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Raidz2,
+                width: 4,
+                vdevs: [[{ devname: 'sda' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: 4,
+                vdevs: [[{ devname: 'sdb' }, { devname: 'sdc' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('emits the warning based on the actual vdev disk count, not the stale higher width', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Warning,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'The metadata VDEV redundancy is lower than the data VDEV redundancy. Losing this VDEV will destroy the pool.',
+        });
+      });
+    });
+
+    describe('when special has mixed-length vdevs', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Raidz2,
+                width: 4,
+                vdevs: [[{ devname: 'sda' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: null,
+                vdevs: [
+                  [{ devname: 'sdb' }, { devname: 'sdc' }, { devname: 'sdd' }],
+                  [{ devname: 'sde' }, { devname: 'sdf' }],
+                ],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('uses the smallest vdev disk count (conservative) — emits the warning when the weakest vdev parity is below data', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Warning,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'The metadata VDEV redundancy is lower than the data VDEV redundancy. Losing this VDEV will destroy the pool.',
+        });
+      });
+    });
+
     describe('when special has only empty vdevs (unreachable in practice)', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -797,6 +797,47 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
+    describe('when special is manually selected (no width set on category)', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Raidz2,
+                width: 4,
+                vdevs: [[{ devname: 'sda' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: null,
+                vdevs: [[{ devname: 'sdb' }, { devname: 'sdc' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('still emits the metadata redundancy warning using the smallest vdev disk count', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).toContainEqual({
+          severity: PoolCreationSeverity.Warning,
+          step: PoolCreationWizardStep.Metadata,
+          text: 'The metadata VDEV redundancy is lower than the data VDEV redundancy. Losing this VDEV will destroy the pool.',
+        });
+      });
+    });
+
     describe('when special parity matches data parity', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -879,6 +879,46 @@ describe('PoolManagerValidationService', () => {
       });
     });
 
+    describe('when special width is stale after manual selection added a disk', () => {
+      let spectator: SpectatorService<PoolManagerValidationService>;
+      const createService = createServiceFactory({
+        service: PoolManagerValidationService,
+        providers: [
+          mockProvider(PoolManagerStore, {
+            ...sharedStoreMock,
+            topology$: of({
+              [VDevType.Data]: {
+                layout: CreateVdevLayout.Raidz2,
+                width: 4,
+                vdevs: [[{ devname: 'sda' }]],
+              },
+              [VDevType.Special]: {
+                layout: CreateVdevLayout.Mirror,
+                width: 2,
+                vdevs: [[{ devname: 'sdb' }, { devname: 'sdc' }, { devname: 'sdd' }]],
+              },
+            }),
+          }),
+          mockProvider(AddVdevsStore, { pool$: of(null) }),
+          provideMockStore({
+            selectors: [{ selector: selectHasEnclosureSupport, value: true }],
+          }),
+        ],
+      });
+
+      beforeEach(() => {
+        spectator = createService();
+      });
+
+      it('clears the redundancy warning based on the actual vdev disk count, not the stale width', async () => {
+        const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
+        expect(errors).not.toContainEqual(expect.objectContaining({
+          step: PoolCreationWizardStep.Metadata,
+          severity: PoolCreationSeverity.Warning,
+        }));
+      });
+    });
+
     describe('when special has only empty vdevs (unreachable in practice)', () => {
       let spectator: SpectatorService<PoolManagerValidationService>;
       const createService = createServiceFactory({

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -98,12 +98,11 @@ function parityFromCategory(category: PoolManagerTopologyCategory): number | nul
     return null;
   }
   let effectiveWidth: number | null = null;
-  // A committed vdev should always carry at least one disk; filtering empty
-  // vdev arrays defensively avoids Infinity (vdevs all empty) or a phantom
-  // width=0 being passed to layoutParity.
+  // A committed vdev should always carry at least one disk; filter empty
+  // vdev arrays to avoid a phantom width=0 being passed to layoutParity.
   const nonEmptyVdevs = category.vdevs.filter((vdev) => vdev.length > 0);
   if (nonEmptyVdevs.length) {
-    effectiveWidth = nonEmptyVdevs.reduce((min, vdev) => Math.min(min, vdev.length), Infinity);
+    effectiveWidth = Math.min(...nonEmptyVdevs.map((vdev) => vdev.length));
   } else if (category.width != null) {
     effectiveWidth = category.width;
   }
@@ -568,8 +567,14 @@ export class PoolManagerValidationService {
       }
       // Existing pool vdevs always carry a children list; the fallback only
       // guards against malformed payloads and is irrelevant for non-Mirror
-      // layouts where parity is layout-determined. Note that a malformed
-      // payload could mask a backend bug as a 2-disk Mirror (parity 1).
+      // layouts where parity is layout-determined. We fall back to 2 (parity
+      // 1) rather than 1 (parity 0) because validateRedundancyMismatch
+      // short-circuits on `dataParity <= 0` — a lower fallback would silently
+      // suppress *all* mismatch warnings for a malformed Mirror payload.
+      // Existing-pool vdevs are not run through parityFromCategory: their
+      // disk count lives in `children`, not in a wizard `vdevs[][]`, and the
+      // wizard's "smallest vdev" convention doesn't translate cleanly to an
+      // existing pool whose vdevs are already created and immutable here.
       const width = existingDataVdevs[0].children?.length ?? 2;
       return layoutParity(layout, width);
     }

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -82,30 +82,30 @@ function parityFromLayoutWidth(
 }
 
 /**
- * Parity for a topology category, accounting for the fact that manual disk
- * selection commits `vdevs` without updating `width` on the category. In that
- * case we fall back to the smallest vdev's disk count, which yields the
- * worst-case parity across the configured vdevs — the conservative choice for
- * a warning. For layout-determined parity (Stripe/RAIDZ/dRAID) the fallback is
- * harmless. Returns null when neither layout nor an effective width can be
- * resolved.
+ * Parity for a topology category. The actual disk count in `vdevs` takes
+ * precedence over the configured `width`: manual disk selection updates
+ * `vdevs` without re-syncing `width` on the category, so `width` can be stale
+ * (e.g. width=2 from a prior automated selection, then a 3rd disk added
+ * manually). When vdevs are present we use the smallest vdev's disk count,
+ * which yields the worst-case parity across configured vdevs — the
+ * conservative choice for a warning. Width is the source of truth only when
+ * vdevs haven't been generated yet. For layout-determined parity
+ * (Stripe/RAIDZ/dRAID) this choice is harmless. Returns null when neither a
+ * layout nor an effective width can be resolved.
  */
 function parityFromCategory(category: PoolManagerTopologyCategory): number | null {
   if (!category.layout) {
     return null;
   }
   let effectiveWidth: number | null = null;
-  if (category.width != null) {
+  // A committed vdev should always carry at least one disk; filtering empty
+  // vdev arrays defensively avoids Infinity (vdevs all empty) or a phantom
+  // width=0 being passed to layoutParity.
+  const nonEmptyVdevs = category.vdevs.filter((vdev) => vdev.length > 0);
+  if (nonEmptyVdevs.length) {
+    effectiveWidth = nonEmptyVdevs.reduce((min, vdev) => Math.min(min, vdev.length), Infinity);
+  } else if (category.width != null) {
     effectiveWidth = category.width;
-  } else {
-    // Filter out empty vdev arrays before computing the min: a committed vdev
-    // should always carry at least one disk, but defensively skipping them
-    // avoids Infinity (no real vdevs) or a phantom width=0 (only empty vdevs)
-    // being passed to layoutParity.
-    const nonEmptyVdevs = category.vdevs.filter((vdev) => vdev.length > 0);
-    if (nonEmptyVdevs.length) {
-      effectiveWidth = nonEmptyVdevs.reduce((min, vdev) => Math.min(min, vdev.length), Infinity);
-    }
   }
   return parityFromLayoutWidth(category.layout, effectiveWidth);
 }

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -81,6 +81,23 @@ function parityFromLayoutWidth(
   return layoutParity(layout, width ?? 0);
 }
 
+/**
+ * Parity for a topology category, accounting for the fact that manual disk
+ * selection commits `vdevs` without updating `width` on the category. In that
+ * case we fall back to the smallest vdev's disk count so worst-case Mirror
+ * parity is still computed. For layout-determined parity (Stripe/RAIDZ/dRAID)
+ * the fallback is harmless. Returns null when neither layout nor an
+ * effective width can be resolved.
+ */
+function parityFromCategory(category: PoolManagerTopologyCategory): number | null {
+  if (!category.layout) {
+    return null;
+  }
+  const effectiveWidth = category.width
+    ?? (category.vdevs.length ? Math.min(...category.vdevs.map((vdev) => vdev.length)) : null);
+  return parityFromLayoutWidth(category.layout, effectiveWidth);
+}
+
 @Injectable()
 export class PoolManagerValidationService {
   protected store = inject(PoolManagerStore);
@@ -471,12 +488,7 @@ export class PoolManagerValidationService {
       if (category.layout === CreateVdevLayout.Stripe) {
         return;
       }
-      // Manual disk selection commits vdevs without updating `width` on the
-      // category, so fall back to the smallest vdev's disk count to compute
-      // worst-case Mirror parity.
-      const effectiveWidth = category.width
-        ?? Math.min(...category.vdevs.map((vdev) => vdev.length));
-      const categoryParity = parityFromLayoutWidth(category.layout, effectiveWidth);
+      const categoryParity = parityFromCategory(category);
       if (categoryParity === null) {
         return;
       }
@@ -555,9 +567,9 @@ export class PoolManagerValidationService {
     // category is unset, so we return null and the mismatch warning is
     // suppressed until parity can actually be resolved.
     const dataCategory = topology[VDevType.Data];
-    if (!dataCategory?.layout) {
+    if (!dataCategory) {
       return null;
     }
-    return parityFromLayoutWidth(dataCategory.layout, dataCategory.width);
+    return parityFromCategory(dataCategory);
   }
 }

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -471,7 +471,12 @@ export class PoolManagerValidationService {
       if (category.layout === CreateVdevLayout.Stripe) {
         return;
       }
-      const categoryParity = parityFromLayoutWidth(category.layout, category.width);
+      // Manual disk selection commits vdevs without updating `width` on the
+      // category, so fall back to the smallest vdev's disk count to compute
+      // worst-case Mirror parity.
+      const effectiveWidth = category.width
+        ?? Math.min(...category.vdevs.map((vdev) => vdev.length));
+      const categoryParity = parityFromLayoutWidth(category.layout, effectiveWidth);
       if (categoryParity === null) {
         return;
       }

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -84,17 +84,22 @@ function parityFromLayoutWidth(
 /**
  * Parity for a topology category, accounting for the fact that manual disk
  * selection commits `vdevs` without updating `width` on the category. In that
- * case we fall back to the smallest vdev's disk count so worst-case Mirror
- * parity is still computed. For layout-determined parity (Stripe/RAIDZ/dRAID)
- * the fallback is harmless. Returns null when neither layout nor an
- * effective width can be resolved.
+ * case we fall back to the smallest vdev's disk count, which yields the
+ * worst-case parity across the configured vdevs — the conservative choice for
+ * a warning. For layout-determined parity (Stripe/RAIDZ/dRAID) the fallback is
+ * harmless. Returns null when neither layout nor an effective width can be
+ * resolved.
  */
 function parityFromCategory(category: PoolManagerTopologyCategory): number | null {
   if (!category.layout) {
     return null;
   }
-  const effectiveWidth = category.width
-    ?? (category.vdevs.length ? Math.min(...category.vdevs.map((vdev) => vdev.length)) : null);
+  let effectiveWidth: number | null = null;
+  if (category.width != null) {
+    effectiveWidth = category.width;
+  } else if (category.vdevs.length) {
+    effectiveWidth = category.vdevs.reduce((min, vdev) => Math.min(min, vdev.length), Infinity);
+  }
   return parityFromLayoutWidth(category.layout, effectiveWidth);
 }
 

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -97,8 +97,15 @@ function parityFromCategory(category: PoolManagerTopologyCategory): number | nul
   let effectiveWidth: number | null = null;
   if (category.width != null) {
     effectiveWidth = category.width;
-  } else if (category.vdevs.length) {
-    effectiveWidth = category.vdevs.reduce((min, vdev) => Math.min(min, vdev.length), Infinity);
+  } else {
+    // Filter out empty vdev arrays before computing the min: a committed vdev
+    // should always carry at least one disk, but defensively skipping them
+    // avoids Infinity (no real vdevs) or a phantom width=0 (only empty vdevs)
+    // being passed to layoutParity.
+    const nonEmptyVdevs = category.vdevs.filter((vdev) => vdev.length > 0);
+    if (nonEmptyVdevs.length) {
+      effectiveWidth = nonEmptyVdevs.reduce((min, vdev) => Math.min(min, vdev.length), Infinity);
+    }
   }
   return parityFromLayoutWidth(category.layout, effectiveWidth);
 }


### PR DESCRIPTION
Testing: see ticket.



Original PR: https://github.com/truenas/webui/pull/13590
