### PR TITLE
NAS-141568 / 27.0.0-BETA.1 / Add tooltip explaining Docker address pool Base normalization

### DIFF
--- a/src/app/helptext/apps/apps.ts
+++ b/src/app/helptext/apps/apps.ts
@@ -31,6 +31,7 @@ export const helptextApps = {
   advanced: T('Advanced Settings'),
 
   dockerSettings: {
+    addressPoolsBase: T('Base network the pool allocates subnets from. Host bits are ignored; the value is saved as its canonical network address (for example, 172.17.0.0/12 becomes 172.16.0.0/12).'),
     addressPoolsSize: T('Network size of each docker network which will be cut off from base subnet.'),
   },
 

--- a/src/app/pages/apps/components/catalog-settings/apps-settings.component.html
+++ b/src/app/pages/apps/components/catalog-settings/apps-settings.component.html
@@ -29,6 +29,7 @@
               formControlName="base"
               [label]="'Base' | translate"
               [required]="true"
+              [tooltip]="helptext.dockerSettings.addressPoolsBase | translate"
             ></ix-ip-input-with-netmask>
 
             <ix-input


### PR DESCRIPTION
**Changes:**

Add a tooltip to the **Base** field under Apps → Settings → Address Pools explaining that host bits are ignored and the value is saved as its canonical network address (e.g. `172.17.0.0/12` becomes `172.16.0.0/12`). Only the **Size** field had a tooltip before, so there was no in-UI explanation for why an entered base can come back normalized (NAS-141568).

**Testing:**

String/tooltip-only change; no behavior change. The normalization itself is implemented and tested in the middleware PR truenas/middleware#19242.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Tooltip wording mirrors the `docker.update` `base` field description
|Testing         | None — no logic change
