### PR TITLE
NAS-141137 / 26.0.0-RC.1 / Show metadata reserve on pool Usage card from tier config (by william-gr)

### DIFF
--- a/src/app/interfaces/pool.interface.ts
+++ b/src/app/interfaces/pool.interface.ts
@@ -53,8 +53,12 @@ export interface Pool {
   dedup_table_size: number;
   all_sed?: boolean;
   special_class_used?: number;
+  /**
+   * Raw special-vdev free space as reported by ZFS, before the metadata reserve
+   * is carved out. The Usage card subtracts the configured reserve for display.
+   */
   special_class_available?: number;
-  special_class_reserved?: number;
+  special_class_usable?: number;
 }
 
 export type PoolTopology = Record<VDevType, VDevItem[]>;

--- a/src/app/interfaces/zfs-tier.interface.ts
+++ b/src/app/interfaces/zfs-tier.interface.ts
@@ -5,6 +5,13 @@ export interface ZfsTierConfig {
   enabled: boolean;
   max_concurrent_jobs: number;
   max_used_percentage: number;
+  /**
+   * Percentage of special-vdev usable capacity reserved for metadata. Once usage
+   * crosses the resulting threshold, ZFS stops placing new data on the special
+   * vdevs and writes metadata only. Surfaced on the pool Usage card as a reserve
+   * zone behind the Performance tier bar.
+   */
+  special_class_metadata_reserve_pct: number;
 }
 
 export interface ZfsTierRewriteJobStats {

--- a/src/app/pages/sharing/components/sharing-tier.service.ts
+++ b/src/app/pages/sharing/components/sharing-tier.service.ts
@@ -42,6 +42,9 @@ export class SharingTierService {
   private tierEnabledSignal = signal(false);
   readonly tierEnabled = this.tierEnabledSignal.asReadonly();
 
+  private metadataReservePctSignal = signal(0);
+  readonly metadataReservePct = this.metadataReservePctSignal.asReadonly();
+
   getTierConfig(): Observable<ZfsTierConfig> {
     if (!this.tierConfig$) {
       // Auto-retry transient failures (websocket reconnect at boot, slow
@@ -53,7 +56,10 @@ export class SharingTierService {
         // 1s, 2s, 4s exponential backoff before giving up.
         retry({ count: 3, delay: (_err, attempt) => timer(2 ** (attempt - 1) * 1000) }),
         catchError(() => of({ enabled: false } as ZfsTierConfig)),
-        tap((config) => this.tierEnabledSignal.set(config.enabled)),
+        tap((config) => {
+          this.tierEnabledSignal.set(config.enabled);
+          this.metadataReservePctSignal.set(config.special_class_metadata_reserve_pct ?? 0);
+        }),
         shareReplay({ bufferSize: 1, refCount: false }),
       );
     }
@@ -63,6 +69,7 @@ export class SharingTierService {
   invalidate(): void {
     this.tierConfig$ = null;
     this.tierEnabledSignal.set(false);
+    this.metadataReservePctSignal.set(0);
   }
 
   subscribeTierJobUpdates(): Observable<ZfsTierRewriteJobEntry> {

--- a/src/app/pages/sharing/components/sharing-tier.service.ts
+++ b/src/app/pages/sharing/components/sharing-tier.service.ts
@@ -43,6 +43,12 @@ export class SharingTierService {
   readonly tierEnabled = this.tierEnabledSignal.asReadonly();
 
   private metadataReservePctSignal = signal(0);
+  /**
+   * Percentage of special-vdev usable capacity reserved for metadata. Defaults to
+   * 0 and is only populated once `getTierConfig()` has been subscribed somewhere
+   * in the component tree (the pools dashboard primes it for the cards). Read it
+   * directly only from components that live under such a subscriber.
+   */
   readonly metadataReservePct = this.metadataReservePctSignal.asReadonly();
 
   getTierConfig(): Observable<ZfsTierConfig> {

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
@@ -80,12 +80,19 @@
               <div
                 class="tier-bar-container"
                 role="img"
-                [attr.aria-label]="'Performance tier: {used} used, {available} available, {reserved} reserved' | translate: {
+                [attr.aria-label]="'Performance tier: {used} used, {available} available, {reserved} reserved for metadata' | translate: {
                   used: performanceUsed() | ixFileSize,
                   available: performanceAvailable() | ixFileSize,
                   reserved: performanceReserved() | ixFileSize
                 }"
               >
+                @if (tierBreakdown().performance.reservedPercent > 0) {
+                  <div
+                    aria-hidden="true"
+                    class="reserve-zone"
+                    [style.width.%]="tierBreakdown().performance.reservedPercent"
+                  ></div>
+                }
                 <div
                   aria-hidden="true"
                   class="tier-bar performance-used"
@@ -95,11 +102,6 @@
                   aria-hidden="true"
                   class="tier-bar performance-available"
                   [style.width.%]="tierBreakdown().performance.availablePercent"
-                ></div>
-                <div
-                  aria-hidden="true"
-                  class="tier-bar performance-reserved"
-                  [style.width.%]="tierBreakdown().performance.reservedPercent"
                 ></div>
               </div>
               <div class="tier-stats-detail">

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.scss
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.scss
@@ -45,7 +45,7 @@
 
   .left {
     align-items: center;
-    flex: 1 1 40%;
+    flex: 0 0 auto;
     flex-direction: column;
 
     > div {
@@ -55,7 +55,7 @@
 
   .right {
     display: flex;
-    flex: 1 1 60%;
+    flex: 1 1 auto;
     flex-direction: column;
   }
 }

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.scss
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.scss
@@ -44,17 +44,12 @@
   }
 
   .left {
-    align-items: flex-end;
+    align-items: center;
     flex: 1 1 40%;
     flex-direction: column;
 
     > div {
       text-align: center;
-    }
-
-    .gauge {
-      margin-left: unset;
-      margin-right: 8px;
     }
   }
 
@@ -92,13 +87,37 @@
   display: flex;
   height: 6px;
   overflow: hidden;
+  position: relative;
   width: 100%;
+}
+
+// Metadata reserve zone: a fixed-width striped overlay pinned to the right of
+// the track, drawn on top of the bars. Its diagonal hatch marks the area as
+// reserved; the Used bar runs underneath, so green showing through the stripes
+// is usage that has eaten into the reserve, while the dark track showing through
+// is reserve still free. The solid left edge marks the reserve threshold.
+.reserve-zone {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    var(--orange) 0,
+    var(--orange) 1.5px,
+    transparent 1.5px,
+    transparent 4px
+  );
+  border-left: 2px solid var(--orange);
+  bottom: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 2;
 }
 
 .tier-bar {
   height: 100%;
   min-width: 0;
+  position: relative;
   transition: width 0.3s ease;
+  z-index: 1;
 
   &.performance-used {
     background-color: var(--green);
@@ -107,11 +126,6 @@
 
   &.performance-available {
     background-color: color-mix(in srgb, var(--green) 30%, transparent);
-  }
-
-  &.performance-reserved {
-    background-color: var(--orange);
-    border-radius: 0 3px 3px 0;
   }
 
   &.regular-used {

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
@@ -21,6 +21,7 @@ import { selectTheme } from 'app/store/preferences/preferences.selectors';
 describe('PoolUsageCardComponent', () => {
   let spectator: Spectator<PoolUsageCardComponent>;
   const tierEnabled = signal(false);
+  const metadataReservePct = signal(0);
 
   const createComponent = createComponentFactory({
     component: PoolUsageCardComponent,
@@ -36,7 +37,11 @@ describe('PoolUsageCardComponent', () => {
       ThemeService,
       mockProvider(SharingTierService, {
         tierEnabled,
-        getTierConfig: () => of({ enabled: tierEnabled() }),
+        metadataReservePct,
+        getTierConfig: () => of({
+          enabled: tierEnabled(),
+          special_class_metadata_reserve_pct: metadataReservePct(),
+        }),
       }),
       provideMockStore({
         selectors: [
@@ -58,6 +63,7 @@ describe('PoolUsageCardComponent', () => {
 
   beforeEach(() => {
     tierEnabled.set(false);
+    metadataReservePct.set(0);
     spectator = createComponent({
       props: {
         poolState: {
@@ -164,6 +170,9 @@ describe('PoolUsageCardComponent', () => {
 
   it('shows tier breakdown when tiering is enabled and pool has special vdev', () => {
     tierEnabled.set(true);
+    // usable 2 GiB, reserve 25% => 512 MiB reserved; display available =
+    // raw available (1.5 GiB) - reserve (512 MiB) = 1 GiB.
+    metadataReservePct.set(25);
 
     spectator.setInput('poolState', {
       healthy: true,
@@ -173,7 +182,7 @@ describe('PoolUsageCardComponent', () => {
       available: 2510301010,
       special_class_used: 536870912,
       special_class_available: 1610612736,
-      special_class_reserved: 268435456,
+      special_class_usable: 2147483648,
       topology: {
         data: [{
           disk: 'sda',
@@ -200,12 +209,58 @@ describe('PoolUsageCardComponent', () => {
     const performanceStatItems = tierRows[0].querySelectorAll('.stat-item');
     expect(performanceStatItems).toHaveLength(3);
     expect(performanceStatItems[0]).toHaveText('512 MiB Used');
-    expect(performanceStatItems[1]).toHaveText('1.5 GiB Available');
-    expect(performanceStatItems[2]).toHaveText('256 MiB Reserved');
+    expect(performanceStatItems[1]).toHaveText('1 GiB Available');
+    expect(performanceStatItems[2]).toHaveText('512 MiB Reserved');
 
     const regularStatItems = tierRows[1].querySelectorAll('.stat-item');
     expect(regularStatItems).toHaveLength(2);
     expect(regularStatItems[0]).toHaveText('3.15 GiB Used');
     expect(regularStatItems[1]).toHaveText('2.34 GiB Available');
+  });
+
+  it('shows used eating into the reserve when usage crosses the threshold', () => {
+    tierEnabled.set(true);
+    // usable 2 GiB, reserve 25% => threshold at 1.5 GiB. Used is 1.75 GiB, so it
+    // has crossed 0.25 GiB (12.5% of usable) into the reserve.
+    metadataReservePct.set(25);
+
+    spectator.setInput('poolState', {
+      healthy: true,
+      name: 'bingo',
+      status: 'ONLINE',
+      used: 3384541603,
+      available: 2510301010,
+      special_class_used: 1879048192,
+      special_class_available: 268435456,
+      special_class_usable: 2147483648,
+      topology: {
+        data: [{
+          disk: 'sda',
+          type: TopologyItemType.Disk,
+        }],
+        special: [{
+          disk: 'nvme0',
+          type: TopologyItemType.Disk,
+        }],
+      },
+    } as Pool);
+
+    spectator.component.ngOnInit();
+    spectator.detectChanges();
+
+    // Reserve zone is a fixed-width striped overlay (25% of usable). The Used bar
+    // runs past the 75% threshold to 87.5%, so it slides under the reserve zone —
+    // that overlap is the usage eating into the reserve.
+    const reserveZone = spectator.query('.reserve-zone');
+    expect(reserveZone).toExist();
+    expect(reserveZone!.getAttribute('style')).toContain('width: 25%');
+
+    const usedBar = spectator.query('.performance-used');
+    expect(usedBar!.getAttribute('style')).toContain('width: 87.5%');
+
+    const performanceStatItems = spectator.queryAll('.tier-row')[0].querySelectorAll('.stat-item');
+    expect(performanceStatItems[0]).toHaveText('1.75 GiB Used');
+    expect(performanceStatItems[1]).toHaveText('0 B Available');
+    expect(performanceStatItems[2]).toHaveText('512 MiB Reserved');
   });
 });

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.ts
@@ -51,6 +51,7 @@ export class PoolUsageCardComponent implements OnInit {
   readonly poolState = input.required<Pool>();
 
   protected readonly tierEnabled = this.tierService.tierEnabled;
+  protected readonly reservePct = this.tierService.metadataReservePct;
 
   chartLowCapacityColor: string;
   chartFillColor: string;
@@ -81,7 +82,9 @@ export class PoolUsageCardComponent implements OnInit {
   });
 
   protected capacity = computed(() => {
-    return this.used() + this.available() + this.performanceReserved();
+    // Usable Capacity excludes the metadata reserve: available() already has the
+    // reserve subtracted, and used() + available() is the space usable for data.
+    return this.used() + this.available();
   });
 
   protected usedPercentage = computed(() => {
@@ -134,12 +137,26 @@ export class PoolUsageCardComponent implements OnInit {
     return this.poolState().special_class_used || 0;
   });
 
-  protected performanceAvailable = computed(() => {
+  // Raw special-vdev free space from ZFS, before the metadata reserve is carved out.
+  private rawPerformanceAvailable = computed(() => {
     return this.poolState().special_class_available || 0;
   });
 
+  protected performanceUsable = computed(() => {
+    return this.poolState().special_class_usable || (this.performanceUsed() + this.rawPerformanceAvailable());
+  });
+
+  // Reserve set aside for metadata once usage crosses the threshold; derived from
+  // zfs.tier.config (special_class_metadata_reserve_pct), so it only applies when tiering is on.
   protected performanceReserved = computed(() => {
-    return Math.max(0, this.poolState().special_class_reserved || 0);
+    if (!this.tierEnabled()) {
+      return 0;
+    }
+    return Math.max(0, (this.performanceUsable() * this.reservePct()) / 100);
+  });
+
+  protected performanceAvailable = computed(() => {
+    return Math.max(0, this.rawPerformanceAvailable() - this.performanceReserved());
   });
 
   protected regularUsed = computed(() => {
@@ -151,15 +168,23 @@ export class PoolUsageCardComponent implements OnInit {
   });
 
   protected tierBreakdown = computed(() => {
-    const performanceTotal = this.performanceUsed() + this.performanceAvailable() + this.performanceReserved();
+    // Performance widths are relative to usable capacity so the reserve occupies
+    // a fixed rightmost zone (reservedPercent) that the used bar overlays as it
+    // grows past the threshold. Used is clamped so it can't overflow the bar.
+    const performanceUsable = this.performanceUsable();
     const regularTotal = this.regularUsed() + this.regularAvailable();
     const pct = (value: number, total: number): number => (total > 0 ? (value / total) * 100 : 0);
+
+    // Widths are relative to usable so the reserve is a fixed-width striped zone
+    // pinned to the right. The Used bar runs the full usedPercent and slides
+    // under that zone, so green showing through the stripes is usage that has
+    // eaten into the reserve.
     return {
       performance: {
-        hasData: performanceTotal > 0,
-        usedPercent: pct(this.performanceUsed(), performanceTotal),
-        availablePercent: pct(this.performanceAvailable(), performanceTotal),
-        reservedPercent: pct(this.performanceReserved(), performanceTotal),
+        hasData: performanceUsable > 0,
+        usedPercent: Math.min(100, pct(this.performanceUsed(), performanceUsable)),
+        availablePercent: pct(this.performanceAvailable(), performanceUsable),
+        reservedPercent: Math.min(100, pct(this.performanceReserved(), performanceUsable)),
       },
       regular: {
         hasData: regularTotal > 0,

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.ts
@@ -143,7 +143,9 @@ export class PoolUsageCardComponent implements OnInit {
   });
 
   protected performanceUsable = computed(() => {
-    return this.poolState().special_class_usable || (this.performanceUsed() + this.rawPerformanceAvailable());
+    // Fall back to used + raw available only when usable is genuinely absent;
+    // ?? keeps a legitimate 0 (empty special vdev) from triggering the fallback.
+    return this.poolState().special_class_usable ?? (this.performanceUsed() + this.rawPerformanceAvailable());
   });
 
   // Reserve set aside for metadata once usage crosses the threshold; derived from
@@ -178,12 +180,14 @@ export class PoolUsageCardComponent implements OnInit {
     // Widths are relative to usable so the reserve is a fixed-width striped zone
     // pinned to the right. The Used bar runs the full usedPercent and slides
     // under that zone, so green showing through the stripes is usage that has
-    // eaten into the reserve.
+    // eaten into the reserve. Available is clamped to the space left after Used
+    // so data skew (used + available > usable) can't push it past the reserve.
+    const usedPercent = Math.min(100, pct(this.performanceUsed(), performanceUsable));
     return {
       performance: {
         hasData: performanceUsable > 0,
-        usedPercent: Math.min(100, pct(this.performanceUsed(), performanceUsable)),
-        availablePercent: pct(this.performanceAvailable(), performanceUsable),
+        usedPercent,
+        availablePercent: Math.min(pct(this.performanceAvailable(), performanceUsable), 100 - usedPercent),
         reservedPercent: Math.min(100, pct(this.performanceReserved(), performanceUsable)),
       },
       regular: {

--- a/src/app/pages/storage/stores/pools-dashboard-store.service.spec.ts
+++ b/src/app/pages/storage/stores/pools-dashboard-store.service.spec.ts
@@ -163,7 +163,7 @@ describe('PoolsDashboardStore', () => {
     });
   });
 
-  it('returns 0 for special_class_reserved when class_special_usable is absent', () => {
+  it('returns 0 for special_class_usable when class_special_usable is absent', () => {
     testScheduler.run(({ cold, expectObservable }) => {
       const mockedApi = spectator.inject(ApiService);
       const pools = [
@@ -213,7 +213,9 @@ describe('PoolsDashboardStore', () => {
         b: [
           expect.objectContaining({
             name: 'pool1',
-            special_class_reserved: 0,
+            special_class_usable: 0,
+            special_class_used: 50,
+            special_class_available: 100,
           }),
         ],
       });

--- a/src/app/pages/storage/stores/pools-dashboard-store.service.spec.ts
+++ b/src/app/pages/storage/stores/pools-dashboard-store.service.spec.ts
@@ -163,7 +163,7 @@ describe('PoolsDashboardStore', () => {
     });
   });
 
-  it('returns 0 for special_class_usable when class_special_usable is absent', () => {
+  it('leaves special_class_usable undefined when class_special_usable is absent', () => {
     testScheduler.run(({ cold, expectObservable }) => {
       const mockedApi = spectator.inject(ApiService);
       const pools = [
@@ -213,7 +213,7 @@ describe('PoolsDashboardStore', () => {
         b: [
           expect.objectContaining({
             name: 'pool1',
-            special_class_usable: 0,
+            special_class_usable: undefined,
             special_class_used: 50,
             special_class_available: 100,
           }),

--- a/src/app/pages/storage/stores/pools-dashboard-store.service.ts
+++ b/src/app/pages/storage/stores/pools-dashboard-store.service.ts
@@ -113,22 +113,16 @@ export class PoolsDashboardStore extends ComponentStore<PoolsDashboardState> {
           const zpool = zpoolsByName[pool.name];
           if (!zpool) return pool;
           const toBytes = (raw: number | string | undefined | null): number => Number(raw ?? 0);
-          const specialUsable = zpool.properties.class_special_usable?.value;
-          const specialReserved = specialUsable === undefined || specialUsable === null
-            ? 0
-            : Math.max(
-                0,
-                Number(specialUsable)
-                - toBytes(zpool.properties.class_special_available?.value)
-                - toBytes(zpool.properties.class_special_used?.value),
-              );
+          // The metadata reserve is derived in the Usage card from
+          // zfs.tier.config (special_class_metadata_reserve_pct), so the raw
+          // ZFS values are passed through here untouched.
           return {
             ...pool,
             used: toBytes(zpool.properties.class_normal_used?.value) || pool.used,
             available: toBytes(zpool.properties.class_normal_available?.value) || pool.available,
             special_class_used: toBytes(zpool.properties.class_special_used?.value),
             special_class_available: toBytes(zpool.properties.class_special_available?.value),
-            special_class_reserved: specialReserved,
+            special_class_usable: toBytes(zpool.properties.class_special_usable?.value),
           };
         });
         this.patchState({

--- a/src/app/pages/storage/stores/pools-dashboard-store.service.ts
+++ b/src/app/pages/storage/stores/pools-dashboard-store.service.ts
@@ -116,13 +116,16 @@ export class PoolsDashboardStore extends ComponentStore<PoolsDashboardState> {
           // The metadata reserve is derived in the Usage card from
           // zfs.tier.config (special_class_metadata_reserve_pct), so the raw
           // ZFS values are passed through here untouched.
+          const rawSpecialUsable = zpool.properties.class_special_usable?.value;
           return {
             ...pool,
             used: toBytes(zpool.properties.class_normal_used?.value) || pool.used,
             available: toBytes(zpool.properties.class_normal_available?.value) || pool.available,
             special_class_used: toBytes(zpool.properties.class_special_used?.value),
             special_class_available: toBytes(zpool.properties.class_special_available?.value),
-            special_class_usable: toBytes(zpool.properties.class_special_usable?.value),
+            // Left undefined (not 0) when ZFS doesn't report it, so the Usage card
+            // can tell "absent" from a genuine empty special vdev and fall back.
+            special_class_usable: rawSpecialUsable == null ? undefined : Number(rawSpecialUsable),
           };
         });
         this.patchState({


### PR DESCRIPTION
**Changes:**

<img width="655" height="336" alt="image" src="https://github.com/user-attachments/assets/0f7ca34a-82ab-4f74-ba10-94e59251023c" />

And after fixing alignment too:
<img width="654" height="344" alt="image" src="https://github.com/user-attachments/assets/b8afd312-fa55-42e7-a965-2d5f949a6450" />


Original PR: https://github.com/truenas/webui/pull/13624
