### PR TITLE
NAS-141432 / 26.0.0-RC.1 / Add TrueCloud Backup to dashboard Backup Tasks widget (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/services/widget-resources.service.ts
+++ b/src/app/pages/dashboard/services/widget-resources.service.ts
@@ -52,6 +52,7 @@ export class WidgetResourcesService {
     this.api.call('replication.query'),
     this.api.call('rsynctask.query'),
     this.api.call('cloudsync.query'),
+    this.api.call('cloud_backup.query'),
   ]).pipe(
     shareReplay({ bufferSize: 1, refCount: true }),
   );

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-tile/backup-task-tile.component.html
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-tile/backup-task-tile.component.html
@@ -1,14 +1,14 @@
 @if (tile(); as tile) {
   <div class="tile">
     <div class="tile-content">
-      <ul class="caption">
-        <span class="title">{{ tile.title | translate }}</span>
+      <div class="caption">
+        <h4 class="title">{{ tile.title | translate }}</h4>
         @if (hasSendTasks() && !tile.totalSend) {
           <div class="backup-actions">
             <ng-template *ngTemplateOutlet="backupActions() || null"></ng-template>
           </div>
         }
-      </ul>
+      </div>
 
       <div class="divider"></div>
 
@@ -41,7 +41,7 @@
 
       <div class="divider"></div>
 
-      <ul [style.max-width.%]="50">
+      <ul class="activity">
         <li>
           @if (tile.lastWeekSend) {
             <span class="label">

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-tile/backup-task-tile.component.scss
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-tile/backup-task-tile.component.scss
@@ -1,6 +1,8 @@
 @import 'mixins/cards';
 
 :host {
+  container: backup-tile / inline-size;
+  display: block;
   height: 100%;
   width: 100%;
 }
@@ -44,18 +46,27 @@ ul {
       }
     }
 
-    ul {
+    ul,
+    .caption {
       box-sizing: border-box;
       display: flex;
       flex: 1 1 100%;
       flex-direction: column;
       justify-content: center;
+    }
 
-      &:first-child {
-        text-align: center;
+    // The title column (first child of the row).
+    .caption {
+      max-width: 25%;
+      text-align: center;
+
+      @media(max-width: $breakpoint-xs) {
+        max-width: 50%;
       }
+    }
 
-      &:first-child,
+    ul {
+      // The task-counts column.
       &:nth-child(3) {
         max-width: 25%;
 
@@ -64,7 +75,9 @@ ul {
         }
       }
 
-      &:nth-child(5) {
+      &.activity {
+        max-width: 50%;
+
         @media(max-width: $breakpoint-xs) {
           display: none;
         }
@@ -93,6 +106,7 @@ ul {
 
     .title {
       font-size: 20px;
+      margin: 0;
       white-space: nowrap;
     }
 
@@ -121,6 +135,74 @@ ul {
 
     &.safe {
       color: var(--green);
+    }
+  }
+}
+
+// The default tile is a wide horizontal row built for full width. When the tile
+// itself gets narrow (e.g. the two-column layout that kicks in once every backup
+// type is configured), the horizontal row no longer fits: stack it vertically —
+// title, then task counts, then the "this week / last successful" activity — and
+// drop the inline backup-actions prompt, which has no room. Keyed off the tile's
+// own width via a container query, so wide tiles (single column, or two columns on
+// a large dashboard) keep the full layout. Scoped through `.tile` to outrank the
+// base `.tile-content` rules above.
+@container backup-tile (max-width: 400px) {
+  .tile .tile-content {
+    // Stretch rows to the full tile width so labels left-align and don't collapse
+    // to a truncated shrink-to-fit width.
+    align-items: stretch;
+    flex-direction: column;
+    gap: 4px;
+    justify-content: center;
+    padding: 8px 14px;
+
+    .divider {
+      display: none;
+    }
+
+    .backup-actions {
+      display: none;
+    }
+
+    // Full width so labels left-align and don't truncate when stacked.
+    ul,
+    .caption {
+      flex: 0 0 auto;
+      max-width: 100%;
+      text-align: left;
+      width: 100%;
+    }
+
+    // The base row layout caps the counts column at 25% via a `:nth-child(3)`
+    // rule whose specificity (0,3,1) outranks the grouped `ul` selector above;
+    // re-cap it at full width here at matching specificity, otherwise the counts
+    // stay 25% wide and their labels truncate ("0 s…" instead of "0 send tasks").
+    ul:nth-child(3) {
+      max-width: 100%;
+    }
+
+    ul {
+      // "this week / last successful" activity — surface the "Last successful"
+      // row stacked under the counts (separated by a hairline) instead of hiding
+      // the whole column. The per-week rows don't fit alongside the counts, so
+      // keep them for the wide layout only.
+      &.activity {
+        border-top: 1px solid var(--lines);
+        display: flex;
+        max-width: 100%;
+        padding-top: 6px;
+        width: 100%;
+
+        li:not(:last-child) {
+          display: none;
+        }
+      }
+    }
+
+    // Match the neighbouring Storage widget's tile-header-title size.
+    .title {
+      font-size: 24px;
     }
   }
 }

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.html
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.html
@@ -43,17 +43,21 @@
     <div [class]="['container', size()]">
       @if (backupsTiles.length) {
         <div class="container-content">
-          <mat-grid-list gutterSize="5px" [cols]="1" [rowHeight]="hasSendTasks ? 105 : 90">
+          <div
+            class="tiles-grid"
+            [class.two-columns]="backupsTiles.length > 3"
+            [style.--tile-height.px]="hasSendTasks ? 105 : 90"
+          >
             @for (tile of backupsTiles; track trackByTile($index, tile)) {
-              <mat-grid-tile>
+              <div class="tile-cell">
                 <ix-backup-task-tile
                   [tile]="tile"
                   [hasSendTasks]="hasSendTasks"
                   [backupActions]="backupActions"
                 ></ix-backup-task-tile>
-              </mat-grid-tile>
+              </div>
             }
-          </mat-grid-list>
+          </div>
           @if (!hasSendTasks) {
             <div class="banner">
               <ng-template *ngTemplateOutlet="backupActions"></ng-template>

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.scss
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.scss
@@ -57,13 +57,16 @@
   }
 
   .container {
+    flex: 1;
+    min-height: 0;
     padding-top: 0;
 
     .container-content {
       display: flex;
       flex-direction: column;
-      height: calc(100% + 10px);
+      height: 100%;
       justify-content: space-between;
+      min-height: 0;
 
       .banner {
         background: var(--bg1);
@@ -74,8 +77,27 @@
   }
 }
 
-mat-grid-tile {
+.tiles-grid {
+  display: grid;
+  gap: 5px;
+  grid-auto-rows: var(--tile-height);
+  grid-template-columns: 1fr;
+
+  // Keep the single-column layout for up to 3 tiles; once every backup type is
+  // configured (4+), wrap into two columns so all tiles fit the fixed-height
+  // card without scrolling. The two-column rows stretch to fill the card height
+  // (like the neighbouring Storage widget) rather than leaving the lower half empty.
+  &.two-columns {
+    flex: 1;
+    grid-auto-rows: minmax(var(--tile-height), 1fr);
+    grid-template-columns: 1fr 1fr;
+    min-height: 0;
+  }
+}
+
+.tile-cell {
   background-color: var(--bg1);
   border-radius: 2px;
   opacity: 0.7;
+  overflow: hidden;
 }

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.spec.ts
@@ -9,6 +9,7 @@ import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { Direction } from 'app/enums/direction.enum';
 import { JobState } from 'app/enums/job-state.enum';
 import { TaskState } from 'app/enums/task-state.enum';
+import { CloudBackup } from 'app/interfaces/cloud-backup.interface';
 import { CloudSyncTask } from 'app/interfaces/cloud-sync-task.interface';
 import { ReplicationTask } from 'app/interfaces/replication-task.interface';
 import { RsyncTask } from 'app/interfaces/rsync-task.interface';
@@ -116,6 +117,29 @@ const cloudSyncTasks = [
   },
 ] as CloudSyncTask[];
 
+const cloudBackupTasks = [
+  {
+    id: 1,
+    job: {
+      id: 1,
+      state: JobState.Success,
+      time_finished: {
+        $date: currentDatetime.getTime() - 20000,
+      },
+    },
+  },
+  {
+    id: 2,
+    job: {
+      id: 2,
+      state: JobState.Failed,
+      time_finished: {
+        $date: currentDatetime.getTime() - 40000,
+      },
+    },
+  },
+] as CloudBackup[];
+
 describe('WidgetBackupComponent', () => {
   let spectator: Spectator<WidgetBackupComponent>;
   let widgetBackup: WidgetBackupHarness;
@@ -144,7 +168,7 @@ describe('WidgetBackupComponent', () => {
         },
         providers: [
           mockProvider(WidgetResourcesService, {
-            backups$: of([[], [], []]),
+            backups$: of([[], [], [], []]),
           }),
         ],
       });
@@ -171,7 +195,7 @@ describe('WidgetBackupComponent', () => {
         },
         providers: [
           mockProvider(WidgetResourcesService, {
-            backups$: of([replicationTasks, rsyncTasks, cloudSyncTasks]),
+            backups$: of([replicationTasks, rsyncTasks, cloudSyncTasks, cloudBackupTasks]),
           }),
         ],
       });
@@ -197,13 +221,17 @@ describe('WidgetBackupComponent', () => {
           firstColumn: ['1 send task', '2 receive tasks', 'Total failed: 0'],
           secondColumn: ['1 sent task this week', '1 received task this week', `Last successful: ${format(currentDatetime.getTime() - 10000, 'yyyy-MM-dd HH:mm:ss')}`],
         },
+        'TrueCloud Backup': {
+          firstColumn: ['2 send tasks', '0 receive tasks', 'Total failed: 1'],
+          secondColumn: ['1 sent task this week', '—', `Last successful: ${format(currentDatetime.getTime() - 20000, 'yyyy-MM-dd HH:mm:ss')}`],
+        },
       });
     });
 
     it('shows alert status when there are errors', async () => {
       const header = await widgetBackup.getHeader();
       expect(header.icon).toBe('alert');
-      expect(header.message).toBe('3 of 8 tasks failed');
+      expect(header.message).toBe('4 of 10 tasks failed');
     });
   });
 
@@ -232,6 +260,7 @@ describe('WidgetBackupComponent', () => {
                   time_finished: { $date: currentDatetime.getTime() - 50000 },
                 },
               }] as RsyncTask[],
+              [],
               [],
             ]),
           }),
