### PR TITLE
NAS-141600 / 27.0.0-BETA.1 / Open dashboard backup wizards in the side panel and fix credential race

### DIFF
--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
@@ -14,7 +14,6 @@ import { ApiTimestamp } from 'app/interfaces/api-date.interface';
 import { BackupTile } from 'app/interfaces/cloud-backup.interface';
 import { FormSidePanelService } from 'app/modules/slide-ins/form-side-panel/form-side-panel.service';
 import { SidePanelForm } from 'app/modules/slide-ins/side-panel-form.directive';
-import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
 import { SlotSize } from 'app/pages/dashboard/types/widget.interface';
 import { backupTasksWidget } from 'app/pages/dashboard/widgets/backup/widget-backup/widget-backup.definition';
@@ -61,7 +60,6 @@ interface BackupRow {
 export class WidgetBackupComponent implements OnInit {
   translate = inject(TranslateService);
   private cdr = inject(ChangeDetectorRef);
-  private slideIn = inject(SlideIn);
   private formPanel = inject(FormSidePanelService);
   private widgetResourcesService = inject(WidgetResourcesService);
   private destroyRef = inject(DestroyRef);
@@ -152,21 +150,29 @@ export class WidgetBackupComponent implements OnInit {
       });
   }
 
+  // CloudSyncWizardComponent / ReplicationWizardComponent / RsyncTaskFormComponent structurally
+  // provide the host surface (closed/canSubmit/submit/hasUnsavedChanges/requiredRoles) the panel
+  // reads; cast past the nominal base type. The wizards are `footerless` — their mat-stepper owns
+  // its Next/Save buttons, and "Advanced" swaps in place via the form panel.
+  private readonly cloudSyncWizard = CloudSyncWizardComponent as unknown as Type<SidePanelForm>;
+  private readonly replicationWizard = ReplicationWizardComponent as unknown as Type<SidePanelForm>;
+  private readonly rsyncTaskForm = RsyncTaskFormComponent as unknown as Type<SidePanelForm>;
+
   addCloudSyncTask(): void {
-    this.slideIn.open(
-      CloudSyncWizardComponent,
-      { wide: true },
-    ).onSuccess(() => this.getBackups(), this.destroyRef);
+    this.formPanel.open(this.cloudSyncWizard, {
+      title: this.translate.instant('Cloud Sync Task Wizard'),
+      wide: true,
+      footerless: true,
+    }).onSuccess(() => this.getBackups(), this.destroyRef);
   }
 
   addReplicationTask(): void {
-    this.slideIn.open(ReplicationWizardComponent, { wide: true })
-      .onSuccess(() => this.getBackups(), this.destroyRef);
+    this.formPanel.open(this.replicationWizard, {
+      title: this.translate.instant('Replication Task Wizard'),
+      wide: true,
+      footerless: true,
+    }).onSuccess(() => this.getBackups(), this.destroyRef);
   }
-
-  // RsyncTaskFormComponent structurally provides the host surface (closed/canSubmit/submit/
-  // hasUnsavedChanges/requiredRoles) the panel reads; cast past the nominal base type.
-  private readonly rsyncTaskForm = RsyncTaskFormComponent as unknown as Type<SidePanelForm>;
 
   addRsyncTask(): void {
     this.formPanel.open(this.rsyncTaskForm, { title: this.translate.instant('Add Rsync Task'), wide: true })

--- a/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-provider/cloudsync-provider.component.spec.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-provider/cloudsync-provider.component.spec.ts
@@ -77,8 +77,17 @@ describe('CloudSyncProviderComponent', () => {
     ],
   });
 
-  beforeEach(() => {
-    spectator = createComponent();
+  // Created per-test (not in a shared beforeEach) so individual tests can override the credentials
+  // mock — overrideProvider must run before TestBed is instantiated.
+  function setup(getCloudSyncCredentials: jest.Mock = jest.fn(() => of([googlePhotosCreds]))): void {
+    spectator = createComponent({
+      providers: [
+        mockProvider(CloudCredentialService, {
+          getCloudSyncCredentials,
+          getProviders: jest.fn(() => of([storjProvider, googlePhotosProvider])),
+        }),
+      ],
+    });
     Object.defineProperty(spectator.component, 'loading', {
       value: loading,
     });
@@ -86,9 +95,10 @@ describe('CloudSyncProviderComponent', () => {
       value: save,
     });
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
-  });
+  }
 
   it('emits the value of credentials when credentials value changes', async () => {
+    setup();
     await (await loader.getHarness(TnSelectHarness.with({ ancestor: '[formControlName="exist_credential"]' })))
       .selectOption('Google Photos (Google Photos)');
 
@@ -99,6 +109,7 @@ describe('CloudSyncProviderComponent', () => {
   });
 
   it('verifies entered values when user presses Verify', async () => {
+    setup();
     await (await loader.getHarness(TnSelectHarness.with({ ancestor: '[formControlName="exist_credential"]' })))
       .selectOption('Google Photos (Google Photos)');
 
@@ -114,5 +125,29 @@ describe('CloudSyncProviderComponent', () => {
       client_secret: 'test-client-secret',
       token: 'test-token',
     }]);
+  });
+
+  it('re-fetches and emits the credential when the chosen one is not cached yet', async () => {
+    // Reproduces the dashboard race: this step's own credentials query is still cold when the user
+    // picks an option (the select loads its options independently), so the first lookup misses.
+    setup(
+      jest.fn()
+        .mockReturnValueOnce(of([])) // cold cache when the step initializes
+        .mockReturnValue(of([googlePhotosCreds])), // populated by the time it re-fetches
+    );
+
+    await (await loader.getHarness(TnSelectHarness.with({ ancestor: '[formControlName="exist_credential"]' })))
+      .selectOption('Google Photos (Google Photos)');
+
+    expect(save.emit).toHaveBeenCalledWith(googlePhotosCreds);
+  });
+
+  it('does nothing on Verify when no credential is selected', () => {
+    setup();
+    spectator.component.onVerify();
+
+    expect(loading.emit).not.toHaveBeenCalled();
+    expect(spectator.inject(ApiService).call)
+      .not.toHaveBeenCalledWith('cloudsync.credentials.verify', expect.anything());
   });
 });

