### PR TITLE
NAS-141758 / 27.0.0-BETA.1 / Restore Advanced Options toggle in SMB and NFS share forms

### DIFF
--- a/src/app/modules/forms/ix-forms/services/form-error-handler.service.spec.ts
+++ b/src/app/modules/forms/ix-forms/services/form-error-handler.service.spec.ts
@@ -205,6 +205,45 @@ describe('FormErrorHandlerService', () => {
         manualValidateErrorMsg: 'Command not allowed',
       });
     });
+
+    it('resolves controls nested in sub-groups from the full error path', () => {
+      const nestedFormGroup = new FormGroup({
+        name: new FormControl(''),
+        audit: new FormGroup({
+          enable: new FormControl(false),
+          watch_list: new FormControl([] as string[]),
+        }),
+      });
+      const nestedError = new ApiCallError({
+        code: JsonRpcErrorCode.CallError,
+        message: 'Validation error',
+        data: {
+          error: 22,
+          errname: ApiErrorName.Validation,
+          extra: [
+            [
+              'sharingsmb_update.audit.watch_list.0',
+              'operator: not an SMB group.',
+              22,
+            ],
+          ],
+          trace: { class: 'ValidationErrors', formatted: 'Formatted string', frames: [] as ApiTraceFrame[] },
+          reason: 'Test reason',
+        },
+      });
+
+      spectator.service.handleValidationErrors(nestedError, nestedFormGroup);
+
+      expect(nestedFormGroup.controls.audit.controls.watch_list.errors).toEqual({
+        ixManualValidateError: {
+          message: 'operator: not an SMB group.',
+        },
+        manualValidateError: true,
+        manualValidateErrorMsg: 'operator: not an SMB group.',
+      });
+      expect(nestedFormGroup.controls.audit.controls.watch_list.touched).toBe(true);
+      expect(spectator.inject(ErrorHandlerService).showErrorModal).not.toHaveBeenCalled();
+    });
   });
 
   describe('clearValidationErrorsForHiddenFields', () => {

--- a/src/app/modules/forms/ix-forms/services/form-error-handler.service.ts
+++ b/src/app/modules/forms/ix-forms/services/form-error-handler.service.ts
@@ -94,7 +94,8 @@ export class FormErrorHandlerService {
 
       const errorMessage = extraItem[1];
 
-      const control = this.getFormField(formGroups, field, fieldsMap);
+      const control = this.getFormField(formGroups, field, fieldsMap)
+        ?? this.getFormFieldByErrorPath(formGroups, fullFieldPath);
 
 
       const mappedFieldName = fieldsMap[field] ?? field; // Get the mapped field name
@@ -205,6 +206,32 @@ export class FormErrorHandlerService {
     // Search through all form groups to find the control
     for (const formGroup of formGroups) {
       const control = formGroup.get(fieldName);
+      if (control) {
+        return control;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Fallback lookup for controls nested in sub-groups, where the leaf name alone can't find them
+   * (`watch_list` won't resolve when the control lives at `audit.watch_list`). The API error path
+   * carries the full location: drop the schema prefix (`sharingsmb_update.`) and any numeric
+   * indices (`.0`), then resolve the rest as a dot-path against the form.
+   */
+  private getFormFieldByErrorPath(
+    formGroups: UntypedFormGroup[],
+    fullFieldPath: string,
+  ): AbstractControl | null {
+    const pathParts = fullFieldPath.split('.').slice(1).filter((part) => !/^\d+$/.test(part));
+    if (pathParts.length < 2) {
+      // A single segment is just the leaf name — getFormField already tried that.
+      return null;
+    }
+
+    const path = pathParts.join('.');
+    for (const formGroup of formGroups) {
+      const control = formGroup.get(path);
       if (control) {
         return control;
       }

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.html
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.html
@@ -131,12 +131,4 @@
       }
     </ix-list>
   </tn-form-section>
-
-  <tn-button
-    ixExtraActions
-    type="button"
-    [testId]="'toggle-advanced-options'"
-    [label]="isAdvancedMode() ? ('Basic Options' | translate) : ('Advanced Options' | translate)"
-    (onClick)="toggleAdvancedMode()"
-  ></tn-button>
 </ix-form>

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.spec.ts
@@ -5,7 +5,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { Store } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
-import { TnDialog, TnButtonHarness, TnCheckboxHarness, TnInputHarness, TnSelectHarness } from '@truenas/ui-components';
+import { TnDialog, TnCheckboxHarness, TnInputHarness, TnSelectHarness } from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
@@ -73,9 +73,13 @@ describe('NfsFormComponent', () => {
   const getTnSelect = (name: string): Promise<TnSelectHarness> => loader.getHarness(
     TnSelectHarness.with({ selector: `[formControlName="${name}"]` }),
   );
+  // The Advanced/Basic toggle is rendered by the side-panel host from `footerActions`.
   const clickAdvancedOptions = async (): Promise<void> => {
-    const button = await loader.getHarness(TnButtonHarness.with({ label: 'Advanced Options' }));
-    await button.click();
+    const [toggleAdvanced] = spectator.component.footerActions;
+    expect(toggleAdvanced.label).toBe('Advanced Options');
+    toggleAdvanced.onClick();
+    spectator.detectChanges();
+    await spectator.fixture.whenStable();
   };
 
   /**

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.ts
@@ -4,11 +4,12 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { Validators, ReactiveFormsModule } from '@angular/forms';
+import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
 import { FormBuilder } from '@ngneat/reactive-forms';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  TnButtonComponent, TnCheckboxComponent, TnFormFieldComponent, TnFormSectionComponent, TnInputComponent,
+  TnCheckboxComponent, TnFormFieldComponent, TnFormSectionComponent, TnInputComponent,
   TnSelectComponent,
 } from '@truenas/ui-components';
 import {
@@ -36,6 +37,7 @@ import { IxListComponent } from 'app/modules/forms/ix-forms/components/ix-list/i
 import { IxUserComboboxComponent } from 'app/modules/forms/ix-forms/components/ix-user-combobox/ix-user-combobox.component';
 import { IxValidatorsService } from 'app/modules/forms/ix-forms/services/ix-validators.service';
 import { ipv4or6cidrValidator } from 'app/modules/forms/ix-forms/validators/ip-validation';
+import { SidePanelFooterAction } from 'app/modules/slide-ins/form-side-panel/form-side-panel-container.component';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { getRootDatasetsValidator } from 'app/pages/sharing/utils/root-datasets-validator';
 import { DatasetService } from 'app/services/dataset/dataset.service';
@@ -63,7 +65,6 @@ export interface NfsFormData {
     TnInputComponent,
     TnCheckboxComponent,
     TnSelectComponent,
-    TnButtonComponent,
     IxExplorerComponent,
     ExplorerCreateDatasetComponent,
     IxUserComboboxComponent,
@@ -118,6 +119,20 @@ export class NfsFormComponent extends IxFormHostForm implements OnInit {
   }
 
   readonly requiredRoles = [Role.SharingNfsWrite, Role.SharingWrite];
+
+  /**
+   * The Advanced/Basic toggle rendered in the `<tn-side-panel>` footer (before Save). Re-read each
+   * change detection, so the label flips with {@link isAdvancedMode}.
+   */
+  get footerActions(): SidePanelFooterAction[] {
+    // Labels are extraction markers — the panel container pipes them through `translate`.
+    return [{
+      label: this.isAdvancedMode() ? T('Basic Options') : T('Advanced Options'),
+      testId: 'toggle-advanced-options',
+      onClick: () => this.toggleAdvancedMode(),
+    }];
+  }
+
   readonly helptext = helptextSharingNfs;
   readonly treeNodeProvider = this.filesystemService.getFilesystemNodeProvider({ directoriesOnly: true });
   readonly isEnterprise = toSignal(this.store$.select(selectIsEnterprise));

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.html
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.html
@@ -6,6 +6,21 @@
   [submitHandler]="handleSubmit"
   (closed)="closed.emit($event)"
 >
+  <!--
+    Hidden trigger anchor: the form error handler clicks it (`triggerAnchor`) to reveal the
+    advanced section before attaching API validation errors to fields inside it. The visible
+    Advanced/Basic toggle lives in the side-panel footer (footerActions), outside this template,
+    so it can't carry the anchor id itself.
+  -->
+  <button
+    hidden
+    id="smb-form-toggle-advanced-options"
+    type="button"
+    tabindex="-1"
+    ixTest="toggle-advanced-options-anchor"
+    (click)="openAdvancedMode()"
+  ></button>
+
   <ix-smb-users-warning></ix-smb-users-warning>
 
   <tn-form-section [heading]="'Basic' | translate">

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.html
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.html
@@ -70,7 +70,7 @@
     </tn-form-field>
   </tn-form-section>
 
-  @if (isAdvancedMode) {
+  @if (isAdvancedMode()) {
     <tn-form-section [heading]="'Access' | translate">
       @if (form.controls.acl.enabled) {
         <tn-form-field [tooltip]="helptextSharingSmb.aclTooltip | translate">
@@ -343,12 +343,4 @@
       </tn-form-section>
     }
   }
-
-  <tn-button
-    ixExtraActions
-    type="button"
-    [testId]="'toggle-advanced-options'"
-    [label]="isAdvancedMode ? ('Basic Options' | translate) : ('Advanced Options' | translate)"
-    (onClick)="toggleAdvancedMode()"
-  ></tn-button>
 </ix-form>

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
@@ -923,7 +923,21 @@ describe('SmbFormComponent', () => {
       expect(spectator.inject(FormErrorHandlerService).handleValidationErrors).toHaveBeenCalledWith(
         expect.any(ApiCallError),
         expect.any(FormGroup),
+        {},
+        'smb-form-toggle-advanced-options',
       );
+    });
+
+    it('opens the advanced section when the hidden trigger anchor is clicked', async () => {
+      // Starts in basic mode — advanced-only controls are absent.
+      expect(await getTnCheckboxes('readonly')).toHaveLength(0);
+
+      const anchor = spectator.query<HTMLButtonElement>('#smb-form-toggle-advanced-options');
+      expect(anchor).toBeTruthy();
+      anchor.click();
+      spectator.detectChanges();
+
+      expect(await getTnCheckbox('readonly')).toBeTruthy();
     });
   });
 

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.spec.ts
@@ -7,7 +7,6 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { Store } from '@ngrx/store';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import {
-  TnButtonHarness,
   TnCheckboxHarness,
   TnChipInputHarness,
   TnDialog,
@@ -211,14 +210,14 @@ describe('SmbFormComponent', () => {
     mockStore$ = spectator.inject(MockStore);
     api = spectator.inject(ApiService);
 
-    // The toggle's label flips between 'Advanced Options' and 'Basic Options';
-    // only click when it currently offers to reveal the advanced section.
-    const advancedButton = await loader.getHarnessOrNull(
-      TnButtonHarness.with({ label: 'Advanced Options' }),
-    );
-    if (advancedButton) {
-      await advancedButton.click();
+    // The Advanced/Basic toggle is rendered by the side-panel host from `footerActions`;
+    // only invoke it when it currently offers to reveal the advanced section.
+    const [toggleAdvanced] = spectator.component.footerActions;
+    if (toggleAdvanced.label === 'Advanced Options') {
+      toggleAdvanced.onClick();
+      spectator.detectChanges();
     }
+    await spectator.fixture.whenStable();
   }
 
   /**
@@ -717,8 +716,10 @@ describe('SmbFormComponent', () => {
       expect(await getTnCheckbox('enable')).toBeTruthy();
       expect(await getTnCheckbox('aapl_name_mangling')).toBeTruthy();
 
-      const basicOptions = await loader.getHarness(TnButtonHarness.with({ label: 'Basic Options' }));
-      await basicOptions.click();
+      const [basicOptions] = spectator.component.footerActions;
+      expect(basicOptions.label).toBe('Basic Options');
+      basicOptions.onClick();
+      spectator.detectChanges();
 
       // Advanced-only controls are gone after switching to Basic Options.
       expect(await getTnCheckboxes('readonly')).toHaveLength(0);
@@ -922,8 +923,6 @@ describe('SmbFormComponent', () => {
       expect(spectator.inject(FormErrorHandlerService).handleValidationErrors).toHaveBeenCalledWith(
         expect.any(ApiCallError),
         expect.any(FormGroup),
-        {},
-        'smb-form-toggle-advanced-options',
       );
     });
   });

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -69,6 +69,7 @@ import { UserGroupExistenceValidationService } from 'app/modules/forms/ix-forms/
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { SidePanelFooterAction } from 'app/modules/slide-ins/form-side-panel/form-side-panel-container.component';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
+import { TestDirective } from 'app/modules/test-id/test.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { RestartSmbDialog } from 'app/pages/sharing/smb/smb-form/restart-smb-dialog/restart-smb-dialog.component';
 import { SmbExtensionsWarningComponent } from 'app/pages/sharing/smb/smb-form/smb-extensions-warning/smb-extensions-warning.component';
@@ -102,6 +103,7 @@ import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors'
     ExplorerCreateDatasetComponent,
     IxInputComponent,
     IxErrorsComponent,
+    TestDirective,
     TranslateModule,
     AsyncPipe,
     WarningComponent,
@@ -364,6 +366,19 @@ export class SmbFormComponent extends IxFormHostForm implements OnInit, AfterVie
     if (this.isAdvancedMode()) {
       this.updateAuditValidationState();
     }
+  }
+
+  /**
+   * Clicked programmatically by {@link FormErrorHandlerService} (via the
+   * `smb-form-toggle-advanced-options` trigger anchor) to reveal advanced fields before it attaches
+   * API validation errors to them. Only ever opens — never collapses an already-open section.
+   */
+  protected openAdvancedMode(): void {
+    if (this.isAdvancedMode()) {
+      return;
+    }
+    this.isAdvancedMode.set(true);
+    this.updateAuditValidationState();
   }
 
   protected form = this.formBuilder.group({
@@ -814,12 +829,7 @@ export class SmbFormComponent extends IxFormHostForm implements OnInit, AfterVie
         if (apiError?.reason?.includes('[ENOENT]') || apiError?.reason?.includes('[EXDEV]')) {
           this.dialogService.closeAllDialogs();
         }
-        this.formErrorHandler.handleValidationErrors(error, this.form);
-        // The Advanced/Basic toggle lives in the side-panel footer now, so there is no in-form
-        // trigger anchor for the error handler to click — reveal errored advanced fields directly.
-        if (this.hasAdvancedErrorsInternal()) {
-          this.isAdvancedMode.set(true);
-        }
+        this.formErrorHandler.handleValidationErrors(error, this.form, {}, 'smb-form-toggle-advanced-options');
         return true;
       },
     };

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -15,11 +15,11 @@ import {
   FormControl, NonNullableFormBuilder, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators,
 } from '@angular/forms';
 import { Router } from '@angular/router';
+import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   InputType,
-  TnButtonComponent,
   TnCheckboxComponent,
   TnChipInputComponent,
   TnDialog,
@@ -67,6 +67,7 @@ import { IxFormatterService } from 'app/modules/forms/ix-forms/services/ix-forma
 import { IxValidatorsService } from 'app/modules/forms/ix-forms/services/ix-validators.service';
 import { UserGroupExistenceValidationService } from 'app/modules/forms/ix-forms/validators/user-group-existence-validation.service';
 import { LoaderService } from 'app/modules/loader/loader.service';
+import { SidePanelFooterAction } from 'app/modules/slide-ins/form-side-panel/form-side-panel-container.component';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { RestartSmbDialog } from 'app/pages/sharing/smb/smb-form/restart-smb-dialog/restart-smb-dialog.component';
@@ -97,7 +98,6 @@ import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors'
     TnSelectComponent,
     TnCheckboxComponent,
     TnChipInputComponent,
-    TnButtonComponent,
     IxExplorerComponent,
     ExplorerCreateDatasetComponent,
     IxInputComponent,
@@ -160,10 +160,23 @@ export class SmbFormComponent extends IxFormHostForm implements OnInit, AfterVie
   readonly isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
 
   protected SmbPresetType = SmbSharePurpose;
-  protected isAdvancedMode = false;
+  protected isAdvancedMode = signal(false);
   private namesInUse: string[] = [];
   protected readonly helptextSharingSmb = helptextSharingSmb;
   readonly requiredRoles = [Role.SharingSmbWrite, Role.SharingWrite];
+
+  /**
+   * The Advanced/Basic toggle rendered in the `<tn-side-panel>` footer (before Save). Re-read each
+   * change detection, so the label flips with {@link isAdvancedMode}.
+   */
+  get footerActions(): SidePanelFooterAction[] {
+    // Labels are extraction markers — the panel container pipes them through `translate`.
+    return [{
+      label: this.isAdvancedMode() ? T('Basic Options') : T('Advanced Options'),
+      testId: 'toggle-advanced-options',
+      onClick: () => this.toggleAdvancedMode(),
+    }];
+  }
 
   private wasStripAclWarningShown = false;
   private smbConfig = signal<SmbConfig | null>(null);
@@ -340,15 +353,15 @@ export class SmbFormComponent extends IxFormHostForm implements OnInit, AfterVie
     this.form.updateValueAndValidity({ emitEvent: false });
 
     if (this.hasAdvancedErrorsInternal()) {
-      this.isAdvancedMode = true;
+      this.isAdvancedMode.set(true);
       this.updateAuditValidationState();
     }
   }
 
   protected toggleAdvancedMode(): void {
-    this.isAdvancedMode = !this.isAdvancedMode;
+    this.isAdvancedMode.update((isAdvanced) => !isAdvanced);
 
-    if (this.isAdvancedMode) {
+    if (this.isAdvancedMode()) {
       this.updateAuditValidationState();
     }
   }
@@ -801,7 +814,12 @@ export class SmbFormComponent extends IxFormHostForm implements OnInit, AfterVie
         if (apiError?.reason?.includes('[ENOENT]') || apiError?.reason?.includes('[EXDEV]')) {
           this.dialogService.closeAllDialogs();
         }
-        this.formErrorHandler.handleValidationErrors(error, this.form, {}, 'smb-form-toggle-advanced-options');
+        this.formErrorHandler.handleValidationErrors(error, this.form);
+        // The Advanced/Basic toggle lives in the side-panel footer now, so there is no in-form
+        // trigger anchor for the error handler to click — reveal errored advanced fields directly.
+        if (this.hasAdvancedErrorsInternal()) {
+          this.isAdvancedMode.set(true);
+        }
         return true;
       },
     };


### PR DESCRIPTION
## Summary

The tn-* migration of the shares create/edit forms (NAS-141552) left the Advanced Options toggle in an `ixExtraActions` slot that `<ix-form>` only renders for the legacy SlideIn host. The SMB and NFS forms are now hosted exclusively in the `<tn-side-panel>`, where the footer owns the actions — so the button never rendered and the advanced section became unreachable.

## Changes

- Expose the Advanced/Basic toggle through the `footerActions` getter (the pattern established by dataset-form), so the side-panel footer renders it before Save with the same `toggle-advanced-options` test id.
- Convert SMB's `isAdvancedMode` to a signal so the footer label flips reactively.
- The migration also dropped the `id="smb-form-toggle-advanced-options"` trigger anchor used to reveal hidden advanced fields on API validation errors; replaced with a direct `hasAdvancedErrorsInternal()` check after the error handler runs.
- Remove the dead `ixExtraActions` buttons and unused `TnButtonComponent` imports; update specs to drive the toggle via `footerActions`.