### PR TITLE
NAS-141613 / 26.0.0-RC.1 / Hide thumbprint on enterprise, simplify thumbprint dialog (by aervin)

### DIFF
--- a/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.html
+++ b/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.html
@@ -7,10 +7,6 @@
       <span>{{ 'Loading thumbprint…' | translate }}</span>
     </div>
   } @else {
-    <p class="hint">
-      {{ 'This identifies your system to the licensing service. Share it with TrueNAS support to request or update a license.' | translate }}
-    </p>
-
     @if (fingerprintFields(); as fields) {
       <dl class="fingerprint-fields">
         @for (field of fields; track field.key) {

--- a/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.scss
+++ b/src/app/pages/system/general-settings/support/license-fingerprint-dialog/license-fingerprint-dialog.component.scss
@@ -2,12 +2,6 @@
   min-width: 480px;
 }
 
-.hint {
-  color: var(--fg2);
-  font-size: 13px;
-  margin: 0 0 12px;
-}
-
 .loading {
   align-items: center;
   display: flex;

--- a/src/app/pages/system/general-settings/support/support-card/support-card.component.scss
+++ b/src/app/pages/system/general-settings/support/support-card/support-card.component.scss
@@ -33,6 +33,7 @@
 
   &.proactive {
     border-left: 3px solid var(--green);
+    margin-top: 1rem;
   }
 
   &.upsell {

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -120,30 +120,32 @@
     }
   }
 
-  <mat-list-item class="fingerprint-row">
-    <span class="label">{{ 'System Thumbprint' | translate }}:</span>
-    <span class="value fingerprint-actions">
-      <button
-        mat-icon-button
-        type="button"
-        ixTest="view-fingerprint"
-        [attr.aria-label]="'View System Thumbprint' | translate"
-        [matTooltip]="'View Thumbprint' | translate"
-        (click)="openFingerprintDialog()"
-      >
-        <tn-icon name="eye" library="mdi" size="md"></tn-icon>
-      </button>
-      <button
-        mat-icon-button
-        type="button"
-        ixTest="copy-fingerprint"
-        [attr.aria-label]="'Copy System Thumbprint' | translate"
-        [disabled]="isFingerprintBusy()"
-        [matTooltip]="'Copy to Clipboard' | translate"
-        (click)="copyFingerprint()"
-      >
-        <tn-icon name="content-copy" library="mdi" size="md"></tn-icon>
-      </button>
-    </span>
-  </mat-list-item>
+  @if (!isEnterprise()) {
+    <mat-list-item class="fingerprint-row">
+      <span class="label">{{ 'System Thumbprint' | translate }}:</span>
+      <span class="value fingerprint-actions">
+        <button
+          mat-icon-button
+          type="button"
+          ixTest="view-fingerprint"
+          [attr.aria-label]="'View System Thumbprint' | translate"
+          [matTooltip]="'View Thumbprint' | translate"
+          (click)="openFingerprintDialog()"
+        >
+          <tn-icon name="eye" library="mdi" size="md"></tn-icon>
+        </button>
+        <button
+          mat-icon-button
+          type="button"
+          ixTest="copy-fingerprint"
+          [attr.aria-label]="'Copy System Thumbprint' | translate"
+          [disabled]="isFingerprintBusy()"
+          [matTooltip]="'Copy to Clipboard' | translate"
+          (click)="copyFingerprint()"
+        >
+          <tn-icon name="content-copy" library="mdi" size="md"></tn-icon>
+        </button>
+      </span>
+    </mat-list-item>
+  }
 </mat-list>

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -4,6 +4,7 @@ import { FormControl } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { createComponentFactory, Spectator, mockProvider } from '@ngneat/spectator/jest';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { ContractType } from 'app/interfaces/system-info.interface';
@@ -14,6 +15,7 @@ import {
 import { LicenseInfoInSupport } from 'app/pages/system/general-settings/support/license-info-in-support.interface';
 import { SysInfoComponent } from 'app/pages/system/general-settings/support/sys-info/sys-info.component';
 import { SystemInfoInSupport } from 'app/pages/system/general-settings/support/system-info-in-support.interface';
+import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors';
 
 describe('SysInfoComponent', () => {
   const systemInfo = {
@@ -42,6 +44,11 @@ describe('SysInfoComponent', () => {
       mockAuth(),
       mockProvider(MatDialog, { open: jest.fn() }),
       mockApi([mockCall('truenas.license.fingerprint', fingerprintBase64)]),
+      provideMockStore({
+        selectors: [
+          { selector: selectIsEnterprise, value: false },
+        ],
+      }),
     ],
   });
 
@@ -171,6 +178,19 @@ describe('SysInfoComponent', () => {
   });
 
   describe('License fingerprint', () => {
+    it('shows the thumbprint row on community (non-enterprise) systems', () => {
+      expect(spectator.query('.fingerprint-row')).toExist();
+    });
+
+    it('hides the thumbprint row on enterprise systems', () => {
+      const store$ = spectator.inject(MockStore);
+      store$.overrideSelector(selectIsEnterprise, true);
+      store$.refreshState();
+      spectator.detectChanges();
+
+      expect(spectator.query('.fingerprint-row')).not.toExist();
+    });
+
     it('renders a View Fingerprint button regardless of license state', async () => {
       spectator.setInput({ hasLicense: false, licenseInfo: undefined });
       expect(spectator.query('.fingerprint-row')).toExist();

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.ts
@@ -1,12 +1,13 @@
 import {
   ChangeDetectionStrategy, Component, DestroyRef, inject, input, output, signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatListModule } from '@angular/material/list';
 import { MatTooltip } from '@angular/material/tooltip';
+import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { TnIconComponent } from '@truenas/ui-components';
 import { Observable, of, tap } from 'rxjs';
@@ -26,6 +27,8 @@ import {
 import { LicenseInfoInSupport } from 'app/pages/system/general-settings/support/license-info-in-support.interface';
 import { SystemInfoInSupport } from 'app/pages/system/general-settings/support/system-info-in-support.interface';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+import { AppState } from 'app/store';
+import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-sys-info',
@@ -52,6 +55,9 @@ export class SysInfoComponent {
   private translate = inject(TranslateService);
   private matDialog = inject(MatDialog);
   private destroyRef = inject(DestroyRef);
+  private store$ = inject<Store<AppState>>(Store);
+
+  protected readonly isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
 
   readonly hasLicense = input<boolean>();
   readonly licenseInfo = input<LicenseInfoInSupport>();


### PR DESCRIPTION
Thumbprint should not be present when system has a registered enterprise license. 

Original PR: https://github.com/truenas/webui/pull/13752
