### PR TITLE
NAS-141442 / 27.0.0-BETA.1 / fix dependabot package deletion from `yarn.lock`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5154,6 +5154,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ws@npm:~8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/1ce05e3174dcacf28dae0e9b854ef1c9a12da44c7ed73617ab6897c5cbe4fccbb155a20be5508ae9a7dde2f83bd80f5cf3baa386b934fc4b40889ec963e94f3a
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
@@ -16030,6 +16039,7 @@ __metadata:
     "@types/node": "npm:^24.0.0"
     "@types/uuid": "npm:~10.0.0"
     "@types/vinyl": "npm:~2.0.12"
+    "@types/ws": "npm:~8.18.1"
     "@typescript-eslint/types": "npm:~8.41.0"
     "@typescript-eslint/utils": "npm:~8.41.0"
     "@uiw/codemirror-theme-material": "npm:~4.23.6"


### PR DESCRIPTION
**Changes:**
looks like dependabot somehow deleted the `@types/ws` package from our `yarn.lock` file in 0c00a73 which seems to have broken the build. all i did here was run `yarn install` to update the lockfile.

**Testing:**
nothing should change with the app, but make sure it builds locally :)

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
