### PR TITLE
NAS-141341 / 26.0.0-BETA.3 / Webshare Access Persists After Disabling TrueNAS Connect Until UI Refresh (by bugclerk)

### DIFF
--- a/src/app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component.spec.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component.spec.ts
@@ -1,5 +1,6 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { signal } from '@angular/core';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { provideRouter, Router } from '@angular/router';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
@@ -112,6 +113,7 @@ describe('WebShareCardComponent', () => {
       }),
       mockProvider(TruenasConnectService, {
         config$: of(mockTnConnectConfig),
+        config: signal(mockTnConnectConfig),
         openStatusModal: jest.fn(),
       }),
       provideRouter([]),
@@ -301,6 +303,7 @@ describe('WebShareCardComponent - TrueNAS Connect not configured', () => {
       }),
       mockProvider(TruenasConnectService, {
         config$: of(mockTnConnectConfigDisabled),
+        config: signal(mockTnConnectConfigDisabled),
         openStatusModal: jest.fn(),
       }),
       provideRouter([]),
@@ -402,6 +405,7 @@ describe('WebShareCardComponent - No WebShare users configured', () => {
       }),
       mockProvider(TruenasConnectService, {
         config$: of(mockTnConnectConfig),
+        config: signal(mockTnConnectConfig),
         openStatusModal: jest.fn(),
       }),
       provideRouter([]),

