### PR TITLE
NAS-141058 / 27.0.0-BETA.1 / Migrate vm-wizard form controls to tn-*

### DIFF
--- a/src/app/helpers/step-completed-signal.helper.ts
+++ b/src/app/helpers/step-completed-signal.helper.ts
@@ -1,6 +1,6 @@
-import { isSignal, Signal } from '@angular/core';
+import { afterNextRender, isSignal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { AbstractControl } from '@angular/forms';
+import { AbstractControl, FormArray, FormGroup } from '@angular/forms';
 import { switchMap } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
@@ -17,6 +17,19 @@ import { map, startWith } from 'rxjs/operators';
  * Must be called in an injection context (e.g. a field initializer).
  */
 export function stepCompletedSignal(form: AbstractControl | Signal<AbstractControl>): Signal<boolean> {
+  // When a ControlValueAccessor attaches (formControlName binding during the first
+  // render), Angular re-runs the control's validators with `emitEvent: false`. An async
+  // validator resolving from that run flips PENDING → VALID/INVALID without a
+  // `statusChanges` emission, so an emission-fed signal goes stale and step gating
+  // swallows Next clicks (NAS-141058). Once the first render is done (CVAs attached),
+  // restart validation with `emitEvent: true` so the eventual resolution is observed.
+  afterNextRender(() => {
+    const control = isSignal(form) ? form() : form;
+    if (control) {
+      revalidateControls(control);
+    }
+  });
+
   if (isSignal(form)) {
     return toSignal(
       toObservable(form).pipe(
@@ -30,4 +43,18 @@ export function stepCompletedSignal(form: AbstractControl | Signal<AbstractContr
     form.statusChanges.pipe(startWith(form.status), map(() => form.valid)),
     { initialValue: form.valid },
   );
+}
+
+function revalidateControls(control: AbstractControl): void {
+  if (control instanceof FormGroup || control instanceof FormArray) {
+    Object.values(control.controls).forEach((child) => revalidateControls(child as AbstractControl));
+  }
+  // Only async validators can resolve silently — sync validators settle at construction,
+  // before the signal first reads. Restricting the restart avoids valueChanges side
+  // effects (e.g. enable/disable relations) on unaffected controls. onlySelf keeps the
+  // walk from re-triggering ancestor validation per child; each control's resolution
+  // still propagates status upward.
+  if (control.asyncValidator) {
+    control.updateValueAndValidity({ onlySelf: true });
+  }
 }

--- a/src/app/pages/vm/utils/free-space-validator.service.spec.ts
+++ b/src/app/pages/vm/utils/free-space-validator.service.spec.ts
@@ -40,5 +40,8 @@ describe('FreeSpaceValidatorService', () => {
         message: 'Not enough free space. Maximum available: 10 TiB',
       },
     });
+    // tn-form-field only shows errors for touched controls; the validator must
+    // mark volsize touched so its programmatically-set error is visible.
+    expect(formGroup.controls.volsize.touched).toBe(true);
   });
 });

--- a/src/app/pages/vm/utils/free-space-validator.service.ts
+++ b/src/app/pages/vm/utils/free-space-validator.service.ts
@@ -46,6 +46,11 @@ export class FreeSpaceValidatorService {
           return null;
         }
 
+        // This error is set programmatically (e.g. on datastore change), but tn-form-field
+        // only displays errors for touched/dirty controls — mark touched first so the error
+        // is visible immediately. Touched must be set before setErrors: the field re-reads
+        // interaction state on the statusChanges emission that setErrors triggers.
+        form.controls.volsize.markAsTouched();
         form.controls.volsize.setErrors(
           this.makeError(freeSpace),
         );

--- a/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.html
+++ b/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.html
@@ -1,96 +1,127 @@
 <form [formGroup]="form">
-  <ix-select
-    formControlName="os"
+  <tn-form-field
     [label]="'Guest Operating System' | translate"
-    [required]="true"
-    [options]="osOptions$"
     [tooltip]="helptext.os_tooltip | translate"
-  ></ix-select>
+    [required]="true"
+  >
+    <tn-select
+      formControlName="os"
+      [options]="(osOptions$ | async) ?? []"
+    ></tn-select>
+  </tn-form-field>
 
   @if (form.controls.os.value === VmOs.Windows) {
-    <ix-checkbox
-      formControlName="hyperv_enlightenments"
-      [label]="'Enable Hyper-V Enlightenments' | translate"
-      [tooltip]="helptext.hyperv_enlightenments_tooltip | translate"
-    ></ix-checkbox>
+    <tn-form-field [tooltip]="helptext.hyperv_enlightenments_tooltip | translate">
+      <tn-checkbox
+        formControlName="hyperv_enlightenments"
+        [label]="'Enable Hyper-V Enlightenments' | translate"
+      ></tn-checkbox>
+    </tn-form-field>
   }
 
-  <ix-input
-    formControlName="name"
+  <tn-form-field
     [label]="'Name' | translate"
-    [required]="true"
     [tooltip]="helptext.name_tooltip | translate"
-  ></ix-input>
+    [required]="true"
+  >
+    <tn-input
+      formControlName="name"
+      [required]="true"
+    ></tn-input>
+  </tn-form-field>
 
-  <ix-input
-    formControlName="description"
+  <tn-form-field
     [label]="'Description' | translate"
     [tooltip]="helptext.description_tooltip | translate"
-  ></ix-input>
+  >
+    <tn-input formControlName="description"></tn-input>
+  </tn-form-field>
 
-  <ix-select
-    formControlName="time"
+  <tn-form-field
     [label]="'System Clock' | translate"
-    [required]="true"
-    [options]="timeOptions$"
     [tooltip]="helptext.time_tooltip | translate"
-  ></ix-select>
-
-  <ix-select
-    formControlName="bootloader"
-    [label]="'Boot Method' | translate"
-    [options]="bootloaderOptions$"
     [required]="true"
+  >
+    <tn-select
+      formControlName="time"
+      [options]="(timeOptions$ | async) ?? []"
+    ></tn-select>
+  </tn-form-field>
+
+  <tn-form-field
+    [label]="'Boot Method' | translate"
     [tooltip]="helptext.bootloader_tooltip | translate"
-  ></ix-select>
+    [required]="true"
+  >
+    <tn-select
+      formControlName="bootloader"
+      [options]="(bootloaderOptions$ | async) ?? []"
+    ></tn-select>
+  </tn-form-field>
 
-  <ix-checkbox
-    formControlName="enable_secure_boot"
-    [label]="'Enable Secure Boot' | translate"
-    [tooltip]="helptext.enableSecureBoot | translate"
-  ></ix-checkbox>
+  <tn-form-field [tooltip]="helptext.enableSecureBoot | translate">
+    <tn-checkbox
+      formControlName="enable_secure_boot"
+      [label]="'Enable Secure Boot' | translate"
+    ></tn-checkbox>
+  </tn-form-field>
 
-  <ix-checkbox
-    formControlName="trusted_platform_module"
-    [label]="'Enable Trusted Platform Module (TPM)' | translate"
-    [tooltip]="helptext.enableTrustedPlatformModule | translate"
-  ></ix-checkbox>
+  <tn-form-field [tooltip]="helptext.enableTrustedPlatformModule | translate">
+    <tn-checkbox
+      formControlName="trusted_platform_module"
+      [label]="'Enable Trusted Platform Module (TPM)' | translate"
+    ></tn-checkbox>
+  </tn-form-field>
 
-  <ix-input
-    formControlName="shutdown_timeout"
-    type="number"
+  <tn-form-field
     [label]="'Shutdown Timeout' | translate"
     [tooltip]="helptext.shutdown_timeout.tooltip | translate"
-  ></ix-input>
+  >
+    <tn-input
+      formControlName="shutdown_timeout"
+      [inputType]="InputType.Number"
+      [allowDecimals]="false"
+    ></tn-input>
+  </tn-form-field>
 
-  <ix-checkbox
-    formControlName="autostart"
-    [label]="'Start on Boot' | translate"
-    [tooltip]="helptext.autostart_tooltip | translate"
-  ></ix-checkbox>
+  <tn-form-field [tooltip]="helptext.autostart_tooltip | translate">
+    <tn-checkbox
+      formControlName="autostart"
+      [label]="'Start on Boot' | translate"
+    ></tn-checkbox>
+  </tn-form-field>
 
