### PR TITLE
NAS-141150 / 26.0.0-RC.1 / TNC tier in header is not aligned (by AlexKarpov98)

### DIFF
--- a/src/app/modules/layout/topbar/status-badge/status-badge.component.scss
+++ b/src/app/modules/layout/topbar/status-badge/status-badge.component.scss
@@ -24,6 +24,7 @@
   font-size: 10px;
   font-weight: 700;
   line-height: 16px;
+  margin: 0;
 }
 
 @keyframes ix-status-badge-spin {


### PR DESCRIPTION
Testing: see ticket.

Preview:

<img width="317" height="75" alt="NAS-141150" src="https://github.com/user-attachments/assets/a0dbe1b6-51f6-4a1e-b725-0265f1c6fac6" />

<img width="322" height="72" alt="Screenshot 2026-05-24 at 20 01 29" src="https://github.com/user-attachments/assets/e7a3e96f-85c3-4b19-bd26-b67850ee88b6" />


Original PR: https://github.com/truenas/webui/pull/13635
