### PR TITLE
NAS-141657 / 27.0.0-BETA.1 / Block clicks on role-gated tn-* controls (pointer-events on host)

### DIFF
--- a/src/app/directives/has-access/missing-access-wrapper.component.scss
+++ b/src/app/directives/has-access/missing-access-wrapper.component.scss
@@ -24,11 +24,16 @@
   // above cancels their built-in disabled opacity. Dim the whole tn-* host instead —
   // opacity compounds over the inner control regardless of that reset — so role-gated
   // tn-* buttons/toggles read as disabled. The lock icon is a sibling, so it stays crisp.
+  // Block pointer events on the host too: the `a, button` reset below only neutralises
+  // tn-button/tn-icon-button (their inner element is an anchor/button), but tn-checkbox
+  // and tn-slide-toggle expose a <label>/<input>, which stays clickable otherwise.
   tn-button,
   tn-icon-button,
   tn-slide-toggle,
   tn-checkbox {
+    cursor: not-allowed;
     opacity: 0.5;
+    pointer-events: none;
   }
 
   .mat-mdc-checkbox,


### PR DESCRIPTION
See before and after:


https://github.com/user-attachments/assets/d3dde9eb-b5d0-478b-8119-ffbb7c83037c

