### PR TITLE
NAS-140488 / 25.10.5 / Show "Allow all hosts" option when no hosts exist on the system (by AlexKarpov98) (by bugclerk)

### DIFF
--- a/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.html
+++ b/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.html
@@ -33,7 +33,9 @@
       </button>
     }
 
-    <mat-divider></mat-divider>
+    @if (unusedHosts().length) {
+      <mat-divider></mat-divider>
+    }
 
     <button
       mat-menu-item

--- a/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.html
+++ b/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.html
@@ -1,4 +1,4 @@
-@if (noHostsExist()) {
+@if (noHostsExist() && !showAllowAnyHost()) {
   <button
     *ixRequiresRoles="requiredRoles"
     mat-button

--- a/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.spec.ts
@@ -71,6 +71,18 @@ describe('AddHostMenuComponent', () => {
     expect(spectator.component.hostSelected.emit).toHaveBeenCalledWith(newHost);
   });
 
+  it('shows menu with Allow all hosts option when no hosts exist but showAllowAnyHost is true', async () => {
+    jest.spyOn(spectator.component.allowAllHostsSelected, 'emit');
+    spectator.setInput('showAllowAnyHost', true);
+
+    const menu = await loader.getHarness(MatMenuHarness.with({ triggerText: 'Add' }));
+    await menu.open();
+
+    await menu.clickItem({ text: 'Allow all hosts' });
+
+    expect(spectator.component.allowAllHostsSelected.emit).toHaveBeenCalled();
+  });
+
   describe('some hosts exist in the system', () => {
     beforeEach(() => {
       allHosts.set([usedHost, unusedHost]);

--- a/src/app/pages/sharing/nvme-of/nvme-of.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/nvme-of.component.spec.ts
@@ -16,8 +16,14 @@ import {
 } from 'app/pages/sharing/nvme-of/nvme-of-configuration/nvme-of-configuration.component';
 import { NvmeOfComponent } from 'app/pages/sharing/nvme-of/nvme-of.component';
 import { NvmeOfStore } from 'app/pages/sharing/nvme-of/services/nvme-of.store';
+import {
+  SubsystemDetailsComponent,
+} from 'app/pages/sharing/nvme-of/subsystem-details/subsystem-details.component';
 import { SubsystemNamespacesCardComponent } from 'app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component';
 import { SubsystemPortsCardComponent } from 'app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component';
+import {
+  SubsystemsDetailsHeaderComponent,
+} from 'app/pages/sharing/nvme-of/subsystem-details-header/subsystems-details-header.component';
 import { SubsystemsListComponent } from 'app/pages/sharing/nvme-of/subsystems-list/subsystems-list.component';
 import { selectAdvancedConfig } from 'app/store/system-config/system-config.selectors';
 
@@ -29,6 +35,8 @@ describe('NvmeOfComponent', () => {
     declarations: [
       MockComponents(
         SubsystemsListComponent,
+        SubsystemDetailsComponent,
+        SubsystemsDetailsHeaderComponent,
         SubsystemNamespacesCardComponent,
         SubsystemPortsCardComponent,
       ),


### PR DESCRIPTION
## Summary                                                                                                                 
  - When no hosts exist on the system, the "Associated Hosts" Add button now shows a dropdown menu with the "Allow all hosts"
   option instead of only opening the host creation form                                                                     
  - Previously, if a user created a subsystem without enabling "Allow all hosts" and had no hosts configured, there was no   
  way to set that option afterward                                                                                           
          
Preview:

https://github.com/user-attachments/assets/3933d0c2-19ee-40fb-9f89-5e5ba8abc624



Original PR: https://github.com/truenas/webui/pull/13437


Original PR: https://github.com/truenas/webui/pull/13446
