### PR TITLE
NAS-140350 / 27.0.0-BETA.1 / Truecommand connected per cli but isn't per WebUI

### DIFF
--- a/src/app/modules/truecommand/truecommand-button.component.spec.ts
+++ b/src/app/modules/truecommand/truecommand-button.component.spec.ts
@@ -110,19 +110,25 @@ describe('TruecommandButtonComponent', () => {
 
   [
     {
-      status: TrueCommandStatus.Failed, apiKey: undefined, statusReason: 'Fake Status Reason', expectedButtonId: '#tc-status', expectedDialogType: 'form',
+      status: TrueCommandStatus.Failed, apiKey: undefined, enabled: false, statusReason: 'Fake Status Reason', expectedButtonId: '#tc-status', expectedDialogType: 'form',
     },
     {
-      status: TrueCommandStatus.Failed, apiKey: '123', statusReason: 'Fake Status Reason', expectedButtonId: '#tc-status', expectedDialogType: 'status',
+      status: TrueCommandStatus.Failed, apiKey: '123', enabled: true, statusReason: 'Fake Status Reason', expectedButtonId: '#tc-status', expectedDialogType: 'status',
     },
     {
-      status: TrueCommandStatus.Connected, apiKey: '123', statusReason: 'Fake Status Reason', expectedButtonId: '#tc-status', expectedDialogType: 'status',
+      status: TrueCommandStatus.Connected, apiKey: '123', enabled: true, statusReason: 'Fake Status Reason', expectedButtonId: '#tc-status', expectedDialogType: 'status',
+    },
+    {
+      // api_key is redacted by the middleware but TrueCommand is connected
+      status: TrueCommandStatus.Connected, apiKey: null, enabled: true, statusReason: 'Fake Status Reason', expectedButtonId: '#tc-status', expectedDialogType: 'status',
     },
   ].forEach(({
-    status, apiKey, statusReason, expectedButtonId, expectedDialogType,
+    status, apiKey, enabled, statusReason, expectedButtonId, expectedDialogType,
   }) => {
-    describe(`For status '${status}'`, () => {
-      const createComponent = createComponentWithData({ status, api_key: apiKey, status_reason: statusReason });
+    describe(`For status '${status}' (api_key: ${apiKey}, enabled: ${enabled})`, () => {
+      const createComponent = createComponentWithData({
+        status, api_key: apiKey, enabled, status_reason: statusReason,
+      });
 
       beforeEach(() => {
         spectator = createComponent();

--- a/src/app/modules/truecommand/truecommand-button.component.ts
+++ b/src/app/modules/truecommand/truecommand-button.component.ts
@@ -99,15 +99,24 @@ export class TruecommandButtonComponent implements OnInit {
   ngOnInit(): void {
     this.api.call('truecommand.config').pipe(takeUntilDestroyed(this.destroyRef)).subscribe((config) => {
       this.tcStatus.set(config);
-      this.tcConnected = !!config.api_key;
+      this.tcConnected = this.isConnected(config);
     });
     this.api.subscribe('truecommand.config').pipe(takeUntilDestroyed(this.destroyRef)).subscribe((event) => {
       this.tcStatus.set(event.fields);
-      this.tcConnected = !!event.fields.api_key;
+      this.tcConnected = this.isConnected(event.fields);
       if (this.isTcStatusOpened && this.tcStatusDialogRef) {
         this.tcStatusDialogRef.componentInstance.update(event.fields);
       }
     });
+  }
+
+  private isConnected(config: TrueCommandConfig | null): boolean {
+    if (!config) {
+      return false;
+    }
+    // `api_key` may be redacted by the middleware, so rely on `enabled`
+    // and the connection status instead of the presence of the api key.
+    return !!config.api_key || (config.enabled && config.status !== TrueCommandStatus.Disabled);
   }
 
   handleUpdate(): void {


### PR DESCRIPTION
Automated fix for [NAS-140350](https://ixsystems.atlassian.net/browse/NAS-140350)

Requested by: U0114E6RL6A

## Changes

The status modal uses `remote_url`, `status`, etc. — not the api_key directly — so it works fine with a redacted key.

The fix is complete. Let me provide a summary.

## Summary

### Bug
After upgrading to 26.0.0-BETA.1, TrueCommand showed as connected via CLI, but clicking the TrueCommand status icon in the WebUI opened the **sign-up screen** instead of the **status dialog**.

### Root Cause
In `TruecommandButtonComponent`, the "is connected" state was derived solely from the presence of the API key:

```typescript
this.tcConnected = !!config.api_key;
```

In the newer middleware version, the `truecommand.config` response **redacts the `api_key`** (returns `null`) for security. As a result, `tcConnected` evaluated to `false` even when TrueCommand was actually connected (`status: CONNECTED`, `enabled: true`), causing `handleClick()` to open the signup dialog rather than the status dialog.

### Fix
Added an `isConnected()` helper that no longer relies exclusively on the API key. It treats TrueCommand as connected when an API key is present **or** when it is enabled and not in the `Disabled` status:

```typescript
private isConnected(config: TrueCommandConfig | null): boolean {
  if (!config) {
    return false;
  }
  // `api_key` may be redacted by the middleware, so rely on `enabled`
  // and the connection status instead of the presence of the api key.
  return !!config.api_key || (config.enabled && config.status !== TrueCommandStatus.Disabled);
}
```

This is applied to both the initial `truecommand.config` call and the live `truecommand.config` subscription.

### Tests
Updated `truecommand-button.component.spec.ts`:
- Added an `enabled` field to existing test cases.
- Added a new case covering a **redacted API key** (`apiKey: null`, `enabled: true`, `status: CONNECTED`) that asserts the **status dialog** is opened — directly reproducing and verifying the fix.

The `Connecting` status path is unaffected since it uses a separate button/handler (`stopTrueCommandConnecting`), and the status modal itself doesn't depend on the api_key, so a redacted key is handled gracefully.

Note: I was unable to run the test suite to completion in this environment (the heavy Angular/Jest setup exceeded the command timeout), but the logic was verified against all existing and new test case expectations.
