### PR TITLE
NAS-141554 / 27.0.0-BETA.1 / Run Claude review workflow on NAS-* branch PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize]
     branches:
       - master
+      - 'NAS-*'
     paths-ignore:
       - 'src/assets/i18n/**'
 jobs:


### PR DESCRIPTION
## Summary
- Add `NAS-*` to the `branches` trigger list in the Claude review workflow so the automated review also runs on PRs targeting feature branches, not just `master`.