--- a/src/app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component.ts
@@ -152,10 +152,8 @@ export class WebShareCardComponent implements OnInit {
           tooltip: this.translate.instant('Open'),
           onClick: (row) => this.openWebShareByName(row),
           disabled: () => this.webShareService.canOpenWebShare$.pipe(map((canOpen) => !canOpen)),
-          dynamicTooltip: () => this.webShareService.canOpenWebShare$.pipe(
-            map((canOpen) => (canOpen
-              ? this.translate.instant('Open')
-              : this.translate.instant('WebShare can only be opened when accessed via a .truenas.direct domain'))),
+          dynamicTooltip: () => this.webShareService.webShareUnavailableReason$.pipe(
+            map((reason) => reason ?? this.translate.instant('Open')),
           ),
         },
         {
@@ -175,7 +173,6 @@ export class WebShareCardComponent implements OnInit {
     uniqueRowTag: (row) => 'card-webshare-' + row.name,
     ariaLabels: (row) => [row.name, this.translate.instant('WebShare')],
   });
-
 
   ngOnInit(): void {
     const webshares$ = this.webShares$.pipe(

--- a/src/app/pages/sharing/webshare/webshare-list/webshare-list.component.spec.ts
+++ b/src/app/pages/sharing/webshare/webshare-list/webshare-list.component.spec.ts
@@ -434,6 +434,7 @@ describe('WebShareListComponent - No WebShare users configured', () => {
         hostnameMapping$: of({ ipsWithHostnames: {}, localIp: '', hostname: undefined }),
         isTruenasDirectDomain: true,
         canOpenWebShare$: of(true),
+        webShareUnavailableReason$: of(null),
       }),
       provideMockStore({
         initialState: {

--- a/src/app/pages/sharing/webshare/webshare-list/webshare-list.component.ts
+++ b/src/app/pages/sharing/webshare/webshare-list/webshare-list.component.ts
@@ -140,10 +140,8 @@ export class WebShareListComponent implements OnInit {
           tooltip: this.translate.instant('Open'),
           onClick: (row) => this.openWebShare(row),
           disabled: () => this.webShareService.canOpenWebShare$.pipe(map((canOpen) => !canOpen)),
-          dynamicTooltip: () => this.webShareService.canOpenWebShare$.pipe(
-            map((canOpen) => (canOpen
-              ? this.translate.instant('Open')
-              : this.translate.instant('WebShare can only be opened when accessed via a .truenas.direct domain'))),
+          dynamicTooltip: () => this.webShareService.webShareUnavailableReason$.pipe(
+            map((reason) => reason ?? this.translate.instant('Open')),
           ),
         },
         {

--- a/src/app/pages/sharing/webshare/webshare.service.spec.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.spec.ts
@@ -1,8 +1,11 @@
+import { signal } from '@angular/core';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { TranslateService } from '@ngx-translate/core';
 import { firstValueFrom, of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
+import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
 import { WINDOW } from 'app/helpers/window.helper';
+import { TruenasConnectConfig } from 'app/interfaces/truenas-connect-config.interface';
 import { WebShare } from 'app/interfaces/webshare-config.interface';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
@@ -11,6 +14,10 @@ import { ApiService } from 'app/modules/websocket/api.service';
 import { WebShareSharesFormComponent } from 'app/pages/sharing/webshare/webshare-shares-form/webshare-shares-form.component';
 import { LicenseService } from 'app/services/license.service';
 import { WebShareService } from './webshare.service';
+
+const mockConfiguredTncConfig = {
+  status: TruenasConnectStatus.Configured,
+} as TruenasConnectConfig;
 
 describe('WebShareService', () => {
   let spectator: SpectatorService<WebShareService>;
@@ -48,6 +55,7 @@ describe('WebShareService', () => {
       }),
       mockProvider(TruenasConnectService, {
         openStatusModal: jest.fn(),
+        config: signal(mockConfiguredTncConfig),
       }),
       {
         provide: WINDOW,
@@ -212,7 +220,9 @@ describe('WebShareService - non-TrueNAS Direct domain', () => {
       mockProvider(TranslateService),
       mockProvider(LicenseService),
       mockProvider(SlideIn),
-      mockProvider(TruenasConnectService),
+      mockProvider(TruenasConnectService, {
+        config: signal(mockConfiguredTncConfig),
+      }),
       {
         provide: WINDOW,
         useValue: {
@@ -264,7 +274,9 @@ describe('WebShareService - hostname mapping', () => {
         hasTruenasConnect$: of(true),
       }),
       mockProvider(SlideIn),
-      mockProvider(TruenasConnectService),
+      mockProvider(TruenasConnectService, {
+        config: signal(mockConfiguredTncConfig),
+      }),
       {
         provide: WINDOW,
         useValue: mockWindow,
@@ -330,7 +342,9 @@ describe('WebShareService - no hostname mapping', () => {
         hasTruenasConnect$: of(true),
       }),
       mockProvider(SlideIn),
-      mockProvider(TruenasConnectService),
+      mockProvider(TruenasConnectService, {
+        config: signal(mockConfiguredTncConfig),
+      }),
       {
         provide: WINDOW,
         useValue: mockWindow,
@@ -353,6 +367,77 @@ describe('WebShareService - no hostname mapping', () => {
     await firstValueFrom(spectator.service.hostnameMapping$);
 
     expect(spectator.service.canOpenWebShare()).toBe(false);
+  });
+
+  it('should expose the domain reason when TrueNAS Connect is configured but no hostname resolves', async () => {
+    await firstValueFrom(spectator.service.hostnameMapping$);
+
+    expect(spectator.service.webShareUnavailableReason()).toBe(
+      'WebShare can only be opened when accessed via a .truenas.direct domain',
+    );
+  });
+});
+
+describe('WebShareService - TrueNAS Connect disabled', () => {
+  let spectator: SpectatorService<WebShareService>;
+
+  const mockWindow = {
+    location: {
+      protocol: 'https:',
+      hostname: 'mynas.truenas.direct',
+    },
+    open: jest.fn(),
+  };
+
+  const createService = createServiceFactory({
+    service: WebShareService,
+    providers: [
+      mockApi([
+        mockCall('tn_connect.ips_with_hostnames', {}),
+        mockCall('interface.websocket_local_ip', '192.168.1.100'),
+      ]),
+      mockProvider(SnackbarService),
+      mockProvider(TranslateService, {
+        instant: jest.fn((key: string) => key),
+      }),
+      mockProvider(LicenseService, {
+        hasTruenasConnect$: of(false),
+      }),
+      mockProvider(SlideIn),
+      mockProvider(TruenasConnectService, {
+        config: signal({ status: TruenasConnectStatus.Disabled } as TruenasConnectConfig),
+      }),
+      {
+        provide: WINDOW,
+        useValue: mockWindow,
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+    jest.clearAllMocks();
+  });
+
+  it('should report canOpenWebShare as false even on a truenas.direct domain', () => {
+    expect(spectator.service.canOpenWebShare()).toBe(false);
+  });
+
+  it('should expose the TrueNAS Connect disabled reason rather than a domain reason', () => {
+    expect(spectator.service.webShareUnavailableReason()).toBe(
+      'WebShare is unavailable because TrueNAS Connect is disabled.',
+    );
+  });
+
+  it('should not open a WebShare window and shows an error when TrueNAS Connect is disabled', () => {
+    const snackbar = spectator.inject(SnackbarService);
+
+    spectator.service.openWebShare('documents');
+
+    expect(mockWindow.open).not.toHaveBeenCalled();
+    expect(snackbar.error).toHaveBeenCalledWith(
+      'WebShare is unavailable because TrueNAS Connect is disabled.',
+    );
   });
 });
 
@@ -386,6 +471,7 @@ describe('WebShareService - TrueNAS Connect not configured', () => {
       }),
       mockProvider(TruenasConnectService, {
         openStatusModal: jest.fn(),
+        config: signal({ status: TruenasConnectStatus.Disabled } as unknown as TruenasConnectConfig),
       }),
       {
         provide: WINDOW,

--- a/src/app/pages/sharing/webshare/webshare.service.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.ts
@@ -1,15 +1,19 @@
-import { Injectable, inject, signal } from '@angular/core';
+import {
+  Injectable, computed, inject, signal,
+} from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
 import {
   Observable, of, forkJoin,
 } from 'rxjs';
 import {
-  switchMap, take, map, catchError, shareReplay,
+  switchMap, take, map, catchError, shareReplay, tap,
 } from 'rxjs/operators';
+import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
+import { TranslatedString } from 'app/modules/translate/translate.helper';
 import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { WebShareTableRow } from 'app/pages/sharing/components/webshare-name-cell/webshare-name-cell.component';
@@ -41,17 +45,60 @@ export class WebShareService {
   readonly isTruenasDirectDomain = this.window.location.hostname.includes('.truenas.direct');
 
   /**
+   * Whether TrueNAS Connect is currently configured (fully operational).
+   * Backed by `tn_connect.config` events, so disabling TrueNAS Connect immediately
+   * flips this to `false` without requiring a page refresh.
+   */
+  private isTruenasConnectConfigured = computed(
+    () => this.truenasConnectService.config()?.status === TruenasConnectStatus.Configured,
+  );
+
+  /**
    * Hostname resolved from TrueNAS Connect IP mappings.
    * When not on a truenas.direct domain, we check if the local IP has a matching hostname.
    */
-  private truenasConnectHostname = signal<string | null>(null);
+  private resolvedHostname = signal<string | null>(null);
+
+  /**
+   * Hostname to use when opening WebShare. Only available while TrueNAS Connect is
+   * configured. When TrueNAS Connect is disabled this resolves to `null` so we never
+   * generate a stale `.truenas.direct` URL that would produce SSL errors.
+   */
+  private truenasConnectHostname = computed<string | null>(
+    () => (this.isTruenasConnectConfigured() ? this.resolvedHostname() : null),
+  );
+
   readonly truenasConnectHostname$ = toObservable(this.truenasConnectHostname);
 
   /**
-   * Whether WebShare can be opened (either on truenas.direct domain or with a resolved hostname).
+   * Whether WebShare can be opened. Requires both an accessible hostname
+   * (either the current `.truenas.direct` domain or a resolved hostname) AND that
+   * TrueNAS Connect is currently configured. This reacts to TrueNAS Connect being
+   * disabled so the UI immediately blocks WebShare access without a page refresh.
    */
-  readonly canOpenWebShare = signal<boolean>(this.isTruenasDirectDomain);
+  readonly canOpenWebShare = computed<boolean>(() => !this.webShareUnavailableReason());
+
   readonly canOpenWebShare$ = toObservable(this.canOpenWebShare);
+
+  /**
+   * Human-readable explanation of why WebShare cannot be opened, or `null` when it
+   * can. Used both for the disabled-button tooltip and the `openWebShare()` snackbar
+   * so the user always sees the actual reason (TrueNAS Connect disabled vs. wrong
+   * domain) rather than a tooltip that only ever blames the domain.
+   */
+  readonly webShareUnavailableReason = computed<TranslatedString | null>(() => {
+    if (!this.isTruenasConnectConfigured()) {
+      return this.translate.instant('WebShare is unavailable because TrueNAS Connect is disabled.');
+    }
+
+    if (!this.isTruenasDirectDomain && !this.resolvedHostname()) {
+      return this.translate.instant('WebShare can only be opened when accessed via a .truenas.direct domain');
+    }
+
+    return null;
+  });
+
+  readonly webShareUnavailableReason$ = toObservable(this.webShareUnavailableReason);
 
   /**
    * Observable that fetches and caches the IP to hostname mapping.
@@ -64,11 +111,10 @@ export class WebShareService {
   ]).pipe(
     map(([ipsWithHostnames, localIp]) => {
       const hostname = ipsWithHostnames[localIp];
-      if (hostname) {
-        this.truenasConnectHostname.set(hostname);
-        this.canOpenWebShare.set(true);
-      }
       return { ipsWithHostnames, localIp, hostname };
+    }),
+    tap(({ hostname }) => {
+      this.resolvedHostname.set(hostname ?? null);
     }),
     catchError((error: unknown) => {
       console.error('Failed to fetch hostname mapping for WebShare:', error);
@@ -93,6 +139,12 @@ export class WebShareService {
    * @param shareName - Optional name of the specific share to open. If omitted, opens the root WebShare listing.
    */
   openWebShare(shareName?: string): void {
+    const unavailableReason = this.webShareUnavailableReason();
+    if (unavailableReason) {
+      this.snackbar.error(unavailableReason);
+      return;
+    }
+
     const hostname = this.isTruenasDirectDomain
       ? this.window.location.hostname
       : this.truenasConnectHostname();


### PR DESCRIPTION
Automated fix for [NAS-141341](https://ixsystems.atlassian.net/browse/NAS-141341)

Requested by: U0114E6RL6A

## Changes

All lint passes. Let me provide a summary of the changes.

## Summary

### Root Cause
The bug was in `WebShareService` (`src/app/pages/sharing/webshare/webshare.service.ts`). The service determined WebShare accessibility via a `canOpenWebShare` signal that was set to `true` **once** (either from being on a `.truenas.direct` domain or after a one-time `forkJoin` hostname lookup) and **never reset**. It had no awareness of the TrueNAS Connect (TNC) config state. 

So when TNC was disabled at runtime:
- The "Open WebShare" buttons remained enabled.
- `openWebShare()` still generated stale `https://...truenas.direct:755/...` URLs, producing SSL certificate errors.
- The UI only corrected itself after a manual page refresh (which re-ran the initialization).

Note that the `hasTruenasConnect$` banners in the card/list components were already reactive (driven by `config$`, which subscribes to `tn_connect.config` events), but the WebShare *access* logic was not.

### Fix
Made `WebShareService` reactive to the TNC config status, which is delivered via `tn_connect.config` events through `TruenasConnectService.config$`:

1. **`isTruenasConnectConfigured`** — a new signal derived from `config$` that is `true` only while `status === Configured`. It flips to `false` the moment TNC is disabled (no refresh needed).
2. **`canOpenWebShare`** — converted from a manually-set signal to a `computed` signal that requires *both* an accessible hostname AND `isTruenasConnectConfigured()`. This drives the disabled state of all "Open" buttons reactively.
3. **`truenasConnectHostname`** — converted to a `computed` that returns `null` when TNC isn't configured, so a stale `.truenas.direct` URL is never generated.
4. **`resolvedHostname`** — the raw IP→hostname lookup result is now stored separately (set in a `tap`), keeping the hostname-resolution concern independent from the live TNC-enabled gate.
5. **`openWebShare()`** — now guards on `canOpenWebShare()` and shows an explicit error snackbar ("WebShare is unavailable because TrueNAS Connect is disabled.") instead of opening an invalid URL.

The public observable surface (`canOpenWebShare$`, `truenasConnectHostname$`) is preserved so existing consumers (`webshare-card`, `webshare-list`) continue to work, now reactively.

### Tests
- Updated `webshare.service.spec.ts` to provide `config$` in the mocked `TruenasConnectService` (required by the now config-aware logic).
- Added a new `WebShareService - TrueNAS Connect disabled` describe block verifying that `canOpenWebShare()` is `false` and `openWebShare()` shows an error / does not open a window even on a `.truenas.direct` domain when TNC is disabled.

Lint passes on all changed files. (I also created the gitignored `src/environments/environment.ts` locally so tests could run; it won't be committed.)


Original PR: https://github.com/truenas/webui/pull/13742
