### PR TITLE
NAS-141831 / 27.0.0-BETA.1 / Change ACL traverse check from an error to a warning

### DIFF
--- a/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
+++ b/src/app/helptext/storage/volumes/datasets/dataset-acl.ts
@@ -82,4 +82,14 @@ export const helptextAcl = {
     message: T('This process continues in the background after closing this dialog.'),
   },
 
+  effectiveAclDialog: {
+    title: T('Traverse Access Warning'),
+    message: T('One or more users or groups do not have permission to traverse to this dataset,\
+ so some Access Control Entries will not grant them the access shown:<br><br>{details}<br><br>\
+This can be expected when a dataset is reached through a path the user cannot traverse, such as a\
+ container volume mounted from another user\'s home directory. Saving will apply the ACL without\
+ validating this access.<br><br>Do you want to save anyway?'),
+    buttonText: T('Save Anyway'),
+  },
+
 };

--- a/src/app/pages/datasets/modules/permissions/stores/dataset-acl-editor.store.spec.ts
+++ b/src/app/pages/datasets/modules/permissions/stores/dataset-acl-editor.store.spec.ts
@@ -1,15 +1,17 @@
 import { Router } from '@angular/router';
 import { SpectatorService, createServiceFactory } from '@ngneat/spectator/jest';
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
 import { mockCall, mockJob, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { AclType } from 'app/enums/acl-type.enum';
 import { NfsAclTag, NfsAclType, NfsBasicPermission } from 'app/enums/nfs-acl.enum';
 import { NfsAcl, SetAcl } from 'app/interfaces/acl.interface';
 import { FileSystemStat } from 'app/interfaces/filesystem-stat.interface';
+import { Job } from 'app/interfaces/job.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+import { FailedJobError } from 'app/services/errors/error.classes';
 import { StorageService } from 'app/services/storage.service';
 import { DatasetAclEditorStore } from './dataset-acl-editor.store';
 
@@ -283,6 +285,87 @@ describe('DatasetAclEditorStore', () => {
       });
 
       expect(router.navigate).toHaveBeenCalledWith(['datasets', 'pool/dataset']);
+    });
+  });
+
+  describe('effective ACL traverse validation', () => {
+    let dialog: DialogService;
+    let errorHandler: ErrorHandlerService;
+
+    const traverseError = new FailedJobError({
+      error: 'Filesystem permissions on path /mnt/pool prevent access for user "john" to the path '
+        + '/mnt/pool/dataset. This may be fixed by granting the aforementioned user execute '
+        + 'permissions on the path: /mnt/pool.',
+    } as Job);
+
+    const saveParams = {
+      recursive: false,
+      traverse: false,
+      owner: 'root',
+      ownerGroup: 'wheel',
+      applyOwner: false,
+      applyGroup: false,
+    };
+
+    beforeEach(async () => {
+      dialog = spectator.inject(DialogService);
+      errorHandler = spectator.inject(ErrorHandlerService);
+
+      store.loadAcl('/mnt/pool/dataset');
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+
+    it('offers to save without validation when the ACL lacks traverse access, then retries', async () => {
+      (dialog.jobDialog as jest.Mock)
+        .mockReturnValueOnce({ afterClosed: () => throwError(() => traverseError) })
+        .mockReturnValueOnce({ afterClosed: () => of(fakeSuccessfulJob()) });
+
+      store.saveAcl(saveParams);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(dialog.confirm).toHaveBeenCalled();
+      expect(errorHandler.showErrorModal).not.toHaveBeenCalled();
+      expect(api.job).toHaveBeenCalledTimes(2);
+      expect(api.job).toHaveBeenLastCalledWith(
+        'filesystem.setacl',
+        [expect.objectContaining({
+          options: expect.objectContaining({ validate_effective_acl: false }),
+        } as SetAcl)],
+      );
+    });
+
+    it('does not retry when the user declines the traverse warning', async () => {
+      (dialog.confirm as jest.Mock).mockReturnValueOnce(of(false));
+      (dialog.jobDialog as jest.Mock)
+        .mockReturnValueOnce({ afterClosed: () => throwError(() => traverseError) });
+
+      store.saveAcl(saveParams);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(dialog.confirm).toHaveBeenCalled();
+      expect(api.job).toHaveBeenCalledTimes(1);
+      expect(errorHandler.showErrorModal).not.toHaveBeenCalled();
+    });
+
+    it('shows the error modal for non-traverse failures without offering to bypass validation', async () => {
+      const otherError = new FailedJobError({ error: 'Something else went wrong.' } as Job);
+      (dialog.jobDialog as jest.Mock)
+        .mockReturnValueOnce({ afterClosed: () => throwError(() => otherError) });
+
+      store.saveAcl(saveParams);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(errorHandler.showErrorModal).toHaveBeenCalledWith(otherError);
+      expect(dialog.confirm).not.toHaveBeenCalled();
+      expect(api.job).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/app/pages/datasets/modules/permissions/stores/dataset-acl-editor.store.ts
+++ b/src/app/pages/datasets/modules/permissions/stores/dataset-acl-editor.store.ts
@@ -11,6 +11,7 @@ import {
 } from 'rxjs/operators';
 import { AclType, DefaultAclType } from 'app/enums/acl-type.enum';
 import { mntPath } from 'app/enums/mnt-path.enum';
+import { isFailedJobError } from 'app/helpers/api.helper';
 import { helptextAcl } from 'app/helptext/storage/volumes/datasets/dataset-acl';
 import {
   Acl, AclTemplateByPath, NfsAclItem, PosixAclItem, SetAcl,
@@ -24,7 +25,16 @@ import {
 } from 'app/pages/datasets/modules/permissions/interfaces/dataset-acl-editor-state.interface';
 import { newNfsAce, newPosixAce } from 'app/pages/datasets/modules/permissions/utils/new-ace.utils';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+import { ErrorParserService } from 'app/services/errors/error-parser.service';
 import { StorageService } from 'app/services/storage.service';
+
+/**
+ * Stable fragment of the backend `filesystem.check_acl_execute` error message
+ * (raised with errno EPERM when a user/group cannot traverse to the dataset).
+ * Used to distinguish the recoverable "no traverse access" case from other
+ * ACL save failures so we can offer to save without effective-ACL validation.
+ */
+const traverseValidationErrorMarker = 'execute permissions on the path';
 
 const initialState: DatasetAclEditorState = {
   isLoading: false,
@@ -43,6 +53,7 @@ const initialState: DatasetAclEditorState = {
 export class DatasetAclEditorStore extends ComponentStore<DatasetAclEditorState> {
   private api = inject(ApiService);
   private errorHandler = inject(ErrorHandlerService);
+  private errorParser = inject(ErrorParserService);
   private dialogService = inject(DialogService);
   private router = inject(Router);
   private translate = inject(TranslateService);
@@ -243,25 +254,65 @@ export class DatasetAclEditorStore extends ComponentStore<DatasetAclEditorState>
   });
 
   private makeSaveRequest(setAcl: SetAcl): Observable<Job> {
+    return this.runSetAclJob(setAcl).pipe(
+      catchError((error: unknown) => this.handleSaveError(setAcl, error)),
+      tap(() => this.onSaveSucceeded()),
+    );
+  }
+
+  private runSetAclJob(setAcl: SetAcl): Observable<Job> {
     return this.dialogService.jobDialog(
       this.api.job('filesystem.setacl', [setAcl]),
       {
         title: this.translate.instant(helptextAcl.saveDialog.title),
         description: this.translate.instant(helptextAcl.saveDialog.message),
       },
-    )
-      .afterClosed()
-      .pipe(
-        this.errorHandler.withErrorHandler(),
-        tap(() => {
-          this.saveSucceeded$.next();
-          const returnUrl = this.state().returnUrl;
-          const returnRoute = returnUrl
-            ? [returnUrl]
-            : ['datasets', this.get()?.mountpoint?.replace(`${mntPath}/`, '')];
-          this.router.navigate(returnRoute);
-        }),
-      );
+    ).afterClosed();
+  }
+
+  /**
+   * If the backend rejected the ACL only because a user/group lacks traverse
+   * access to the dataset, warn the user and offer to save anyway with
+   * effective-ACL validation disabled. Any other error is shown as usual.
+   */
+  private handleSaveError(setAcl: SetAcl, error: unknown): Observable<Job> {
+    if (!this.isTraverseValidationError(error)) {
+      this.errorHandler.showErrorModal(error);
+      return EMPTY;
+    }
+
+    return this.dialogService.confirm({
+      title: this.translate.instant(helptextAcl.effectiveAclDialog.title),
+      message: this.translate.instant(helptextAcl.effectiveAclDialog.message, {
+        details: this.errorParser.getFirstErrorMessage(error),
+      }),
+      buttonText: this.translate.instant(helptextAcl.effectiveAclDialog.buttonText),
+    }).pipe(
+      filter(Boolean),
+      switchMap(() => {
+        // On success the job flows out to the outer `tap` in makeSaveRequest, which
+        // navigates away. withErrorHandler swallows any failure of the retry itself.
+        return this.runSetAclJob({
+          ...setAcl,
+          options: { ...setAcl.options, validate_effective_acl: false },
+        }).pipe(
+          this.errorHandler.withErrorHandler(),
+        );
+      }),
+    );
+  }
+
+  private isTraverseValidationError(error: unknown): boolean {
+    return isFailedJobError(error) && (error.job.error || '').includes(traverseValidationErrorMarker);
+  }
+
+  private onSaveSucceeded(): void {
+    this.saveSucceeded$.next();
+    const returnUrl = this.state().returnUrl;
+    const returnRoute = returnUrl
+      ? [returnUrl]
+      : ['datasets', this.get()?.mountpoint?.replace(`${mntPath}/`, '')];
+    this.router.navigate(returnRoute);
   }
 
   /**


### PR DESCRIPTION
**Problem**

When editing a dataset's ACL, the save is rejected outright if any user/group in the ACL lacks traverse (execute) permission on a parent path leading to the dataset. This is too strict for legitimate nested-dataset use cases — e.g. a container volume mounted from a user's home directory — forcing users to build more complex ACLs starting above the mount point.

Per backend guidance (Andrew Walker), the middleware already supports skipping this sanity check (validate_effective_acl: false). Validation should stay on by default, but instead of refusing to save, the UI should warn the user that some ACL entries won't grant the expected access and let them proceed.

**Solution**

The dataset ACL editor now saves with validation on as before. If the backend rejects the save specifically because a user/group can't traverse to the dataset, the UI shows a "Traverse Access Warning" dialog (including the backend's specific detail) with a Save Anyway action. Confirming re-submits with validate_effective_acl: false. Any other failure still surfaces the normal error dialog — no bypass offered.

**How the traverse failure is detected**

The backend's filesystem.setacl → filesystem.check_acl_execute raises a CallError (errno EPERM) whose message contains the stable text execute permissions on the path (NFSv4 propagates the CallError; POSIX wraps it as a filesystem_acl.path validation error with the same text). The failed job surfaces as a FailedJobError, so detection matches on that marker in job.error. This correctly excludes unrelated failures such as the ENOENT "path component does not exist" case.

**Changes**

- dataset-acl-editor.store.ts — split makeSaveRequest into runSetAclJob / handleSaveError / isTraverseValidationError / onSaveSucceeded; added the warn-and-retry flow (retry with validate_effective_acl: false on confirm).
- dataset-acl.ts (helptext) — added effectiveAclDialog strings (title, interpolated message with backend detail, "Save Anyway" button).
- dataset-acl-editor.store.spec.ts — 3 new tests: retry on confirm, no retry on decline, normal error modal for non-traverse failures.
- i18n — extracted the 3 new strings into all locale files.

**Testing**

- Unit: dataset-acl-editor.store.spec.ts — 10 tests pass (incl. the 3 new branches).
- Lint clean; validate-translations passes.
- Manual E2E against a live backend: created a nested dataset whose parent denies traverse to a user, added that user to the child's ACL, and saved:
  - Save → "Traverse Access Warning" dialog appears (not a hard error) with the backend detail and a Confirm-gated Save Anyway button.
  - Confirm → Save Anyway → ACL saves (bypass applied) and the entry persists.
  - Removing the un-traversable user and re-saving goes through cleanly with no dialog (normal saves unaffected).

**Notes**

No debug file needed — this is not a configuration issue. Related prior ticket: NAS-135444 (closed as a cleanup duplicate).