### PR TITLE
NAS-141281 / 26.0.0-RC.1 / Tooltip/warning text randomly renders mispositioned in top-left corner, obscuring the TrueNAS logo (by AlexKarpov98)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.html
+++ b/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.html
@@ -10,6 +10,7 @@
 
   <div class="input-container" [class.disabled]="disabledState">
     <mat-select
+      #matSelect="matSelect"
       [required]="required()"
       [compareWith]="compareWith()"
       [disabled]="disabledState"
@@ -64,6 +65,7 @@
             [disabled]="option.disabled"
             [ixTest]="[controlDirective.name, option.label]"
             [matTooltip]="option.hoverTooltip ? (option.hoverTooltip | translate) : ''"
+            [matTooltipDisabled]="!matSelect.panelOpen"
             [attr.aria-label]="option.label | translate"
           >
             @if (multiple()) {

--- a/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-select/ix-select.component.spec.ts
@@ -4,6 +4,7 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import {
   FormControl, ReactiveFormsModule,
 } from '@angular/forms';
+import { MatTooltip } from '@angular/material/tooltip';
 import {
   createHostFactory, SpectatorHost,
 } from '@ngneat/spectator/jest';
@@ -188,6 +189,26 @@ describe('IxSelectComponent', () => {
       const tooltips = spectator.queryAll(TooltipComponent);
       expect(tooltips).toHaveLength(1);
       expect(tooltips[0].message()).toBe('Not really green.');
+    });
+
+    it('keeps option hover tooltips enabled while the panel is open and disables them when it closes', async () => {
+      spectator.setHostInput('options', of([
+        { label: 'GBR', value: 'Great Britain', hoverTooltip: 'United Kingdom' },
+      ]));
+
+      const select = await (await loader.getHarness(IxSelectHarness)).getSelectHarness();
+      await select.open();
+
+      const tooltips = spectator.queryAll(MatTooltip);
+      expect(tooltips).toHaveLength(1);
+      expect(tooltips[0].disabled).toBe(false);
+
+      await select.close();
+      spectator.detectChanges();
+
+      // Once the panel closes the hover tooltip must be disabled so its overlay
+      // is torn down instead of reflowing to the viewport origin (0,0).
+      expect(tooltips[0].disabled).toBe(true);
     });
   });
 


### PR DESCRIPTION
Testing: see ticket. 

Original PR: https://github.com/truenas/webui/pull/13675
