### PR TITLE
NAS-141286 / 26.0.0-RC.1 / “Save” button is misnamed on “unlock datasets” page; it does not save (by AlexKarpov98)

### DIFF
--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.html
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.html
@@ -74,10 +74,10 @@
           mat-button
           type="submit"
           color="primary"
-          ixTest="save"
+          ixTest="unlock"
           [disabled]="form.invalid || isFormLoading"
         >
-          {{ 'Save' | translate }}
+          {{ 'Unlock' | translate }}
         </button>
         <button
           mat-button

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.spec.ts
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.spec.ts
@@ -68,8 +68,8 @@ describe('DatasetUnlockComponent', () => {
     const fileInput = await loader.getHarness(IxFileInputHarness.with({ label: 'Upload Key file' }));
     await fileInput.setValue([file]);
 
-    const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
-    await saveButton.click();
+    const unlockButton = await loader.getHarness(MatButtonHarness.with({ text: 'Unlock' }));
+    await unlockButton.click();
 
     expect(spectator.inject(DialogService).jobDialog).toHaveBeenCalled();
     expect(spectator.inject(UploadService).uploadAsJob).toHaveBeenCalledWith({
@@ -91,8 +91,8 @@ describe('DatasetUnlockComponent', () => {
       },
     );
 
-    const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
-    await saveButton.click();
+    const unlockButton = await loader.getHarness(MatButtonHarness.with({ text: 'Unlock' }));
+    await unlockButton.click();
 
     expect(spectator.inject(ApiService).job).toHaveBeenCalledWith(
       'pool.dataset.encryption_summary',


### PR DESCRIPTION
Code review is enough.

Original PR: https://github.com/truenas/webui/pull/13776