--- a/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-provider/cloudsync-provider.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-provider/cloudsync-provider.component.ts
@@ -123,6 +123,9 @@ export class CloudSyncProviderComponent implements OnInit {
   }
 
   onVerify(): void {
+    if (!this.existingCredential) {
+      return;
+    }
     this.loading.emit(true);
 
     const payload = this.existingCredential.provider;
@@ -194,8 +197,28 @@ export class CloudSyncProviderComponent implements OnInit {
   }
 
   private emitSelectedCredential(credsId: number): void {
-    this.existingCredential = this.credentials.find((credential) => credential.id === credsId);
-    this.save.emit(this.existingCredential);
-    this.cdr.markForCheck();
+    const cached = this.credentials.find((credential) => credential.id === credsId);
+    if (cached) {
+      this.existingCredential = cached;
+      this.save.emit(this.existingCredential);
+      this.cdr.markForCheck();
+      return;
+    }
+
+    // The credentials cache may not be loaded yet — e.g. when the wizard is opened from the
+    // dashboard, where many concurrent API calls delay this step's own credentials query. Fetch
+    // before resolving so actions (Next/Verify) never operate on an undefined credential.
+    this.loading.emit(true);
+    this.cloudCredentialService.getCloudSyncCredentials().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (creds) => {
+        this.credentials = creds;
+        this.existingCredential = creds.find((credential) => credential.id === credsId);
+        this.save.emit(this.existingCredential);
+        this.cdr.markForCheck();
+      },
+      complete: () => {
+        this.loading.emit(false);
+      },
+    });
   }
 }

--- a/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-provider/cloudsync-provider.component.ts
+++ b/src/app/pages/data-protection/cloudsync/cloudsync-wizard/steps/cloudsync-provider/cloudsync-provider.component.ts
@@ -6,9 +6,7 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { MatStepper } from '@angular/material/stepper';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { TnButtonComponent, TnFormSectionComponent } from '@truenas/ui-components';
-import {
-  catchError, EMPTY, of, pairwise, startWith,
-} from 'rxjs';
+import { catchError, EMPTY, of } from 'rxjs';
 import { helptextSystemCloudcredentials as helptext } from 'app/helptext/system/cloud-credentials';
 import { CloudSyncCredential } from 'app/interfaces/cloudsync-credential.interface';
 import { newOption } from 'app/interfaces/option.interface';
@@ -165,12 +163,8 @@ export class CloudSyncProviderComponent implements OnInit {
 
   private setFormEvents(): void {
     this.form.controls.exist_credential.valueChanges
-      .pipe(
-        startWith(undefined),
-        pairwise(),
-        takeUntilDestroyed(this.destroyRef),
-      ).subscribe(([previousCreds, currentCreds]) => {
-        const isPreviousValueAddNew = previousCreds != null && previousCreds.toString() === addNewIxSelectValue;
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((currentCreds) => {
         const isCurrentValueExists = currentCreds != null;
         const isCurrentValueAddNew = isCurrentValueExists && currentCreds.toString() === addNewIxSelectValue;
 
@@ -178,21 +172,9 @@ export class CloudSyncProviderComponent implements OnInit {
           return;
         }
 
-        if (!isPreviousValueAddNew) {
-          this.emitSelectedCredential(currentCreds as number);
-          return;
-        }
-
-        this.loading.emit(true);
-        this.cloudCredentialService.getCloudSyncCredentials().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-          next: (creds) => {
-            this.credentials = creds;
-            this.emitSelectedCredential(currentCreds as number);
-          },
-          complete: () => {
-            this.loading.emit(false);
-          },
-        });
+        // A freshly created credential (via the select's "Add New") isn't in the cached list yet;
+        // emitSelectedCredential re-fetches on a cache miss, so both cases funnel through it.
+        this.emitSelectedCredential(currentCreds as number);
       });
   }
 
@@ -214,6 +196,11 @@ export class CloudSyncProviderComponent implements OnInit {
         this.credentials = creds;
         this.existingCredential = creds.find((credential) => credential.id === credsId);
         this.save.emit(this.existingCredential);
+        this.cdr.markForCheck();
+      },
+      error: (error: unknown) => {
+        this.loading.emit(false);
+        this.formErrorHandler.handleValidationErrors(error, this.form);
         this.cdr.markForCheck();
       },
       complete: () => {


### PR DESCRIPTION
The dashboard backup widget opened the Cloud Sync and Replication wizards in the
legacy `SlideIn`, unlike the rest of the app (side-panel form panel). This also
broke the wizard ⇄ "Advanced Options" swap and exposed a race where the selected
credential wasn't loaded yet.

- Open both wizards via `FormSidePanelService` (`footerless`), matching the
  data-protection cards/lists.
- cloudsync-provider: re-fetch credentials on a cache miss, guard `onVerify`
  against an undefined credential, and handle re-fetch errors.

Tested: new specs for the re-fetch and verify-guard paths; specs + lint pass.
