### PR TITLE
NAS-141715 / 27.0.0-BETA.1 / Fix side-panel loading indicator across forms and wizards

### DIFF
--- a/src/app/pages/apps/components/catalog-settings/apps-settings.component.ts
+++ b/src/app/pages/apps/components/catalog-settings/apps-settings.component.ts
@@ -13,6 +13,7 @@ import {
 import {
   combineLatest,
   filter,
+  finalize,
   forkJoin,
   take,
 } from 'rxjs';
@@ -113,13 +114,14 @@ export class AppsSettingsComponent extends SidePanelForm implements OnInit {
   }
 
   setupForm(): void {
+    this.isFormLoading.set(true);
     combineLatest([
       this.api.call('catalog.config'),
       this.dockerStore.dockerConfig$.pipe(filter(Boolean), take(1)),
       this.api.call('system.advanced.nvidia_present'),
       this.api.call('system.advanced.config'),
     ])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(finalize(() => this.isFormLoading.set(false)), takeUntilDestroyed(this.destroyRef))
       .subscribe(([catalogConfig, dockerConfig, hasNvidiaCard, advancedConfig]) => {
         this.showNvidiaCheckbox.set(hasNvidiaCard || advancedConfig.nvidia);
 

--- a/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
+++ b/src/app/pages/credentials/backup-credentials/cloud-credentials-form/cloud-credentials-form.component.ts
@@ -101,6 +101,14 @@ export class CloudCredentialsFormComponent extends SidePanelForm<CloudSyncCreden
     return this.commonStatus() === 'VALID' && this.providerFormValid() && !this.isLoading();
   });
 
+  /**
+   * Surfaces the panel's progress bar during initial load and submit. Overridden (not backed by
+   * `trackCanSubmit`) because this form builds `canSubmit` from its dynamic provider sub-form.
+   */
+  override isBusy(): boolean {
+    return this.isLoading();
+  }
+
   existingCredential: CloudSyncCredential;
   limitProviders: CloudSyncProviderName[];
   providers: CloudSyncProvider[] = [];

--- a/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
+++ b/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
@@ -1,7 +1,7 @@
 // cspell:ignore zvol zvols volsize volblocksize snapdev Snapdev Vdev helptext ngneat rawvalue pbkdf
 import { AsyncPipe } from '@angular/common';
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, signal, inject, input, output, viewChild,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, signal, inject, input,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -42,6 +42,7 @@ import { DetailsItemComponent } from 'app/modules/details-table/details-item/det
 import { DetailsTableComponent } from 'app/modules/details-table/details-table.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EditableComponent } from 'app/modules/forms/editable/editable.component';
+import { IxFormHostForm } from 'app/modules/forms/ix-forms/components/ix-form/ix-form-host-form.directive';
 import { FormSubmitEvent, IxFormComponent, SubmitResult } from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
 import { IxFormatterService } from 'app/modules/forms/ix-forms/services/ix-formatter.service';
 import {
@@ -50,7 +51,6 @@ import {
 import { matchOthersFgValidator } from 'app/modules/forms/ix-forms/validators/password-validation/password-validation';
 import { exactLength } from 'app/modules/forms/ix-forms/validators/validators';
 import { FileSizePipe } from 'app/modules/pipes/file-size/file-size.pipe';
-import { SidePanelHostForm } from 'app/modules/slide-ins/side-panel-form.directive';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { datasetNameTooLong } from 'app/pages/datasets/components/dataset-form/utils/name-length-validation';
@@ -87,7 +87,7 @@ const volsizeUnchangedRelativeTolerance = 0.001;
     FileSizePipe,
   ],
 })
-export class ZvolFormComponent implements OnInit, SidePanelHostForm<Dataset> {
+export class ZvolFormComponent extends IxFormHostForm<Dataset> implements OnInit {
   private formatter = inject(IxFormatterService);
   private translate = inject(TranslateService);
   private formBuilder = inject(NonNullableFormBuilder);
@@ -111,10 +111,6 @@ export class ZvolFormComponent implements OnInit, SidePanelHostForm<Dataset> {
    */
   readonly params = input<{ isNew: boolean; parentOrZvolId: string }>();
 
-  /** Emits the created/updated zvol when hosted in a `<tn-side-panel>`. */
-  readonly closed = output<Dataset>();
-
-  private ixForm = viewChild.required(IxFormComponent);
   private savedDataset: Dataset | undefined;
 
   protected readonly addTitle = this.translate.instant(helptextZvol.addTitle);
@@ -207,6 +203,7 @@ export class ZvolFormComponent implements OnInit, SidePanelHostForm<Dataset> {
   );
 
   constructor() {
+    super();
     this.form.controls.key.disable();
     this.form.controls.passphrase.disable();
     this.form.controls.confirm_passphrase.disable();
@@ -252,19 +249,6 @@ export class ZvolFormComponent implements OnInit, SidePanelHostForm<Dataset> {
     }
     return this.buildEditResult(event);
   };
-
-  /** Public entry point for a `<tn-side-panel>` footer Save. */
-  submit(): void {
-    this.ixForm().submit();
-  }
-
-  canSubmit(): boolean {
-    return this.ixForm().canSubmit();
-  }
-
-  hasUnsavedChanges(): boolean {
-    return this.ixForm().hasUnsavedChanges();
-  }
 
   /**
    * `<ix-form>` closes host-agnostically: in a SlideIn host it hands the saved zvol back

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
@@ -269,6 +269,11 @@ export class IscsiWizardComponent implements OnInit, SidePanelHostCloseable<Iscs
     return this.form.dirty;
   }
 
+  /** The footerless `<tn-side-panel>` host shows its progress bar while this is true. */
+  isBusy(): boolean {
+    return this.isLoading();
+  }
+
   constructor() {
     this.iscsiService.getExtents().pipe(takeUntilDestroyed(this.destroyRef)).subscribe((extents) => {
       this.namesInUse.set(extents.map((extent) => extent.name));

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.ts
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.ts
@@ -91,6 +91,11 @@ export class AddSubsystemComponent implements SidePanelHostCloseable<NvmeOfSubsy
     return this.form.dirty;
   }
 
+  /** The footerless `<tn-side-panel>` host shows its progress bar while this is true. */
+  isBusy(): boolean {
+    return this.isLoading();
+  }
+
   protected form = this.formBuilder.group({
     name: ['', Validators.required],
     subnqn: [''],

--- a/src/app/pages/system/advanced/failover/failover-form/failover-form.component.ts
+++ b/src/app/pages/system/advanced/failover/failover-form/failover-form.component.ts
@@ -7,7 +7,7 @@ import {
   InputType, TnButtonComponent, TnCheckboxComponent, TnFormFieldComponent, TnFormSectionComponent,
   TnInputComponent,
 } from '@truenas/ui-components';
-import { filter, switchMap } from 'rxjs/operators';
+import { filter, finalize, switchMap } from 'rxjs/operators';
 import { helptextSystemFailover } from 'app/helptext/system/failover';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
@@ -60,7 +60,11 @@ export class FailoverFormComponent extends SidePanelForm {
   constructor() {
     super();
 
-    this.api.call('failover.config').pipe(takeUntilDestroyed(this.destroyRef)).subscribe((config) => {
+    this.isLoading.set(true);
+    this.api.call('failover.config').pipe(
+      finalize(() => this.isLoading.set(false)),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((config) => {
       this.form.patchValue({
         enabled: !config.disabled,
         timeout: config.timeout,

--- a/src/app/pages/system/advanced/storage/storage-settings-form/storage-settings-form.component.ts
+++ b/src/app/pages/system/advanced/storage/storage-settings-form/storage-settings-form.component.ts
@@ -112,11 +112,13 @@ export class StorageSettingsFormComponent extends SidePanelForm implements OnIni
   }
 
   private setFormData(): void {
+    this.isLoading.set(true);
     forkJoin([
       this.api.call('systemdataset.config'),
       this.api.call('pool.resilver.config'),
     ]).pipe(
       take(1),
+      finalize(() => this.isLoading.set(false)),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe(([systemDatasetConfig, resilverConfig]) => {
       this.form.patchValue({


### PR DESCRIPTION
The tn-side-panel host shows its progress bar/overlay from the hosted form's isBusy(). Several forms tracked loading but never surfaced it, so no indicator showed during initial load or submit:

- zvol-form: extend IxFormHostForm (drops hand-rolled host surface, gains isBusy)
- cloud-credentials-form: override isBusy() -> existing isLoading signal
- apps-settings / failover-form / storage-settings-form: toggle the loading signal during initial config fetch (matches sibling config forms)
- iscsi-wizard / add-subsystem (footerless wizards): expose isBusy() -> isLoading so the panel bar shows during submit (matches cloudsync/replication wizards)
