### PR TITLE
NAS-141148 / 26.0.0-RC.1 / Replication Task Wizard: "Sudo Enabled" dialog appears twice when loading from previous (by AlexKarpov98)

### DIFF
--- a/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
+++ b/src/app/pages/data-protection/replication/replication-form/replication-form.component.ts
@@ -342,6 +342,7 @@ export class ReplicationFormComponent implements OnInit {
           return;
         }
 
+        this.isSudoDialogShown = true;
         this.dialog.confirm({
           title: this.translate.instant('Sudo Enabled'),
           message: this.translate.instant(helptextReplicationWizard.sudoWarning),
@@ -349,7 +350,6 @@ export class ReplicationFormComponent implements OnInit {
           buttonText: this.translate.instant('Use Sudo For ZFS Commands'),
         }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe((useSudo) => {
           this.generalSection().form.controls.sudo.setValue(useSudo);
-          this.isSudoDialogShown = true;
         });
       });
   }

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
@@ -344,6 +344,7 @@ export class ReplicationWhatAndWhereComponent implements OnInit, SummaryProvider
           return;
         }
 
+        this.isSudoDialogShown = true;
         this.dialogService.confirm({
           title: this.translate.instant('Sudo Enabled'),
           message: this.translate.instant(helptextReplicationWizard.sudoWarning),
@@ -351,7 +352,6 @@ export class ReplicationWhatAndWhereComponent implements OnInit, SummaryProvider
           buttonText: this.translate.instant('Use Sudo For ZFS Commands'),
         }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe((useSudo) => {
           this.form.controls.sudo.setValue(useSudo);
-          this.isSudoDialogShown = true;
         });
       });
   }


### PR DESCRIPTION
Testing: see ticket.


https://github.com/user-attachments/assets/594d13e5-29a7-47a3-b492-447aaada520f



Original PR: https://github.com/truenas/webui/pull/13634
