### PR TITLE
NAS-141226 / 26.0.0-RC.1 / Lose ability to Save changes to AD when enter an incorrect Kerberos password initial config time (by AlexKarpov98)

### DIFF
--- a/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.spec.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.spec.ts
@@ -1,6 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { MockComponents } from 'ng-mocks';
@@ -102,6 +102,44 @@ describe('DirectoryServicesConfigFormComponent', () => {
       });
 
       expect(spectator.query(IpaConfigComponent)).toBeTruthy();
+    });
+  });
+
+  describe('clearing stale credential validation errors', () => {
+    interface TestableComponent {
+      form: FormGroup;
+      onCredentialDataChanged: (data: unknown) => void;
+      onCredentialValidityChanged: (isValid: boolean) => void;
+    }
+
+    function setBindPasswordError(component: TestableComponent): void {
+      // FormErrorHandlerService maps credential errors (e.g. a wrong bind password) onto
+      // the main form's service_type control via getFieldsMap().
+      component.form.controls.service_type.setErrors({
+        manualValidateError: true,
+        manualValidateErrorMsg: 'The bind password is not correct.',
+        ixManualValidateError: { message: 'The bind password is not correct.' },
+      });
+    }
+
+    it('clears the manual error when the user edits the credential data', () => {
+      const component = spectator.component as unknown as TestableComponent;
+      setBindPasswordError(component);
+      expect(component.form.controls.service_type.errors).not.toBeNull();
+
+      component.onCredentialDataChanged({ username: 'Administrator', password: 'correct' });
+
+      expect(component.form.controls.service_type.errors).toBeNull();
+    });
+
+    it('clears the manual error when credential validity changes', () => {
+      const component = spectator.component as unknown as TestableComponent;
+      setBindPasswordError(component);
+      expect(component.form.controls.service_type.errors).not.toBeNull();
+
+      component.onCredentialValidityChanged(true);
+
+      expect(component.form.controls.service_type.errors).toBeNull();
     });
   });
 

--- a/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
@@ -157,17 +157,28 @@ export class DirectoryServicesFormComponent implements OnInit {
 
   onCredentialDataChanged(credentialData: DirectoryServicesUpdate['credential']): void {
     this.credentialData = credentialData;
+    // Backend validation errors for credential fields (e.g. an incorrect bind password) are
+    // mapped onto the main form's `service_type` control via getFieldsMap(). Clear those stale
+    // errors when the user edits the credentials so the Save button re-enables once corrected.
+    this.clearManualValidationErrors();
     this.updateFormValidity();
   }
 
   onCredentialValidityChanged(isValid: boolean): void {
     this.validationService.setCredentialValid(isValid);
+    this.clearManualValidationErrors();
     this.updateFormValidity();
   }
 
   onConfigurationDataChanged(configurationData: DirectoryServicesUpdate['configuration']): void {
     this.configurationData = configurationData;
+    this.clearManualValidationErrors();
+    this.updateFormValidity();
     this.cdr.markForCheck();
+  }
+
+  private clearManualValidationErrors(): void {
+    this.validationService.clearFormControlErrors(this.form);
   }
 
   onIpaValidityChanged(isValid: boolean): void {


### PR DESCRIPTION
Testing: see ticket.

Preview:


https://github.com/user-attachments/assets/9a7f342a-50d5-44b3-addb-708c48c8586e



Original PR: https://github.com/truenas/webui/pull/13662
