### PR TITLE
NAS-141262 / 26.0.0-RC.1 /  Est. Usable Raw Capacity displays "NaN B" when dRAID spare count is 0 (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.spec.ts
@@ -372,7 +372,7 @@ describe('PoolManagerValidationService', () => {
     it('adds a warning when dRAID children is less than 10', async () => {
       const errors = await firstValueFrom(spectator.service.getPoolCreationErrors());
       expect(errors).toContainEqual({
-        text: 'In order for dRAID to overweight its benefits over RaidZ the minimum recommended number of disks per dRAID vdev is 10.',
+        text: 'For dRAID\'s benefits to outweigh those of RaidZ, we recommend at least 10 disks per dRAID vdev.',
         severity: PoolCreationSeverity.Warning,
         step: PoolCreationWizardStep.Data,
       });

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager-validation.service.ts
@@ -355,7 +355,7 @@ export class PoolManagerValidationService {
 
     if (Number(topologyCategory.width) < 10) {
       errors.push({
-        text: this.translate.instant('In order for dRAID to overweight its benefits over RaidZ the minimum recommended number of disks per dRAID vdev is 10.'),
+        text: this.translate.instant('For dRAID\'s benefits to outweigh those of RaidZ, we recommend at least 10 disks per dRAID vdev.'),
         severity: PoolCreationSeverity.Warning,
         step: PoolCreationWizardStep.Data,
       });

--- a/src/app/pages/storage/modules/pool-manager/utils/capacity.utils.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/capacity.utils.spec.ts
@@ -16,6 +16,32 @@ describe('categoryCapacity', () => {
 
     expect(categoryCapacity(category)).toEqual(11 * GiB);
   });
+
+  it('calculates dRAID capacity when spare count is 0', () => {
+    const category = {
+      layout: CreateVdevLayout.Draid1,
+      draidDataDisks: 2,
+      draidSpareDisks: 0,
+      vdevs: [
+        [{ size: 3 * GiB }, { size: 5 * GiB }, { size: 5 * GiB }],
+      ],
+    } as PoolManagerTopologyCategory;
+
+    expect(categoryCapacity(category) / GiB).toBeCloseTo(6);
+  });
+
+  it('returns 0 for an incomplete dRAID config with no data disks selected', () => {
+    const category = {
+      layout: CreateVdevLayout.Draid1,
+      draidDataDisks: null,
+      draidSpareDisks: 0,
+      vdevs: [
+        [{ size: 15 * GiB }],
+      ],
+    } as PoolManagerTopologyCategory;
+
+    expect(categoryCapacity(category)).toBe(0);
+  });
 });
 
 describe('vdevCapacity', () => {

--- a/src/app/pages/storage/modules/pool-manager/utils/capacity.utils.ts
+++ b/src/app/pages/storage/modules/pool-manager/utils/capacity.utils.ts
@@ -8,8 +8,8 @@ export function categoryCapacity(topologyCategory: PoolManagerTopologyCategory):
     return sum + vdevCapacity({
       vdev,
       layout: topologyCategory.layout,
-      draidDataDisks: topologyCategory.draidDataDisks || undefined,
-      draidSpareDisks: topologyCategory.draidSpareDisks || undefined,
+      draidDataDisks: topologyCategory.draidDataDisks ?? undefined,
+      draidSpareDisks: topologyCategory.draidSpareDisks ?? undefined,
     });
   }, 0);
 }
@@ -83,7 +83,11 @@ function dRaidCapacity(values: {
   size: number;
   spares: number;
 }): number {
-  return (values.children - values.spares)
+  const capacity = (values.children - values.spares)
     * (values.dataPerGroup / (values.dataPerGroup + values.parity))
     * values.size;
+
+  // Configuration may be incomplete (e.g. data disks not yet selected),
+  // which would make the estimate NaN. Treat that as no estimate.
+  return Number.isFinite(capacity) ? capacity : 0;
 }


### PR DESCRIPTION
Preview:

<img width="881" height="404" alt="NAS-141262" src="https://github.com/user-attachments/assets/cc2480c7-6bbc-48eb-941c-768364978954" />


Original PR: https://github.com/truenas/webui/pull/13665
