### PR TITLE
NAS-141096 / 26.0.0-RC.1 / Filter disks correctly when SED encryption is selected (by william-gr)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/pool-warnings/pool-warnings.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/pool-warnings/pool-warnings.component.spec.ts
@@ -4,7 +4,8 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { Spectator } from '@ngneat/spectator';
 import { mockProvider, createComponentFactory } from '@ngneat/spectator/jest';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
+import { SedStatus } from 'app/enums/sed-status.enum';
 import { DetailsDisk } from 'app/interfaces/disk.interface';
 import { IxRadioGroupHarness } from 'app/modules/forms/ix-forms/components/ix-radio-group/ix-radio-group.harness';
 import { PoolWarningsComponent } from 'app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/pool-warnings/pool-warnings.component';
@@ -85,5 +86,53 @@ describe('PoolWarningsComponent', () => {
     const [nonUnique, exportedDisks] = spectator.queryAll('ix-warning');
     expect(nonUnique).toHaveText('There are 2 disks available that have non-unique serial numbers');
     expect(exportedDisks).toHaveText('You will lose any and all data in selected disks.');
+  });
+
+  describe('SED filtering of exported pool disks', () => {
+    const sedExportedPoolDisk = {
+      identifier: '{uuid}sed-exported',
+      duplicate_serial: [] as string[],
+      exported_zpool: 'SED_POOL',
+      devname: 'sdw',
+      sed_status: SedStatus.Uninitialized,
+    } as DetailsDisk;
+
+    const nonSedExportedPoolDisk = {
+      identifier: '{uuid}non-sed-exported',
+      duplicate_serial: [] as string[],
+      exported_zpool: 'NON_SED_POOL',
+      devname: 'sdi',
+    } as DetailsDisk;
+
+    let encryptionType$: BehaviorSubject<EncryptionType>;
+    const createSedComponent = createComponentFactory({
+      component: PoolWarningsComponent,
+      imports: [ReactiveFormsModule],
+      providers: [
+        mockProvider(PoolManagerStore, {
+          setDiskWarningOptions: jest.fn(),
+          get encryptionType$() { return encryptionType$; },
+        }),
+        mockProvider(DiskStore, {
+          selectableDisks$: of([sedExportedPoolDisk, nonSedExportedPoolDisk]),
+        }),
+      ],
+    });
+
+    it('clears stale exported pool entries when encryption type switches to SED', async () => {
+      encryptionType$ = new BehaviorSubject<EncryptionType>(EncryptionType.None);
+      const sedSpectator = createSedComponent();
+      const sedLoader = TestbedHarnessEnvironment.loader(sedSpectator.fixture);
+
+      let checkboxes = await sedLoader.getAllHarnesses(MatCheckboxHarness);
+      expect(checkboxes).toHaveLength(2);
+
+      encryptionType$.next(EncryptionType.Sed);
+      sedSpectator.detectChanges();
+
+      checkboxes = await sedLoader.getAllHarnesses(MatCheckboxHarness);
+      expect(checkboxes).toHaveLength(1);
+      expect(await checkboxes[0].getLabelText()).toContain('SED_POOL');
+    });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/pool-warnings/pool-warnings.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/components/pool-warnings/pool-warnings.component.ts
@@ -105,6 +105,7 @@ export class PoolWarningsComponent implements OnInit {
   }
 
   private setExportedPoolOptions(): void {
+    this.poolAndDisks.clear();
     const exportedPools = this.disksWithExportedPools
       .map((disk) => disk.exported_zpool)
       .filter((pool): pool is string => !!pool);

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.spec.ts
@@ -364,6 +364,19 @@ describe('PoolManagerStore', () => {
         expect(state.encryption).toBeNull();
         expect(state.sedPassword).toBeNull();
       });
+
+      it('resets topology categories holding non-SED-capable disks when switching to SED', async () => {
+        spectator.service.setManualTopologyCategory(VDevType.Data, [[disks[0]]]);
+
+        spectator.service.setEncryptionOptions({
+          encryptionType: EncryptionType.Sed,
+          encryption: null,
+          sedPassword: 'mypassword',
+        });
+
+        const state = await firstValueFrom(spectator.service.state$);
+        expect(state.topology[VDevType.Data].vdevs).toEqual([]);
+      });
     });
 
     describe('setHasSedCapableDisks', () => {

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -310,16 +310,14 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
     };
   });
 
-  readonly setEncryptionOptions = this.updater((state, options: {
+  setEncryptionOptions(options: {
     encryptionType: EncryptionType;
     encryption: string | null;
     sedPassword: string | null;
-  }) => {
-    return {
-      ...state,
-      ...options,
-    };
-  });
+  }): void {
+    this.patchState(options);
+    this.resetTopologyIfNotEnoughDisks();
+  }
 
   readonly setHasSedCapableDisks = this.updater((state, hasSedCapableDisks: boolean) => {
     return {


### PR DESCRIPTION
**Changes:**

<img width="1322" height="680" alt="image" src="https://github.com/user-attachments/assets/e25ed4e5-69cf-458b-a0f2-1b55bc3ae7f1" />

<img width="1328" height="706" alt="image" src="https://github.com/user-attachments/assets/dcc3667b-da95-4ffa-a32a-f4e3fb282c7f" />


**Testing:**

If you want yu can use our m40g3 but a code review is fine.

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/13612
