### PR TITLE
NAS-141024 / None / sharing/ tn-* migration (final pass)

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@smarttools/eslint-plugin-rxjs": "~1.0.22",
     "@stylistic/eslint-plugin": "~2.9.0",
     "@truenas/common-typescript": "github:truenas/tn-common-typescript#master",
-    "@truenas/ui-components": "~0.3.21",
+    "@truenas/ui-components": "~0.3.23",
     "@types/cheerio": "~0.22.35",
     "@types/d3": "~7.4.3",
     "@types/dygraphs": "^2.1.10",

--- a/src/app/modules/ix-table/components/table-column-picker/table-column-picker.component.ts
+++ b/src/app/modules/ix-table/components/table-column-picker/table-column-picker.component.ts
@@ -4,7 +4,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Store } from '@ngrx/store';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { TnSelectComponent, type TnSelectOption } from '@truenas/ui-components';
 import { map, take } from 'rxjs';
 import { Column, ColumnComponent } from 'app/modules/ix-table/interfaces/column-component.class';
@@ -36,6 +36,7 @@ import { waitForPreferences } from 'app/store/preferences/preferences.selectors'
 })
 export class TableColumnPickerComponent<T = unknown> implements OnInit {
   private store$ = inject<Store<AppState>>(Store);
+  private translate = inject(TranslateService);
   private destroyRef = inject(DestroyRef);
 
   readonly columns = input.required<Column<T, ColumnComponent<T>>[]>();
@@ -44,8 +45,14 @@ export class TableColumnPickerComponent<T = unknown> implements OnInit {
 
   protected readonly control = new FormControl<string[]>([], { nonNullable: true });
 
+  // Label is translated for display; value stays the raw title — it is the
+  // persistence key and must remain wire-compatible with the legacy selector's
+  // saved preferences.
   protected readonly options = computed<TnSelectOption<string>[]>(
-    () => this.selectableColumns().map((column) => ({ value: column.title, label: column.title })),
+    () => this.selectableColumns().map((column) => ({
+      value: column.title,
+      label: this.translate.instant(column.title),
+    })),
   );
 
   private lastSelected: string[] = [];

--- a/src/app/modules/slide-ins/form-side-panel/form-side-panel-container.component.spec.ts
+++ b/src/app/modules/slide-ins/form-side-panel/form-side-panel-container.component.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { ComponentPortal } from '@angular/cdk/portal';
 import {
   ChangeDetectionStrategy, Component, computed, signal,
@@ -6,12 +7,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import {
-  TnIconButtonHarness, TnIconTesting, TnMenuHarness, TnMenuTesting,
+  TnButtonHarness, TnIconButtonHarness, TnIconTesting, TnMenuHarness, TnMenuTesting,
 } from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import {
   FormSidePanelContainerComponent,
+  SidePanelFooterAction,
   SidePanelFooterMenu,
 } from 'app/modules/slide-ins/form-side-panel/form-side-panel-container.component';
 import { SidePanelForm } from 'app/modules/slide-ins/side-panel-form.directive';
@@ -130,5 +132,94 @@ describe('FormSidePanelContainerComponent footer menu', () => {
 
     expect(publicKeyClick).toHaveBeenCalled();
     expect(privateKeyClick).not.toHaveBeenCalled();
+  });
+});
+
+const backClick = jest.fn();
+const nextClick = jest.fn();
+
+@Component({
+  selector: 'ix-actions-test-form',
+  template: '<p>form body</p>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class ActionsTestFormComponent extends SidePanelForm {
+  protected readonly form = new FormControl('');
+  readonly canSubmit = signal(true);
+
+  // Next is disabled until this flips — mirrors the iscsi wizard's step-validity
+  // predicate so we can assert the container re-evaluates `disabled` reactively.
+  readonly nextReady = signal(false);
+
+  readonly footerActions: SidePanelFooterAction[] = [
+    {
+      label: 'Back',
+      testId: 'back',
+      onClick: () => backClick(),
+    },
+    {
+      label: 'Next',
+      testId: 'next',
+      color: 'primary',
+      disabled: () => !this.nextReady(),
+      onClick: () => nextClick(),
+    },
+  ];
+
+  protected onSubmit(): void {
+    this.close(true);
+  }
+}
+
+describe('FormSidePanelContainerComponent footer actions', () => {
+  let fixture: ComponentFixture<FormSidePanelContainerComponent>;
+
+  const getForm = (): ActionsTestFormComponent => fixture.debugElement.query(
+    (node) => node.componentInstance instanceof ActionsTestFormComponent,
+  ).componentInstance as ActionsTestFormComponent;
+
+  beforeEach(() => {
+    backClick.mockClear();
+    nextClick.mockClear();
+
+    TestBed.configureTestingModule({
+      imports: [FormSidePanelContainerComponent, ActionsTestFormComponent, TranslateModule.forRoot()],
+      providers: [
+        mockAuth(),
+        {
+          provide: UnsavedChangesService,
+          useValue: { showConfirmDialog: jest.fn(() => of(true)) },
+        },
+        ...TnIconTesting.jest.providers(),
+      ],
+    });
+
+    fixture = TestBed.createComponent(FormSidePanelContainerComponent);
+    fixture.componentRef.setInput('portal', new ComponentPortal(ActionsTestFormComponent));
+    fixture.componentRef.setInput('open', true);
+    fixture.detectChanges();
+  });
+
+  it('renders each footerActions entry as a footer button', async () => {
+    const loader = TnMenuTesting.rootLoader(fixture);
+
+    const backButton = await loader.getHarness(TnButtonHarness.with({ label: 'Back' }));
+    const nextButton = await loader.getHarness(TnButtonHarness.with({ label: 'Next' }));
+
+    expect(await backButton.isDisabled()).toBe(false);
+    expect(await nextButton.isDisabled()).toBe(true);
+  });
+
+  it('re-evaluates the reactive disabled predicate and invokes onClick', async () => {
+    const loader = TnMenuTesting.rootLoader(fixture);
+    const nextButton = await loader.getHarness(TnButtonHarness.with({ label: 'Next' }));
+
+    getForm().nextReady.set(true);
+    fixture.detectChanges();
+    expect(await nextButton.isDisabled()).toBe(false);
+
+    await nextButton.click();
+    expect(nextClick).toHaveBeenCalled();
+    expect(backClick).not.toHaveBeenCalled();
   });
 });

--- a/src/app/modules/slide-ins/form-side-panel/form-side-panel.service.spec.ts
+++ b/src/app/modules/slide-ins/form-side-panel/form-side-panel.service.spec.ts
@@ -162,7 +162,7 @@ describe('FormSidePanelService', () => {
     await save.click();
     flushPanelClose();
 
-    expect(document.querySelector('.tn-side-panel__panel')).toBeNull();
+    expect(await rootLoader.hasHarness(TnSidePanelHarness)).toBe(false);
   });
 
   it('dedupes a re-entrant open of the same component, returning the in-flight result', async () => {
@@ -173,13 +173,13 @@ describe('FormSidePanelService', () => {
     fixture.detectChanges();
 
     expect(second$).toBe(first$);
-    expect(document.querySelectorAll('.tn-side-panel__panel')).toHaveLength(1);
+    expect(await rootLoader.getAllHarnesses(TnSidePanelHarness)).toHaveLength(1);
 
     const panel = await rootLoader.getHarness(TnSidePanelHarness);
     expect(await panel.getTitle()).toBe('NFS');
   });
 
-  it('stacks a second panel for a different component (nested open)', () => {
+  it('stacks a second panel for a different component (nested open)', async () => {
     service.open(TestFormComponent, { title: 'NFS' });
     fixture.detectChanges();
 
@@ -187,20 +187,20 @@ describe('FormSidePanelService', () => {
     fixture.detectChanges();
 
     // Both panels are mounted; the newer one is appended later so it paints on top.
-    expect(document.querySelectorAll('.tn-side-panel__panel')).toHaveLength(2);
+    expect(await rootLoader.getAllHarnesses(TnSidePanelHarness)).toHaveLength(2);
   });
 
-  it('closeAll tears down every panel in the stack', () => {
+  it('closeAll tears down every panel in the stack', async () => {
     service.open(TestFormComponent, { title: 'NFS' });
     fixture.detectChanges();
     service.open(SecondTestFormComponent, { title: 'SMB' });
     fixture.detectChanges();
-    expect(document.querySelectorAll('.tn-side-panel__panel')).toHaveLength(2);
+    expect(await rootLoader.getAllHarnesses(TnSidePanelHarness)).toHaveLength(2);
 
     service.closeAll();
     fixture.detectChanges();
 
-    expect(document.querySelector('.tn-side-panel__panel')).toBeNull();
+    expect(await rootLoader.hasHarness(TnSidePanelHarness)).toBe(false);
   });
 
   it('allows opening a new panel after the previous one closed', async () => {
@@ -230,7 +230,7 @@ describe('FormSidePanelService', () => {
     service.closeAll();
     fixture.detectChanges();
 
-    expect(document.querySelector('.tn-side-panel__panel')).toBeNull();
+    expect(await rootLoader.hasHarness(TnSidePanelHarness)).toBe(false);
     expect(onCancel).toHaveBeenCalled();
     expect(onSuccess).not.toHaveBeenCalled();
   });

--- a/src/app/pages/services/components/service-smb/service-smb.component.html
+++ b/src/app/pages/services/components/service-smb/service-smb.component.html
@@ -19,12 +19,9 @@
       [label]="'NetBIOS Alias' | translate"
       [tooltip]="tooltips.netbiosalias | translate"
     >
-      <!-- TODO(NAS-141021): [ariaLabel] duplicates the tn-form-field label — remove once the
-        library associates its label with the projected control (for/aria-labelledby). -->
       <tn-chip-input
         formControlName="netbiosalias"
         [testId]="'netbiosalias'"
-        [ariaLabel]="'NetBIOS Alias' | translate"
         [allowCustomValue]="true"
       ></tn-chip-input>
     </tn-form-field>
@@ -124,8 +121,6 @@
         [label]="'Administrators Group' | translate"
         [tooltip]="tooltips.admin_group | translate"
       >
-        <!-- TODO(NAS-141021): [placeholder] doubles as the accessible-name fallback — tn-autocomplete
-          has no [ariaLabel] input and tn-form-field does not associate its label yet. -->
         <tn-autocomplete
           formControlName="admin_group"
           [testId]="'admin-group'"

--- a/src/app/pages/services/components/service-smb/service-smb.component.spec.ts
+++ b/src/app/pages/services/components/service-smb/service-smb.component.spec.ts
@@ -598,8 +598,10 @@ describe('ServiceSmbComponent', () => {
       const advancedButton = await loader.getHarness(TnButtonHarness.with({ label: 'Advanced Settings' }));
       await advancedButton.click();
 
-      const statefulFailoverCheckbox = spectator.query('[formControlName="stateful_failover"]');
-      expect(statefulFailoverCheckbox).toBeFalsy();
+      const statefulFailoverCheckbox = await loader.getHarnessOrNull(
+        TnCheckboxHarness.with({ selector: '[formControlName="stateful_failover"]' }),
+      );
+      expect(statefulFailoverCheckbox).toBeNull();
     });
 
     it('should show and enable Stateful Failover checkbox when HA is licensed with no incompatible shares and SMB1 disabled', async () => {

--- a/src/app/pages/sharing/components/shares-dashboard/_card-flush-table.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/_card-flush-table.scss
@@ -1,0 +1,10 @@
+// TEMP: the dashboard cards render their tn-table flush against the card edges
+// ([padContent]="false"), so the table's internal rounded corners
+// (.tn-table__table border-radius: 4px) poke out against the card's square content
+// area. Square them on all sides. Remove once @truenas/ui-components exposes
+// control over the table's corner radius.
+@mixin card-flush-table {
+  :host ::ng-deep tn-table .tn-table__table {
+    border-radius: 0;
+  }
+}

--- a/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.html
@@ -1,5 +1,6 @@
 <tn-card
   padding="small"
+  [padContent]="false"
   [headerStatus]="serviceStatus()"
   [headerMenu]="serviceMenu()"
   [headerMenuTriggerTestId]="headerMenuTriggerTestId()"

--- a/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.scss
@@ -1,5 +1,7 @@
+@import '../card-flush-table';
 @import '../card-service-toggle';
 
+@include card-flush-table;
 @include card-service-toggle;
 
 .card-title-link {

--- a/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.spec.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.spec.ts
@@ -138,6 +138,7 @@ describe('IscsiCardComponent', () => {
     expect(spectator.inject(FormSidePanelService).open).toHaveBeenCalledWith(IscsiWizardComponent, {
       title: 'iSCSI Wizard',
       wide: true,
+      footerless: true,
     });
   });
 

--- a/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.ts
@@ -207,10 +207,11 @@ export class IscsiCardComponent implements OnInit {
 
   protected openForm(row?: IscsiTarget, openWizard?: boolean): void {
     if (openWizard) {
-      // The panel footer owns Back/Next/Save (via the wizard's footerActions/hideSave).
+      // Opened footerless — the wizard's stepper owns its own Next/Back/Save buttons.
       this.formPanel.open(IscsiWizardComponent, {
         title: this.translate.instant('iSCSI Wizard'),
         wide: true,
+        footerless: true,
       }).onSuccess(() => this.dataProvider.load(), this.destroyRef);
     } else {
       this.formPanel.open(TargetFormComponent, {

--- a/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/iscsi-card/iscsi-card.component.ts
@@ -106,9 +106,9 @@ export class IscsiCardComponent implements OnInit {
   private authService = inject(AuthService);
   protected actionsMenu = inject(ServiceActionsMenuService);
 
-  service$ = this.store$.select(selectService(ServiceName.Iscsi));
+  private service$ = this.store$.select(selectService(ServiceName.Iscsi));
   protected service = toSignal(this.service$);
-  requiredRoles = [
+  protected requiredRoles = [
     Role.SharingIscsiTargetWrite,
     Role.SharingIscsiWrite,
     Role.SharingWrite,
@@ -116,7 +116,7 @@ export class IscsiCardComponent implements OnInit {
 
   private hasWriteRole = toSignal(this.authService.hasRole(this.requiredRoles), { initialValue: false });
 
-  targets = signal<IscsiTarget[] | null>(null);
+  private targets = signal<IscsiTarget[] | null>(null);
 
   protected readonly hasFibreChannel = toSignal(
     this.license.hasFibreChannel$.pipe(startWith(false)),
@@ -148,7 +148,7 @@ export class IscsiCardComponent implements OnInit {
     takeUntilDestroyed(this.destroyRef),
   );
 
-  dataProvider = new AsyncDataProvider<IscsiTarget>(this.iscsiShares$);
+  protected dataProvider = new AsyncDataProvider<IscsiTarget>(this.iscsiShares$);
   protected readonly rows = dataProviderRows(this.dataProvider);
   protected readonly isLoading = dataProviderLoading(this.dataProvider);
 
@@ -205,7 +205,7 @@ export class IscsiCardComponent implements OnInit {
     this.dataProvider.load();
   }
 
-  openForm(row?: IscsiTarget, openWizard?: boolean): void {
+  protected openForm(row?: IscsiTarget, openWizard?: boolean): void {
     if (openWizard) {
       // The panel footer owns Back/Next/Save (via the wizard's footerActions/hideSave).
       this.formPanel.open(IscsiWizardComponent, {
@@ -221,7 +221,7 @@ export class IscsiCardComponent implements OnInit {
     }
   }
 
-  doDelete(iscsi: IscsiTarget): void {
+  private doDelete(iscsi: IscsiTarget): void {
     this.tnDialog
       .open(DeleteTargetDialog, { data: iscsi, width: '600px' })
       .closed
@@ -229,7 +229,7 @@ export class IscsiCardComponent implements OnInit {
       .subscribe(() => this.dataProvider.load());
   }
 
-  setDefaultSort(): void {
+  private setDefaultSort(): void {
     this.dataProvider.setSorting({
       active: 0,
       direction: SortDirection.Asc,

--- a/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.html
@@ -1,5 +1,6 @@
 <tn-card
   padding="small"
+  [padContent]="false"
   [headerStatus]="serviceStatus()"
   [headerMenu]="serviceMenu()"
   [headerMenuTriggerTestId]="headerMenuTriggerTestId()"

--- a/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/nfs-card/nfs-card.component.scss
@@ -1,7 +1,9 @@
 @import '../../storage-tier-cell/tier-cell-host';
+@import '../card-flush-table';
 @import '../card-service-toggle';
 
 @include tier-cell-host;
+@include card-flush-table;
 @include card-service-toggle;
 
 .card-title-link {

--- a/src/app/pages/sharing/components/shares-dashboard/nvme-of-card/nvme-of-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/nvme-of-card/nvme-of-card.component.html
@@ -1,5 +1,6 @@
 <tn-card
   padding="small"
+  [padContent]="false"
   [headerStatus]="serviceStatus()"
   [headerMenu]="serviceMenu()"
   [headerMenuTriggerTestId]="headerMenuTriggerTestId()"

--- a/src/app/pages/sharing/components/shares-dashboard/nvme-of-card/nvme-of-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/nvme-of-card/nvme-of-card.component.scss
@@ -1,5 +1,7 @@
+@import '../card-flush-table';
 @import '../card-service-toggle';
 
+@include card-flush-table;
 @include card-service-toggle;
 
 .card-title-link {

--- a/src/app/pages/sharing/components/shares-dashboard/nvme-of-card/nvme-of-card.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/nvme-of-card/nvme-of-card.component.ts
@@ -194,6 +194,7 @@ export class NvmeOfCardComponent implements OnInit {
     // stacks on top.
     this.formPanel.open(AddSubsystemComponent, {
       title: this.translate.instant('Add Subsystem'),
+      footerless: true,
     })
       .onSuccess(() => this.nvmeOfStore.initialize(), this.destroyRef);
   }

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.html
@@ -1,5 +1,6 @@
 <tn-card
   padding="small"
+  [padContent]="false"
   [headerStatus]="serviceStatus()"
   [headerMenu]="serviceMenu()"
   [headerMenuTriggerTestId]="headerMenuTriggerTestId()"

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.html
@@ -112,7 +112,7 @@
         </ng-template>
       </ng-container>
 
-      <ng-container [tnColumnDef]="'audit'" [width]="'120px'">
+      <ng-container [tnColumnDef]="'audit'" [width]="'72px'">
         <ng-template tnHeaderCellDef>{{ 'Audit Logging' | translate }}</ng-template>
         <ng-template let-row tnCellDef>
           <span

--- a/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component.scss
@@ -1,7 +1,9 @@
 @import '../../storage-tier-cell/tier-cell-host';
+@import '../card-flush-table';
 @import '../card-service-toggle';
 
 @include tier-cell-host;
+@include card-flush-table;
 @include card-service-toggle;
 
 .card-title-link {

--- a/src/app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component.html
@@ -1,5 +1,6 @@
 <tn-card
   padding="small"
+  [padContent]="false"
   [headerStatus]="serviceStatus()"
   [headerMenu]="serviceMenu()"
   [headerMenuTriggerTestId]="headerMenuTriggerTestId()"

--- a/src/app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component.scss
@@ -1,5 +1,7 @@
+@import '../card-flush-table';
 @import '../card-service-toggle';
 
+@include card-flush-table;
 @include card-service-toggle;
 
 .card-title-link {

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.html
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.html
@@ -1,21 +1,64 @@
-<tn-card class="card">
-  <form [formGroup]="form" (keydown.enter)="$event.preventDefault()" (submit)="onSubmit()">
-    <tn-stepper #stepper orientation="vertical">
-      <tn-step [label]="'Target' | translate" [completed]="targetStep().completed()">
-        <ix-target-wizard-step [form]="form.controls.target"></ix-target-wizard-step>
-        <div class="step-buttons">
+<form [formGroup]="form" (keydown.enter)="$event.preventDefault()" (submit)="onSubmit()">
+  <tn-stepper #stepper orientation="vertical">
+    <tn-step [label]="'Target' | translate" [completed]="targetStep().completed()">
+      <ix-target-wizard-step [form]="form.controls.target"></ix-target-wizard-step>
+      <div class="step-buttons">
+        <tn-button
+          tnStepperNext
+          color="primary"
+          [testId]="'next'"
+          [label]="'Next' | translate"
+          [disabled]="form.controls.target.invalid"
+        ></tn-button>
+      </div>
+    </tn-step>
+
+    <tn-step [label]="'Extent' | translate" [completed]="extentStep().completed()">
+      <ix-extent-wizard-step [form]="form.controls.extent"></ix-extent-wizard-step>
+      <div class="step-buttons">
+        <tn-button
+          tnStepperPrevious
+          color="secondary"
+          [testId]="'back'"
+          [label]="'Back' | translate"
+        ></tn-button>
+        @if (isNewTarget) {
           <tn-button
             tnStepperNext
             color="primary"
             [testId]="'next'"
             [label]="'Next' | translate"
-            [disabled]="form.controls.target.invalid"
+            [disabled]="form.controls.extent.invalid"
           ></tn-button>
-        </div>
-      </tn-step>
+        } @else {
+          <tn-button
+            color="primary"
+            type="submit"
+            [testId]="'save'"
+            [label]="'Save' | translate"
+            [disabled]="form.invalid || isLoading()"
+          ></tn-button>
+        }
+      </div>
+    </tn-step>
 
-      <tn-step [label]="'Extent' | translate" [completed]="extentStep().completed()">
-        <ix-extent-wizard-step [form]="form.controls.extent"></ix-extent-wizard-step>
+    @if (isNewTarget) {
+      <tn-step [label]="'Protocol Options' | translate" [completed]="protocolOptionsStep()?.completed()">
+        <ix-protocol-options-wizard-step
+          [form]="form.controls.options"
+          [isFibreChannelMode]="isFibreChannelMode"
+          [addFcPort]="addFcPort.bind(this)"
+          [deleteFcPort]="deleteFcPort.bind(this)"
+          [getUsedPhysicalPorts]="getUsedPhysicalPortsFn()"
+          [availablePorts]="availableFcPorts()"
+        ></ix-protocol-options-wizard-step>
+
+        @if (isFibreChannelMode && validateFcPorts().length > 0) {
+          <div class="fc-port-error" role="alert">
+            {{ validateFcPorts().join(', ') }}
+          </div>
+        }
+
         <div class="step-buttons">
           <tn-button
             tnStepperPrevious
@@ -23,61 +66,16 @@
             [testId]="'back'"
             [label]="'Back' | translate"
           ></tn-button>
-          @if (isNewTarget) {
-            <tn-button
-              tnStepperNext
-              color="primary"
-              [testId]="'next'"
-              [label]="'Next' | translate"
-              [disabled]="form.controls.extent.invalid"
-            ></tn-button>
-          } @else {
-            <tn-button
-              color="primary"
-              type="submit"
-              [testId]="'save'"
-              [label]="'Save' | translate"
-              [disabled]="form.invalid || isLoading()"
-            ></tn-button>
-          }
+          <tn-button
+            *ixRequiresRoles="requiredRoles"
+            color="primary"
+            type="submit"
+            [testId]="'save'"
+            [label]="'Save' | translate"
+            [disabled]="form.invalid || (isFibreChannelMode && !areFcPortsValid()) || isLoading()"
+          ></tn-button>
         </div>
       </tn-step>
-
-      @if (isNewTarget) {
-        <tn-step [label]="'Protocol Options' | translate" [completed]="protocolOptionsStep()?.completed()">
-          <ix-protocol-options-wizard-step
-            [form]="form.controls.options"
-            [isFibreChannelMode]="isFibreChannelMode"
-            [addFcPort]="addFcPort.bind(this)"
-            [deleteFcPort]="deleteFcPort.bind(this)"
-            [getUsedPhysicalPorts]="getUsedPhysicalPortsFn()"
-            [availablePorts]="availableFcPorts()"
-          ></ix-protocol-options-wizard-step>
-
-          @if (isFibreChannelMode && validateFcPorts().length > 0) {
-            <div class="fc-port-error" role="alert">
-              {{ validateFcPorts().join(', ') }}
-            </div>
-          }
-
-          <div class="step-buttons">
-            <tn-button
-              tnStepperPrevious
-              color="secondary"
-              [testId]="'back'"
-              [label]="'Back' | translate"
-            ></tn-button>
-            <tn-button
-              *ixRequiresRoles="requiredRoles"
-              color="primary"
-              type="submit"
-              [testId]="'save'"
-              [label]="'Save' | translate"
-              [disabled]="form.invalid || (isFibreChannelMode && !areFcPortsValid()) || isLoading()"
-            ></tn-button>
-          </div>
-        </tn-step>
-      }
-    </tn-stepper>
-  </form>
-</tn-card>
+    }
+  </tn-stepper>
+</form>

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.html
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.html
@@ -1,30 +1,83 @@
-<form [formGroup]="form" (keydown.enter)="$event.preventDefault()">
-  <tn-stepper orientation="vertical">
-    <tn-step [label]="'Target' | translate" [completed]="targetStep().completed()">
-      <ix-target-wizard-step [form]="form.controls.target"></ix-target-wizard-step>
-    </tn-step>
-
-    <tn-step [label]="'Extent' | translate" [completed]="extentStep().completed()">
-      <ix-extent-wizard-step [form]="form.controls.extent"></ix-extent-wizard-step>
-    </tn-step>
-
-    @if (isNewTarget) {
-      <tn-step [label]="'Protocol Options' | translate" [completed]="protocolOptionsStep()?.completed()">
-        <ix-protocol-options-wizard-step
-          [form]="form.controls.options"
-          [isFibreChannelMode]="isFibreChannelMode"
-          [addFcPort]="addFcPort.bind(this)"
-          [deleteFcPort]="deleteFcPort.bind(this)"
-          [getUsedPhysicalPorts]="getUsedPhysicalPortsFn()"
-          [availablePorts]="availableFcPorts()"
-        ></ix-protocol-options-wizard-step>
-
-        @if (isFibreChannelMode && fcPortErrors().length > 0) {
-          <div class="fc-port-error" role="alert">
-            {{ fcPortErrors().join(', ') }}
-          </div>
-        }
+<tn-card class="card">
+  <form [formGroup]="form" (keydown.enter)="$event.preventDefault()" (submit)="onSubmit()">
+    <tn-stepper #stepper orientation="vertical">
+      <tn-step [label]="'Target' | translate" [completed]="targetStep().completed()">
+        <ix-target-wizard-step [form]="form.controls.target"></ix-target-wizard-step>
+        <div class="step-buttons">
+          <tn-button
+            tnStepperNext
+            color="primary"
+            [testId]="'next'"
+            [label]="'Next' | translate"
+            [disabled]="form.controls.target.invalid"
+          ></tn-button>
+        </div>
       </tn-step>
-    }
-  </tn-stepper>
-</form>
+
+      <tn-step [label]="'Extent' | translate" [completed]="extentStep().completed()">
+        <ix-extent-wizard-step [form]="form.controls.extent"></ix-extent-wizard-step>
+        <div class="step-buttons">
+          <tn-button
+            tnStepperPrevious
+            color="secondary"
+            [testId]="'back'"
+            [label]="'Back' | translate"
+          ></tn-button>
+          @if (isNewTarget) {
+            <tn-button
+              tnStepperNext
+              color="primary"
+              [testId]="'next'"
+              [label]="'Next' | translate"
+              [disabled]="form.controls.extent.invalid"
+            ></tn-button>
+          } @else {
+            <tn-button
+              color="primary"
+              type="submit"
+              [testId]="'save'"
+              [label]="'Save' | translate"
+              [disabled]="form.invalid || isLoading()"
+            ></tn-button>
+          }
+        </div>
+      </tn-step>
+
+      @if (isNewTarget) {
+        <tn-step [label]="'Protocol Options' | translate" [completed]="protocolOptionsStep()?.completed()">
+          <ix-protocol-options-wizard-step
+            [form]="form.controls.options"
+            [isFibreChannelMode]="isFibreChannelMode"
+            [addFcPort]="addFcPort.bind(this)"
+            [deleteFcPort]="deleteFcPort.bind(this)"
+            [getUsedPhysicalPorts]="getUsedPhysicalPortsFn()"
+            [availablePorts]="availableFcPorts()"
+          ></ix-protocol-options-wizard-step>
+
+          @if (isFibreChannelMode && validateFcPorts().length > 0) {
+            <div class="fc-port-error" role="alert">
+              {{ validateFcPorts().join(', ') }}
+            </div>
+          }
+
+          <div class="step-buttons">
+            <tn-button
+              tnStepperPrevious
+              color="secondary"
+              [testId]="'back'"
+              [label]="'Back' | translate"
+            ></tn-button>
+            <tn-button
+              *ixRequiresRoles="requiredRoles"
+              color="primary"
+              type="submit"
+              [testId]="'save'"
+              [label]="'Save' | translate"
+              [disabled]="form.invalid || (isFibreChannelMode && !areFcPortsValid()) || isLoading()"
+            ></tn-button>
+          </div>
+        </tn-step>
+      }
+    </tn-stepper>
+  </form>
+</tn-card>

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.scss
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.scss
@@ -1,12 +1,3 @@
-// The wizard steps render bare `tn-form-field`s (no `<ix-form>`/`<tn-form-section>` to space them).
-// The legacy SlideIn host spaced them via the global `ix-slide-in-container tn-form-field` margin;
-// the `<tn-side-panel>` host has no such rule, so consecutive step fields butt together (a label sits
-// tight under the control above). Restore the inter-field gap for the projected step controls.
-:host ::ng-deep tn-form-field {
-  display: block;
-  margin-bottom: 12px;
-}
-
 .fc-port-error {
   color: var(--red);
   font-size: 12px;

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.scss
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.scss
@@ -1,9 +1,3 @@
-@import 'mixins/cards';
-
-.card {
-  @include details-card();
-}
-
 .step-buttons {
   display: flex;
   gap: 12px;

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.scss
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.scss
@@ -1,3 +1,15 @@
+@import 'mixins/cards';
+
+.card {
+  @include details-card();
+}
+
+.step-buttons {
+  display: flex;
+  gap: 12px;
+  padding-top: 12px;
+}
+
 .fc-port-error {
   color: var(--red);
   font-size: 12px;

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.spec.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.spec.ts
@@ -4,7 +4,9 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { Store } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
-import { TnChipInputHarness, TnInputHarness, TnSelectHarness } from '@truenas/ui-components';
+import {
+  TnButtonHarness, TnChipInputHarness, TnInputHarness, TnSelectHarness,
+} from '@truenas/ui-components';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
@@ -141,16 +143,11 @@ describe('IscsiWizardComponent', () => {
     jest.spyOn(store$, 'dispatch');
   });
 
-  // Back/Next/Save live in the side-panel footer (rendered by the host container, not
-  // this fixture), so navigation is driven through the public footer surface — same
-  // pattern as the add-subsystem wizard spec.
+  // tn-stepper renders only the active step's content, so navigate with the
+  // Next button and re-resolve the form on each step.
   async function clickNext(): Promise<void> {
-    const next = spectator.component.footerActions.find((action) => action.testId === 'next');
-    expect(next).toBeTruthy();
-    expect(next.disabled?.()).toBeFalsy();
-    next.onClick();
-    spectator.detectChanges();
-    await spectator.fixture.whenStable();
+    const nextButton = await loader.getHarness(TnButtonHarness.with({ label: 'Next' }));
+    await nextButton.click();
   }
 
   async function fillIscsiWizard(): Promise<void> {
@@ -184,10 +181,8 @@ describe('IscsiWizardComponent', () => {
   }
 
   async function submitWizard(): Promise<void> {
-    // Save renders in the host footer and calls the form's public submit().
-    expect(spectator.component.hideSave()).toBe(false);
-    expect(spectator.component.canSubmit()).toBe(true);
-    spectator.component.submit();
+    const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+    await saveButton.click();
 
     // Wait for all async operations to complete
     await new Promise<void>((resolve) => {
@@ -377,8 +372,9 @@ describe('IscsiWizardComponent', () => {
 
       spectator.detectChanges();
 
-      // The footer Save is disabled via canSubmit due to the validation failure.
-      expect(spectator.component.canSubmit()).toBe(false);
+      // Verify submit button is disabled due to validation failure
+      const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+      expect(await saveButton.isDisabled()).toBe(true);
 
       // Note: Error detection for NPIV ports would require backend resolution
       // of host_id to port string, so validation happens at a different level

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
@@ -7,7 +7,7 @@ import { FormBuilder, FormControl } from '@ngneat/reactive-forms';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  TnButtonComponent, TnCardComponent, TnStepComponent, TnStepperComponent, TnStepperNextDirective,
+  TnButtonComponent, TnStepComponent, TnStepperComponent, TnStepperNextDirective,
   TnStepperPreviousDirective,
 } from '@truenas/ui-components';
 import {
@@ -64,7 +64,6 @@ import { ExtentWizardStepComponent } from './steps/extent-wizard-step/extent-wiz
   styleUrls: ['./iscsi-wizard.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    TnCardComponent,
     ReactiveFormsModule,
     TnStepperComponent,
     TnStepComponent,

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
@@ -1,21 +1,22 @@
 import {
-  ChangeDetectionStrategy, Component, computed, DestroyRef, OnInit, signal, viewChild, inject,
+  ChangeDetectionStrategy, Component, computed, DestroyRef, OnInit, output, signal, viewChild, inject,
 } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Validators, ReactiveFormsModule } from '@angular/forms';
-import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
 import { FormBuilder, FormControl } from '@ngneat/reactive-forms';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  TnStepComponent, TnStepperComponent,
+  TnButtonComponent, TnCardComponent, TnStepComponent, TnStepperComponent, TnStepperNextDirective,
+  TnStepperPreviousDirective,
 } from '@truenas/ui-components';
 import {
   lastValueFrom, forkJoin,
   of,
 } from 'rxjs';
-import { startWith, switchMap } from 'rxjs/operators';
+import { switchMap } from 'rxjs/operators';
 import { patterns } from 'app/constants/name-patterns.constant';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { DatasetType } from 'app/enums/dataset.enum';
 import {
   IscsiAuthMethod,
@@ -46,8 +47,7 @@ import { newOption } from 'app/interfaces/option.interface';
 import { forbiddenValues } from 'app/modules/forms/ix-forms/validators/forbidden-values-validation/forbidden-values-validation';
 import { matchOthersFgValidator } from 'app/modules/forms/ix-forms/validators/password-validation/password-validation';
 import { LoaderService } from 'app/modules/loader/loader.service';
-import { SidePanelFooterAction } from 'app/modules/slide-ins/form-side-panel/form-side-panel-container.component';
-import { SidePanelForm } from 'app/modules/slide-ins/side-panel-form.directive';
+import { SidePanelHostCloseable } from 'app/modules/slide-ins/side-panel-form.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ProtocolOptionsWizardStepComponent } from 'app/pages/sharing/iscsi/iscsi-wizard/steps/protocol-options-wizard-step/protocol-options-wizard-step.component';
 import { TargetWizardStepComponent } from 'app/pages/sharing/iscsi/iscsi-wizard/steps/target-wizard-step/target-wizard-step.component';
@@ -64,16 +64,21 @@ import { ExtentWizardStepComponent } from './steps/extent-wizard-step/extent-wiz
   styleUrls: ['./iscsi-wizard.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    TnCardComponent,
     ReactiveFormsModule,
     TnStepperComponent,
     TnStepComponent,
+    TnButtonComponent,
+    TnStepperNextDirective,
+    TnStepperPreviousDirective,
     TargetWizardStepComponent,
     ExtentWizardStepComponent,
     ProtocolOptionsWizardStepComponent,
+    RequiresRolesDirective,
     TranslateModule,
   ],
 })
-export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements OnInit {
+export class IscsiWizardComponent implements OnInit, SidePanelHostCloseable<IscsiTarget> {
   private fb = inject(FormBuilder);
   private iscsiService = inject(IscsiService);
   private fcService = inject(FibreChannelService);
@@ -84,12 +89,14 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
   private store$ = inject<Store<ServicesState>>(Store);
   private destroyRef = inject(DestroyRef);
 
+  /** Emitted to the `tn-side-panel` host with the created target on save. */
+  readonly closed = output<IscsiTarget>();
+
   protected readonly targetStep = viewChild.required(TargetWizardStepComponent);
   protected readonly extentStep = viewChild.required(ExtentWizardStepComponent);
   protected readonly protocolOptionsStep = viewChild(ProtocolOptionsWizardStepComponent);
-  private readonly stepper = viewChild(TnStepperComponent);
 
-  private isLoading = signal<boolean>(false);
+  protected isLoading = signal<boolean>(false);
   private toStop = signal<boolean>(false);
   private namesInUse = signal<string[]>([]);
   private fcHosts = signal<{ id: number; alias: string }[]>([]);
@@ -103,7 +110,7 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
   private createdTarget: IscsiTarget | undefined;
   private createdTargetExtent: IscsiTargetExtent | undefined;
 
-  protected readonly form = this.fb.group({
+  form = this.fb.group({
     target: this.fb.group({
       target: [newOption as typeof newOption | number, [Validators.required]],
       mode: [IscsiTargetMode.Iscsi],
@@ -149,84 +156,11 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
     this.destroyRef,
   );
 
-  /** Gates the host-rendered footer Save. */
-  readonly requiredRoles = [
+  protected readonly requiredRoles = [
     Role.SharingIscsiTargetWrite,
     Role.SharingIscsiWrite,
     Role.SharingWrite,
   ];
-
-  /** Reactive mirror of the target mode so `canSubmit`/`fcPortErrors` recompute on change. */
-  private readonly targetMode = toSignal(
-    this.form.controls.target.controls.mode.valueChanges.pipe(startWith(IscsiTargetMode.Iscsi)),
-    { initialValue: IscsiTargetMode.Iscsi },
-  );
-
-  private readonly isOnFinalStep = computed(() => {
-    const stepper = this.stepper();
-    return !!stepper && stepper.selectedIndex() === stepper.steps().length - 1;
-  });
-
-  /** Duplicate-physical-port errors for FC mode; reactive via the fcPorts snapshot. */
-  protected readonly fcPortErrors = computed<string[]>(() => {
-    const ports = this.fcPortsSnapshot();
-    const validation = this.fcService.validatePhysicalPortUniqueness(ports, this.fcHosts());
-
-    if (!validation.valid) {
-      return validation.duplicates.map((port) => this.translate.instant(
-        'Physical port {port} is used multiple times. Each target port must use a different physical FC port.',
-        { port },
-      ));
-    }
-
-    return [];
-  });
-
-  private readonly baseCanSubmit = this.trackCanSubmit(this.isLoading);
-
-  /** Also gated on the final step + FC port uniqueness so the footer Save can't short-circuit the wizard. */
-  readonly canSubmit = computed(() => {
-    const fcPortsOk = this.targetMode() === IscsiTargetMode.Iscsi || this.fcPortErrors().length === 0;
-    return this.baseCanSubmit() && this.isOnFinalStep() && fcPortsOk;
-  });
-
-  /** Hides the host footer Save until the final step — Next is the only way forward before that. */
-  hideSave(): boolean {
-    return !this.isOnFinalStep();
-  }
-
-  /**
-   * Step-dependent wizard navigation rendered in the `<tn-side-panel>` footer before Save:
-   * Next until the final step (gated on the current step's controls), Back from the second
-   * step on. Re-read each change detection, so the buttons swap as the stepper advances.
-   * Labels are extraction markers — the panel container pipes them through `translate`.
-   */
-  get footerActions(): SidePanelFooterAction[] {
-    const currentIndex = this.stepper()?.selectedIndex() ?? 0;
-    const actions: SidePanelFooterAction[] = [];
-
-    if (currentIndex > 0) {
-      actions.push({
-        label: T('Back'),
-        testId: 'back',
-        onClick: () => this.stepper()?.previous(),
-      });
-    }
-
-    if (!this.isOnFinalStep()) {
-      actions.push({
-        label: T('Next'),
-        testId: 'next',
-        color: 'primary',
-        disabled: () => (currentIndex === 0
-          ? this.form.controls.target.invalid
-          : this.form.controls.extent.invalid),
-        onClick: () => this.stepper()?.next(),
-      });
-    }
-
-    return actions;
-  }
 
   get isNewZvol(): boolean {
     return this.form.controls.extent.enabled && this.form.value.extent.disk === newOption;
@@ -331,8 +265,17 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
     } as IscsiTargetExtentUpdate;
   }
 
+  /** Host hook (tn-side-panel closeGuard) to confirm before discarding unsaved edits. */
+  hasUnsavedChanges(): boolean {
+    return this.form.dirty;
+  }
+
+  /** The footerless `<tn-side-panel>` host shows its progress bar while this is true. */
+  isBusy(): boolean {
+    return this.isLoading();
+  }
+
   constructor() {
-    super();
     this.iscsiService.getExtents().pipe(takeUntilDestroyed(this.destroyRef)).subscribe((extents) => {
       this.namesInUse.set(extents.map((extent) => extent.name));
     });
@@ -352,6 +295,24 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
 
   protected deleteFcPort(index: number): void {
     this.form.controls.options.controls.fcPorts.removeAt(index);
+  }
+
+  protected validateFcPorts(): string[] {
+    const ports = this.form.controls.options.controls.fcPorts.getRawValue();
+    const validation = this.fcService.validatePhysicalPortUniqueness(ports, this.fcHosts());
+
+    if (!validation.valid) {
+      return validation.duplicates.map((port) => this.translate.instant(
+        'Physical port {port} is used multiple times. Each target port must use a different physical FC port.',
+        { port },
+      ));
+    }
+
+    return [];
+  }
+
+  protected areFcPortsValid(): boolean {
+    return this.form.controls.options.controls.fcPorts.valid && this.validateFcPorts().length === 0;
   }
 
   // Array of used physical ports for each index (excluding that index)
@@ -513,7 +474,7 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
     this.errorHandler.showErrorModal(error);
   }
 
-  protected async onSubmit(): Promise<void> {
+  async onSubmit(): Promise<void> {
     this.isLoading.set(true);
     this.toStop.set(false);
 
@@ -606,6 +567,6 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
 
     this.isLoading.set(false);
     this.form.markAsPristine();
-    this.closeWith(this.createdTarget);
+    this.closed.emit(this.createdTarget);
   }
 }

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/iscsi-wizard.component.ts
@@ -89,18 +89,19 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
   protected readonly protocolOptionsStep = viewChild(ProtocolOptionsWizardStepComponent);
   private readonly stepper = viewChild(TnStepperComponent);
 
-  isLoading = signal<boolean>(false);
-  toStop = signal<boolean>(false);
-  namesInUse = signal<string[]>([]);
-  fcHosts = signal<{ id: number; alias: string }[]>([]);
-  availableFcPorts = signal<string[]>([]);
+  private isLoading = signal<boolean>(false);
+  private toStop = signal<boolean>(false);
+  private namesInUse = signal<string[]>([]);
+  private fcHosts = signal<{ id: number; alias: string }[]>([]);
+  protected availableFcPorts = signal<string[]>([]);
 
+  // Public: the spec seeds this directly to exercise the rollback path.
   createdZvol: Dataset | undefined;
-  createdExtent: IscsiExtent | undefined;
-  createdPortal: IscsiPortal | undefined;
-  createdInitiator: IscsiInitiatorGroup | undefined;
-  createdTarget: IscsiTarget | undefined;
-  createdTargetExtent: IscsiTargetExtent | undefined;
+  private createdExtent: IscsiExtent | undefined;
+  private createdPortal: IscsiPortal | undefined;
+  private createdInitiator: IscsiInitiatorGroup | undefined;
+  private createdTarget: IscsiTarget | undefined;
+  private createdTargetExtent: IscsiTargetExtent | undefined;
 
   protected readonly form = this.fb.group({
     target: this.fb.group({
@@ -455,7 +456,7 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
     return lastValueFrom(this.api.call('iscsi.targetextent.create', [payload]));
   }
 
-  rollBack(): void {
+  private rollBack(): void {
     this.isLoading.set(false);
 
     const requests = [];
@@ -507,7 +508,7 @@ export class IscsiWizardComponent extends SidePanelForm<IscsiTarget> implements 
     }
   }
 
-  handleError(error: unknown): void {
+  private handleError(error: unknown): void {
     this.toStop.set(true);
     this.errorHandler.showErrorModal(error);
   }

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/steps/extent-wizard-step/extent-wizard-step.component.scss
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/steps/extent-wizard-step/extent-wizard-step.component.scss
@@ -1,3 +1,10 @@
+// Bare tn-form-fields (no <ix-form>/<tn-form-section> host to space them): restore the
+// inter-field gap the legacy SlideIn container's global margin used to provide.
+tn-form-field {
+  display: block;
+  margin-bottom: 12px;
+}
+
 .snapshot-info-box {
   background-color: var(--alt-bg1);
   border: 1px solid var(--lines);

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/steps/protocol-options-wizard-step/protocol-options-wizard-step.component.scss
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/steps/protocol-options-wizard-step/protocol-options-wizard-step.component.scss
@@ -1,0 +1,6 @@
+// Bare tn-form-fields (no <ix-form>/<tn-form-section> host to space them): restore the
+// inter-field gap the legacy SlideIn container's global margin used to provide.
+tn-form-field {
+  display: block;
+  margin-bottom: 12px;
+}

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/steps/protocol-options-wizard-step/protocol-options-wizard-step.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/steps/protocol-options-wizard-step/protocol-options-wizard-step.component.ts
@@ -27,6 +27,7 @@ import { IscsiService } from 'app/services/iscsi.service';
 @Component({
   selector: 'ix-protocol-options-wizard-step',
   templateUrl: './protocol-options-wizard-step.component.html',
+  styleUrls: ['./protocol-options-wizard-step.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ReactiveFormsModule,

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/steps/target-wizard-step/target-wizard-step.component.scss
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/steps/target-wizard-step/target-wizard-step.component.scss
@@ -1,0 +1,6 @@
+// Bare tn-form-fields (no <ix-form>/<tn-form-section> host to space them): restore the
+// inter-field gap the legacy SlideIn container's global margin used to provide.
+tn-form-field {
+  display: block;
+  margin-bottom: 12px;
+}

--- a/src/app/pages/sharing/iscsi/iscsi-wizard/steps/target-wizard-step/target-wizard-step.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi-wizard/steps/target-wizard-step/target-wizard-step.component.ts
@@ -19,6 +19,7 @@ import { LicenseService } from 'app/services/license.service';
 @Component({
   selector: 'ix-target-wizard-step',
   templateUrl: './target-wizard-step.component.html',
+  styleUrls: ['./target-wizard-step.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ReactiveFormsModule,

--- a/src/app/pages/sharing/iscsi/iscsi.component.html
+++ b/src/app/pages/sharing/iscsi/iscsi.component.html
@@ -18,10 +18,15 @@
 
 <!-- tn-tabs is content/index-based, so routing is wired manually: the URL drives
   [selectedIndex] and a user tab switch navigates (see onTabChange). Tabs render as
-  buttons — legacy `link-*` test ids become `tab-*` (e2e callout). -->
+  buttons — legacy `link-*` test ids become `tab-*` (e2e callout), and anchor semantics
+  (middle-click/open-in-new-tab) are lost — accepted trade-off of the tn-tabs mapping.
+  The div supplies the tabpanel role mat-tab-nav-panel used to provide; a projected
+  tn-tab-panel can't host router content (panels are index-matched to selectedIndex). -->
 <tn-tabs [selectedIndex]="activeTabIndex()" (tabChange)="onTabChange($event)">
   @for (link of navLinks(); track link.path) {
     <tn-tab [label]="link.label" [testId]="link.slug" />
   }
 </tn-tabs>
-<router-outlet></router-outlet>
+<div role="tabpanel" [attr.aria-label]="navLinks()[activeTabIndex()]?.label">
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/pages/sharing/iscsi/iscsi.component.ts
+++ b/src/app/pages/sharing/iscsi/iscsi.component.ts
@@ -116,10 +116,11 @@ export class IscsiComponent {
   }
 
   protected openWizard(): void {
-    // The panel footer owns Back/Next/Save (via the wizard's footerActions/hideSave).
+    // Opened footerless — the wizard's stepper owns its own Next/Back/Save buttons.
     this.formPanel.open(IscsiWizardComponent, {
       title: this.translate.instant('iSCSI Wizard'),
       wide: true,
+      footerless: true,
     })
       .onSuccess((response) => {
         this.iscsiService.refreshData(response);

--- a/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.spec.ts
+++ b/src/app/pages/sharing/iscsi/portal/portal-form/portal-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
+// TODO(NAS-141028): swap to TnButtonHarness once the shared ix-form's Save migrates to tn-button.
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';

--- a/src/app/pages/sharing/iscsi/target/all-targets/target-details/associated-extents-card/associated-extents-card.component.ts
+++ b/src/app/pages/sharing/iscsi/target/all-targets/target-details/associated-extents-card/associated-extents-card.component.ts
@@ -16,7 +16,6 @@ import {
   AssociatedTargetDialogData, IscsiExtent, IscsiTarget, IscsiTargetExtent,
 } from 'app/interfaces/iscsi.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
-import { convertStringToId } from 'app/modules/ix-table/utils';
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { AssociatedTargetFormComponent } from 'app/pages/sharing/iscsi/target/all-targets/target-details/associated-extents-card/associated-target-form/associated-target-form.component';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
@@ -49,9 +48,11 @@ export class AssociatedExtentsCardComponent {
 
   readonly target = input.required<IscsiTarget>();
 
-  // Pre-split with lodash kebabCase so digit-bearing target names resolve identically
-  // through the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
-  protected readonly targetTestIdSlug = computed(() => kebabCase(convertStringToId(this.target().name)));
+  // Pre-split with lodash kebabCase so digit-bearing and camelCase target names resolve
+  // identically through the legacy [ixTest] directive and the library [tnTestId] directive.
+  // No convertStringToId here: the legacy path was a raw [ixTest] array (no table config),
+  // and its lowercasing would destroy the camelCase boundaries lodash kebab splits on.
+  protected readonly targetTestIdSlug = computed(() => kebabCase(this.target().name));
 
   readonly isLoadingExtents = signal<boolean>(false);
   readonly targetExtents = signal<IscsiTargetExtent[]>([]);

--- a/src/app/pages/sharing/iscsi/target/target-form/target-form.component.spec.ts
+++ b/src/app/pages/sharing/iscsi/target/target-form/target-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
+// TODO(NAS-141028): swap to TnButtonHarness once the shared ix-form's Save migrates to tn-button.
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.html
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.html
@@ -21,13 +21,10 @@
 
   <tn-form-section [heading]="'General Options' | translate">
     <tn-form-field [label]="'Description' | translate">
-      <!-- TODO: [ariaLabel] duplicates the tn-form-field label — remove once the
-        library associates its label with the projected control (for/aria-labelledby). -->
       <tn-input
         testId="comment"
         name="comment"
         formControlName="comment"
-        [ariaLabel]="'Description' | translate"
       ></tn-input>
     </tn-form-field>
 
@@ -52,8 +49,6 @@
         [label]="'Maproot User' | translate"
         [tooltip]="helptext.maprootUserTooltip | translate"
       >
-        <!-- TODO: [placeholder] doubles as the accessible-name fallback — tn-autocomplete
-          has no [ariaLabel] input and tn-form-field does not associate its label yet. -->
         <tn-autocomplete
           formControlName="maproot_user"
           [testId]="'maproot-user'"

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.spec.ts
@@ -2,6 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Provider } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+// TODO(NAS-141028): swap to TnButtonHarness once the shared ix-form's Save migrates to tn-button.
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { Store } from '@ngrx/store';

--- a/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/app/pages/sharing/nfs/nfs-form/nfs-form.component.spec.ts
@@ -180,9 +180,14 @@ describe('NfsFormComponent', () => {
       muteNestedFormArrayAdvisory();
     });
 
-    it('gives the Description input an accessible name matching its field label', async () => {
+    it('gives the Description input an accessible name via its field label', async () => {
+      // The tn-form-field label is auto-associated (aria-labelledby) since 0.3.23, so the
+      // input carries no aria-label of its own. White-box: no harness API for labelledby yet.
       const description = await loader.getHarness(TnInputHarness.with({ name: 'comment' }));
-      expect(await description.getAriaLabel()).toBe('Description');
+      expect(await description.getAriaLabel()).toBeNull();
+
+      const inputEl = spectator.query('tn-input[formcontrolname="comment"] input');
+      expect(inputEl.getAttribute('aria-labelledby')).toBeTruthy();
     });
 
     it('shows Access fields when Advanced Options button is pressed', async () => {

--- a/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.html
+++ b/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.html
@@ -32,7 +32,7 @@
     </div>
   </ng-template>
 
-  @if ((dataProvider.emptyType$ | async) === EmptyType.NoPageData && !(dataProvider.currentPageCount$ | async)) {
+  @if (emptyType() === EmptyType.NoPageData && !currentPageCount()) {
     <tn-empty
       icon="nfs-share"
       iconLibrary="custom"
@@ -40,15 +40,15 @@
       [title]="'Optimized for Linux and Unix systems, offering deeper integration in those environments. Choose NFS if you\'re working primarily with Linux servers or need efficient file access in Unix-based workflows.' | translate"
     ></tn-empty>
   } @else {
-    @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+    @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
     <tn-table
       class="table"
       [testId]="'table-table'"
       [ixUiSearch]="searchableElements.elements.nfs"
-      [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+      [dataSource]="rows()"
       [displayedColumns]="displayedColumns()"
       [trackBy]="trackByNfsId"
-      [loading]="!!(dataProvider.isLoading$ | async)"
+      [loading]="isLoading()"
       [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
       [emptyIcon]="emptyConf?.icon ?? ''"
       (sortChange)="onSortChange($event)"

--- a/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-list/nfs-list.component.ts
@@ -1,4 +1,3 @@
-import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, signal,
 } from '@angular/core';
@@ -31,7 +30,9 @@ import { toggleColumn } from 'app/modules/ix-table/components/ix-table-body/cell
 import { yesNoColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-yes-no/ix-cell-yes-no.component';
 import { TableColumnPickerComponent } from 'app/modules/ix-table/components/table-column-picker/table-column-picker.component';
 import { SortDirection } from 'app/modules/ix-table/enums/sort-direction.enum';
-import { convertStringToId, createTable, mapTnSortToTableSort, toDisplayedColumns } from 'app/modules/ix-table/utils';
+import {
+  convertStringToId, createTable, dataProviderLoading, dataProviderRows, mapTnSortToTableSort, toDisplayedColumns,
+} from 'app/modules/ix-table/utils';
 import { YesNoPipe } from 'app/modules/pipes/yes-no/yes-no.pipe';
 import { FormSidePanelService } from 'app/modules/slide-ins/form-side-panel/form-side-panel.service';
 import { TableActionsCellComponent } from 'app/modules/tn-table-cells/actions-cell/table-actions-cell.component';
@@ -73,7 +74,6 @@ import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors'
     TnTablePagerComponent,
     TnTooltipDirective,
     TranslateModule,
-    AsyncPipe,
     YesNoPipe,
   ],
 })
@@ -94,7 +94,17 @@ export class NfsListComponent implements OnInit {
   protected readonly EmptyType = EmptyType;
 
   protected readonly searchQuery = signal('');
-  protected dataProvider: AsyncDataProvider<NfsShare>;
+
+  private readonly shares$ = this.api.call('sharing.nfs.query').pipe(
+    tap((shares) => this.nfsShares = shares),
+    takeUntilDestroyed(this.destroyRef),
+  );
+
+  protected readonly dataProvider = new AsyncDataProvider<NfsShare>(this.shares$);
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(this.dataProvider.emptyType$);
+  protected readonly currentPageCount = toSignal(this.dataProvider.currentPageCount$);
   protected readonly isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
 
   private nfsShares: NfsShare[] = [];
@@ -200,11 +210,6 @@ export class NfsListComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    const shares$ = this.api.call('sharing.nfs.query').pipe(
-      tap((shares) => this.nfsShares = shares),
-      takeUntilDestroyed(this.destroyRef),
-    );
-    this.dataProvider = new AsyncDataProvider<NfsShare>(shares$);
     this.setDefaultSort();
     this.dataProvider.emptyType$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.onListFiltered(this.searchQuery());

--- a/src/app/pages/sharing/nfs/nfs-session-list/nfs-session-list.component.html
+++ b/src/app/pages/sharing/nfs/nfs-session-list/nfs-session-list.component.html
@@ -37,15 +37,15 @@
 </ix-page-header>
 
 @if (activeNfsType() === NfsType.Nfs3) {
-  @let emptyConf = emptyService.defaultEmptyConfig(nfs3DataProvider.emptyType$ | async);
+  @let emptyConf = emptyService.defaultEmptyConfig(nfs3EmptyType());
   <tn-table
     class="table"
     [testId]="'table-table'"
     [ixUiSearch]="searchableElements.elements.nfsSessions"
-    [dataSource]="(nfs3DataProvider.currentPage$ | async) ?? []"
+    [dataSource]="nfs3Rows()"
     [displayedColumns]="nfs3DisplayedColumns()"
     [trackBy]="trackByNfs3"
-    [loading]="!!(nfs3DataProvider.isLoading$ | async)"
+    [loading]="nfs3Loading()"
     [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
     [emptyIcon]="emptyConf?.icon ?? ''"
     (sortChange)="onNfs3SortChange($event)"
@@ -72,15 +72,15 @@
   </tn-table>
   <tn-table-pager [dataProvider]="nfs3DataProvider"></tn-table-pager>
 } @else {
-  @let emptyConf = emptyService.defaultEmptyConfig(nfs4DataProvider.emptyType$ | async);
+  @let emptyConf = emptyService.defaultEmptyConfig(nfs4EmptyType());
   <tn-table
     class="table"
     [testId]="'table-table'"
     [ixUiSearch]="searchableElements.elements.nfsSessions"
-    [dataSource]="(nfs4DataProvider.currentPage$ | async) ?? []"
+    [dataSource]="nfs4Rows()"
     [displayedColumns]="nfs4DisplayedColumns()"
     [trackBy]="trackByNfs4"
-    [loading]="!!(nfs4DataProvider.isLoading$ | async)"
+    [loading]="nfs4Loading()"
     [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
     [emptyIcon]="emptyConf?.icon ?? ''"
     (sortChange)="onNfs4SortChange($event)"

--- a/src/app/pages/sharing/nfs/nfs-session-list/nfs-session-list.component.ts
+++ b/src/app/pages/sharing/nfs/nfs-session-list/nfs-session-list.component.ts
@@ -1,8 +1,7 @@
-import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
@@ -20,7 +19,9 @@ import { BasicSearchComponent } from 'app/modules/forms/search-input/components/
 import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provider/async-data-provider';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { TableColumnPickerComponent } from 'app/modules/ix-table/components/table-column-picker/table-column-picker.component';
-import { convertStringToId, createTable, mapTnSortToTableSort, toDisplayedColumns } from 'app/modules/ix-table/utils';
+import {
+  convertStringToId, createTable, dataProviderLoading, dataProviderRows, mapTnSortToTableSort, toDisplayedColumns,
+} from 'app/modules/ix-table/utils';
 import { PageHeaderComponent } from 'app/modules/page-header/page-title-header/page-header.component';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { nfsSessionListElements } from 'app/pages/sharing/nfs/nfs-session-list/nfs-session-list.elements';
@@ -48,7 +49,6 @@ let nextLabelId = 0;
     UiSearchDirective,
     TnTablePagerComponent,
     TranslateModule,
-    AsyncPipe,
   ],
 })
 export class NfsSessionListComponent implements OnInit {
@@ -141,6 +141,9 @@ export class NfsSessionListComponent implements OnInit {
   );
 
   protected readonly nfs3DataProvider = new AsyncDataProvider<Nfs3Session>(this.nfs3ProviderRequest$);
+  protected readonly nfs3Rows = dataProviderRows(this.nfs3DataProvider);
+  protected readonly nfs3Loading = dataProviderLoading(this.nfs3DataProvider);
+  protected readonly nfs3EmptyType = toSignal(this.nfs3DataProvider.emptyType$);
 
   private readonly nfs4ProviderRequest$ = this.api.call('nfs.get_nfs4_clients', []).pipe(
     map((sessions) => sessions.map((session) => session.info)),
@@ -154,6 +157,9 @@ export class NfsSessionListComponent implements OnInit {
   );
 
   protected readonly nfs4DataProvider = new AsyncDataProvider<Nfs4Session['info']>(this.nfs4ProviderRequest$);
+  protected readonly nfs4Rows = dataProviderRows(this.nfs4DataProvider);
+  protected readonly nfs4Loading = dataProviderLoading(this.nfs4DataProvider);
+  protected readonly nfs4EmptyType = toSignal(this.nfs4DataProvider.emptyType$);
 
   protected formatStatus(status: string): string {
     return stringToTitleCase(status);

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.html
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.html
@@ -1,60 +1,88 @@
-<form [formGroup]="form" (keydown.enter)="$event.preventDefault()">
-  <tn-stepper orientation="vertical">
-    <tn-step [label]="'What To Share' | translate" [completed]="whatToShareCompleted()">
-      <tn-form-field
-        class="name-input"
-        [label]="'Subsystem Name' | translate"
-      >
-        <tn-input formControlName="name" [required]="true"></tn-input>
-      </tn-form-field>
-
-      <ix-details-table>
-        <ix-details-item
-          [label]="'NQN' | translate"
-          [tooltip]="helptext.subsystemNqn | translate"
+<tn-card class="card">
+  <form [formGroup]="form" (keydown.enter)="$event.preventDefault()">
+    <tn-stepper #stepper orientation="vertical">
+      <tn-step [label]="'What To Share' | translate" [completed]="whatToShareCompleted()">
+        <tn-form-field
+          class="name-input"
+          [label]="'Subsystem Name' | translate"
         >
-          <ix-editable>
-            <div view>
-              {{ form.value.subnqn || ('Generate from global settings' | translate) }}
-            </div>
+          <tn-input formControlName="name" [required]="true"></tn-input>
+        </tn-form-field>
 
-            <div edit>
-              <tn-input
-                class="nqn-input"
-                name="subnqn"
-                formControlName="subnqn"
-                [ariaLabel]="'NQN' | translate"
-              ></tn-input>
-            </div>
-          </ix-editable>
-        </ix-details-item>
-      </ix-details-table>
+        <ix-details-table>
+          <ix-details-item
+            [label]="'NQN' | translate"
+            [tooltip]="helptext.subsystemNqn | translate"
+          >
+            <ix-editable>
+              <div view>
+                {{ form.value.subnqn || ('Generate from global settings' | translate) }}
+              </div>
 
-      <ix-add-subsystem-namespaces
-        class="namespaces-block"
-        [namespacesControl]="form.controls.namespaces"
-      ></ix-add-subsystem-namespaces>
-    </tn-step>
+              <div edit>
+                <tn-input
+                  class="nqn-input"
+                  name="subnqn"
+                  formControlName="subnqn"
+                  [ariaLabel]="'NQN' | translate"
+                ></tn-input>
+              </div>
+            </ix-editable>
+          </ix-details-item>
+        </ix-details-table>
 
-    <tn-step [label]="'Access' | translate">
-      <tn-form-field>
-        <tn-checkbox
-          formControlName="allowAnyHost"
-          [label]="'Allow any host to connect' | translate"
-        ></tn-checkbox>
-      </tn-form-field>
+        <ix-add-subsystem-namespaces
+          class="namespaces-block"
+          [namespacesControl]="form.controls.namespaces"
+        ></ix-add-subsystem-namespaces>
 
-      @if (!form.value.allowAnyHost) {
-        <ix-add-subsystem-hosts
-          class="hosts-block"
-          [hostsControl]="form.controls.allowedHosts"
-        ></ix-add-subsystem-hosts>
-      }
+        <div class="step-buttons">
+          <tn-button
+            tnStepperNext
+            color="primary"
+            [testId]="'next'"
+            [label]="'Next' | translate"
+            [disabled]="form.controls.name.invalid"
+          ></tn-button>
+        </div>
+      </tn-step>
 
-      <ix-add-subsystem-ports
-        class="ports-block"
-        [portsControl]="form.controls.ports"
-      ></ix-add-subsystem-ports>
-    </tn-step>
-  </tn-stepper>
-</form>
+      <tn-step [label]="'Access' | translate">
+        <tn-form-field>
+          <tn-checkbox
+            formControlName="allowAnyHost"
+            [label]="'Allow any host to connect' | translate"
+          ></tn-checkbox>
+        </tn-form-field>
+
+        @if (!form.value.allowAnyHost) {
+          <ix-add-subsystem-hosts
+            class="hosts-block"
+            [hostsControl]="form.controls.allowedHosts"
+          ></ix-add-subsystem-hosts>
+        }
+
+        <ix-add-subsystem-ports
+          class="ports-block"
+          [portsControl]="form.controls.ports"
+        ></ix-add-subsystem-ports>
+
+        <div class="step-buttons last-step-buttons">
+          <tn-button
+            tnStepperPrevious
+            [testId]="'back'"
+            [label]="'Back' | translate"
+          ></tn-button>
+          <tn-button
+            *ixRequiresRoles="requiredRoles"
+            color="primary"
+            [testId]="'save'"
+            [label]="'Save' | translate"
+            [disabled]="form.invalid || isLoading()"
+            (onClick)="onSubmit()"
+          ></tn-button>
+        </div>
+      </tn-step>
+    </tn-stepper>
+  </form>
+</tn-card>

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.html
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.html
@@ -1,88 +1,86 @@
-<tn-card class="card">
-  <form [formGroup]="form" (keydown.enter)="$event.preventDefault()">
-    <tn-stepper #stepper orientation="vertical">
-      <tn-step [label]="'What To Share' | translate" [completed]="whatToShareCompleted()">
-        <tn-form-field
-          class="name-input"
-          [label]="'Subsystem Name' | translate"
+<form [formGroup]="form" (keydown.enter)="$event.preventDefault()">
+  <tn-stepper #stepper orientation="vertical">
+    <tn-step [label]="'What To Share' | translate" [completed]="whatToShareCompleted()">
+      <tn-form-field
+        class="name-input"
+        [label]="'Subsystem Name' | translate"
+      >
+        <tn-input formControlName="name" [required]="true"></tn-input>
+      </tn-form-field>
+
+      <ix-details-table>
+        <ix-details-item
+          [label]="'NQN' | translate"
+          [tooltip]="helptext.subsystemNqn | translate"
         >
-          <tn-input formControlName="name" [required]="true"></tn-input>
-        </tn-form-field>
+          <ix-editable>
+            <div view>
+              {{ form.value.subnqn || ('Generate from global settings' | translate) }}
+            </div>
 
-        <ix-details-table>
-          <ix-details-item
-            [label]="'NQN' | translate"
-            [tooltip]="helptext.subsystemNqn | translate"
-          >
-            <ix-editable>
-              <div view>
-                {{ form.value.subnqn || ('Generate from global settings' | translate) }}
-              </div>
+            <div edit>
+              <tn-input
+                class="nqn-input"
+                name="subnqn"
+                formControlName="subnqn"
+                [ariaLabel]="'NQN' | translate"
+              ></tn-input>
+            </div>
+          </ix-editable>
+        </ix-details-item>
+      </ix-details-table>
 
-              <div edit>
-                <tn-input
-                  class="nqn-input"
-                  name="subnqn"
-                  formControlName="subnqn"
-                  [ariaLabel]="'NQN' | translate"
-                ></tn-input>
-              </div>
-            </ix-editable>
-          </ix-details-item>
-        </ix-details-table>
+      <ix-add-subsystem-namespaces
+        class="namespaces-block"
+        [namespacesControl]="form.controls.namespaces"
+      ></ix-add-subsystem-namespaces>
 
-        <ix-add-subsystem-namespaces
-          class="namespaces-block"
-          [namespacesControl]="form.controls.namespaces"
-        ></ix-add-subsystem-namespaces>
+      <div class="step-buttons">
+        <tn-button
+          tnStepperNext
+          color="primary"
+          [testId]="'next'"
+          [label]="'Next' | translate"
+          [disabled]="form.controls.name.invalid"
+        ></tn-button>
+      </div>
+    </tn-step>
 
-        <div class="step-buttons">
-          <tn-button
-            tnStepperNext
-            color="primary"
-            [testId]="'next'"
-            [label]="'Next' | translate"
-            [disabled]="form.controls.name.invalid"
-          ></tn-button>
-        </div>
-      </tn-step>
+    <tn-step [label]="'Access' | translate">
+      <tn-form-field>
+        <tn-checkbox
+          formControlName="allowAnyHost"
+          [label]="'Allow any host to connect' | translate"
+        ></tn-checkbox>
+      </tn-form-field>
 
-      <tn-step [label]="'Access' | translate">
-        <tn-form-field>
-          <tn-checkbox
-            formControlName="allowAnyHost"
-            [label]="'Allow any host to connect' | translate"
-          ></tn-checkbox>
-        </tn-form-field>
+      @if (!form.value.allowAnyHost) {
+        <ix-add-subsystem-hosts
+          class="hosts-block"
+          [hostsControl]="form.controls.allowedHosts"
+        ></ix-add-subsystem-hosts>
+      }
 
-        @if (!form.value.allowAnyHost) {
-          <ix-add-subsystem-hosts
-            class="hosts-block"
-            [hostsControl]="form.controls.allowedHosts"
-          ></ix-add-subsystem-hosts>
-        }
+      <ix-add-subsystem-ports
+        class="ports-block"
+        [portsControl]="form.controls.ports"
+      ></ix-add-subsystem-ports>
 
-        <ix-add-subsystem-ports
-          class="ports-block"
-          [portsControl]="form.controls.ports"
-        ></ix-add-subsystem-ports>
-
-        <div class="step-buttons last-step-buttons">
-          <tn-button
-            tnStepperPrevious
-            [testId]="'back'"
-            [label]="'Back' | translate"
-          ></tn-button>
-          <tn-button
-            *ixRequiresRoles="requiredRoles"
-            color="primary"
-            [testId]="'save'"
-            [label]="'Save' | translate"
-            [disabled]="form.invalid || isLoading()"
-            (onClick)="onSubmit()"
-          ></tn-button>
-        </div>
-      </tn-step>
-    </tn-stepper>
-  </form>
-</tn-card>
+      <div class="step-buttons last-step-buttons">
+        <tn-button
+          tnStepperPrevious
+          [testId]="'back'"
+          [label]="'Back' | translate"
+        ></tn-button>
+        <tn-button
+          *ixRequiresRoles="requiredRoles"
+          color="primary"
+          [testId]="'save'"
+          [label]="'Save' | translate"
+          [disabled]="form.invalid || isLoading()"
+          (onClick)="onSubmit()"
+        ></tn-button>
+      </div>
+    </tn-step>
+  </tn-stepper>
+</form>

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.scss
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.scss
@@ -12,6 +12,15 @@
   width: auto;
 }
 
+.step-buttons {
+  display: flex;
+  gap: 6px;
+}
+
+.last-step-buttons {
+  margin-top: 30px;
+}
+
 .hosts-block,
 .namespaces-block,
 .ports-block {

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.spec.ts
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.spec.ts
@@ -2,7 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnCheckboxHarness, TnInputHarness } from '@truenas/ui-components';
+import { TnButtonHarness, TnCheckboxHarness, TnInputHarness } from '@truenas/ui-components';
 import { MockComponents } from 'ng-mocks';
 import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
@@ -90,12 +90,8 @@ describe('AddSubsystemComponent', () => {
     ] as NamespaceChanges[];
     (addNamespaces.namespacesControl as unknown as FormControl).setValue(namespaces);
 
-    // Next/Back/Save live in the side-panel footer, driven through the form's public
-    // footer surface (footerActions / hideSave / canSubmit / submit) — there's no host here.
-    expect(spectator.component.hideSave()).toBe(true);
-    expect(spectator.component.footerActions).toMatchObject([{ testId: 'next' }]);
-    spectator.component.footerActions[0].onClick();
-    spectator.detectChanges();
+    const nextButton = await loader.getHarness(TnButtonHarness.with({ label: 'Next' }));
+    await nextButton.click();
 
     // Ports, hosts
     const addPorts = spectator.query(AddSubsystemPortsComponent);
@@ -113,10 +109,8 @@ describe('AddSubsystemComponent', () => {
       { id: 200 } as NvmeOfHost,
     ]);
 
-    expect(spectator.component.footerActions).toMatchObject([{ testId: 'back' }]);
-    expect(spectator.component.hideSave()).toBe(false);
-    expect(spectator.component.canSubmit()).toBe(true);
-    spectator.component.submit();
+    const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+    await saveButton.click();
 
     expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('nvmet.subsys.create', [
       {

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.ts
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.ts
@@ -4,7 +4,7 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  TnButtonComponent, TnCardComponent, TnCheckboxComponent, TnFormFieldComponent, TnInputComponent,
+  TnButtonComponent, TnCheckboxComponent, TnFormFieldComponent, TnInputComponent,
   TnStepComponent, TnStepperComponent, TnStepperNextDirective, TnStepperPreviousDirective,
 } from '@truenas/ui-components';
 import {
@@ -50,7 +50,6 @@ import { checkIfServiceIsEnabled } from 'app/store/services/services.actions';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     TranslateModule,
-    TnCardComponent,
     ReactiveFormsModule,
     TnStepperComponent,
     TnStepComponent,

--- a/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.ts
+++ b/src/app/pages/sharing/nvme-of/add-subsystem/add-subsystem.component.ts
@@ -1,20 +1,18 @@
-import {
-  ChangeDetectionStrategy, Component, DestroyRef, computed, inject, signal, viewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, output, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  TnCheckboxComponent, TnFormFieldComponent, TnInputComponent,
-  TnStepComponent, TnStepperComponent,
+  TnButtonComponent, TnCardComponent, TnCheckboxComponent, TnFormFieldComponent, TnInputComponent,
+  TnStepComponent, TnStepperComponent, TnStepperNextDirective, TnStepperPreviousDirective,
 } from '@truenas/ui-components';
 import {
   catchError,
   finalize, forkJoin, map, Observable, of, switchMap,
   tap,
 } from 'rxjs';
+import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { stepCompletedSignal } from 'app/helpers/step-completed-signal.helper';
@@ -26,8 +24,7 @@ import { DetailsItemComponent } from 'app/modules/details-table/details-item/det
 import { DetailsTableComponent } from 'app/modules/details-table/details-table.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EditableComponent } from 'app/modules/forms/editable/editable.component';
-import { SidePanelFooterAction } from 'app/modules/slide-ins/form-side-panel/form-side-panel-container.component';
-import { SidePanelForm } from 'app/modules/slide-ins/side-panel-form.directive';
+import { SidePanelHostCloseable } from 'app/modules/slide-ins/side-panel-form.directive';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import {
@@ -53,21 +50,26 @@ import { checkIfServiceIsEnabled } from 'app/store/services/services.actions';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     TranslateModule,
+    TnCardComponent,
     ReactiveFormsModule,
     TnStepperComponent,
     TnStepComponent,
+    TnButtonComponent,
+    TnStepperNextDirective,
+    TnStepperPreviousDirective,
     TnFormFieldComponent,
     TnInputComponent,
     TnCheckboxComponent,
     AddSubsystemHostsComponent,
     AddSubsystemNamespacesComponent,
+    RequiresRolesDirective,
     AddSubsystemPortsComponent,
     DetailsItemComponent,
     DetailsTableComponent,
     EditableComponent,
   ],
 })
-export class AddSubsystemComponent extends SidePanelForm<NvmeOfSubsystem> {
+export class AddSubsystemComponent implements SidePanelHostCloseable<NvmeOfSubsystem> {
   private formBuilder = inject(FormBuilder);
   private api = inject(ApiService);
   private snackbar = inject(SnackbarService);
@@ -79,13 +81,22 @@ export class AddSubsystemComponent extends SidePanelForm<NvmeOfSubsystem> {
   private destroyRef = inject(DestroyRef);
 
   protected isLoading = signal(false);
+  requiredRoles = [Role.SharingNvmeTargetWrite];
 
-  /** Gates the host-rendered footer Save. */
-  readonly requiredRoles = [Role.SharingNvmeTargetWrite];
+  /** Emitted to a `tn-side-panel` host with the created subsystem on save. */
+  readonly closed = output<NvmeOfSubsystem>();
 
-  private readonly stepper = viewChild(TnStepperComponent);
+  /** Host hook (tn-side-panel closeGuard) to confirm before discarding unsaved edits. */
+  hasUnsavedChanges(): boolean {
+    return this.form.dirty;
+  }
 
-  protected readonly form = this.formBuilder.group({
+  /** The footerless `<tn-side-panel>` host shows its progress bar while this is true. */
+  isBusy(): boolean {
+    return this.isLoading();
+  }
+
+  protected form = this.formBuilder.group({
     name: ['', Validators.required],
     subnqn: [''],
     namespaces: [[] as NamespaceChanges[]],
@@ -100,45 +111,6 @@ export class AddSubsystemComponent extends SidePanelForm<NvmeOfSubsystem> {
 
   // Drives the stepper's "finished step" pencil icon (replaces mat's [stepControl]).
   protected readonly whatToShareCompleted = stepCompletedSignal(this.form.controls.name);
-
-  private readonly isOnFinalStep = computed(() => {
-    const stepper = this.stepper();
-    return !!stepper && stepper.selectedIndex() === stepper.steps().length - 1;
-  });
-
-  private readonly baseCanSubmit = this.trackCanSubmit(this.isLoading);
-
-  /** Also gated on the final step so the footer Save can't short-circuit the wizard. */
-  readonly canSubmit = computed(() => this.baseCanSubmit() && this.isOnFinalStep());
-
-  /** Hides the host footer Save until the final step — Next is the only way forward before that. */
-  hideSave(): boolean {
-    return !this.isOnFinalStep();
-  }
-
-  /**
-   * Step-dependent wizard navigation rendered in the `<tn-side-panel>` footer before Save:
-   * Next until the final step, Back on it. Re-read each change detection, so the buttons
-   * swap as the stepper advances. Labels are extraction markers — the panel container
-   * pipes them through `translate`.
-   */
-  get footerActions(): SidePanelFooterAction[] {
-    if (this.isOnFinalStep()) {
-      return [{
-        label: T('Back'),
-        testId: 'back',
-        onClick: () => this.stepper()?.previous(),
-      }];
-    }
-
-    return [{
-      label: T('Next'),
-      testId: 'next',
-      color: 'primary',
-      disabled: () => !this.whatToShareCompleted(),
-      onClick: () => this.stepper()?.next(),
-    }];
-  }
 
   protected onSubmit(): void {
     this.isLoading.set(true);
@@ -162,7 +134,7 @@ export class AddSubsystemComponent extends SidePanelForm<NvmeOfSubsystem> {
       }
 
       this.snackbar.success(this.translate.instant('New subsystem added'));
-      this.closeWith(subsystem);
+      this.closed.emit(subsystem);
     });
   }
 

--- a/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.html
+++ b/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.html
@@ -19,7 +19,7 @@
   <tn-menu #addMenu>
     @for (host of unusedHosts(); track host.id) {
       <tn-menu-item
-        [testId]="['add-host', host.hostnqn]"
+        [testId]="['add-host', hostTestIdSlug(host)]"
         (itemClick)="selectHost(host)"
       >
         @if (host.description) {

--- a/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.ts
+++ b/src/app/pages/sharing/nvme-of/hosts/add-host-menu/add-host-menu.component.ts
@@ -6,7 +6,7 @@ import {
   TnButtonComponent, TnDialog, TnDividerComponent, TnMenuComponent, TnMenuItemComponent, TnMenuTriggerDirective,
   tnIconMarker,
 } from '@truenas/ui-components';
-import { sortBy } from 'lodash-es';
+import { kebabCase, sortBy } from 'lodash-es';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { NvmeOfHost } from 'app/interfaces/nvme-of.interface';
@@ -53,6 +53,13 @@ export class AddHostMenuComponent {
   });
 
   protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
+
+  // Pre-split with lodash kebabCase so digit-bearing values resolve identically
+  // through the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+  protected hostTestIdSlug(host: NvmeOfHost): string {
+    return kebabCase(host.hostnqn);
+  }
+
   protected readonly menuDownIcon = tnIconMarker('menu-down', 'mdi');
 
   protected openHostForm(): void {

--- a/src/app/pages/sharing/nvme-of/hosts/manage-hosts/manage-hosts-dialog.component.html
+++ b/src/app/pages/sharing/nvme-of/hosts/manage-hosts/manage-hosts-dialog.component.html
@@ -35,7 +35,7 @@
       <ng-template let-row tnCellDef>
         <span
           tnTestIdType="text"
-          [tnTestId]="[('Has Host Authentication' | translate), uniqueRowTag(row), 'row-text']"
+          [tnTestId]="[('Has Host Authentication' | translate), uniqueRowTag(row), 'row-yesno']"
         >{{ row.dhchap_key ? ('Yes' | translate) : ('No' | translate) }}</span>
       </ng-template>
     </ng-container>

--- a/src/app/pages/sharing/nvme-of/hosts/manage-hosts/manage-hosts-dialog.component.html
+++ b/src/app/pages/sharing/nvme-of/hosts/manage-hosts/manage-hosts-dialog.component.html
@@ -1,33 +1,53 @@
 <tn-dialog-shell testId="dialog" [title]="'Hosts' | translate">
-  @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+  @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
   <tn-table
     class="table"
     [testId]="'table-table'"
-    [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+    [dataSource]="rows()"
     [displayedColumns]="displayedColumns"
     [trackBy]="trackByHostId"
-    [loading]="!!(dataProvider.isLoading$ | async)"
+    [loading]="isLoading()"
     [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
     [emptyIcon]="emptyConf?.icon ?? ''"
   >
     <ng-container [tnColumnDef]="'hostnqn'">
       <ng-template tnHeaderCellDef>{{ 'NQN' | translate }}</ng-template>
-      <ng-template let-row tnCellDef>{{ row.hostnqn }}</ng-template>
+      <ng-template let-row tnCellDef>
+        <span
+          tnTestIdType="text"
+          [tnTestId]="[('NQN' | translate), uniqueRowTag(row), 'row-text']"
+        >{{ row.hostnqn }}</span>
+      </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'description'">
       <ng-template tnHeaderCellDef>{{ 'Description' | translate }}</ng-template>
-      <ng-template let-row tnCellDef>{{ row.description }}</ng-template>
+      <ng-template let-row tnCellDef>
+        <span
+          tnTestIdType="text"
+          [tnTestId]="[('Description' | translate), uniqueRowTag(row), 'row-text']"
+        >{{ row.description }}</span>
+      </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'dhchap_key'">
       <ng-template tnHeaderCellDef>{{ 'Has Host Authentication' | translate }}</ng-template>
-      <ng-template let-row tnCellDef>{{ row.dhchap_key ? ('Yes' | translate) : ('No' | translate) }}</ng-template>
+      <ng-template let-row tnCellDef>
+        <span
+          tnTestIdType="text"
+          [tnTestId]="[('Has Host Authentication' | translate), uniqueRowTag(row), 'row-text']"
+        >{{ row.dhchap_key ? ('Yes' | translate) : ('No' | translate) }}</span>
+      </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'usedInSubsystems'">
       <ng-template tnHeaderCellDef>{{ 'Used In Subsystems' | translate }}</ng-template>
-      <ng-template let-row tnCellDef>{{ row.usedInSubsystems }}</ng-template>
+      <ng-template let-row tnCellDef>
+        <span
+          tnTestIdType="text"
+          [tnTestId]="[('Used In Subsystems' | translate), uniqueRowTag(row), 'row-text']"
+        >{{ row.usedInSubsystems }}</span>
+      </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'actions'" [width]="'120px'">
@@ -37,7 +57,7 @@
           mode="inline"
           [actions]="actions"
           [row]="row"
-          [uniqueRowTag]="'host-' + row.hostnqn"
+          [uniqueRowTag]="uniqueRowTag(row)"
           [ariaLabel]="row.id + ' ' + ('Host' | translate)"
         ></ix-table-actions-cell>
       </ng-template>

--- a/src/app/pages/sharing/nvme-of/hosts/manage-hosts/manage-hosts-dialog.component.ts
+++ b/src/app/pages/sharing/nvme-of/hosts/manage-hosts/manage-hosts-dialog.component.ts
@@ -1,17 +1,18 @@
-import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   TnButtonComponent, TnCellDefDirective, TnDialog, TnDialogShellComponent, TnHeaderCellDefDirective,
-  TnTableColumnDirective, TnTableComponent, tnIconMarker,
+  TnTableColumnDirective, TnTableComponent, TnTestIdDirective, tnIconMarker,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { Role } from 'app/enums/role.enum';
 import { NvmeOfHost, PortOrHostDeleteDialogData, PortOrHostDeleteType } from 'app/interfaces/nvme-of.interface';
 import { EmptyService } from 'app/modules/empty/empty.service';
 import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provider/async-data-provider';
 import { IconActionConfig } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-actions/icon-action-config.interface';
+import { convertStringToId, dataProviderLoading, dataProviderRows } from 'app/modules/ix-table/utils';
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { FormSidePanelService } from 'app/modules/slide-ins/form-side-panel/form-side-panel.service';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
@@ -35,11 +36,11 @@ interface NvmeOfHostAndUsage extends NvmeOfHost {
     TnDialogShellComponent,
     TnButtonComponent,
     TranslateModule,
-    AsyncPipe,
     TnTableComponent,
     TnTableColumnDirective,
     TnHeaderCellDefDirective,
     TnCellDefDirective,
+    TnTestIdDirective,
     TableActionsCellComponent,
   ],
 })
@@ -60,6 +61,12 @@ export class ManageHostsDialog implements OnInit {
   protected readonly displayedColumns = ['hostnqn', 'description', 'dhchap_key', 'usedInSubsystems', 'actions'];
 
   protected readonly trackByHostId = (_: number, row: NvmeOfHostAndUsage): number => row.id;
+
+  // Pre-split with lodash kebabCase so digit-bearing values resolve identically
+  // through the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+  protected uniqueRowTag(row: NvmeOfHostAndUsage): string {
+    return kebabCase(convertStringToId('host-' + row.hostnqn));
+  }
 
   protected readonly actions: IconActionConfig<NvmeOfHostAndUsage>[] = [
     {
@@ -87,6 +94,10 @@ export class ManageHostsDialog implements OnInit {
       }),
     ),
   );
+
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(this.dataProvider.emptyType$);
 
   ngOnInit(): void {
     this.dataProvider.load();

--- a/src/app/pages/sharing/nvme-of/nvme-of.component.ts
+++ b/src/app/pages/sharing/nvme-of/nvme-of.component.ts
@@ -135,6 +135,7 @@ export class NvmeOfComponent implements OnInit {
   protected addSubsystem(): void {
     this.formPanel.open(AddSubsystemComponent, {
       title: this.translate.instant('Add Subsystem'),
+      footerless: true,
     })
       .onSuccess((response) => {
         this.selectedSubsystemName = response.name;

--- a/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.html
+++ b/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.html
@@ -19,7 +19,7 @@
   <tn-menu #addMenu>
     @for (port of unusedPorts(); track port.id) {
       <tn-menu-item
-        [testId]="['add-port', port.addr_trtype, port.addr_traddr, port.addr_trsvcid]"
+        [testId]="addPortTestId(port)"
         (itemClick)="selectPort(port)"
       >
         <ix-port-description [port]="port"></ix-port-description>

--- a/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.ts
+++ b/src/app/pages/sharing/nvme-of/ports/add-port-menu/add-port-menu.component.ts
@@ -6,7 +6,7 @@ import {
   TnButtonComponent, TnDialog, TnDividerComponent, TnMenuComponent, TnMenuItemComponent, TnMenuTriggerDirective,
   tnIconMarker,
 } from '@truenas/ui-components';
-import { sortBy } from 'lodash-es';
+import { kebabCase, sortBy } from 'lodash-es';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import { NvmeOfPort } from 'app/interfaces/nvme-of.interface';
@@ -52,6 +52,13 @@ export class AddPortMenuComponent {
   });
 
   protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
+
+  // Pre-split with lodash kebabCase so digit-bearing values resolve identically
+  // through the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+  protected addPortTestId(port: NvmeOfPort): string[] {
+    return ['add-port', kebabCase(port.addr_trtype), kebabCase(port.addr_traddr), kebabCase(String(port.addr_trsvcid))];
+  }
+
   protected readonly menuDownIcon = tnIconMarker('menu-down', 'mdi');
 
   protected openPortForm(): void {

--- a/src/app/pages/sharing/nvme-of/ports/manage-ports/manage-ports-dialog.component.html
+++ b/src/app/pages/sharing/nvme-of/ports/manage-ports/manage-ports-dialog.component.html
@@ -1,33 +1,53 @@
 <tn-dialog-shell testId="dialog" [title]="'Ports' | translate">
-  @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+  @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
   <tn-table
     class="table"
     [testId]="'table-table'"
-    [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+    [dataSource]="rows()"
     [displayedColumns]="displayedColumns"
     [trackBy]="trackByPortId"
-    [loading]="!!(dataProvider.isLoading$ | async)"
+    [loading]="isLoading()"
     [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
     [emptyIcon]="emptyConf?.icon ?? ''"
   >
     <ng-container [tnColumnDef]="'addr_trtype'">
       <ng-template tnHeaderCellDef>{{ 'Type' | translate }}</ng-template>
-      <ng-template let-row tnCellDef>{{ transportLabel(row) }}</ng-template>
+      <ng-template let-row tnCellDef>
+        <span
+          tnTestIdType="text"
+          [tnTestId]="[('Type' | translate), uniqueRowTag(row), 'row-text']"
+        >{{ transportLabel(row) }}</span>
+      </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'addr_traddr'">
       <ng-template tnHeaderCellDef>{{ 'Address' | translate }}</ng-template>
-      <ng-template let-row tnCellDef>{{ row.addr_traddr }}</ng-template>
+      <ng-template let-row tnCellDef>
+        <span
+          tnTestIdType="text"
+          [tnTestId]="[('Address' | translate), uniqueRowTag(row), 'row-text']"
+        >{{ row.addr_traddr }}</span>
+      </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'addr_trsvcid'">
       <ng-template tnHeaderCellDef>{{ 'Port' | translate }}</ng-template>
-      <ng-template let-row tnCellDef>{{ row.addr_trsvcid }}</ng-template>
+      <ng-template let-row tnCellDef>
+        <span
+          tnTestIdType="text"
+          [tnTestId]="[('Port' | translate), uniqueRowTag(row), 'row-text']"
+        >{{ row.addr_trsvcid }}</span>
+      </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'usedInSubsystems'">
       <ng-template tnHeaderCellDef>{{ 'Used In Subsystems' | translate }}</ng-template>
-      <ng-template let-row tnCellDef>{{ row.usedInSubsystems }}</ng-template>
+      <ng-template let-row tnCellDef>
+        <span
+          tnTestIdType="text"
+          [tnTestId]="[('Used In Subsystems' | translate), uniqueRowTag(row), 'row-text']"
+        >{{ row.usedInSubsystems }}</span>
+      </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'actions'" [width]="'120px'">
@@ -37,7 +57,7 @@
           mode="inline"
           [actions]="actions"
           [row]="row"
-          [uniqueRowTag]="'port-' + row.addr_trtype + '-' + row.addr_traddr + '-' + row.addr_trsvcid"
+          [uniqueRowTag]="uniqueRowTag(row)"
           [ariaLabel]="row.id + ' ' + ('Port' | translate)"
         ></ix-table-actions-cell>
       </ng-template>

--- a/src/app/pages/sharing/nvme-of/ports/manage-ports/manage-ports-dialog.component.ts
+++ b/src/app/pages/sharing/nvme-of/ports/manage-ports/manage-ports-dialog.component.ts
@@ -1,11 +1,11 @@
-import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   TnButtonComponent, TnCellDefDirective, TnDialog, TnDialogShellComponent, TnHeaderCellDefDirective,
-  TnTableColumnDirective, TnTableComponent, tnIconMarker,
+  TnTableColumnDirective, TnTableComponent, TnTestIdDirective, tnIconMarker,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { nvmeOfTransportTypeLabels } from 'app/enums/nvme-of.enum';
 import { Role } from 'app/enums/role.enum';
@@ -13,6 +13,7 @@ import { NvmeOfPort, PortOrHostDeleteDialogData, PortOrHostDeleteType } from 'ap
 import { EmptyService } from 'app/modules/empty/empty.service';
 import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provider/async-data-provider';
 import { IconActionConfig } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-actions/icon-action-config.interface';
+import { convertStringToId, dataProviderLoading, dataProviderRows } from 'app/modules/ix-table/utils';
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { FormSidePanelService } from 'app/modules/slide-ins/form-side-panel/form-side-panel.service';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
@@ -36,11 +37,11 @@ interface NvmeOfPortAndUsage extends NvmeOfPort {
     TnDialogShellComponent,
     TnButtonComponent,
     TranslateModule,
-    AsyncPipe,
     TnTableComponent,
     TnTableColumnDirective,
     TnHeaderCellDefDirective,
     TnCellDefDirective,
+    TnTestIdDirective,
     TableActionsCellComponent,
   ],
 })
@@ -61,6 +62,12 @@ export class ManagePortsDialog implements OnInit {
   protected readonly displayedColumns = ['addr_trtype', 'addr_traddr', 'addr_trsvcid', 'usedInSubsystems', 'actions'];
 
   protected readonly trackByPortId = (_: number, row: NvmeOfPortAndUsage): number => row.id;
+
+  // Pre-split with lodash kebabCase so digit-bearing values resolve identically
+  // through the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+  protected uniqueRowTag(row: NvmeOfPortAndUsage): string {
+    return kebabCase(convertStringToId(`port-${row.addr_trtype}-${row.addr_traddr}-${row.addr_trsvcid}`));
+  }
 
   protected readonly actions: IconActionConfig<NvmeOfPortAndUsage>[] = [
     {
@@ -92,6 +99,10 @@ export class ManagePortsDialog implements OnInit {
       }),
     ),
   );
+
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(this.dataProvider.emptyType$);
 
   ngOnInit(): void {
     this.dataProvider.load();

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.html
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.html
@@ -47,7 +47,7 @@
                 iconClass="icon"
                 [ariaLabel]="'Remove host from the subsystem' | translate"
                 [tooltip]="'Remove host from the subsystem' | translate"
-                [testId]="['remove-host-association', host.hostnqn]"
+                [testId]="['remove-host-association', hostTestIdSlug(host)]"
                 (onClick)="removeAssociation(host)"
               ></tn-icon-button>
             </span>

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.ts
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-hosts-card/subsystem-hosts-card.component.ts
@@ -5,6 +5,7 @@ import {
   TnBannerComponent, TnCardComponent, TnCardFooterActionsDirective, TnIconButtonComponent, TnIconComponent,
   TnTooltipDirective,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { forkJoin, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
@@ -54,6 +55,12 @@ export class SubsystemHostsCardComponent {
   protected readonly searchableElements = subsystemHostsCardElements;
 
   protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
+
+  // Pre-split with lodash kebabCase so digit-bearing values resolve identically
+  // through the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+  protected hostTestIdSlug(host: NvmeOfHost): string {
+    return kebabCase(host.hostnqn);
+  }
 
   protected hostAdded(host: NvmeOfHost): void {
     const subsystem = this.subsystem();

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.html
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.html
@@ -29,7 +29,7 @@
                 library="mdi"
                 [ariaLabel]="'Delete namespace' | translate"
                 [tooltip]="'Delete namespace' | translate"
-                [testId]="['delete-namespace', namespace.device_path]"
+                [testId]="['delete-namespace', namespaceTestIdSlug(namespace)]"
                 (onClick)="onDeleteNamespace(namespace)"
               ></tn-icon-button>
             </span>

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.ts
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-namespaces-card/subsystem-namespaces-card.component.ts
@@ -6,6 +6,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   TnBannerComponent, TnButtonComponent, TnCardComponent, TnCardFooterActionsDirective, TnDialog, TnIconButtonComponent,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { filter } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
@@ -54,6 +55,12 @@ export class SubsystemNamespacesCardComponent {
   protected readonly searchableElements = subsystemNamespacesCardElements;
 
   protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
+
+  // Pre-split with lodash kebabCase so digit-bearing values resolve identically
+  // through the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+  protected namespaceTestIdSlug(namespace: NvmeOfNamespace): string {
+    return kebabCase(namespace.device_path);
+  }
 
   protected onAddNamespace(): void {
     this.formPanel.open(NamespaceFormComponent, {

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.html
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.html
@@ -28,7 +28,7 @@
                 iconClass="icon"
                 [ariaLabel]="'Remove port from the subsystem' | translate"
                 [tooltip]="'Remove port from the subsystem' | translate"
-                [testId]="['remove-port-association', port.addr_trtype, port.addr_traddr, port.addr_trsvcid]"
+                [testId]="removePortTestId(port)"
                 (onClick)="onRemoveAssociation(port)"
               ></tn-icon-button>
             </span>

--- a/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.ts
+++ b/src/app/pages/sharing/nvme-of/subsystem-details/subsystem-ports-card/subsystem-ports-card.component.ts
@@ -4,6 +4,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   TnBannerComponent, TnCardComponent, TnCardFooterActionsDirective, TnIconButtonComponent,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { Role } from 'app/enums/role.enum';
@@ -51,6 +52,12 @@ export class SubsystemPortsCardComponent {
   protected readonly searchableElements = subsystemPortsCardElements;
 
   protected readonly requiredRoles = [Role.SharingNvmeTargetWrite];
+
+  // Pre-split with lodash kebabCase so digit-bearing values resolve identically
+  // through the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+  protected removePortTestId(port: NvmeOfPort): string[] {
+    return ['remove-port-association', kebabCase(port.addr_trtype), kebabCase(port.addr_traddr), kebabCase(String(port.addr_trsvcid))];
+  }
 
   protected onPortAdded(port: NvmeOfPort): void {
     this.nvmeOfService.associatePorts(this.subsystem(), [port])

--- a/src/app/pages/sharing/nvme-of/subsystems-list/subsystems-list.component.html
+++ b/src/app/pages/sharing/nvme-of/subsystems-list/subsystems-list.component.html
@@ -10,7 +10,7 @@
     </div>
   </ng-template>
 
-  @if (!(dataProvider()?.currentPageCount$ | async) && !(dataProvider().isLoading$ | async)) {
+  @if (!rows().length && !isProviderLoading()) {
     @if (searchQuery().length) {
       <tn-empty
         [title]="noSearchResults.title | translate"
@@ -29,7 +29,7 @@
     <tn-table
       class="table"
       [testId]="'table-table'"
-      [dataSource]="(dataProvider().currentPage$ | async) ?? []"
+      [dataSource]="rows()"
       [displayedColumns]="displayedColumns"
       [trackBy]="trackBySubsystemId"
       [loading]="isLoading()"
@@ -46,17 +46,32 @@
 
       <ng-container [tnColumnDef]="'namespaces'">
         <ng-template tnHeaderCellDef>{{ 'Namespaces' | translate }}</ng-template>
-        <ng-template let-row tnCellDef>{{ row.namespaces.length }}</ng-template>
+        <ng-template let-row tnCellDef>
+          <span
+            tnTestIdType="text"
+            [tnTestId]="[('Namespaces' | translate), uniqueRowTag(row), 'row-text']"
+          >{{ row.namespaces.length }}</span>
+        </ng-template>
       </ng-container>
 
       <ng-container [tnColumnDef]="'ports'">
         <ng-template tnHeaderCellDef>{{ 'Ports' | translate }}</ng-template>
-        <ng-template let-row tnCellDef>{{ row.ports.length }}</ng-template>
+        <ng-template let-row tnCellDef>
+          <span
+            tnTestIdType="text"
+            [tnTestId]="[('Ports' | translate), uniqueRowTag(row), 'row-text']"
+          >{{ row.ports.length }}</span>
+        </ng-template>
       </ng-container>
 
       <ng-container [tnColumnDef]="'hosts'">
         <ng-template tnHeaderCellDef>{{ 'Hosts' | translate }}</ng-template>
-        <ng-template let-row tnCellDef>{{ row.hosts.length }}</ng-template>
+        <ng-template let-row tnCellDef>
+          <span
+            tnTestIdType="text"
+            [tnTestId]="[('Hosts' | translate), uniqueRowTag(row), 'row-text']"
+          >{{ row.hosts.length }}</span>
+        </ng-template>
       </ng-container>
 
       <ng-container [tnColumnDef]="'actions'" [width]="'60px'">
@@ -69,7 +84,7 @@
               [ariaLabel]="('View Details' | translate) + ' ' + row.name"
               [ariaExpanded]="dataProvider().expandedRow === row"
               [tooltip]="'View Details' | translate"
-              [testId]="['nvmeof-subsys-' + row.name, 'mdi-chevron-right', 'row-action']"
+              [testId]="[uniqueRowTag(row), 'mdi-chevron-right', 'row-action']"
               (onClick)="$event.stopPropagation(); onRowClick(row)"
             ></tn-icon-button>
           </span>

--- a/src/app/pages/sharing/nvme-of/subsystems-list/subsystems-list.component.ts
+++ b/src/app/pages/sharing/nvme-of/subsystems-list/subsystems-list.component.ts
@@ -1,16 +1,18 @@
-import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, input, output, inject, signal } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   TnCardComponent, TnCardHeaderActionsDirective, TnCardHeaderDirective, TnCellDefDirective, TnEmptyComponent,
   TnHeaderCellDefDirective, TnIconButtonComponent, TnTableColumnDirective, TnTableComponent, TnTablePagerComponent,
+  TnTestIdDirective,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { noSearchResultsConfig } from 'app/constants/empty-configs';
 import { NvmeOfSubsystemDetails } from 'app/interfaces/nvme-of.interface';
 import { BasicSearchComponent } from 'app/modules/forms/search-input/components/basic-search/basic-search.component';
 import { searchDelayConst } from 'app/modules/global-search/constants/delay.const';
 import { UiSearchDirectivesService } from 'app/modules/global-search/services/ui-search-directives.service';
 import { ArrayDataProvider } from 'app/modules/ix-table/classes/array-data-provider/array-data-provider';
+import { convertStringToId, dataProviderLoading, dataProviderRows } from 'app/modules/ix-table/utils';
 import { SubSystemNameCellComponent } from 'app/pages/sharing/nvme-of/subsystems-list/subsystem-name-cell/subsystem-name-cell.component';
 
 @Component({
@@ -24,7 +26,6 @@ import { SubSystemNameCellComponent } from 'app/pages/sharing/nvme-of/subsystems
     TnCardHeaderActionsDirective,
     BasicSearchComponent,
     TranslateModule,
-    AsyncPipe,
     TnTableComponent,
     TnTableColumnDirective,
     TnHeaderCellDefDirective,
@@ -32,6 +33,7 @@ import { SubSystemNameCellComponent } from 'app/pages/sharing/nvme-of/subsystems
     TnIconButtonComponent,
     TnEmptyComponent,
     TnTablePagerComponent,
+    TnTestIdDirective,
     SubSystemNameCellComponent,
   ],
 })
@@ -43,6 +45,9 @@ export class SubsystemsListComponent {
   readonly toggleShowMobileDetails = output<boolean>();
   readonly subsystemSelected = output<NvmeOfSubsystemDetails>();
   readonly dataProvider = input.required<ArrayDataProvider<NvmeOfSubsystemDetails>>();
+
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isProviderLoading = dataProviderLoading(this.dataProvider);
   // eslint-disable-next-line @angular-eslint/no-output-native
   readonly search = output<string>();
 
@@ -53,6 +58,12 @@ export class SubsystemsListComponent {
   protected readonly displayedColumns = ['name', 'namespaces', 'ports', 'hosts', 'actions'];
 
   protected readonly trackBySubsystemId = (_: number, row: NvmeOfSubsystemDetails): number => row.id;
+
+  // Pre-split with lodash kebabCase so digit-bearing values resolve identically
+  // through the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+  protected uniqueRowTag(row: NvmeOfSubsystemDetails): string {
+    return kebabCase(convertStringToId('nvmeof-subsys-' + row.name));
+  }
 
   constructor() {
     setTimeout(() => this.handlePendingGlobalSearchElement(), searchDelayConst * 5);

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.html
@@ -39,8 +39,6 @@
 
             @if (entry.controls.ae_who.value === nfsAclTag.User) {
               <tn-form-field [label]="'User' | translate" [required]="true">
-                <!-- TODO(NAS-141021): [placeholder] doubles as the accessible-name fallback — tn-autocomplete
-                  has no [ariaLabel] input and tn-form-field does not associate its label yet. -->
                 <tn-autocomplete
                   formControlName="user"
                   [testId]="'user'"

--- a/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-acl/smb-acl.component.spec.ts
@@ -1,6 +1,7 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
+// TODO(NAS-141028): swap to TnButtonHarness once the shared ix-form's Save migrates to tn-button.
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { TnAutocompleteHarness, TnSelectHarness } from '@truenas/ui-components';

--- a/src/app/pages/sharing/smb/smb-form/smb-extensions-warning/smb-extensions-warning.component.spec.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-extensions-warning/smb-extensions-warning.component.spec.ts
@@ -26,11 +26,12 @@ describe('SmbExtensionsWarningComponent', () => {
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   });
 
-  it('shows the warning', () => {
+  it('shows the warning', async () => {
     expect(spectator.query('.warning-text')).toHaveText(
       'This parameter requires Apple SMB2/3 protocol extension support to be enabled in SMB service.',
     );
-    expect(spectator.query('[data-test="button-enable-apple-extensions"]')).toHaveText('Enable Now');
+
+    expect(await loader.hasHarness(TnButtonHarness.with({ label: 'Enable Now' }))).toBe(true);
   });
 
   it('updates SMB config when Enable Now is pressed', async () => {

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.html
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.html
@@ -17,7 +17,8 @@
     id="smb-form-toggle-advanced-options"
     type="button"
     tabindex="-1"
-    ixTest="toggle-advanced-options-anchor"
+    tnTestIdType="button"
+    [tnTestId]="'toggle-advanced-options-anchor'"
     (click)="openAdvancedMode()"
   ></button>
 

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.html
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.html
@@ -178,7 +178,6 @@
           <tn-chip-input
             testId="watch-list"
             formControlName="watch_list"
-            [ariaLabel]="'Watch List' | translate"
             [suggestions]="(groupSuggestions$ | async) ?? []"
             [allowCustomValue]="true"
             (searchChange)="onGroupSearch($event)"
@@ -192,7 +191,6 @@
           <tn-chip-input
             testId="ignore-list"
             formControlName="ignore_list"
-            [ariaLabel]="'Ignore List' | translate"
             [suggestions]="(groupSuggestions$ | async) ?? []"
             [allowCustomValue]="true"
             (searchChange)="onGroupSearch($event)"

--- a/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
+++ b/src/app/pages/sharing/smb/smb-form/smb-form.component.ts
@@ -27,6 +27,7 @@ import {
   TnFormSectionComponent,
   TnInputComponent,
   TnSelectComponent,
+  TnTestIdDirective,
 } from '@truenas/ui-components';
 import {
   BehaviorSubject, endWith, Observable, of,
@@ -69,7 +70,6 @@ import { UserGroupExistenceValidationService } from 'app/modules/forms/ix-forms/
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { SidePanelFooterAction } from 'app/modules/slide-ins/form-side-panel/form-side-panel-container.component';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
-import { TestDirective } from 'app/modules/test-id/test.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { RestartSmbDialog } from 'app/pages/sharing/smb/smb-form/restart-smb-dialog/restart-smb-dialog.component';
 import { SmbExtensionsWarningComponent } from 'app/pages/sharing/smb/smb-form/smb-extensions-warning/smb-extensions-warning.component';
@@ -103,7 +103,7 @@ import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors'
     ExplorerCreateDatasetComponent,
     IxInputComponent,
     IxErrorsComponent,
-    TestDirective,
+    TnTestIdDirective,
     TranslateModule,
     AsyncPipe,
     WarningComponent,

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.html
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.html
@@ -2,8 +2,8 @@
   <div tnCardHeader class="header-title">
     <h3 class="tn-card__title">{{ 'SMB' | translate }}</h3>
     <ix-service-state-button
-      [service]="service$ | async"
-      [count]="+(dataProvider.currentPageCount$ | async)"
+      [service]="service()"
+      [count]="currentPageCount() ?? 0"
     ></ix-service-state-button>
   </div>
 
@@ -42,7 +42,7 @@
     </div>
   </ng-template>
 
-  @if ((dataProvider.emptyType$ | async) === EmptyType.NoPageData && !(dataProvider.currentPageCount$ | async)) {
+  @if (emptyType() === EmptyType.NoPageData && !currentPageCount()) {
     <tn-empty
       icon="smb-share"
       iconLibrary="custom"
@@ -50,15 +50,15 @@
       [title]="'Well supported by all major operating systems, allows for easy authentication and authorization. Choose SMB for easy file sharing across mixed operating systems, especially in home or office networks.' | translate"
     ></tn-empty>
   } @else {
-    @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+    @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
     <tn-table
       class="table"
       [testId]="'table-table'"
       [ixUiSearch]="searchableElements.elements.smbList"
-      [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+      [dataSource]="rows()"
       [displayedColumns]="displayedColumns()"
       [trackBy]="trackBySmbId"
-      [loading]="!!(dataProvider.isLoading$ | async)"
+      [loading]="isLoading()"
       [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
       [emptyIcon]="emptyConf?.icon ?? ''"
       (sortChange)="onSortChange($event)"
@@ -67,7 +67,8 @@
         <ng-template tnHeaderCellDef>{{ 'Name' | translate }}</ng-template>
         <ng-template let-row tnCellDef>
           <span
-            [ixTest]="[('Name' | translate), uniqueRowTag(row), 'row-text']"
+            tnTestIdType="text"
+            [tnTestId]="[('Name' | translate), uniqueRowTag(row), 'row-text']"
             [tnTooltip]="row.name || ''"
           >{{ row.name }}</span>
         </ng-template>
@@ -78,7 +79,8 @@
         <ng-template let-row tnCellDef>
           @let path = getPathValue(row);
           <span
-            [ixTest]="[('Path' | translate), uniqueRowTag(row), 'row-text']"
+            tnTestIdType="text"
+            [tnTestId]="[('Path' | translate), uniqueRowTag(row), 'row-text']"
             [tnTooltip]="path || ''"
           >{{ path }}</span>
         </ng-template>
@@ -88,7 +90,8 @@
         <ng-template tnHeaderCellDef>{{ 'Description' | translate }}</ng-template>
         <ng-template let-row tnCellDef>
           <span
-            [ixTest]="[('Description' | translate), uniqueRowTag(row), 'row-text']"
+            tnTestIdType="text"
+            [tnTestId]="[('Description' | translate), uniqueRowTag(row), 'row-text']"
             [tnTooltip]="row.comment || ''"
           >{{ row.comment }}</span>
         </ng-template>
@@ -114,7 +117,8 @@
         <ng-template tnHeaderCellDef>{{ 'Audit Logging' | translate }}</ng-template>
         <ng-template let-row tnCellDef>
           <span
-            [ixTest]="[('Audit Logging' | translate), uniqueRowTag(row), 'row-yesno']"
+            tnTestIdType="text"
+            [tnTestId]="[('Audit Logging' | translate), uniqueRowTag(row), 'row-yesno']"
           >{{ !!row.audit?.enable | yesNo | translate }}</span>
         </ng-template>
       </ng-container>

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.scss
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.scss
@@ -1,3 +1,7 @@
+@import '../../components/tn-table-in-card';
+
+@include tn-table-in-card;
+
 :host {
   display: block;
   max-width: 1080px;
@@ -15,14 +19,6 @@
   }
 }
 
-// The library defaults tn-card to height: 100%, which suits the equal-height
-// dashboard grid but makes this full-page list card fill the viewport. Let it
-// grow to content instead.
-tn-card {
-  display: block;
-  height: auto;
-}
-
 .header-title {
   align-items: center;
   display: flex;
@@ -35,22 +31,4 @@ tn-card {
   flex-wrap: wrap;
   gap: 8px;
   justify-content: flex-end;
-}
-
-// TEMP: tn-table-pager hardcodes a bordered, boxed footer on its host with no
-// input to disable it. Drop the box and keep just a top divider. Remove once
-// the library exposes the option.
-tn-table-pager {
-  background-color: transparent;
-  border: none;
-  border-top: 1px solid var(--tn-lines);
-}
-
-// TEMP: tn-table rounds all four corners via the internal .tn-table__table
-// border-radius, which rounds the header's top corners. Square them so the
-// table sits flush inside the card. Remove once the library exposes control
-// over the table's corner radius.
-:host ::ng-deep tn-table .tn-table__table {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
 }

--- a/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-list/smb-list.component.ts
@@ -1,8 +1,7 @@
-import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, computed, inject, signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
@@ -32,11 +31,12 @@ import { toggleColumn } from 'app/modules/ix-table/components/ix-table-body/cell
 import { yesNoColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-yes-no/ix-cell-yes-no.component';
 import { TableColumnPickerComponent } from 'app/modules/ix-table/components/table-column-picker/table-column-picker.component';
 import { SortDirection } from 'app/modules/ix-table/enums/sort-direction.enum';
-import { convertStringToId, createTable, mapTnSortToTableSort, toDisplayedColumns } from 'app/modules/ix-table/utils';
+import {
+  convertStringToId, createTable, dataProviderLoading, dataProviderRows, mapTnSortToTableSort, toDisplayedColumns,
+} from 'app/modules/ix-table/utils';
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { YesNoPipe } from 'app/modules/pipes/yes-no/yes-no.pipe';
 import { FormSidePanelService } from 'app/modules/slide-ins/form-side-panel/form-side-panel.service';
-import { TestDirective } from 'app/modules/test-id/test.directive';
 import { TableActionsCellComponent } from 'app/modules/tn-table-cells/actions-cell/table-actions-cell.component';
 import { TableToggleCellComponent } from 'app/modules/tn-table-cells/toggle-cell/table-toggle-cell.component';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -69,7 +69,6 @@ import { selectService } from 'app/store/services/services.selectors';
     TnButtonComponent,
     TnTestIdDirective,
     RouterLink,
-    TestDirective,
     UiSearchDirective,
     TnEmptyComponent,
     TnTableComponent,
@@ -82,7 +81,6 @@ import { selectService } from 'app/store/services/services.selectors';
     TnTablePagerComponent,
     TnTooltipDirective,
     TranslateModule,
-    AsyncPipe,
     YesNoPipe,
   ],
 })
@@ -105,12 +103,23 @@ export class SmbListComponent implements OnInit {
   protected readonly searchableElements = smbListElements;
   protected readonly EmptyType = EmptyType;
 
-  service$ = this.store$.select(selectService(ServiceName.Cifs));
+  private readonly service$ = this.store$.select(selectService(ServiceName.Cifs));
+  protected readonly service = toSignal(this.service$);
 
-  searchQuery = signal('');
-  dataProvider: AsyncDataProvider<SmbShare>;
+  protected searchQuery = signal('');
 
-  smbShares: SmbShare[] = [];
+  private readonly shares$ = this.api.call('sharing.smb.query').pipe(
+    tap((shares) => this.smbShares = shares),
+    takeUntilDestroyed(this.destroyRef),
+  );
+
+  protected dataProvider = new AsyncDataProvider<SmbShare>(this.shares$);
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(this.dataProvider.emptyType$);
+  protected readonly currentPageCount = toSignal(this.dataProvider.currentPageCount$);
+
+  private smbShares: SmbShare[] = [];
   /** null = pools not yet loaded; string[] once pool.query completes */
   private activePoolPaths = signal<string[] | null>(null);
 
@@ -230,11 +239,6 @@ export class SmbListComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    const shares$ = this.api.call('sharing.smb.query').pipe(
-      tap((shares) => this.smbShares = shares),
-      takeUntilDestroyed(this.destroyRef),
-    );
-    this.dataProvider = new AsyncDataProvider<SmbShare>(shares$);
     this.setDefaultSort();
     this.dataProvider.emptyType$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.onListFiltered(this.searchQuery());

--- a/src/app/pages/sharing/smb/smb-status/components/smb-lock-list/smb-lock-list.component.html
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-lock-list/smb-lock-list.component.html
@@ -20,15 +20,15 @@
     </div>
   </ng-template>
 
-  @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+  @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
   <tn-table
     class="table"
     [testId]="'table-table'"
     [expandable]="true"
-    [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+    [dataSource]="rows()"
     [displayedColumns]="displayedColumns()"
     [trackBy]="trackByLock"
-    [loading]="!!(dataProvider.isLoading$ | async)"
+    [loading]="isLoading()"
     [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
     [emptyIcon]="emptyConf?.icon ?? ''"
     (sortChange)="onSortChange($event)"
@@ -36,35 +36,35 @@
     <ng-container [tnColumnDef]="'service_path'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Path' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Path' | translate), uniqueRowTag(row), 'row-text']">{{ row.service_path }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Path' | translate), uniqueRowTag(row), 'row-text']">{{ row.service_path }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'filename'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Filename' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Filename' | translate), uniqueRowTag(row), 'row-text']">{{ row.filename }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Filename' | translate), uniqueRowTag(row), 'row-text']">{{ row.filename }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'fileid'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'File ID' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('File ID' | translate), uniqueRowTag(row), 'row-text']">{{ getFileId(row) }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('File ID' | translate), uniqueRowTag(row), 'row-text']">{{ getFileId(row) }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'opens'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Open Files' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Open Files' | translate), uniqueRowTag(row), 'row-text']">{{ getOpenFilesLabel(row) }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Open Files' | translate), uniqueRowTag(row), 'row-text']">{{ getOpenFilesLabel(row) }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'num_pending_deletes'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Num Pending Deletes' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Num Pending Deletes' | translate), uniqueRowTag(row), 'row-text']">
+        <span tnTestIdType="text" [tnTestId]="[('Num Pending Deletes' | translate), uniqueRowTag(row), 'row-text']">
           {{ row.num_pending_deletes }}
         </span>
       </ng-template>

--- a/src/app/pages/sharing/smb/smb-status/components/smb-lock-list/smb-lock-list.component.scss
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-lock-list/smb-lock-list.component.scss
@@ -1,7 +1,6 @@
-tn-card {
-  display: block;
-  height: auto;
-}
+@import '../../../../components/tn-table-in-card';
+
+@include tn-table-in-card;
 
 .actions {
   align-items: center;
@@ -9,17 +8,4 @@ tn-card {
   flex-wrap: wrap;
   gap: 8px;
   justify-content: flex-end;
-}
-
-// TEMP: tn-table-pager hardcodes a bordered boxed footer; drop the box, keep a top divider.
-tn-table-pager {
-  background-color: transparent;
-  border: none;
-  border-top: 1px solid var(--tn-lines);
-}
-
-// TEMP: square the table header's top corners (tn-table rounds all corners).
-:host ::ng-deep tn-table .tn-table__table {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
 }

--- a/src/app/pages/sharing/smb/smb-status/components/smb-lock-list/smb-lock-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-lock-list/smb-lock-list.component.ts
@@ -1,14 +1,15 @@
-import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, computed, inject, signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
   TnButtonComponent, TnCardComponent, TnCardHeaderActionsDirective, TnCardHeaderDirective, TnCellDefDirective,
   TnDetailRowDefDirective, TnHeaderCellDefDirective, TnTableColumnDirective, TnTableComponent, TnTablePagerComponent,
+  TnTestIdDirective,
   type TnSortEvent,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { tap } from 'rxjs';
 import { SmbInfoLevel } from 'app/enums/smb-info-level.enum';
 import { SmbLockInfo, SmbOpenInfo } from 'app/interfaces/smb-status.interface';
@@ -17,8 +18,9 @@ import { BasicSearchComponent } from 'app/modules/forms/search-input/components/
 import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provider/async-data-provider';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { TableColumnPickerComponent } from 'app/modules/ix-table/components/table-column-picker/table-column-picker.component';
-import { convertStringToId, createTable, mapTnSortToTableSort, toDisplayedColumns } from 'app/modules/ix-table/utils';
-import { TestDirective } from 'app/modules/test-id/test.directive';
+import {
+  convertStringToId, createTable, dataProviderLoading, dataProviderRows, mapTnSortToTableSort, toDisplayedColumns,
+} from 'app/modules/ix-table/utils';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { SmbOpenFilesComponent } from 'app/pages/sharing/smb/smb-status/components/smb-open-files/smb-open-files.component';
 
@@ -34,7 +36,7 @@ import { SmbOpenFilesComponent } from 'app/pages/sharing/smb/smb-status/componen
     BasicSearchComponent,
     TableColumnPickerComponent,
     TnButtonComponent,
-    TestDirective,
+    TnTestIdDirective,
     TnTableComponent,
     TnTableColumnDirective,
     TnHeaderCellDefDirective,
@@ -43,7 +45,6 @@ import { SmbOpenFilesComponent } from 'app/pages/sharing/smb/smb-status/componen
     SmbOpenFilesComponent,
     TnTablePagerComponent,
     TranslateModule,
-    AsyncPipe,
   ],
 })
 export class SmbLockListComponent implements OnInit {
@@ -54,7 +55,20 @@ export class SmbLockListComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   searchQuery = signal('');
-  dataProvider: AsyncDataProvider<SmbLockInfo>;
+  private readonly smbStatus$ = this.api.call('smb.status', [SmbInfoLevel.Locks]).pipe(
+    tap((locks: SmbLockInfo[]) => {
+      this.locks = locks;
+      if (this.searchQuery()) {
+        this.onListFiltered(this.searchQuery());
+      }
+    }),
+    takeUntilDestroyed(this.destroyRef),
+  );
+
+  dataProvider = new AsyncDataProvider<SmbLockInfo>(this.smbStatus$);
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(this.dataProvider.emptyType$);
   locks: SmbLockInfo[] = [];
   files: SmbOpenInfo[] = [];
 
@@ -91,17 +105,6 @@ export class SmbLockListComponent implements OnInit {
   };
 
   ngOnInit(): void {
-    const smbStatus$ = this.api.call('smb.status', [SmbInfoLevel.Locks]).pipe(
-      tap((locks: SmbLockInfo[]) => {
-        this.locks = locks;
-        if (this.searchQuery()) {
-          this.onListFiltered(this.searchQuery());
-        }
-      }),
-      takeUntilDestroyed(this.destroyRef),
-    );
-
-    this.dataProvider = new AsyncDataProvider(smbStatus$);
     this.loadData();
     this.dataProvider.emptyType$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.onListFiltered(this.searchQuery());
@@ -129,7 +132,9 @@ export class SmbLockListComponent implements OnInit {
   }
 
   protected uniqueRowTag(row: SmbLockInfo): string {
-    return convertStringToId(`smb-lock-${row.filename}-${row.fileid.devid}-${row.fileid.extid}`);
+    // Pre-split with lodash kebabCase so digit-bearing values resolve identically through
+    // the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+    return kebabCase(convertStringToId(`smb-lock-${row.filename}-${row.fileid.devid}-${row.fileid.extid}`));
   }
 
   protected onColumnsChange(columns: ReturnType<typeof this.columns>): void {

--- a/src/app/pages/sharing/smb/smb-status/components/smb-notification-list/smb-notification-list.component.html
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-notification-list/smb-notification-list.component.html
@@ -20,14 +20,14 @@
     </div>
   </ng-template>
 
-  @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+  @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
   <tn-table
     class="table"
     [testId]="'table-table'"
-    [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+    [dataSource]="rows()"
     [displayedColumns]="displayedColumns()"
     [trackBy]="trackByNotification"
-    [loading]="!!(dataProvider.isLoading$ | async)"
+    [loading]="isLoading()"
     [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
     [emptyIcon]="emptyConf?.icon ?? ''"
     (sortChange)="onSortChange($event)"
@@ -35,28 +35,28 @@
     <ng-container [tnColumnDef]="'path'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Path' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Path' | translate), uniqueRowTag(row), 'row-text']">{{ row.path }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Path' | translate), uniqueRowTag(row), 'row-text']">{{ row.path }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'filter'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Filter' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Filter' | translate), uniqueRowTag(row), 'row-text']">{{ row.filter }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Filter' | translate), uniqueRowTag(row), 'row-text']">{{ row.filter }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'subdir_filter'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Subdir Filter' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Subdir Filter' | translate), uniqueRowTag(row), 'row-text']">{{ row.subdir_filter }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Subdir Filter' | translate), uniqueRowTag(row), 'row-text']">{{ row.subdir_filter }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'creation_time'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Creation Time' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Creation Time' | translate), uniqueRowTag(row), 'row-text']">{{ row.creation_time }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Creation Time' | translate), uniqueRowTag(row), 'row-text']">{{ row.creation_time }}</span>
       </ng-template>
     </ng-container>
   </tn-table>

--- a/src/app/pages/sharing/smb/smb-status/components/smb-notification-list/smb-notification-list.component.scss
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-notification-list/smb-notification-list.component.scss
@@ -1,7 +1,6 @@
-tn-card {
-  display: block;
-  height: auto;
-}
+@import '../../../../components/tn-table-in-card';
+
+@include tn-table-in-card;
 
 .actions {
   align-items: center;
@@ -9,17 +8,4 @@ tn-card {
   flex-wrap: wrap;
   gap: 8px;
   justify-content: flex-end;
-}
-
-// TEMP: tn-table-pager hardcodes a bordered boxed footer; drop the box, keep a top divider.
-tn-table-pager {
-  background-color: transparent;
-  border: none;
-  border-top: 1px solid var(--tn-lines);
-}
-
-// TEMP: square the table header's top corners (tn-table rounds all corners).
-:host ::ng-deep tn-table .tn-table__table {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
 }

--- a/src/app/pages/sharing/smb/smb-status/components/smb-notification-list/smb-notification-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-notification-list/smb-notification-list.component.ts
@@ -1,13 +1,14 @@
-import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, computed, inject, signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
   TnButtonComponent, TnCardComponent, TnCardHeaderActionsDirective, TnCardHeaderDirective, TnCellDefDirective,
-  TnHeaderCellDefDirective, TnTableColumnDirective, TnTableComponent, TnTablePagerComponent, type TnSortEvent,
+  TnHeaderCellDefDirective, TnTableColumnDirective, TnTableComponent, TnTablePagerComponent, TnTestIdDirective,
+  type TnSortEvent,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { tap } from 'rxjs';
 import { SmbInfoLevel } from 'app/enums/smb-info-level.enum';
 import { SmbNotificationInfo } from 'app/interfaces/smb-status.interface';
@@ -16,8 +17,9 @@ import { BasicSearchComponent } from 'app/modules/forms/search-input/components/
 import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provider/async-data-provider';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { TableColumnPickerComponent } from 'app/modules/ix-table/components/table-column-picker/table-column-picker.component';
-import { convertStringToId, createTable, mapTnSortToTableSort, toDisplayedColumns } from 'app/modules/ix-table/utils';
-import { TestDirective } from 'app/modules/test-id/test.directive';
+import {
+  convertStringToId, createTable, dataProviderLoading, dataProviderRows, mapTnSortToTableSort, toDisplayedColumns,
+} from 'app/modules/ix-table/utils';
 import { ApiService } from 'app/modules/websocket/api.service';
 
 @Component({
@@ -32,14 +34,13 @@ import { ApiService } from 'app/modules/websocket/api.service';
     BasicSearchComponent,
     TableColumnPickerComponent,
     TnButtonComponent,
-    TestDirective,
+    TnTestIdDirective,
     TnTableComponent,
     TnTableColumnDirective,
     TnHeaderCellDefDirective,
     TnCellDefDirective,
     TnTablePagerComponent,
     TranslateModule,
-    AsyncPipe,
   ],
 })
 export class SmbNotificationListComponent implements OnInit {
@@ -50,7 +51,20 @@ export class SmbNotificationListComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   searchQuery = signal('');
-  dataProvider: AsyncDataProvider<SmbNotificationInfo>;
+  private readonly smbStatus$ = this.api.call('smb.status', [SmbInfoLevel.Notifications]).pipe(
+    tap((shares: SmbNotificationInfo[]) => {
+      this.notifications = shares;
+      if (this.searchQuery()) {
+        this.onListFiltered(this.searchQuery());
+      }
+    }),
+    takeUntilDestroyed(this.destroyRef),
+  );
+
+  dataProvider = new AsyncDataProvider<SmbNotificationInfo>(this.smbStatus$);
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(this.dataProvider.emptyType$);
   notifications: SmbNotificationInfo[] = [];
 
   protected readonly columns = signal(createTable<SmbNotificationInfo>([
@@ -70,17 +84,6 @@ export class SmbNotificationListComponent implements OnInit {
   };
 
   ngOnInit(): void {
-    const smbStatus$ = this.api.call('smb.status', [SmbInfoLevel.Notifications]).pipe(
-      tap((shares: SmbNotificationInfo[]) => {
-        this.notifications = shares;
-        if (this.searchQuery()) {
-          this.onListFiltered(this.searchQuery());
-        }
-      }),
-      takeUntilDestroyed(this.destroyRef),
-    );
-
-    this.dataProvider = new AsyncDataProvider<SmbNotificationInfo>(smbStatus$);
     this.loadData();
     this.dataProvider.emptyType$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.onListFiltered(this.searchQuery());
@@ -100,7 +103,9 @@ export class SmbNotificationListComponent implements OnInit {
   }
 
   protected uniqueRowTag(row: SmbNotificationInfo): string {
-    return convertStringToId('smb-notification-' + row.creation_time + '-' + row.server_id.unique_id);
+    // Pre-split with lodash kebabCase so digit-bearing values resolve identically through
+    // the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+    return kebabCase(convertStringToId('smb-notification-' + row.creation_time + '-' + row.server_id.unique_id));
   }
 
   protected onColumnsChange(columns: ReturnType<typeof this.columns>): void {

--- a/src/app/pages/sharing/smb/smb-status/components/smb-open-files/smb-open-files.component.html
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-open-files/smb-open-files.component.html
@@ -1,37 +1,37 @@
 <tn-card [padContent]="false">
   <h3 tnCardHeader class="tn-card__title">{{ 'Open Files' | translate }}</h3>
 
-  @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+  @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
   <tn-table
     class="table"
     [testId]="'table-table'"
-    [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+    [dataSource]="rows()"
     [displayedColumns]="displayedColumns()"
     [trackBy]="trackByOpenFile"
-    [loading]="!!(dataProvider.isLoading$ | async)"
+    [loading]="isLoading()"
     [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
     [emptyIcon]="emptyConf?.icon ?? ''"
   >
     <ng-container [tnColumnDef]="'server_id'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Server' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Server' | translate), uniqueRowTag(row), 'row-text']">{{ formatServer(row) }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Server' | translate), uniqueRowTag(row), 'row-text']">{{ formatServer(row) }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'uid'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Username' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Username' | translate), uniqueRowTag(row), 'row-text']">{{ formatUsername(row) }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Username' | translate), uniqueRowTag(row), 'row-text']">{{ formatUsername(row) }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'opened_at'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Opened at' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Opened at' | translate), uniqueRowTag(row), 'row-text']">{{ row.opened_at }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Opened at' | translate), uniqueRowTag(row), 'row-text']">{{ row.opened_at }}</span>
       </ng-template>
     </ng-container>
   </tn-table>
-  <tn-table-pager [dataProvider]="dataProvider"></tn-table-pager>
+  <tn-table-pager [dataProvider]="dataProvider()"></tn-table-pager>
 </tn-card>

--- a/src/app/pages/sharing/smb/smb-status/components/smb-open-files/smb-open-files.component.scss
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-open-files/smb-open-files.component.scss
@@ -1,3 +1,7 @@
+@import '../../../../components/tn-table-in-card';
+
+@include tn-table-in-card;
+
 .open-files-list {
   list-style: none;
   padding-left: 0;
@@ -7,22 +11,4 @@
     margin-top: 8px;
     padding-top: 8px;
   }
-}
-
-tn-card {
-  display: block;
-  height: auto;
-}
-
-// TEMP: tn-table-pager hardcodes a bordered boxed footer; drop the box, keep a top divider.
-tn-table-pager {
-  background-color: transparent;
-  border: none;
-  border-top: 1px solid var(--tn-lines);
-}
-
-// TEMP: square the table header's top corners (tn-table rounds all corners).
-:host ::ng-deep tn-table .tn-table__table {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
 }

--- a/src/app/pages/sharing/smb/smb-status/components/smb-open-files/smb-open-files.component.ts
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-open-files/smb-open-files.component.ts
@@ -1,20 +1,23 @@
-import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, Component, computed, input, OnChanges, inject, signal,
 } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
   TnCardComponent, TnCardHeaderDirective, TnCellDefDirective, TnHeaderCellDefDirective, TnTableColumnDirective,
   TnTableComponent, TnTablePagerComponent,
+  TnTestIdDirective,
 } from '@truenas/ui-components';
-import { of } from 'rxjs';
+import { kebabCase } from 'lodash-es';
+import { of, switchMap } from 'rxjs';
 import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
 import { SmbLockInfo, SmbOpenInfo } from 'app/interfaces/smb-status.interface';
 import { EmptyService } from 'app/modules/empty/empty.service';
 import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provider/async-data-provider';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
-import { convertStringToId, createTable, toDisplayedColumns } from 'app/modules/ix-table/utils';
-import { TestDirective } from 'app/modules/test-id/test.directive';
+import {
+  convertStringToId, createTable, dataProviderLoading, dataProviderRows, toDisplayedColumns,
+} from 'app/modules/ix-table/utils';
 
 @Component({
   selector: 'ix-smb-open-files',
@@ -24,14 +27,13 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
   imports: [
     TnCardComponent,
     TnCardHeaderDirective,
-    TestDirective,
+    TnTestIdDirective,
     TnTableComponent,
     TnTableColumnDirective,
     TnHeaderCellDefDirective,
     TnCellDefDirective,
     TnTablePagerComponent,
     TranslateModule,
-    AsyncPipe,
   ],
 })
 export class SmbOpenFilesComponent implements OnChanges {
@@ -43,7 +45,15 @@ export class SmbOpenFilesComponent implements OnChanges {
     return Object.values(this.lock()?.opens || []);
   });
 
-  dataProvider: AsyncDataProvider<SmbOpenInfo>;
+  // The provider is rebuilt whenever the lock input changes, so it is held in a
+  // signal and adapted via the Signal<provider> helper overload (see target-list).
+  dataProvider = signal(new AsyncDataProvider<SmbOpenInfo>(of([] as SmbOpenInfo[])));
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(
+    toObservable(this.dataProvider).pipe(switchMap((provider) => provider.emptyType$)),
+  );
+
   protected readonly columns = signal(createTable<SmbOpenInfo>([
     textColumn({
       title: this.translate.instant('Server'),
@@ -80,12 +90,15 @@ export class SmbOpenFilesComponent implements OnChanges {
   }
 
   protected uniqueRowTag(row: SmbOpenInfo): string {
-    return convertStringToId(`smb-open-file-${row.username}-${row.uid}`);
+    // Pre-split with lodash kebabCase so digit-bearing values resolve identically through
+    // the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+    return kebabCase(convertStringToId(`smb-open-file-${row.username}-${row.uid}`));
   }
 
   private createProvider(): void {
-    this.dataProvider = new AsyncDataProvider(of(this.files()));
-    this.dataProvider.load();
+    const provider = new AsyncDataProvider(of(this.files()));
+    this.dataProvider.set(provider);
+    provider.load();
   }
 
   ngOnChanges(changes: IxSimpleChanges<this>): void {

--- a/src/app/pages/sharing/smb/smb-status/components/smb-session-list/smb-session-list.component.html
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-session-list/smb-session-list.component.html
@@ -20,14 +20,14 @@
     </div>
   </ng-template>
 
-  @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+  @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
   <tn-table
     class="table"
     [testId]="'table-table'"
-    [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+    [dataSource]="rows()"
     [displayedColumns]="displayedColumns()"
     [trackBy]="trackBySession"
-    [loading]="!!(dataProvider.isLoading$ | async)"
+    [loading]="isLoading()"
     [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
     [emptyIcon]="emptyConf?.icon ?? ''"
     (sortChange)="onSortChange($event)"
@@ -35,70 +35,70 @@
     <ng-container [tnColumnDef]="'session_id'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Session ID' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Session ID' | translate), uniqueRowTag(row), 'row-text']">{{ row.session_id }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Session ID' | translate), uniqueRowTag(row), 'row-text']">{{ row.session_id }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'hostname'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Hostname' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Hostname' | translate), uniqueRowTag(row), 'row-text']">{{ row.hostname }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Hostname' | translate), uniqueRowTag(row), 'row-text']">{{ row.hostname }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'remote_machine'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Remote machine' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Remote machine' | translate), uniqueRowTag(row), 'row-text']">{{ row.remote_machine }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Remote machine' | translate), uniqueRowTag(row), 'row-text']">{{ row.remote_machine }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'username'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Username' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Username' | translate), uniqueRowTag(row), 'row-text']">{{ row.username }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Username' | translate), uniqueRowTag(row), 'row-text']">{{ row.username }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'groupname'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Groupname' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Groupname' | translate), uniqueRowTag(row), 'row-text']">{{ row.groupname }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Groupname' | translate), uniqueRowTag(row), 'row-text']">{{ row.groupname }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'uid'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'UID' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('UID' | translate), uniqueRowTag(row), 'row-text']">{{ row.uid }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('UID' | translate), uniqueRowTag(row), 'row-text']">{{ row.uid }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'gid'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'GID' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('GID' | translate), uniqueRowTag(row), 'row-text']">{{ row.gid }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('GID' | translate), uniqueRowTag(row), 'row-text']">{{ row.gid }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'session_dialect'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Session dialect' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Session dialect' | translate), uniqueRowTag(row), 'row-text']">{{ row.session_dialect }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Session dialect' | translate), uniqueRowTag(row), 'row-text']">{{ row.session_dialect }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'encryption'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Encryption' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Encryption' | translate), uniqueRowTag(row), 'row-text']">{{ row.encryption.cipher }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Encryption' | translate), uniqueRowTag(row), 'row-text']">{{ row.encryption.cipher }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'signing'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Signing' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Signing' | translate), uniqueRowTag(row), 'row-text']">{{ row.signing.cipher }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Signing' | translate), uniqueRowTag(row), 'row-text']">{{ row.signing.cipher }}</span>
       </ng-template>
     </ng-container>
   </tn-table>

--- a/src/app/pages/sharing/smb/smb-status/components/smb-session-list/smb-session-list.component.scss
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-session-list/smb-session-list.component.scss
@@ -1,7 +1,6 @@
-tn-card {
-  display: block;
-  height: auto;
-}
+@import '../../../../components/tn-table-in-card';
+
+@include tn-table-in-card;
 
 .actions {
   align-items: center;
@@ -9,17 +8,4 @@ tn-card {
   flex-wrap: wrap;
   gap: 8px;
   justify-content: flex-end;
-}
-
-// TEMP: tn-table-pager hardcodes a bordered boxed footer; drop the box, keep a top divider.
-tn-table-pager {
-  background-color: transparent;
-  border: none;
-  border-top: 1px solid var(--tn-lines);
-}
-
-// TEMP: square the table header's top corners (tn-table rounds all corners).
-:host ::ng-deep tn-table .tn-table__table {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
 }

--- a/src/app/pages/sharing/smb/smb-status/components/smb-session-list/smb-session-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-session-list/smb-session-list.component.ts
@@ -1,13 +1,14 @@
-import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, computed, inject, signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
   TnButtonComponent, TnCardComponent, TnCardHeaderActionsDirective, TnCardHeaderDirective, TnCellDefDirective,
-  TnHeaderCellDefDirective, TnTableColumnDirective, TnTableComponent, TnTablePagerComponent, type TnSortEvent,
+  TnHeaderCellDefDirective, TnTableColumnDirective, TnTableComponent, TnTablePagerComponent, TnTestIdDirective,
+  type TnSortEvent,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { tap } from 'rxjs';
 import { SmbInfoLevel } from 'app/enums/smb-info-level.enum';
 import { SmbSession } from 'app/interfaces/smb-status.interface';
@@ -16,8 +17,9 @@ import { BasicSearchComponent } from 'app/modules/forms/search-input/components/
 import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provider/async-data-provider';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { TableColumnPickerComponent } from 'app/modules/ix-table/components/table-column-picker/table-column-picker.component';
-import { convertStringToId, createTable, mapTnSortToTableSort, toDisplayedColumns } from 'app/modules/ix-table/utils';
-import { TestDirective } from 'app/modules/test-id/test.directive';
+import {
+  convertStringToId, createTable, dataProviderLoading, dataProviderRows, mapTnSortToTableSort, toDisplayedColumns,
+} from 'app/modules/ix-table/utils';
 import { ApiService } from 'app/modules/websocket/api.service';
 
 @Component({
@@ -32,14 +34,13 @@ import { ApiService } from 'app/modules/websocket/api.service';
     BasicSearchComponent,
     TableColumnPickerComponent,
     TnButtonComponent,
-    TestDirective,
+    TnTestIdDirective,
     TnTableComponent,
     TnTableColumnDirective,
     TnHeaderCellDefDirective,
     TnCellDefDirective,
     TnTablePagerComponent,
     TranslateModule,
-    AsyncPipe,
   ],
 })
 export class SmbSessionListComponent implements OnInit {
@@ -50,7 +51,20 @@ export class SmbSessionListComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   searchQuery = signal('');
-  dataProvider: AsyncDataProvider<SmbSession>;
+  private readonly smbStatus$ = this.api.call('smb.status', [SmbInfoLevel.Sessions]).pipe(
+    tap((sessions: SmbSession[]) => {
+      this.sessions = sessions;
+      if (this.searchQuery()) {
+        this.onListFiltered(this.searchQuery());
+      }
+    }),
+    takeUntilDestroyed(this.destroyRef),
+  );
+
+  dataProvider = new AsyncDataProvider<SmbSession>(this.smbStatus$);
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(this.dataProvider.emptyType$);
   sessions: SmbSession[] = [];
 
   protected readonly columns = signal(createTable<SmbSession>([
@@ -82,17 +96,6 @@ export class SmbSessionListComponent implements OnInit {
   protected readonly trackBySession = (_index: number, row: SmbSession): string => row.session_id;
 
   ngOnInit(): void {
-    const smbStatus$ = this.api.call('smb.status', [SmbInfoLevel.Sessions]).pipe(
-      tap((sessions: SmbSession[]) => {
-        this.sessions = sessions;
-        if (this.searchQuery()) {
-          this.onListFiltered(this.searchQuery());
-        }
-      }),
-      takeUntilDestroyed(this.destroyRef),
-    );
-
-    this.dataProvider = new AsyncDataProvider<SmbSession>(smbStatus$);
     this.loadData();
     this.dataProvider.emptyType$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.onListFiltered(this.searchQuery());
@@ -112,7 +115,9 @@ export class SmbSessionListComponent implements OnInit {
   }
 
   protected uniqueRowTag(row: SmbSession): string {
-    return convertStringToId('smb-session-' + row.session_id);
+    // Pre-split with lodash kebabCase so digit-bearing values resolve identically through
+    // the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+    return kebabCase(convertStringToId('smb-session-' + row.session_id));
   }
 
   protected onColumnsChange(columns: ReturnType<typeof this.columns>): void {

--- a/src/app/pages/sharing/smb/smb-status/components/smb-share-list/smb-share-list.component.html
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-share-list/smb-share-list.component.html
@@ -20,14 +20,14 @@
     </div>
   </ng-template>
 
-  @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+  @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
   <tn-table
     class="table"
     [testId]="'table-table'"
-    [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+    [dataSource]="rows()"
     [displayedColumns]="displayedColumns()"
     [trackBy]="trackByShare"
-    [loading]="!!(dataProvider.isLoading$ | async)"
+    [loading]="isLoading()"
     [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
     [emptyIcon]="emptyConf?.icon ?? ''"
     (sortChange)="onSortChange($event)"
@@ -35,42 +35,42 @@
     <ng-container [tnColumnDef]="'service'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Service' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Service' | translate), uniqueRowTag(row), 'row-text']">{{ row.service }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Service' | translate), uniqueRowTag(row), 'row-text']">{{ row.service }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'session_id'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Session ID' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Session ID' | translate), uniqueRowTag(row), 'row-text']">{{ row.session_id }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Session ID' | translate), uniqueRowTag(row), 'row-text']">{{ row.session_id }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'machine'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Machine' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Machine' | translate), uniqueRowTag(row), 'row-text']">{{ row.machine }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Machine' | translate), uniqueRowTag(row), 'row-text']">{{ row.machine }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'connected_at'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Connected at' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Connected at' | translate), uniqueRowTag(row), 'row-text']">{{ row.connected_at }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Connected at' | translate), uniqueRowTag(row), 'row-text']">{{ row.connected_at }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'encryption'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Encryption' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Encryption' | translate), uniqueRowTag(row), 'row-text']">{{ row.encryption.cipher }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Encryption' | translate), uniqueRowTag(row), 'row-text']">{{ row.encryption.cipher }}</span>
       </ng-template>
     </ng-container>
 
     <ng-container [tnColumnDef]="'signing'" [sortable]="true">
       <ng-template tnHeaderCellDef>{{ 'Signing' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
-        <span [ixTest]="[('Signing' | translate), uniqueRowTag(row), 'row-text']">{{ row.signing.cipher }}</span>
+        <span tnTestIdType="text" [tnTestId]="[('Signing' | translate), uniqueRowTag(row), 'row-text']">{{ row.signing.cipher }}</span>
       </ng-template>
     </ng-container>
   </tn-table>

--- a/src/app/pages/sharing/smb/smb-status/components/smb-share-list/smb-share-list.component.scss
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-share-list/smb-share-list.component.scss
@@ -1,7 +1,6 @@
-tn-card {
-  display: block;
-  height: auto;
-}
+@import '../../../../components/tn-table-in-card';
+
+@include tn-table-in-card;
 
 .actions {
   align-items: center;
@@ -9,17 +8,4 @@ tn-card {
   flex-wrap: wrap;
   gap: 8px;
   justify-content: flex-end;
-}
-
-// TEMP: tn-table-pager hardcodes a bordered boxed footer; drop the box, keep a top divider.
-tn-table-pager {
-  background-color: transparent;
-  border: none;
-  border-top: 1px solid var(--tn-lines);
-}
-
-// TEMP: square the table header's top corners (tn-table rounds all corners).
-:host ::ng-deep tn-table .tn-table__table {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
 }

--- a/src/app/pages/sharing/smb/smb-status/components/smb-share-list/smb-share-list.component.ts
+++ b/src/app/pages/sharing/smb/smb-status/components/smb-share-list/smb-share-list.component.ts
@@ -1,13 +1,14 @@
-import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, computed, inject, signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
   TnButtonComponent, TnCardComponent, TnCardHeaderActionsDirective, TnCardHeaderDirective, TnCellDefDirective,
-  TnHeaderCellDefDirective, TnTableColumnDirective, TnTableComponent, TnTablePagerComponent, type TnSortEvent,
+  TnHeaderCellDefDirective, TnTableColumnDirective, TnTableComponent, TnTablePagerComponent, TnTestIdDirective,
+  type TnSortEvent,
 } from '@truenas/ui-components';
+import { kebabCase } from 'lodash-es';
 import { tap } from 'rxjs';
 import { SmbInfoLevel } from 'app/enums/smb-info-level.enum';
 import { SmbShareInfo } from 'app/interfaces/smb-status.interface';
@@ -16,8 +17,9 @@ import { BasicSearchComponent } from 'app/modules/forms/search-input/components/
 import { AsyncDataProvider } from 'app/modules/ix-table/classes/async-data-provider/async-data-provider';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { TableColumnPickerComponent } from 'app/modules/ix-table/components/table-column-picker/table-column-picker.component';
-import { convertStringToId, createTable, mapTnSortToTableSort, toDisplayedColumns } from 'app/modules/ix-table/utils';
-import { TestDirective } from 'app/modules/test-id/test.directive';
+import {
+  convertStringToId, createTable, dataProviderLoading, dataProviderRows, mapTnSortToTableSort, toDisplayedColumns,
+} from 'app/modules/ix-table/utils';
 import { ApiService } from 'app/modules/websocket/api.service';
 
 @Component({
@@ -32,14 +34,13 @@ import { ApiService } from 'app/modules/websocket/api.service';
     BasicSearchComponent,
     TableColumnPickerComponent,
     TnButtonComponent,
-    TestDirective,
+    TnTestIdDirective,
     TnTableComponent,
     TnTableColumnDirective,
     TnHeaderCellDefDirective,
     TnCellDefDirective,
     TnTablePagerComponent,
     TranslateModule,
-    AsyncPipe,
   ],
 })
 export class SmbShareListComponent implements OnInit {
@@ -50,7 +51,20 @@ export class SmbShareListComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   searchQuery = signal('');
-  dataProvider: AsyncDataProvider<SmbShareInfo>;
+  private readonly smbStatus$ = this.api.call('smb.status', [SmbInfoLevel.Shares]).pipe(
+    tap((shares: SmbShareInfo[]) => {
+      this.shares = shares;
+      if (this.searchQuery()) {
+        this.onListFiltered(this.searchQuery());
+      }
+    }),
+    takeUntilDestroyed(this.destroyRef),
+  );
+
+  dataProvider = new AsyncDataProvider<SmbShareInfo>(this.smbStatus$);
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(this.dataProvider.emptyType$);
   shares: SmbShareInfo[] = [];
 
   protected readonly columns = signal(createTable<SmbShareInfo>([
@@ -80,17 +94,6 @@ export class SmbShareListComponent implements OnInit {
   };
 
   ngOnInit(): void {
-    const smbStatus$ = this.api.call('smb.status', [SmbInfoLevel.Shares]).pipe(
-      tap((shares: SmbShareInfo[]) => {
-        this.shares = shares;
-        if (this.searchQuery()) {
-          this.onListFiltered(this.searchQuery());
-        }
-      }),
-      takeUntilDestroyed(this.destroyRef),
-    );
-
-    this.dataProvider = new AsyncDataProvider<SmbShareInfo>(smbStatus$);
     this.loadData();
     this.dataProvider.emptyType$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.onListFiltered(this.searchQuery());
@@ -110,7 +113,9 @@ export class SmbShareListComponent implements OnInit {
   }
 
   protected uniqueRowTag(row: SmbShareInfo): string {
-    return convertStringToId('smb-share-' + row.server_id.unique_id + '-' + row.machine);
+    // Pre-split with lodash kebabCase so digit-bearing values resolve identically through
+    // the legacy [ixTest] directive and the library [tnTestId] directive (see nfs-list).
+    return kebabCase(convertStringToId('smb-share-' + row.server_id.unique_id + '-' + row.machine));
   }
 
   protected onColumnsChange(columns: ReturnType<typeof this.columns>): void {

--- a/src/app/pages/sharing/webshare/webshare-list/webshare-list.component.html
+++ b/src/app/pages/sharing/webshare/webshare-list/webshare-list.component.html
@@ -1,4 +1,4 @@
-@if (!(hasTruenasConnect$ | async)) {
+@if (!hasTruenasConnect()) {
   <tn-banner
     class="clickable"
     role="button"
@@ -11,7 +11,7 @@
     (keydown.space)="openTruenasConnectDialog(); $event.preventDefault()"
   ></tn-banner>
 }
-@if (showNoWebshareUsersNotice$ | async) {
+@if (showNoWebshareUsersNotice()) {
   <tn-banner
     class="clickable"
     role="button"
@@ -29,15 +29,15 @@
   <div tnCardHeader class="header-title">
     <h3 class="tn-card__title">{{ 'WebShare' | translate }}</h3>
     <ix-service-state-button
-      [service]="service$ | async"
-      [count]="+(dataProvider.currentPageCount$ | async)"
+      [service]="service()"
+      [count]="currentPageCount() ?? 0"
     ></ix-service-state-button>
   </div>
 
   <ng-template tnCardHeaderActions>
     <div class="actions">
       <ix-basic-search
-        [query]="searchQuery"
+        [query]="searchQuery()"
         (queryChange)="onListFiltered($event)"
       ></ix-basic-search>
 
@@ -52,14 +52,14 @@
         color="primary"
         [testId]="'add-webshare'"
         [ixUiSearch]="searchableElements.elements.createWebShare"
-        [disabled]="!(hasTruenasConnect$ | async)"
+        [disabled]="!hasTruenasConnect()"
         [label]="'Add' | translate"
         (onClick)="doAdd()"
       ></tn-button>
     </div>
   </ng-template>
 
-  @if ((dataProvider.emptyType$ | async) === EmptyType.NoPageData && !(dataProvider.currentPageCount$ | async)) {
+  @if (emptyType() === EmptyType.NoPageData && !currentPageCount()) {
     <tn-empty
       icon="webshare"
       iconLibrary="custom"
@@ -68,15 +68,15 @@
       [description]="'Users can access these shares if they have the WebShare Enabled option set on their account.' | translate"
     ></tn-empty>
   } @else {
-    @let emptyConf = emptyService.defaultEmptyConfig(dataProvider.emptyType$ | async);
+    @let emptyConf = emptyService.defaultEmptyConfig(emptyType());
     <tn-table
       class="table"
       [testId]="'table-table'"
       [ixUiSearch]="searchableElements.elements.webshareList"
-      [dataSource]="(dataProvider.currentPage$ | async) ?? []"
+      [dataSource]="rows()"
       [displayedColumns]="displayedColumns()"
       [trackBy]="trackByWebShareId"
-      [loading]="!!(dataProvider.isLoading$ | async)"
+      [loading]="isLoading()"
       [emptyMessage]="emptyConf?.title ? (emptyConf.title | translate) : ''"
       [emptyIcon]="emptyConf?.icon ?? ''"
       (sortChange)="onSortChange($event)"
@@ -86,15 +86,17 @@
         <ng-template let-row tnCellDef>
           <span class="webshare-name-container">
             <span
-              role="text"
-              [ixTest]="[('Name' | translate), uniqueRowTag(row), 'row-text']"
-              [attr.aria-label]="('WebShare name' | translate) + ': ' + row.name"
+              tnTestIdType="text"
+              [tnTestId]="[('Name' | translate), uniqueRowTag(row), 'row-text']"
             >{{ row.name }}</span>
             @if (row.isHomeBase) {
+              <!-- role/aria-label expose the icon-only home-share state to AT; the tooltip is hover-only. -->
               <tn-icon
                 class="home-icon"
                 name="folder-account"
                 library="mdi"
+                role="img"
+                [attr.aria-label]="'Home Share' | translate"
                 [tnTooltip]="'Home Share' | translate"
               ></tn-icon>
             }
@@ -106,7 +108,8 @@
         <ng-template tnHeaderCellDef>{{ 'Path' | translate }}</ng-template>
         <ng-template let-row tnCellDef>
           <span
-            [ixTest]="[('Path' | translate), uniqueRowTag(row), 'row-text']"
+            tnTestIdType="text"
+            [tnTestId]="[('Path' | translate), uniqueRowTag(row), 'row-text']"
             [tnTooltip]="row.path || ''"
           >{{ row.path }}</span>
         </ng-template>

--- a/src/app/pages/sharing/webshare/webshare-list/webshare-list.component.ts
+++ b/src/app/pages/sharing/webshare/webshare-list/webshare-list.component.ts
@@ -1,15 +1,15 @@
-import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, Component, OnInit, computed, inject, signal, DestroyRef,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
   tnIconMarker, TnBannerComponent, TnButtonComponent, TnCardComponent, TnCardHeaderActionsDirective,
   TnCardHeaderDirective, TnCellDefDirective, TnEmptyComponent, TnHeaderCellDefDirective, TnIconComponent,
-  TnTableColumnDirective, TnTableComponent, TnTablePagerComponent, TnTooltipDirective, type TnSortEvent,
+  TnTableColumnDirective, TnTableComponent, TnTablePagerComponent, TnTestIdDirective, TnTooltipDirective,
+  type TnSortEvent,
 } from '@truenas/ui-components';
 import { kebabCase } from 'lodash-es';
 import { filter, map } from 'rxjs';
@@ -30,9 +30,10 @@ import { actionsColumn } from 'app/modules/ix-table/components/ix-table-body/cel
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
 import { TableColumnPickerComponent } from 'app/modules/ix-table/components/table-column-picker/table-column-picker.component';
 import { SortDirection } from 'app/modules/ix-table/enums/sort-direction.enum';
-import { convertStringToId, createTable, mapTnSortToTableSort, toDisplayedColumns } from 'app/modules/ix-table/utils';
+import {
+  convertStringToId, createTable, dataProviderLoading, dataProviderRows, mapTnSortToTableSort, toDisplayedColumns,
+} from 'app/modules/ix-table/utils';
 import { FormSidePanelService } from 'app/modules/slide-ins/form-side-panel/form-side-panel.service';
-import { TestDirective } from 'app/modules/test-id/test.directive';
 import { TableActionsCellComponent } from 'app/modules/tn-table-cells/actions-cell/table-actions-cell.component';
 import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -59,7 +60,7 @@ import { selectService } from 'app/store/services/services.selectors';
     TableColumnPickerComponent,
     RequiresRolesDirective,
     TnButtonComponent,
-    TestDirective,
+    TnTestIdDirective,
     UiSearchDirective,
     TnBannerComponent,
     TnEmptyComponent,
@@ -72,7 +73,6 @@ import { selectService } from 'app/store/services/services.selectors';
     TnIconComponent,
     TnTooltipDirective,
     TranslateModule,
-    AsyncPipe,
   ],
 })
 export class WebShareListComponent implements OnInit {
@@ -91,18 +91,32 @@ export class WebShareListComponent implements OnInit {
   private truenasConnectService = inject(TruenasConnectService);
   private router = inject(Router);
 
-  service$ = this.store$.select(selectService(ServiceName.WebShare));
-  searchQuery = '';
-  dataProvider: AsyncDataProvider<WebShareTableRow>;
+  private readonly service$ = this.store$.select(selectService(ServiceName.WebShare));
+  protected readonly service = toSignal(this.service$);
 
-  hasTruenasConnect$ = this.truenasConnectService.config$.pipe(
+  protected searchQuery = signal('');
+
+  private readonly webshares$ = this.webShareService.getWebShareTableRows().pipe(
+    takeUntilDestroyed(this.destroyRef),
+  );
+
+  // Public: the spec drives filtering/sorting/loading through the provider directly.
+  dataProvider = new AsyncDataProvider<WebShareTableRow>(this.webshares$);
+  protected readonly rows = dataProviderRows(this.dataProvider);
+  protected readonly isLoading = dataProviderLoading(this.dataProvider);
+  protected readonly emptyType = toSignal(this.dataProvider.emptyType$);
+  protected readonly currentPageCount = toSignal(this.dataProvider.currentPageCount$);
+
+  private readonly hasTruenasConnect$ = this.truenasConnectService.config$.pipe(
     map((config) => config?.status === TruenasConnectStatus.Configured),
   );
 
-  showNoWebshareUsersNotice$ = this.hasTruenasConnect$.pipe(
+  protected readonly hasTruenasConnect = toSignal(this.hasTruenasConnect$);
+
+  protected readonly showNoWebshareUsersNotice = toSignal(this.hasTruenasConnect$.pipe(
     combineLatestWith(this.webShareService.hasWebshareUsers$),
     map(([hasTruenasConnect, hasWebshareUsers]) => hasTruenasConnect && !hasWebshareUsers),
-  );
+  ));
 
   protected readonly helptext = helptextSharingWebshare;
 
@@ -160,10 +174,10 @@ export class WebShareListComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.setDataProvider();
+    this.dataProvider.load();
     this.setDefaultSort();
     this.dataProvider.emptyType$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
-      this.onListFiltered(this.searchQuery);
+      this.onListFiltered(this.searchQuery());
     });
 
     // Trigger hostname lookup to enable WebShare opening when not on truenas.direct domain
@@ -193,7 +207,7 @@ export class WebShareListComponent implements OnInit {
   }
 
   onListFiltered(query: string): void {
-    this.searchQuery = query;
+    this.searchQuery.set(query);
     this.dataProvider.setFilter({
       query,
       columnKeys: ['name', 'path'],
@@ -240,15 +254,6 @@ export class WebShareListComponent implements OnInit {
     }).pipe(
       takeUntilDestroyed(this.destroyRef),
     ).subscribe(() => this.loadWebShareConfig());
-  }
-
-  private setDataProvider(): void {
-    const webshares$ = this.webShareService.getWebShareTableRows().pipe(
-      takeUntilDestroyed(this.destroyRef),
-    );
-
-    this.dataProvider = new AsyncDataProvider<WebShareTableRow>(webshares$);
-    this.dataProvider.load();
   }
 
   private loadWebShareConfig(): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4543,9 +4543,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@truenas/ui-components@npm:~0.3.21":
-  version: 0.3.21
-  resolution: "@truenas/ui-components@npm:0.3.21"
+"@truenas/ui-components@npm:~0.3.23":
+  version: 0.3.23
+  resolution: "@truenas/ui-components@npm:0.3.23"
   dependencies:
     "@material-design-icons/svg": "npm:~0.14.13"
     "@mdi/svg": "npm:~7.4.47"
@@ -4566,7 +4566,7 @@ __metadata:
     "@mdi/js": ^7.4.47
   bin:
     truenas-icons: scripts/icon-sprite/cli.js
-  checksum: 10/c618afe5e9cea484c91d3a5d1ba9b5db6f5e4fd17e8c1316b1e23f0b3ae28e90a2585c3ec2a756ca533a9fb6e966855e3b189ef7fcfabb39887b9e9320ba038e
+  checksum: 10/8de042e3fe4f5c17127a2d327740a612f9a753439ad7db452983f856574d99e5106e234cd3b0f4ce7b21dc4becb23e6a440bf310a33b79ab47dfecdd1c7a76c2
   languageName: node
   linkType: hard
 
@@ -16053,7 +16053,7 @@ __metadata:
     "@smarttools/eslint-plugin-rxjs": "npm:~1.0.22"
     "@stylistic/eslint-plugin": "npm:~2.9.0"
     "@truenas/common-typescript": "github:truenas/tn-common-typescript#master"
-    "@truenas/ui-components": "npm:~0.3.21"
+    "@truenas/ui-components": "npm:~0.3.23"
     "@types/cheerio": "npm:~0.22.35"
     "@types/d3": "npm:~7.4.3"
     "@types/dygraphs": "npm:^2.1.10"


### PR DESCRIPTION
NAS-141024-final — review-driven cleanup of the sharing/ tn-* migration
Four commits on top of the merged iscsi work, driven by a full six-lane migration review of the branch. Net effect: every review blocker and warning is resolved, and the sharing area is fully off Angular Material (one documented hold), off | async provider bindings, and off the legacy [ixTest] directive.

Correctness fixes (review blockers)

Column picker i18n — the shared ix-table-column-picker now translates option labels; the raw column title stays as the option value since it's the saved-preferences key.
nvme-of test-id parity — dynamic test-id segments (NQNs, device paths, subsystem names) are pre-split with lodash kebabCase so digit-bearing values resolve byte-identically to the legacy ids (8 sites), and the text-*-row-text cell ids dropped during the tn-table migration were restored in subsystems-list and both manage dialogs.
Spec hygiene — the one forbidden data-test locator replaced with TnButtonHarness.
Signals over async pipe — every remaining list binds rows() / isLoading() / emptyType() via the shared dataProviderRows/dataProviderLoading helpers, which now also accept a Signal<provider> for input.required providers (target-list, subsystems-list) and rebuilt-on-input providers (smb-open-files). Provider construction moved to field initializers throughout.

Accessibility — the iscsi tn-tabs migration regained its role="tabpanel" container; webshare-list's name cell dropped the nonstandard role="text" and its home-share icon is now exposed to AT (role="img" + label); and — enabled by the library bump to 0.3.23, whose tn-form-field now auto-associates its label via aria-labelledby — the redundant [ariaLabel] overrides and stale TODO comments were removed from nfs-form, service-smb, smb-form, and smb-acl.

Consistency/debt — smb-list and the five smb-status stylesheets deduped onto the shared tn-table-in-card mixin; last [ixTest] consumers swapped to [tnTestId]; member scoping tightened (spec-driven seams kept public with comments); new spec coverage for the side-panel footerActions contract.