-  <ix-checkbox
-    formControlName="enable_vnc"
-    [label]="'Enable Display (VNC)' | translate"
-    [tooltip]="helptext.enable_vnc_tooltip | translate"
-  ></ix-checkbox>
+  <tn-form-field [tooltip]="helptext.enable_vnc_tooltip | translate">
+    <tn-checkbox
+      formControlName="enable_vnc"
+      [label]="'Enable Display (VNC)' | translate"
+    ></tn-checkbox>
+  </tn-form-field>
 
   @if (form.value.enable_vnc) {
-    <ix-select
-      formControlName="vnc_bind"
+    <tn-form-field
       [label]="'Bind' | translate"
-      [options]="bindOptions$"
-      [required]="true"
       [tooltip]="helptext.vnc_bind_tooltip | translate"
-    ></ix-select>
-
-    <ix-input
-      formControlName="vnc_password"
-      type="password"
-      [label]="'Password' | translate"
       [required]="true"
+    >
+      <tn-select
+        formControlName="vnc_bind"
+        [options]="(bindOptions$ | async) ?? []"
+      ></tn-select>
+    </tn-form-field>
+
+    <tn-form-field
+      [label]="'Password' | translate"
       [tooltip]="helptext.vnc_password_tooltip | translate"
-    ></ix-input>
+      [required]="true"
+    >
+      <tn-input
+        formControlName="vnc_password"
+        [inputType]="InputType.Password"
+        [required]="true"
+        [testId]="'vnc_password'"
+      ></tn-input>
+    </tn-form-field>
 
     <div class="vnc-warning">
       <p><strong>{{ 'Note' | translate }}:</strong> {{ 'VNC requires a separate client application and cannot be accessed through the web browser. Password is limited to 8 characters.' | translate }}</p>

--- a/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.spec.ts
@@ -75,6 +75,18 @@ describe('OsStepComponent', () => {
     await setSelect('vnc_bind', '10.10.16.82');
   }
 
+  it('requires an OS to be selected before the step is valid', async () => {
+    await setInput('name', 'vm1');
+    await setInput('vnc_password', '12345678');
+
+    expect(spectator.component.form.controls.os.hasError('required')).toBe(true);
+    expect(spectator.component.form.invalid).toBe(true);
+
+    await setSelect('os', 'Linux');
+
+    expect(spectator.component.form.valid).toBe(true);
+  });
+
   it('shows a form with basic VM fields like name, description, OS, etc.', async () => {
     await fillForm();
 

--- a/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.spec.ts
@@ -2,18 +2,18 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnStepperComponent } from '@truenas/ui-components';
+import {
+  TnCheckboxHarness, TnInputHarness, TnSelectHarness, TnStepperComponent,
+} from '@truenas/ui-components';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import {
   VmBootloader, VmOs, VmTime,
 } from 'app/enums/vm.enum';
-import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { OsStepComponent } from 'app/pages/vm/vm-wizard/steps/1-os-step/os-step.component';
 
 describe('OsStepComponent', () => {
   let spectator: Spectator<OsStepComponent>;
   let loader: HarnessLoader;
-  let form: IxFormHarness;
   const createComponent = createComponentFactory({
     component: OsStepComponent,
     imports: [
@@ -35,26 +35,44 @@ describe('OsStepComponent', () => {
     ],
   });
 
-  beforeEach(async () => {
+  async function setInput(controlName: string, value: string): Promise<void> {
+    const input = await loader.getHarness(TnInputHarness.with({ selector: `[formControlName="${controlName}"]` }));
+    await input.setValue(value);
+  }
+
+  async function setSelect(controlName: string, optionLabel: string): Promise<void> {
+    const select = await loader.getHarness(TnSelectHarness.with({ selector: `[formControlName="${controlName}"]` }));
+    await select.selectOption(optionLabel);
+  }
+
+  async function setCheckbox(controlName: string, checked: boolean): Promise<void> {
+    const checkbox = await loader.getHarness(
+      TnCheckboxHarness.with({ selector: `[formControlName="${controlName}"]` }),
+    );
+    if (checked) {
+      await checkbox.check();
+    } else {
+      await checkbox.uncheck();
+    }
+  }
+
+  beforeEach(() => {
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
-    form = await loader.getHarness(IxFormHarness);
   });
 
   async function fillForm(): Promise<void> {
-    await form.fillForm({
-      'Guest Operating System': 'Linux',
-      'Enable Secure Boot': 'Linux',
-      Name: 'vm1',
-      Description: 'My first VM',
-      'System Clock': 'UTC',
-      'Boot Method': 'UEFI',
-      'Shutdown Timeout': 90,
-      'Start on Boot': true,
-      'Enable Display (VNC)': true,
-      Password: '12345678',
-      Bind: '10.10.16.82',
-    });
+    await setSelect('os', 'Linux');
+    await setCheckbox('enable_secure_boot', true);
+    await setInput('name', 'vm1');
+    await setInput('description', 'My first VM');
+    await setSelect('time', 'UTC');
+    await setSelect('bootloader', 'UEFI');
+    await setInput('shutdown_timeout', '90');
+    await setCheckbox('autostart', true);
+    await setCheckbox('enable_vnc', true);
+    await setInput('vnc_password', '12345678');
+    await setSelect('vnc_bind', '10.10.16.82');
   }
 
   it('shows a form with basic VM fields like name, description, OS, etc.', async () => {
@@ -80,12 +98,8 @@ describe('OsStepComponent', () => {
   it('shows Hyper-V Enlightenments checkbox when Windows is selected as OS', async () => {
     await fillForm();
 
-    await form.fillForm(
-      {
-        'Guest Operating System': 'Windows',
-        'Enable Hyper-V Enlightenments': true,
-      },
-    );
+    await setSelect('os', 'Windows');
+    await setCheckbox('hyperv_enlightenments', true);
 
     expect(spectator.component.form.value).toMatchObject({
       os: VmOs.Windows,
@@ -110,14 +124,12 @@ describe('OsStepComponent', () => {
 
   describe('VNC Display', () => {
     it('enables VNC fields when Enable Display (VNC) is checked', async () => {
-      await form.fillForm({
-        'Enable Display (VNC)': true,
-      });
+      await setCheckbox('enable_vnc', true);
 
-      const formValues = await form.getValues();
-      expect(formValues).toMatchObject({
-        'Enable Display (VNC)': true,
-      });
+      const vncCheckbox = await loader.getHarness(
+        TnCheckboxHarness.with({ selector: '[formControlName="enable_vnc"]' }),
+      );
+      expect(await vncCheckbox.isChecked()).toBe(true);
 
       // VNC fields should be accessible
       expect(spectator.component.form.controls.vnc_bind.enabled).toBe(true);
@@ -125,15 +137,11 @@ describe('OsStepComponent', () => {
     });
 
     it('disables VNC fields when Enable Display (VNC) is unchecked', async () => {
-      await form.fillForm({
-        'Enable Display (VNC)': true,
-        Bind: '10.10.16.82',
-        Password: 'vncpass',
-      });
+      await setCheckbox('enable_vnc', true);
+      await setSelect('vnc_bind', '10.10.16.82');
+      await setInput('vnc_password', 'vncpass');
 
-      await form.fillForm({
-        'Enable Display (VNC)': false,
-      });
+      await setCheckbox('enable_vnc', false);
 
       // VNC fields should be disabled
       expect(spectator.component.form.controls.vnc_bind.disabled).toBe(true);
@@ -141,40 +149,34 @@ describe('OsStepComponent', () => {
     });
 
     it('validates VNC password with 8-character limit', async () => {
-      await form.fillForm({
-        'Enable Display (VNC)': true,
-        Password: '123456789', // 9 characters - should be invalid
-      });
+      await setCheckbox('enable_vnc', true);
+      await setInput('vnc_password', '123456789'); // 9 characters - should be invalid
 
       expect(spectator.component.form.controls.vnc_password.invalid).toBe(true);
       expect(spectator.component.form.controls.vnc_password.hasError('maxlength')).toBe(true);
     });
 
     it('accepts VNC password with 8 characters or less', async () => {
-      await form.fillForm({
-        'Enable Display (VNC)': true,
-        Password: '12345678', // 8 characters - should be valid
-      });
+      await setCheckbox('enable_vnc', true);
+      await setInput('vnc_password', '12345678'); // 8 characters - should be valid
 
       expect(spectator.component.form.controls.vnc_password.valid).toBe(true);
     });
 
     it('requires VNC password when VNC is enabled', async () => {
-      await form.fillForm({
-        'Enable Display (VNC)': true,
-        Password: '', // Empty password - should be invalid
-      });
+      await setCheckbox('enable_vnc', true);
+      // TnInputHarness.setValue('') cannot send empty keys; set the control directly.
+      spectator.component.form.controls.vnc_password.setValue('');
+      spectator.component.form.controls.vnc_password.markAsTouched();
 
       expect(spectator.component.form.controls.vnc_password.invalid).toBe(true);
       expect(spectator.component.form.controls.vnc_password.hasError('required')).toBe(true);
     });
 
     it('shows VNC form values when enabled', async () => {
-      await form.fillForm({
-        'Enable Display (VNC)': true,
-        Password: 'vncpass',
-        Bind: '10.10.16.82',
-      });
+      await setCheckbox('enable_vnc', true);
+      await setInput('vnc_password', 'vncpass');
+      await setSelect('vnc_bind', '10.10.16.82');
 
       expect(spectator.component.form.value).toMatchObject({
         enable_vnc: true,
@@ -184,13 +186,11 @@ describe('OsStepComponent', () => {
     });
 
     it('shows complete form values with VNC enabled', async () => {
-      await form.fillForm({
-        'Guest Operating System': 'Linux',
-        Name: 'vnc-test-vm',
-        'Enable Display (VNC)': true,
-        Password: 'vncpass',
-        Bind: '10.10.16.82',
-      });
+      await setSelect('os', 'Linux');
+      await setInput('name', 'vnc-test-vm');
+      await setCheckbox('enable_vnc', true);
+      await setInput('vnc_password', 'vncpass');
+      await setSelect('vnc_bind', '10.10.16.82');
 
       expect(spectator.component.form.value).toMatchObject({
         os: VmOs.Linux,

--- a/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.ts
@@ -58,7 +58,7 @@ export class OsStepComponent implements SummaryProvider {
   private destroyRef = inject(DestroyRef);
 
   form = this.formBuilder.nonNullable.group({
-    os: [null as VmOs | null],
+    os: [null as VmOs | null, Validators.required],
     hyperv_enlightenments: [false],
     name: ['',
       [Validators.required, Validators.pattern(vmNamePattern)],

--- a/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/1-os-step/os-step.component.ts
@@ -1,8 +1,17 @@
+import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { TnButtonComponent, TnStepperNextDirective } from '@truenas/ui-components';
+import {
+  InputType,
+  TnButtonComponent,
+  TnCheckboxComponent,
+  TnFormFieldComponent,
+  TnInputComponent,
+  TnSelectComponent,
+  TnStepperNextDirective,
+} from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {
@@ -17,9 +26,6 @@ import { mapToOptions } from 'app/helpers/options.helper';
 import { stepCompletedSignal } from 'app/helpers/step-completed-signal.helper';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
-import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
-import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
-import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import {
   forbiddenAsyncValues,
 } from 'app/modules/forms/ix-forms/validators/forbidden-values-validation/forbidden-values-validation';
@@ -33,10 +39,12 @@ import { vmNamePattern } from 'app/pages/vm/utils/vm-form-patterns.constant';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
+    AsyncPipe,
     ReactiveFormsModule,
-    IxSelectComponent,
-    IxCheckboxComponent,
-    IxInputComponent,
+    TnFormFieldComponent,
+    TnInputComponent,
+    TnSelectComponent,
+    TnCheckboxComponent,
     FormActionsComponent,
     TnButtonComponent,
     TnStepperNextDirective,
@@ -77,6 +85,7 @@ export class OsStepComponent implements SummaryProvider {
 
   readonly helptext = helptextVmWizard;
   readonly VmOs = VmOs;
+  protected readonly InputType = InputType;
 
   readonly osOptions$ = of(mapToOptions(vmOsLabels, this.translate));
   readonly timeOptions$ = of(mapToOptions(vmTimeNames, this.translate));

--- a/src/app/pages/vm/vm-wizard/steps/2-cpu-and-memory-step/cpu-and-memory-step.component.html
+++ b/src/app/pages/vm/vm-wizard/steps/2-cpu-and-memory-step/cpu-and-memory-step.component.html
@@ -5,78 +5,105 @@
     </p>
   }
 
-  <ix-input
-    formControlName="vcpus"
-    type="number"
+  <tn-form-field
     [label]="'Virtual CPUs' | translate"
-    [required]="true"
     [tooltip]="helptext.vcpus_tooltip | translate"
-  ></ix-input>
+    [required]="true"
+  >
+    <tn-input
+      formControlName="vcpus"
+      [inputType]="InputType.Number"
+      [allowDecimals]="false"
+      [required]="true"
+    ></tn-input>
+  </tn-form-field>
 
-  <ix-input
-    formControlName="cores"
-    type="number"
+  <tn-form-field
     [label]="'Cores' | translate"
-    [required]="true"
     [tooltip]="helptext.cores.tooltip | translate"
-  ></ix-input>
-
-  <ix-input
-    formControlName="threads"
-    type="number"
-    [label]="'Threads' | translate"
     [required]="true"
-    [tooltip]="helptext.threads.tooltip | translate"
-  ></ix-input>
+  >
+    <tn-input
+      formControlName="cores"
+      [inputType]="InputType.Number"
+      [allowDecimals]="false"
+      [required]="true"
+    ></tn-input>
+  </tn-form-field>
 
-  <ix-input
-    formControlName="cpuset"
+  <tn-form-field
+    [label]="'Threads' | translate"
+    [tooltip]="helptext.threads.tooltip | translate"
+    [required]="true"
+  >
+    <tn-input
+      formControlName="threads"
+      [inputType]="InputType.Number"
+      [allowDecimals]="false"
+      [required]="true"
+    ></tn-input>
+  </tn-form-field>
+
+  <tn-form-field
     [label]="'Optional: CPU Set (Examples: 0-3,8-11)' | translate"
     [tooltip]="helptext.cpuset.tooltip | translate"
-  ></ix-input>
+  >
+    <tn-input formControlName="cpuset"></tn-input>
+  </tn-form-field>
 
-  <ix-checkbox
-    formControlName="pin_vcpus"
-    [label]="'Pin vcpus' | translate"
-    [tooltip]="helptext.pin_vcpus.tooltip | translate"
-  ></ix-checkbox>
+  <tn-form-field [tooltip]="helptext.pin_vcpus.tooltip | translate">
+    <tn-checkbox
+      formControlName="pin_vcpus"
+      [label]="'Pin vcpus' | translate"
+    ></tn-checkbox>
+  </tn-form-field>
 
-  <ix-select
-    formControlName="cpu_mode"
+  <tn-form-field
     [label]="'CPU Mode' | translate"
-    [options]="cpuModes$"
     [required]="true"
-  ></ix-select>
+  >
+    <tn-select
+      formControlName="cpu_mode"
+      [options]="(cpuModes$ | async) ?? []"
+    ></tn-select>
+  </tn-form-field>
 
   @if (isCpuCustom) {
-    <ix-select
-      formControlName="cpu_model"
-      [label]="'CPU Model' | translate"
-      [options]="cpuModels$"
-    ></ix-select>
+    <tn-form-field [label]="'CPU Model' | translate">
+      <tn-select
+        formControlName="cpu_model"
+        [options]="(cpuModels$ | async) ?? []"
+        [allowEmpty]="true"
+      ></tn-select>
+    </tn-form-field>
   }
 
-  <ix-input
-    formControlName="memory"
+  <tn-form-field
     [label]="'Memory Size' | translate"
-    [format]="formatter.memorySizeFormatting"
-    [parse]="formatter.memorySizeParsing"
     [tooltip]="helptext.memory_tooltip | translate"
-  ></ix-input>
+  >
+    <tn-input
+      formControlName="memory"
+      [inputType]="InputType.Size"
+    ></tn-input>
+  </tn-form-field>
 
-  <ix-input
-    formControlName="min_memory"
+  <tn-form-field
     [label]="'Minimum Memory Size' | translate"
-    [format]="formatter.memorySizeFormatting"
-    [parse]="formatter.memorySizeParsing"
     [tooltip]="helptext.min_memory_tooltip | translate"
-  ></ix-input>
+  >
+    <tn-input
+      formControlName="min_memory"
+      [inputType]="InputType.Size"
+    ></tn-input>
+  </tn-form-field>
 
-  <ix-input
-    formControlName="nodeset"
+  <tn-form-field
     [label]="'Optional: NUMA nodeset (Example: 0-1)' | translate"
     [tooltip]="helptext.nodeset.tooltip | translate"
-  ></ix-input>
+  >
+    <tn-input formControlName="nodeset"></tn-input>
+  </tn-form-field>
 
   <p class="warning-text">{{ helptext.memory_warning | translate }}</p>
 

--- a/src/app/pages/vm/vm-wizard/steps/2-cpu-and-memory-step/cpu-and-memory-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/2-cpu-and-memory-step/cpu-and-memory-step.component.spec.ts
@@ -2,10 +2,11 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnStepperComponent } from '@truenas/ui-components';
+import {
+  TnCheckboxHarness, TnInputHarness, TnSelectHarness, TnStepperComponent,
+} from '@truenas/ui-components';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { VmCpuMode } from 'app/enums/vm.enum';
-import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { CpuValidatorService } from 'app/pages/vm/utils/cpu-validator.service';
 import {
   CpuAndMemoryStepComponent,
@@ -13,7 +14,6 @@ import {
 
 describe('CpuAndMemoryStepComponent', () => {
   let spectator: Spectator<CpuAndMemoryStepComponent>;
-  let form: IxFormHarness;
   let loader: HarnessLoader;
   const createComponent = createComponentFactory({
     component: CpuAndMemoryStepComponent,
@@ -33,25 +33,33 @@ describe('CpuAndMemoryStepComponent', () => {
     ],
   });
 
-  beforeEach(async () => {
+  async function setInput(controlName: string, value: string): Promise<void> {
+    const input = await loader.getHarness(TnInputHarness.with({ selector: `[formControlName="${controlName}"]` }));
+    await input.setValue(value);
+  }
+
+  async function setSelect(controlName: string, optionLabel: string): Promise<void> {
+    const select = await loader.getHarness(TnSelectHarness.with({ selector: `[formControlName="${controlName}"]` }));
+    await select.selectOption(optionLabel);
+  }
+
+  beforeEach(() => {
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
-    form = await loader.getHarness(IxFormHarness);
   });
 
   async function fillForm(): Promise<void> {
-    await form.fillForm({
-      'Virtual CPUs': 2,
-      Cores: 1,
-      Threads: 1,
-      'Optional: CPU Set (Examples: 0-3,8-11)': 2,
-      'Pin vcpus': true,
-      'CPU Mode': 'Custom',
-      'CPU Model': 'EPYC',
-      'Memory Size': '1 GiB',
-      'Minimum Memory Size': '512 MiB',
-      'Optional: NUMA nodeset (Example: 0-1)': 2,
-    });
+    await setInput('vcpus', '2');
+    await setInput('cores', '1');
+    await setInput('threads', '1');
+    await setInput('cpuset', '2');
+    const pinVcpus = await loader.getHarness(TnCheckboxHarness.with({ selector: '[formControlName="pin_vcpus"]' }));
+    await pinVcpus.check();
+    await setSelect('cpu_mode', 'Custom');
+    await setSelect('cpu_model', 'EPYC');
+    await setInput('memory', '1 GiB');
+    await setInput('min_memory', '512 MiB');
+    await setInput('nodeset', '2');
   }
 
   it('shows a form with fields for CPU and Memory settings', async () => {

--- a/src/app/pages/vm/vm-wizard/steps/2-cpu-and-memory-step/cpu-and-memory-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/2-cpu-and-memory-step/cpu-and-memory-step.component.ts
@@ -1,8 +1,18 @@
+import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { TnButtonComponent, TnStepperNextDirective, TnStepperPreviousDirective } from '@truenas/ui-components';
+import {
+  InputType,
+  TnButtonComponent,
+  TnCheckboxComponent,
+  TnFormFieldComponent,
+  TnInputComponent,
+  TnSelectComponent,
+  TnStepperNextDirective,
+  TnStepperPreviousDirective,
+} from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
 import { VmCpuMode, vmCpuModeLabels } from 'app/enums/vm.enum';
@@ -12,10 +22,6 @@ import { mapToOptions } from 'app/helpers/options.helper';
 import { stepCompletedSignal } from 'app/helpers/step-completed-signal.helper';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
-import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
-import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
-import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
-import { IxFormatterService } from 'app/modules/forms/ix-forms/services/ix-formatter.service';
 import { IxValidatorsService } from 'app/modules/forms/ix-forms/services/ix-validators.service';
 import { SummaryProvider, SummarySection } from 'app/modules/summary/summary.interface';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -31,10 +37,12 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
   providers: [CpuValidatorService],
   standalone: true,
   imports: [
+    AsyncPipe,
     ReactiveFormsModule,
-    IxInputComponent,
-    IxCheckboxComponent,
-    IxSelectComponent,
+    TnFormFieldComponent,
+    TnInputComponent,
+    TnCheckboxComponent,
+    TnSelectComponent,
     FormActionsComponent,
     TnButtonComponent,
     TnStepperPreviousDirective,
@@ -43,7 +51,6 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
   ],
 })
 export class CpuAndMemoryStepComponent implements OnInit, SummaryProvider {
-  formatter = inject(IxFormatterService);
   private formBuilder = inject(FormBuilder);
   private cpuValidator = inject(CpuValidatorService);
   private validator = inject(IxValidatorsService);
@@ -87,6 +94,7 @@ export class CpuAndMemoryStepComponent implements OnInit, SummaryProvider {
   readonly completed = stepCompletedSignal(this.form);
 
   readonly helptext = helptextVmWizard;
+  protected readonly InputType = InputType;
 
   readonly cpuModes$ = of(mapToOptions(vmCpuModeLabels, this.translate));
   readonly cpuModels$ = this.api.call('vm.cpu_model_choices').pipe(choicesToOptions());

--- a/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.html
+++ b/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.html
@@ -1,14 +1,27 @@
 <form [formGroup]="form">
-  <ix-radio-group
-    formControlName="newOrExisting"
-    [options]="newOrExistingOptions$"
-  ></ix-radio-group>
+  <tn-form-field
+    [label]="'Disk' | translate"
+    [tooltip]="helptext.disk_radio_tooltip | translate"
+  >
+    @for (option of (newOrExistingOptions$ | async) ?? []; track option.value) {
+      <tn-radio
+        name="newOrExisting"
+        formControlName="newOrExisting"
+        [value]="option.value"
+        [label]="option.label"
+        [testId]="['newOrExisting', option.value]"
+      ></tn-radio>
+    }
+  </tn-form-field>
 
-  <ix-checkbox
-    formControlName="import_image"
-    [label]="'Import Image' | translate"
+  <tn-form-field
     [tooltip]="'Import a disk image (qcow2, qed, raw, vdi, vhdx, vmdk) to the zvol' | translate"
-  ></ix-checkbox>
+  >
+    <tn-checkbox
+      formControlName="import_image"
+      [label]="'Import Image' | translate"
+    ></tn-checkbox>
+  </tn-form-field>
 
   @if (isImportingImage) {
     <ix-explorer
@@ -20,38 +33,49 @@
     ></ix-explorer>
   }
 
-  <ix-select
-    formControlName="hdd_type"
-    [required]="true"
+  <tn-form-field
     [label]="'Select Disk Type' | translate"
-    [options]="hddTypeOptions$"
     [tooltip]="helptext.hdd_type_tooltip | translate"
-  ></ix-select>
+    [required]="true"
+  >
+    <tn-select
+      formControlName="hdd_type"
+      [options]="(hddTypeOptions$ | async) ?? []"
+    ></tn-select>
+  </tn-form-field>
 
   @if (isCreatingNewDisk) {
-    <ix-select
-      formControlName="datastore"
+    <tn-form-field
       [label]="'Zvol Location' | translate"
-      [required]="true"
-      [options]="datastoreOptions$"
       [tooltip]="helptext.datastore_tooltip | translate"
-    ></ix-select>
-
-    <ix-input
-      formControlName="volsize"
-      [label]="'Size' | translate"
-      [format]="formatter.memorySizeFormatting"
-      [parse]="formatter.memorySizeParsing"
-      [tooltip]="helptext.volsize_tooltip | translate"
-    ></ix-input>
-  } @else {
-    <ix-select
-      formControlName="hdd_path"
-      [label]="'Select Existing Zvol' | translate"
-      [options]="hddPathOptions$"
       [required]="true"
+    >
+      <tn-select
+        formControlName="datastore"
+        [options]="(datastoreOptions$ | async) ?? []"
+      ></tn-select>
+    </tn-form-field>
+
+    <tn-form-field
+      [label]="'Size' | translate"
+      [tooltip]="helptext.volsize_tooltip | translate"
+    >
+      <tn-input
+        formControlName="volsize"
+        [inputType]="InputType.Size"
+      ></tn-input>
+    </tn-form-field>
+  } @else {
+    <tn-form-field
+      [label]="'Select Existing Zvol' | translate"
       [tooltip]="helptext.hdd_path_tooltip | translate"
-    ></ix-select>
+      [required]="true"
+    >
+      <tn-select
+        formControlName="hdd_path"
+        [options]="(hddPathOptions$ | async) ?? []"
+      ></tn-select>
+    </tn-form-field>
 
     @if (selectedZvolOtherVmNames.length > 0) {
       <tn-banner

--- a/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.spec.ts
@@ -2,16 +2,16 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnStepperComponent } from '@truenas/ui-components';
+import {
+  TnCheckboxHarness, TnInputHarness, TnRadioHarness, TnSelectHarness, TnStepperComponent,
+} from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { GiB } from 'app/constants/bytes.constant';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { VmDeviceType, VmDiskMode } from 'app/enums/vm.enum';
 import { VirtualMachine } from 'app/interfaces/virtual-machine.interface';
 import { VmDiskDevice } from 'app/interfaces/vm-device.interface';
-import { IxCheckboxHarness } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.harness';
-import { IxRadioGroupHarness } from 'app/modules/forms/ix-forms/components/ix-radio-group/ix-radio-group.harness';
-import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
+import { IxExplorerHarness } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.harness';
 import { FreeSpaceValidatorService } from 'app/pages/vm/utils/free-space-validator.service';
 import { ImageVirtualSizeValidatorService } from 'app/pages/vm/utils/image-virtual-size-validator.service';
 import { DiskStepComponent, NewOrExistingDisk } from 'app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component';
@@ -20,7 +20,6 @@ import { FilesystemService } from 'app/services/filesystem.service';
 describe('DiskStepComponent', () => {
   let spectator: Spectator<DiskStepComponent>;
   let loader: HarnessLoader;
-  let form: IxFormHarness;
 
   const createComponent = createComponentFactory({
     component: DiskStepComponent,
@@ -54,19 +53,42 @@ describe('DiskStepComponent', () => {
     ],
   });
 
-  beforeEach(async () => {
+  async function setInput(controlName: string, value: string): Promise<void> {
+    const input = await loader.getHarness(TnInputHarness.with({ selector: `[formControlName="${controlName}"]` }));
+    await input.setValue(value);
+  }
+
+  async function setSelect(controlName: string, optionLabel: string): Promise<void> {
+    const select = await loader.getHarness(TnSelectHarness.with({ selector: `[formControlName="${controlName}"]` }));
+    await select.selectOption(optionLabel);
+  }
+
+  async function setImportImage(checked: boolean): Promise<void> {
+    const checkbox = await loader.getHarness(
+      TnCheckboxHarness.with({ selector: '[formControlName="import_image"]' }),
+    );
+    if (checked) {
+      await checkbox.check();
+    } else {
+      await checkbox.uncheck();
+    }
+  }
+
+  async function selectDiskMode(label: string): Promise<void> {
+    const radio = await loader.getHarness(TnRadioHarness.with({ label }));
+    await radio.check();
+  }
+
+  beforeEach(() => {
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
-    form = await loader.getHarness(IxFormHarness);
   });
 
   describe('create new disk image', () => {
     beforeEach(async () => {
-      await form.fillForm({
-        'Select Disk Type': 'AHCI',
-        'Zvol Location': 'poolio',
-        Size: '20 GiB',
-      });
+      await setSelect('hdd_type', 'AHCI');
+      await setSelect('datastore', 'poolio');
+      await setInput('volsize', '20 GiB');
     });
 
     it('shows form fields', () => {
@@ -97,13 +119,10 @@ describe('DiskStepComponent', () => {
 
   describe('use existing disk image', () => {
     beforeEach(async () => {
-      const modeRadio = await loader.getHarness(IxRadioGroupHarness);
-      await modeRadio.setValue('Use existing disk image');
+      await selectDiskMode('Use existing disk image');
 
-      await form.fillForm({
-        'Select Disk Type': 'VirtIO',
-        'Select Existing Zvol': 'poolio/test-327brn',
-      });
+      await setSelect('hdd_type', 'VirtIO');
+      await setSelect('hdd_path', 'poolio/test-327brn');
     });
 
     it('shows form fields', () => {
@@ -134,18 +153,16 @@ describe('DiskStepComponent', () => {
 
   describe('import disk image', () => {
     beforeEach(async () => {
-      const importCheckbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Import Image' }));
-      await importCheckbox.setValue(true);
+      await setImportImage(true);
     });
 
     it('shows image source field when import checkbox is checked', async () => {
-      const formValues = await form.getValues();
-      expect(formValues).toMatchObject({
-        'Import Image': true,
+      expect(spectator.component.form.value).toMatchObject({
+        import_image: true,
       });
 
-      const labels = await form.getLabels();
-      expect(labels).toContain('Image Source');
+      const explorer = await loader.getHarness(IxExplorerHarness.with({ label: 'Image Source' }));
+      expect(explorer).toBeTruthy();
     });
 
     it('validates image file extensions', () => {
@@ -169,11 +186,9 @@ describe('DiskStepComponent', () => {
     });
 
     it('includes import information in summary when image is selected', async () => {
-      await form.fillForm({
-        'Select Disk Type': 'AHCI',
-        'Zvol Location': 'poolio',
-        Size: '20 GiB',
-      });
+      await setSelect('hdd_type', 'AHCI');
+      await setSelect('datastore', 'poolio');
+      await setInput('volsize', '20 GiB');
 
       spectator.component.form.controls.image_source.setValue('/mnt/pool/ubuntu.qcow2');
 
@@ -223,8 +238,7 @@ describe('DiskStepComponent', () => {
     it('attaches volsize async validator when creating new disk and importing image', async () => {
       const validateVolsizeSpy = jest.spyOn(imageVirtualSizeValidator, 'validateVolsize');
 
-      const importCheckbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Import Image' }));
-      await importCheckbox.setValue(true);
+      await setImportImage(true);
 
       expect(validateVolsizeSpy).toHaveBeenCalledWith(spectator.component.form, expect.any(Function));
     });
@@ -232,11 +246,8 @@ describe('DiskStepComponent', () => {
     it('attaches hdd_path async validator when using existing disk and importing image', async () => {
       const validateHddPathSpy = jest.spyOn(imageVirtualSizeValidator, 'validateHddPath');
 
-      const modeRadio = await loader.getHarness(IxRadioGroupHarness);
-      await modeRadio.setValue('Use existing disk image');
-
-      const importCheckbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Import Image' }));
-      await importCheckbox.setValue(true);
+      await selectDiskMode('Use existing disk image');
+      await setImportImage(true);
 
       expect(validateHddPathSpy).toHaveBeenCalledWith(
         spectator.component.form,
@@ -261,8 +272,7 @@ describe('DiskStepComponent', () => {
       const validateVolsizeSpy = jest.spyOn(imageVirtualSizeValidator, 'validateVolsize');
       const validateHddPathSpy = jest.spyOn(imageVirtualSizeValidator, 'validateHddPath');
 
-      const importCheckbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Import Image' }));
-      await importCheckbox.setValue(true);
+      await setImportImage(true);
 
       // Initially in "new disk" mode - validateVolsize should be called
       expect(validateVolsizeSpy).toHaveBeenCalledTimes(1);
@@ -272,8 +282,7 @@ describe('DiskStepComponent', () => {
       validateHddPathSpy.mockClear();
 
       // Switch to "existing disk" mode
-      const modeRadio = await loader.getHarness(IxRadioGroupHarness);
-      await modeRadio.setValue('Use existing disk image');
+      await selectDiskMode('Use existing disk image');
 
       // Now validateHddPath should be called
       expect(validateHddPathSpy).toHaveBeenCalledTimes(1);
@@ -283,7 +292,7 @@ describe('DiskStepComponent', () => {
       validateHddPathSpy.mockClear();
 
       // Switch back to "new disk" mode
-      await modeRadio.setValue('Create new disk image');
+      await selectDiskMode('Create new disk image');
 
       // validateVolsize should be called again
       expect(validateVolsizeSpy).toHaveBeenCalledTimes(1);
@@ -291,15 +300,14 @@ describe('DiskStepComponent', () => {
     });
 
     it('does not trigger validation on image source change if import is disabled', async () => {
-      const importCheckbox = await loader.getHarness(IxCheckboxHarness.with({ label: 'Import Image' }));
-      await importCheckbox.setValue(true);
+      await setImportImage(true);
 
       // Spy on updateValueAndValidity
       const volsizeUpdateSpy = jest.spyOn(spectator.component.form.controls.volsize, 'updateValueAndValidity');
       const hddPathUpdateSpy = jest.spyOn(spectator.component.form.controls.hdd_path, 'updateValueAndValidity');
 
       // Disable import - this will trigger updateValueAndValidity via setConditionalValidators
-      await importCheckbox.setValue(false);
+      await setImportImage(false);
 
       // Clear spy call history after setup
       volsizeUpdateSpy.mockClear();

--- a/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/3-disk-step/disk-step.component.ts
@@ -1,9 +1,19 @@
+import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, Validators, ReactiveFormsModule, ValidatorFn, AbstractControl, ValidationErrors } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  TnBannerComponent, TnButtonComponent, TnStepperNextDirective, TnStepperPreviousDirective,
+  InputType,
+  TnBannerComponent,
+  TnButtonComponent,
+  TnCheckboxComponent,
+  TnFormFieldComponent,
+  TnInputComponent,
+  TnRadioComponent,
+  TnSelectComponent,
+  TnStepperNextDirective,
+  TnStepperPreviousDirective,
 } from '@truenas/ui-components';
 import { Observable, forkJoin, of } from 'rxjs';
 import { catchError, debounceTime, map, shareReplay, tap } from 'rxjs/operators';
@@ -17,12 +27,7 @@ import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { Dataset } from 'app/interfaces/dataset.interface';
 import { VmDiskDevice } from 'app/interfaces/vm-device.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
-import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
-import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
-import { IxRadioGroupComponent } from 'app/modules/forms/ix-forms/components/ix-radio-group/ix-radio-group.component';
-import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
-import { IxFormatterService } from 'app/modules/forms/ix-forms/services/ix-formatter.service';
 import { SummaryProvider, SummarySection } from 'app/modules/summary/summary.interface';
 import { ApiService } from 'app/modules/websocket/api.service';
 import {
@@ -46,12 +51,14 @@ const validImageExtensions = ['.qcow2', '.qed', '.raw', '.vdi', '.vhdx', '.vmdk'
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
+    AsyncPipe,
     ReactiveFormsModule,
-    IxCheckboxComponent,
     IxExplorerComponent,
-    IxRadioGroupComponent,
-    IxSelectComponent,
-    IxInputComponent,
+    TnFormFieldComponent,
+    TnRadioComponent,
+    TnCheckboxComponent,
+    TnSelectComponent,
+    TnInputComponent,
     FormActionsComponent,
     TnButtonComponent,
     TnStepperPreviousDirective,
@@ -67,7 +74,6 @@ export class DiskStepComponent implements OnInit, SummaryProvider {
   private freeSpaceValidator = inject(FreeSpaceValidatorService);
   private imageVirtualSizeValidator = inject(ImageVirtualSizeValidatorService);
   private filesystemService = inject(FilesystemService);
-  formatter = inject(IxFormatterService);
   private destroyRef = inject(DestroyRef);
 
   // Cache for virtual size API calls, keyed by image path
@@ -93,13 +99,14 @@ export class DiskStepComponent implements OnInit, SummaryProvider {
     {
       label: this.translate.instant('Create new disk image'),
       value: NewOrExistingDisk.New,
-      tooltip: helptextVmWizard.disk_radio_tooltip,
     },
     {
       label: this.translate.instant('Use existing disk image'),
       value: NewOrExistingDisk.Existing,
     },
   ]);
+
+  protected readonly InputType = InputType;
 
   private annotatedZvolOptions: AnnotatedZvolOption[] = [];
 

--- a/src/app/pages/vm/vm-wizard/steps/4-network-interface-step/network-interface-step.component.html
+++ b/src/app/pages/vm/vm-wizard/steps/4-network-interface-step/network-interface-step.component.html
@@ -1,32 +1,44 @@
 <form [formGroup]="form">
-  <ix-select
-    formControlName="nic_type"
+  <tn-form-field
     [label]="'Adapter Type' | translate"
-    [required]="true"
-    [options]="nicTypeOptions$"
     [tooltip]="helptext.NIC_type_tooltip | translate"
-  ></ix-select>
+    [required]="true"
+  >
+    <tn-select
+      formControlName="nic_type"
+      [options]="(nicTypeOptions$ | async) ?? []"
+    ></tn-select>
+  </tn-form-field>
 
-  <ix-input
-    formControlName="nic_mac"
+  <tn-form-field
     [label]="'Mac Address' | translate"
-    [required]="true"
     [tooltip]="helptext.NIC_mac_tooltip | translate"
-  ></ix-input>
-
-  <ix-select
-    formControlName="nic_attach"
-    [label]="'Attach NIC' | translate"
     [required]="true"
-    [options]="nicAttachOptions$"
+  >
+    <tn-input
+      formControlName="nic_mac"
+      [required]="true"
+    ></tn-input>
+  </tn-form-field>
+
+  <tn-form-field
+    [label]="'Attach NIC' | translate"
     [tooltip]="helptext.nic_attach_tooltip | translate"
-  ></ix-select>
+    [required]="true"
+  >
+    <tn-select
+      formControlName="nic_attach"
+      [options]="(nicAttachOptions$ | async) ?? []"
+    ></tn-select>
+  </tn-form-field>
 
   @if (isVirtio) {
-    <ix-checkbox
-      formControlName="trust_guest_rx_filters"
-      [label]="'Trust Guest Filters' | translate"
-    ></ix-checkbox>
+    <tn-form-field>
+      <tn-checkbox
+        formControlName="trust_guest_rx_filters"
+        [label]="'Trust Guest Filters' | translate"
+      ></tn-checkbox>
+    </tn-form-field>
   }
 
   <ix-form-actions>

--- a/src/app/pages/vm/vm-wizard/steps/4-network-interface-step/network-interface-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/4-network-interface-step/network-interface-step.component.spec.ts
@@ -2,11 +2,11 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnStepperComponent } from '@truenas/ui-components';
+import {
+  TnCheckboxHarness, TnInputHarness, TnSelectHarness, TnStepperComponent,
+} from '@truenas/ui-components';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { VmNicType } from 'app/enums/vm.enum';
-import { IxInputHarness } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.harness';
-import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { ApiService } from 'app/modules/websocket/api.service';
 import {
   NetworkInterfaceStepComponent,
@@ -15,7 +15,6 @@ import {
 describe('NetworkInterfaceStepComponent', () => {
   let spectator: Spectator<NetworkInterfaceStepComponent>;
   let loader: HarnessLoader;
-  let form: IxFormHarness;
   const createComponent = createComponentFactory({
     component: NetworkInterfaceStepComponent,
     imports: [
@@ -33,19 +32,25 @@ describe('NetworkInterfaceStepComponent', () => {
     ],
   });
 
-  beforeEach(async () => {
+  beforeEach(() => {
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
-    form = await loader.getHarness(IxFormHarness);
   });
 
   async function fillForm(): Promise<void> {
-    await form.fillForm({
-      'Adapter Type': 'VirtIO',
-      'Mac Address': '00:00:00:00:00:AA',
-      'Attach NIC': 'eno1',
-      'Trust Guest Filters': true,
-    });
+    const nicType = await loader.getHarness(TnSelectHarness.with({ selector: '[formControlName="nic_type"]' }));
+    await nicType.selectOption('VirtIO');
+
+    const macAddress = await loader.getHarness(TnInputHarness.with({ selector: '[formControlName="nic_mac"]' }));
+    await macAddress.setValue('00:00:00:00:00:AA');
+
+    const nicAttach = await loader.getHarness(TnSelectHarness.with({ selector: '[formControlName="nic_attach"]' }));
+    await nicAttach.selectOption('eno1');
+
+    const trustGuestFilters = await loader.getHarness(
+      TnCheckboxHarness.with({ selector: '[formControlName="trust_guest_rx_filters"]' }),
+    );
+    await trustGuestFilters.check();
   }
 
   it('shows form with fields related to NIC', async () => {
@@ -73,7 +78,7 @@ describe('NetworkInterfaceStepComponent', () => {
   it('generates random MAC when form is initialized', async () => {
     expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('vm.random_mac');
 
-    const macAddress = await form.getControl('Mac Address') as IxInputHarness;
+    const macAddress = await loader.getHarness(TnInputHarness.with({ selector: '[formControlName="nic_mac"]' }));
     expect(await macAddress.getValue()).toBe('00:00:00:00:00:01');
   });
 });

--- a/src/app/pages/vm/vm-wizard/steps/4-network-interface-step/network-interface-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/4-network-interface-step/network-interface-step.component.ts
@@ -1,8 +1,17 @@
+import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { TnButtonComponent, TnStepperNextDirective, TnStepperPreviousDirective } from '@truenas/ui-components';
+import {
+  TnButtonComponent,
+  TnCheckboxComponent,
+  TnFormFieldComponent,
+  TnInputComponent,
+  TnSelectComponent,
+  TnStepperNextDirective,
+  TnStepperPreviousDirective,
+} from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { VmNicType, vmNicTypeLabels } from 'app/enums/vm.enum';
 import { nicChoicesToOptions } from 'app/helpers/operators/options.operators';
@@ -10,9 +19,6 @@ import { mapToOptions } from 'app/helpers/options.helper';
 import { stepCompletedSignal } from 'app/helpers/step-completed-signal.helper';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
-import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
-import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
-import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import { SummaryProvider, SummarySection } from 'app/modules/summary/summary.interface';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
@@ -23,10 +29,12 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
+    AsyncPipe,
     ReactiveFormsModule,
-    IxSelectComponent,
-    IxInputComponent,
-    IxCheckboxComponent,
+    TnFormFieldComponent,
+    TnSelectComponent,
+    TnInputComponent,
+    TnCheckboxComponent,
     FormActionsComponent,
     TnButtonComponent,
     TnStepperPreviousDirective,

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.html
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.html
@@ -1,21 +1,25 @@
 <form [formGroup]="form">
-  <ix-checkbox
-    formControlName="hide_from_msr"
-    [label]="'Hide from MSR' | translate"
-  ></ix-checkbox>
+  <tn-form-field>
+    <tn-checkbox
+      formControlName="hide_from_msr"
+      [label]="'Hide from MSR' | translate"
+    ></tn-checkbox>
+  </tn-form-field>
 
-  <ix-checkbox
-    formControlName="ensure_display_device"
-    [label]="'Ensure Display Device' | translate"
-    [tooltip]="helptext.ensure_display_device.tooltip | translate"
-  ></ix-checkbox>
+  <tn-form-field [tooltip]="helptext.ensure_display_device.tooltip | translate">
+    <tn-checkbox
+      formControlName="ensure_display_device"
+      [label]="'Ensure Display Device' | translate"
+    ></tn-checkbox>
+  </tn-form-field>
 
-  <ix-select
-    formControlName="gpus"
-    [label]="'GPUs' | translate"
-    [options]="gpuOptions$"
-    [multiple]="true"
-  ></ix-select>
+  <tn-form-field [label]="'GPUs' | translate">
+    <tn-select
+      formControlName="gpus"
+      [options]="(gpuOptions$ | async) ?? []"
+      [multiple]="true"
+    ></tn-select>
+  </tn-form-field>
 
   <ix-form-actions>
     <tn-button

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.spec.ts
@@ -1,10 +1,9 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnStepperComponent } from '@truenas/ui-components';
+import { TnCheckboxHarness, TnSelectHarness, TnStepperComponent } from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
-import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { GpuStepComponent } from 'app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component';
 import { GpuService } from 'app/services/gpu/gpu.service';
 import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-validator.service';
@@ -12,7 +11,6 @@ import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-valid
 describe('GpuStepComponent', () => {
   let spectator: Spectator<GpuStepComponent>;
   let loader: HarnessLoader;
-  let form: IxFormHarness;
 
   const createComponent = createComponentFactory({
     component: GpuStepComponent,
@@ -55,18 +53,24 @@ describe('GpuStepComponent', () => {
     ],
   });
 
-  beforeEach(async () => {
+  beforeEach(() => {
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
-    form = await loader.getHarness(IxFormHarness);
   });
 
   async function fillForm(): Promise<void> {
-    await form.fillForm({
-      'Hide from MSR': true,
-      'Ensure Display Device': true,
-      GPUs: ['GeForce GTX 1080 Ti [0000:04:00.0]'],
-    });
+    const hideFromMsr = await loader.getHarness(
+      TnCheckboxHarness.with({ selector: '[formControlName="hide_from_msr"]' }),
+    );
+    await hideFromMsr.check();
+
+    const ensureDisplayDevice = await loader.getHarness(
+      TnCheckboxHarness.with({ selector: '[formControlName="ensure_display_device"]' }),
+    );
+    await ensureDisplayDevice.check();
+
+    const gpusSelect = await loader.getHarness(TnSelectHarness.with({ selector: '[formControlName="gpus"]' }));
+    await gpusSelect.selectOption('GeForce GTX 1080 Ti [0000:04:00.0]');
   }
 
   it('shows form with GPU fields', async () => {

--- a/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
+++ b/src/app/pages/vm/vm-wizard/steps/6-gpu-step/gpu-step.component.ts
@@ -1,14 +1,20 @@
+import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { TnButtonComponent, TnStepperNextDirective, TnStepperPreviousDirective } from '@truenas/ui-components';
+import {
+  TnButtonComponent,
+  TnCheckboxComponent,
+  TnFormFieldComponent,
+  TnSelectComponent,
+  TnStepperNextDirective,
+  TnStepperPreviousDirective,
+} from '@truenas/ui-components';
 import { map, shareReplay } from 'rxjs';
 import { stepCompletedSignal } from 'app/helpers/step-completed-signal.helper';
 import { helptextVmWizard } from 'app/helptext/vm/vm-wizard/vm-wizard';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
-import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
-import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
 import { SummaryProvider, SummarySection } from 'app/modules/summary/summary.interface';
 import { CriticalGpuPreventionService } from 'app/services/gpu/critical-gpu-prevention.service';
 import { GpuService } from 'app/services/gpu/gpu.service';
@@ -20,9 +26,11 @@ import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-valid
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
+    AsyncPipe,
     ReactiveFormsModule,
-    IxCheckboxComponent,
-    IxSelectComponent,
+    TnFormFieldComponent,
+    TnCheckboxComponent,
+    TnSelectComponent,
     FormActionsComponent,
     TnButtonComponent,
     TnStepperPreviousDirective,

--- a/src/app/pages/vm/vm-wizard/upload-iso-dialog/upload-iso-dialog.component.html
+++ b/src/app/pages/vm/vm-wizard/upload-iso-dialog/upload-iso-dialog.component.html
@@ -10,13 +10,20 @@
     <ix-explorer-create-dataset></ix-explorer-create-dataset>
   </ix-explorer>
 
-  <ix-file-input
-    formControlName="files"
-    acceptedFiles=".img,.iso"
-    [required]="true"
+  <tn-form-field
     [label]="'Installer image file' | translate"
     [tooltip]="helptext.upload_iso_tooltip | translate"
-  ></ix-file-input>
+  >
+    <tn-file-input
+      formControlName="files"
+      accept=".img,.iso"
+      testId="files"
+      [showFileName]="true"
+      [buttonLabel]="'Choose File' | translate"
+      [noFileText]="'No file chosen' | translate"
+      [ariaLabel]="'Installer image file' | translate"
+    ></tn-file-input>
+  </tn-form-field>
 
   </form>
 <ix-form-actions tnDialogAction>

--- a/src/app/pages/vm/vm-wizard/upload-iso-dialog/upload-iso-dialog.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/upload-iso-dialog/upload-iso-dialog.component.spec.ts
@@ -59,8 +59,10 @@ describe('UploadIsoDialogComponent', () => {
 
     await form.fillForm({
       'ISO save location': '/mnt/tank/iso',
-      'Installer image file': [upload],
     });
+    // Native file inputs cannot be populated programmatically; set the control directly.
+    spectator.component.form.patchValue({ files: upload });
+    spectator.detectChanges();
 
     const uploadButton = await loader.getHarness(TnButtonHarness.with({ label: 'Upload' }));
     await uploadButton.click();
@@ -85,8 +87,9 @@ describe('UploadIsoDialogComponent', () => {
 
     await form.fillForm({
       'ISO save location': '/mnt/tank/iso',
-      'Installer image file': [upload],
     });
+    spectator.component.form.patchValue({ files: upload });
+    spectator.detectChanges();
 
     const uploadButton = await loader.getHarness(TnButtonHarness.with({ label: 'Upload' }));
     await uploadButton.click();
@@ -152,7 +155,7 @@ describe('UploadIsoDialogComponent', () => {
     it('accepts dataset paths like /mnt/poolname/dataset', () => {
       spectator.component.form.patchValue({
         path: '/mnt/tank/iso',
-        files: [fakeFile('test.iso')],
+        files: fakeFile('test.iso'),
       });
       spectator.detectChanges();
 
@@ -163,7 +166,7 @@ describe('UploadIsoDialogComponent', () => {
     it('accepts nested dataset paths', () => {
       spectator.component.form.patchValue({
         path: '/mnt/tank/iso/images',
-        files: [fakeFile('test.iso')],
+        files: fakeFile('test.iso'),
       });
       spectator.detectChanges();
 

--- a/src/app/pages/vm/vm-wizard/upload-iso-dialog/upload-iso-dialog.component.ts
+++ b/src/app/pages/vm/vm-wizard/upload-iso-dialog/upload-iso-dialog.component.ts
@@ -1,9 +1,11 @@
 import { Dialog, DialogRef } from '@angular/cdk/dialog';
 import { HttpEventType, HttpProgressEvent, HttpResponse } from '@angular/common/http';
 import { ChangeDetectionStrategy, Component, inject, OnDestroy } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { TnButtonComponent, TnDialogShellComponent } from '@truenas/ui-components';
+import {
+  TnButtonComponent, TnDialogShellComponent, TnFileInputComponent, TnFormFieldComponent,
+} from '@truenas/ui-components';
 import {
   catchError, of, Subject, Subscription, takeUntil, tap,
 } from 'rxjs';
@@ -16,7 +18,6 @@ import {
   ExplorerCreateDatasetComponent,
 } from 'app/modules/forms/ix-forms/components/ix-explorer/explorer-create-dataset/explorer-create-dataset.component';
 import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
-import { IxFileInputComponent } from 'app/modules/forms/ix-forms/components/ix-file-input/ix-file-input.component';
 import { validateNotPoolRoot } from 'app/modules/forms/ix-forms/validators/validators';
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
@@ -34,7 +35,8 @@ import { UploadService } from 'app/services/upload.service';
     TnDialogShellComponent,
     ReactiveFormsModule,
     IxExplorerComponent,
-    IxFileInputComponent,
+    TnFormFieldComponent,
+    TnFileInputComponent,
     FormActionsComponent,
     TnButtonComponent,
     RequiresRolesDirective,
@@ -59,7 +61,8 @@ export class UploadIsoDialogComponent implements OnDestroy {
     // Start with empty path instead of '/mnt' to avoid showing immediate validation error
     // Users will use the file explorer to navigate to a valid dataset path
     path: ['', [validateNotPoolRoot(this.translate.instant(this.helptext.upload_iso_pool_root_error))]],
-    files: [[] as File[]],
+    // tn-file-input in single mode emits File | null (ix-file-input used File[]).
+    files: [null as File | null, Validators.required],
   });
 
   readonly directoryNodeProvider = this.filesystemService.getFilesystemNodeProvider({ directoriesOnly: true });
@@ -104,8 +107,10 @@ export class UploadIsoDialogComponent implements OnDestroy {
   }
 
   onSubmit(): void {
-    const { path, files } = this.form.getRawValue();
-    const file = files[0];
+    const { path, files: file } = this.form.getRawValue();
+    if (!file) {
+      return;
+    }
     const uploadPath = `${path}/${file.name}`;
 
     // Cancel any existing upload before starting new one

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.html
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.html
@@ -4,52 +4,50 @@
   [loading]="isLoading"
 ></ix-modal-header>
 
-<tn-card>
-  <tn-stepper #stepper orientation="vertical" [linear]="true" (selectionChange)="updateSummary()">
-    <tn-step [label]="'Operating System' | translate" [completed]="osStep().completed()">
-      <ix-os-step></ix-os-step>
-    </tn-step>
+<tn-stepper #stepper orientation="vertical" [linear]="true" (selectionChange)="updateSummary()">
+  <tn-step [label]="'Operating System' | translate" [completed]="osStep().completed()">
+    <ix-os-step></ix-os-step>
+  </tn-step>
 
-    <tn-step [label]="'CPU And Memory' | translate" [completed]="cpuAndMemoryStep().completed()">
-      <ix-cpu-and-memory-step></ix-cpu-and-memory-step>
-    </tn-step>
+  <tn-step [label]="'CPU And Memory' | translate" [completed]="cpuAndMemoryStep().completed()">
+    <ix-cpu-and-memory-step></ix-cpu-and-memory-step>
+  </tn-step>
 
-    <tn-step [label]="'Disks' | translate" [completed]="diskStep().completed()">
-      <ix-disk-step></ix-disk-step>
-    </tn-step>
+  <tn-step [label]="'Disks' | translate" [completed]="diskStep().completed()">
+    <ix-disk-step></ix-disk-step>
+  </tn-step>
 
-    <tn-step [label]="'Network Interface' | translate" [completed]="networkInterfaceStep().completed()">
-      <ix-network-interface-step></ix-network-interface-step>
-    </tn-step>
+  <tn-step [label]="'Network Interface' | translate" [completed]="networkInterfaceStep().completed()">
+    <ix-network-interface-step></ix-network-interface-step>
+  </tn-step>
 
-    <tn-step [label]="'Installation Media' | translate" [completed]="installationMediaStep().completed()">
-      <ix-installation-media-step></ix-installation-media-step>
-    </tn-step>
+  <tn-step [label]="'Installation Media' | translate" [completed]="installationMediaStep().completed()">
+    <ix-installation-media-step></ix-installation-media-step>
+  </tn-step>
 
-    <tn-step [label]="'GPU' | translate" [completed]="gpuStep().completed()">
-      <ix-gpu-step></ix-gpu-step>
-    </tn-step>
+  <tn-step [label]="'GPU' | translate" [completed]="gpuStep().completed()">
+    <ix-gpu-step></ix-gpu-step>
+  </tn-step>
 
-    <tn-step [label]="'Confirm Options' | translate">
-      <ix-summary [summary]="summary"></ix-summary>
+  <tn-step [label]="'Confirm Options' | translate">
+    <ix-summary [summary]="summary"></ix-summary>
 
-      <p class="confirm-line">{{ 'Confirm these settings.' | translate }}</p>
+    <p class="confirm-line">{{ 'Confirm these settings.' | translate }}</p>
 
-      <ix-form-actions>
-        <tn-button
-          tnStepperPrevious
-          [testId]="'back'"
-          [label]="'Back' | translate"
-        ></tn-button>
-        <tn-button
-          *ixRequiresRoles="requiredRoles"
-          color="primary"
-          [testId]="'save'"
-          [label]="'Save' | translate"
-          [disabled]="isLoading"
-          (onClick)="onSubmit()"
-        ></tn-button>
-      </ix-form-actions>
-    </tn-step>
-  </tn-stepper>
-</tn-card>
+    <ix-form-actions>
+      <tn-button
+        tnStepperPrevious
+        [testId]="'back'"
+        [label]="'Back' | translate"
+      ></tn-button>
+      <tn-button
+        *ixRequiresRoles="requiredRoles"
+        color="primary"
+        [testId]="'save'"
+        [label]="'Save' | translate"
+        [disabled]="isLoading"
+        (onClick)="onSubmit()"
+      ></tn-button>
+    </ix-form-actions>
+  </tn-step>
+</tn-stepper>

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.spec.ts
@@ -2,7 +2,9 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnButtonHarness } from '@truenas/ui-components';
+import {
+  TnButtonHarness, TnCheckboxHarness, TnInputHarness, TnSelectHarness,
+} from '@truenas/ui-components';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { GiB } from 'app/constants/bytes.constant';
@@ -40,7 +42,6 @@ import { IsolatedGpuValidatorService } from 'app/services/gpu/isolated-gpu-valid
 describe('VmWizardComponent', () => {
   let spectator: Spectator<VmWizardComponent>;
   let loader: HarnessLoader;
-  let form: IxFormHarness;
   let nextButton: TnButtonHarness;
 
   const slideInRef: SlideInRef<undefined, unknown> = {
@@ -156,46 +157,60 @@ describe('VmWizardComponent', () => {
 
   async function updateStepHarnesses(): Promise<void> {
     // tn-stepper renders only the active step's content, so the single visible
-    // form and Next button resolve straight from the document-root loader.
-    form = await loader.getHarness(IxFormHarness);
+    // Next button and form controls resolve straight from the document-root loader.
     nextButton = await loader.getHarness(TnButtonHarness.with({ label: 'Next' }));
   }
 
+  async function setInput(controlName: string, value: string): Promise<void> {
+    const input = await loader.getHarness(TnInputHarness.with({ selector: `[formControlName="${controlName}"]` }));
+    await input.setValue(value);
+  }
+
+  async function setSelect(controlName: string, optionLabel: string): Promise<void> {
+    const select = await loader.getHarness(TnSelectHarness.with({ selector: `[formControlName="${controlName}"]` }));
+    await select.selectOption(optionLabel);
+  }
+
+  async function setCheckbox(controlName: string, checked: boolean): Promise<void> {
+    const checkbox = await loader.getHarness(
+      TnCheckboxHarness.with({ selector: `[formControlName="${controlName}"]` }),
+    );
+    if (checked) {
+      await checkbox.check();
+    } else {
+      await checkbox.uncheck();
+    }
+  }
+
   async function fillWizard(): Promise<void> {
-    await form.fillForm({
-      'Guest Operating System': 'Windows',
-      Name: 'test',
-      'Enable Display (VNC)': true,
-      Password: '12345678',
-    });
+    await setSelect('os', 'Windows');
+    await setInput('name', 'test');
+    await setCheckbox('enable_vnc', true);
+    await setInput('vnc_password', '12345678');
     await nextButton.click();
     await updateStepHarnesses();
 
     await nextButton.click();
     await updateStepHarnesses();
 
-    await form.fillForm({
-      'Zvol Location': 'poolio',
-    });
+    await setSelect('datastore', 'poolio');
     await nextButton.click();
     await updateStepHarnesses();
 
-    await form.fillForm({
-      'Adapter Type': 'Intel e82585 (e1000)',
-      'Attach NIC': 'eno2',
-    });
+    await setSelect('nic_type', 'Intel e82585 (e1000)');
+    await setSelect('nic_attach', 'eno2');
     await nextButton.click();
     await updateStepHarnesses();
 
-    await form.fillForm({
+    // Installation media step still uses ix-explorer.
+    const mediaForm = await loader.getHarness(IxFormHarness);
+    await mediaForm.fillForm({
       'Optional: Choose installation media image': '/mnt/iso/FreeNAS-11.3-U3.iso',
     });
     await nextButton.click();
     await updateStepHarnesses();
 
-    await form.fillForm({
-      GPUs: ['GeForce GTX 1080 [0000:03:00.0]'],
-    });
+    await setSelect('gpus', 'GeForce GTX 1080 [0000:03:00.0]');
     await nextButton.click();
   }
 
@@ -203,10 +218,8 @@ describe('VmWizardComponent', () => {
     jest.spyOn(spectator.component.cpuAndMemoryStep().form, 'patchValue');
     jest.spyOn(spectator.component.diskStep().form, 'patchValue');
 
-    await form.fillForm({
-      'Guest Operating System': 'Windows',
-      Name: 'test',
-    });
+    await setSelect('os', 'Windows');
+    await setInput('name', 'test');
 
     expect(spectator.component.cpuAndMemoryStep().form.patchValue).toHaveBeenCalledWith({
       cores: 1,

--- a/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
+++ b/src/app/pages/vm/vm-wizard/vm-wizard.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnIn
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  TnButtonComponent, TnCardComponent, TnStepComponent, TnStepperComponent, TnStepperPreviousDirective,
+  TnButtonComponent, TnStepComponent, TnStepperComponent, TnStepperPreviousDirective,
 } from '@truenas/ui-components';
 import { pick } from 'lodash-es';
 import {
@@ -49,7 +49,6 @@ import { GpuService } from 'app/services/gpu/gpu.service';
   standalone: true,
   imports: [
     ModalHeaderComponent,
-    TnCardComponent,
     TnStepperComponent,
     TnStepComponent,
     OsStepComponent,

--- a/src/app/services/gpu/isolated-gpu-validator.service.spec.ts
+++ b/src/app/services/gpu/isolated-gpu-validator.service.spec.ts
@@ -73,7 +73,7 @@ describe('IsolatedGpuValidatorService', () => {
       const result = await firstValueFrom(spectator.service.validateGpu(control));
       expect(result).toEqual({
         gpus: {
-          message: 'At least 1 GPU is required by the host for its functions.<p>With your selection, no GPU is available for the host to consume.</p>',
+          message: 'At least 1 GPU is required by the host for its functions. With your selection, no GPU is available for the host to consume.',
         },
       });
     });
@@ -83,7 +83,7 @@ describe('IsolatedGpuValidatorService', () => {
       const result = await firstValueFrom(spectator.service.validateGpu(control));
       expect(result).toEqual({
         gpus: {
-          message: 'At least 1 GPU is required by the host for its functions.<p>Currently following GPU(s) have been isolated:<ol><li>1. Radeon</li></ol></p><p>With your selection, no GPU is available for the host to consume.</p>',
+          message: 'At least 1 GPU is required by the host for its functions. Currently isolated GPU(s): Radeon. With your selection, no GPU is available for the host to consume.',
         },
       });
     });

--- a/src/app/services/gpu/isolated-gpu-validator.service.ts
+++ b/src/app/services/gpu/isolated-gpu-validator.service.ts
@@ -38,19 +38,20 @@ export class IsolatedGpuValidatorService {
   private makeErrorMessage(): Observable<ValidationErrors> {
     return this.gpuService.getIsolatedGpus().pipe(
       map((isolatedGpus) => {
-        let errorMessage = this.translate.instant('At least 1 GPU is required by the host for its functions.');
+        // Plain text only — the message is rendered as text (tn-form-field subscript), not HTML.
+        const messageParts = [
+          this.translate.instant('At least 1 GPU is required by the host for its functions.'),
+        ];
 
         if (isolatedGpus.length) {
-          const gpuListItems = isolatedGpus.map((gpu, index) => `${index + 1}. ${gpu.description}`);
-          const listItems = '<li>' + gpuListItems.join('</li><li>') + '</li>';
-          errorMessage += this.translate.instant(
-            '<p>Currently following GPU(s) have been isolated:<ol>{gpus}</ol></p>',
-            { gpus: listItems },
-          );
+          messageParts.push(this.translate.instant(
+            'Currently isolated GPU(s): {gpus}.',
+            { gpus: isolatedGpus.map((gpu) => gpu.description).join(', ') },
+          ));
         }
 
-        errorMessage += `<p>${this.translate.instant('With your selection, no GPU is available for the host to consume.')}</p>`;
-        return this.validatorsService.makeErrorMessage('gpus', errorMessage);
+        messageParts.push(this.translate.instant('With your selection, no GPU is available for the host to consume.'));
+        return this.validatorsService.makeErrorMessage('gpus', messageParts.join(' '));
       }),
     );
   }


### PR DESCRIPTION
## Summary

Migrates the VM wizard's form controls from `ix-*` to `@truenas/ui-components` (`tn-*`) primitives, per Epic NAS-141021. Direct Material usage was already removed earlier (NAS-141617 stepper, NAS-141022 dialog); this PR completes the incremental primitive swaps.

- `ix-input`/`ix-select`/`ix-checkbox` → `tn-form-field` + `tn-input`/`tn-select`/`tn-checkbox` across all six wizard steps
- Memory-size fields (`memory`, `min_memory`, `volsize`) move from `[format]`/`[parse]` + `IxFormatterService` to `InputType.Size` (byte model, IEC/MiB defaults — parity with the old formatter)
- `ix-radio-group` (disk step) → looped `tn-radio` under a labelled `tn-form-field`, per-option `[testId]`
- `ix-file-input` (upload ISO dialog) → `tn-file-input`; control retyped `File[]` → `File | null` per the single-file contract, `Validators.required` added so the required indicator is enforced
- `cpu_model` select gains `[allowEmpty]` to keep the clear option; required text inputs carry native `[required]` for a11y semantics
- Specs rewritten from `IxFormHarness.fillForm` to per-control `Tn*Harness` lookups by `formControlName`; `IxFormHarness` remains only for the intentional `ix-explorer` surfaces

Intentionally still `ix-*`: `ix-explorer`(+create-dataset), `ix-modal-header` (SlideIn host), `ix-form-actions`, `ix-summary`.

Test-ID note: control-level `data-test` values are preserved via the library's `formControlName` fallback. Select **option** IDs switch discriminator from label to value (e.g. `option-nic-type-virt-io` → `option-nic-type-virtio`, gpus options now use PCI slot), and the disk radios resolve `radio-new-or-existing-new/-existing` — flag if e2e needs the label-based IDs pinned.

## Testing

- `yarn test src/app/pages/vm/vm-wizard` — 8 suites, 46/46 pass
- `yarn lint` clean on all changed files
- Full six-agent migration review (`/migration-review`) run; all blockers fixed, remaining items are epic-level library gaps (tn-form-field label association, tooltip-button test IDs)