### PR TITLE
NAS-141764 / 27.0.0-BETA.1 / [UI Bug] ACME Certificate creation forces "DNS:" prefix to SAN domain strings causing EFAULT malformed validation

### DIFF
--- a/src/app/pages/credentials/certificates-dash/certificate-acme-add/certificate-acme-add.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/certificate-acme-add/certificate-acme-add.component.spec.ts
@@ -88,9 +88,10 @@ describe('CertificateAcmeAddComponent', () => {
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   });
 
-  it('loads and shows domain names associated with the certificate', () => {
-    expect(spectator.fixture.nativeElement.textContent).toContain('DNS:truenas.com');
-    expect(spectator.fixture.nativeElement.textContent).toContain('DNS:truenas.io');
+  it('loads and shows domain names associated with the certificate without the DNS: prefix', () => {
+    expect(spectator.fixture.nativeElement.textContent).toContain('truenas.com');
+    expect(spectator.fixture.nativeElement.textContent).toContain('truenas.io');
+    expect(spectator.fixture.nativeElement.textContent).not.toContain('DNS:');
     expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('webui.crypto.get_certificate_domain_names', [2]);
   });
 
@@ -112,8 +113,8 @@ describe('CertificateAcmeAddComponent', () => {
         create_type: CertificateCreateType.CreateAcme,
         csr_id: 2,
         dns_mapping: {
-          'DNS:truenas.com': 1,
-          'DNS:truenas.io': 2,
+          'truenas.com': 1,
+          'truenas.io': 2,
         },
         name: 'new',
         renew_days: 10,
@@ -143,8 +144,8 @@ describe('CertificateAcmeAddComponent', () => {
         create_type: CertificateCreateType.CreateAcme,
         csr_id: 2,
         dns_mapping: {
-          'DNS:truenas.com': 1,
-          'DNS:truenas.io': 2,
+          'truenas.com': 1,
+          'truenas.io': 2,
         },
         name: 'new',
         renew_days: 10,

--- a/src/app/pages/credentials/certificates-dash/certificate-acme-add/certificate-acme-add.component.ts
+++ b/src/app/pages/credentials/certificates-dash/certificate-acme-add/certificate-acme-add.component.ts
@@ -158,8 +158,9 @@ export class CertificateAcmeAddComponent extends SidePanelForm implements OnInit
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (domains) => {
-          this.domains = domains.map(ignoreTranslation);
-          domains.forEach((domain) => this.addDomainControls(domain));
+          const normalizedDomains = domains.map((domain) => this.normalizeDomain(domain));
+          this.domains = normalizedDomains.map(ignoreTranslation);
+          normalizedDomains.forEach((domain) => this.addDomainControls(domain));
           this.isLoading.set(false);
         },
         error: (error: unknown) => {
@@ -167,6 +168,16 @@ export class CertificateAcmeAddComponent extends SidePanelForm implements OnInit
           this.errorHandler.showErrorModal(error);
         },
       });
+  }
+
+  /**
+   * The backend returns SAN entries prefixed with their type (e.g. `DNS:truenas.com`).
+   * Strip the `DNS:` prefix so the rendered value and the resulting `dns_mapping` keys
+   * contain the raw domain name, otherwise the payload fails backend validation with
+   * "[EFAULT] ... Domain name needs at least one dot".
+   */
+  private normalizeDomain(domain: string): string {
+    return domain.replace(/^DNS:/i, '').trim();
   }
 
   private addDomainControls(domain: string): void {


### PR DESCRIPTION
Automated fix for [NAS-141764](https://ixsystems.atlassian.net/browse/NAS-141764)

Requested by: U010F6A94RF

## Changes

The fix is complete. Let me try running the test once more with a background-friendly single spec (the earlier timeout was likely jest compiling the whole project). I'll rely on lint success since the env file is missing for tests.

The changes are complete and lint-clean.

## Summary

**Bug (NAS-141764):** When creating an ACME certificate from a CSR that has Subject Alternative Names (SANs), the UI displayed and submitted the SAN domains with a literal `DNS:` prefix (e.g. `DNS:truenas.beechlab.net`). This is because `webui.crypto.get_certificate_domain_names` returns SAN entries in their typed form (`DNS:<domain>`). Those prefixed strings were:
1. Rendered as-is in the Domains section of the form.
2. Used verbatim as the keys of the `dns_mapping` object in the `certificate.create` payload.

The backend then rejected the malformed domain with `[EFAULT] ... Domain name needs at least one dot`.

**Fix:** In `certificate-acme-add.component.ts`, I added a `normalizeDomain()` helper that strips the leading `DNS:` prefix (case-insensitive) and trims whitespace. `loadDomains()` now normalizes each returned domain before storing it for display (`this.domains`) and before creating the form controls. Since both the rendered strings and the `dns_mapping` keys are derived from these normalized values, the submitted payload now contains clean raw domain names.

**Tests:** Updated `certificate-acme-add.component.spec.ts` to assert that:
- The rendered output shows `truenas.com` / `truenas.io` and does **not** contain `DNS:`.
- The `certificate.create` payload's `dns_mapping` uses the un-prefixed domain keys.

Both the component and spec pass ESLint. (I could not run the Jest suite locally because the required environment file — normally created by `yarn ui reset`, which isn't in the allowed command set — is missing.)