@@ -276,6 +305,7 @@ describe('WidgetBackupComponent', () => {
                 },
               }] as RsyncTask[],
               [],
+              [],
             ]),
           }),
         ],
@@ -305,6 +335,7 @@ describe('WidgetBackupComponent', () => {
               [],
               [],
               cloudSyncTasks,
+              [],
             ]),
           }),
         ],

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
@@ -3,7 +3,6 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnIn
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatIconAnchor } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
-import { MatGridList, MatGridTile } from '@angular/material/grid-list';
 import { MatTooltip } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
@@ -31,6 +30,7 @@ enum BackupType {
   CloudSync = 'Cloud Sync',
   Rsync = 'Rsync',
   Replication = 'Replication',
+  CloudBackup = 'TrueCloud Backup',
 }
 
 interface BackupRow {
@@ -55,8 +55,6 @@ interface BackupRow {
     TestDirective,
     MatTooltip,
     RouterLink,
-    MatGridList,
-    MatGridTile,
     BackupTaskTileComponent,
     BackupTaskEmptyComponent,
     BackupTaskActionsComponent,
@@ -103,6 +101,10 @@ export class WidgetBackupComponent implements OnInit {
     return this.backups.filter((backup) => backup.type === BackupType.Rsync);
   }
 
+  get cloudBackupTasks(): BackupRow[] {
+    return this.backups.filter((backup) => backup.type === BackupType.CloudBackup);
+  }
+
   get backupsTiles(): BackupTile[] {
     const tiles: BackupTile[] = [];
     if (this.cloudSyncTasks.length) {
@@ -115,6 +117,10 @@ export class WidgetBackupComponent implements OnInit {
 
     if (this.rsyncTasks.length) {
       tiles.push(this.getTile(this.translate.instant('Rsync'), this.rsyncTasks));
+    }
+
+    if (this.cloudBackupTasks.length) {
+      tiles.push(this.getTile(this.translate.instant('TrueCloud Backup'), this.cloudBackupTasks));
     }
     return tiles;
   }
@@ -131,7 +137,7 @@ export class WidgetBackupComponent implements OnInit {
     this.isLoading = true;
     this.widgetResourcesService.backups$
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(([replicationTasks, rsyncTasks, cloudSyncTasks]) => {
+      .subscribe(([replicationTasks, rsyncTasks, cloudSyncTasks, cloudBackupTasks]) => {
         this.isLoading = false;
         this.backups = [
           ...replicationTasks.map((task) => ({
@@ -149,6 +155,12 @@ export class WidgetBackupComponent implements OnInit {
           ...cloudSyncTasks.map((task) => ({
             type: BackupType.CloudSync,
             direction: task.direction,
+            state: task.job?.state || (task.locked ? TaskState.Locked : TaskState.Pending),
+            timestamp: task.job?.time_finished,
+          })),
+          ...cloudBackupTasks.map((task) => ({
+            type: BackupType.CloudBackup,
+            direction: Direction.Push,
             state: task.job?.state || (task.locked ? TaskState.Locked : TaskState.Pending),
             timestamp: task.job?.time_finished,
           })),


### PR DESCRIPTION
for 4 tasks I introduced 2 column layout, if <= 3 then 1 column layout preserved:

<img width="574" height="429" alt="Screenshot 2026-06-30 at 12 03 39" src="https://github.com/user-attachments/assets/39d9b96a-4549-49de-bf62-0d4af0c0b9f2" />

<img width="577" height="434" alt="Screenshot 2026-06-30 at 12 12 54" src="https://github.com/user-attachments/assets/c52f079e-5c05-497d-91e4-15b3a3d6684d" />


Original PR: https://github.com/truenas/webui/pull/13748
