### PR TITLE
NAS-141402 / 27.0.0-BETA.1 / Improve System Information card call to action messaging

### DIFF
--- a/src/app/constants/marketing-messages.constant.ts
+++ b/src/app/constants/marketing-messages.constant.ts
@@ -1,0 +1,86 @@
+import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
+import { exploreNasEnterpriseLink } from 'app/constants/explore-nas-enterprise-link.constant';
+import { truenasConnectLink } from 'app/constants/truenas-connect-link.constant';
+import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
+import { TruenasConnectTier } from 'app/enums/truenas-connect-tier.enum';
+import { TruenasConnectConfig } from 'app/interfaces/truenas-connect-config.interface';
+
+export interface MarketingMessage {
+  /** Untranslated tagline shown as the highlighted primary line. */
+  text: string;
+  /** Untranslated call-to-action shown below the tagline. Empty when the message is informational only. */
+  cta: string;
+  /** External link the message points to, or `null` for a non-clickable message. */
+  href: string | null;
+}
+
+const exploreEnterpriseCta = T('Explore TrueNAS Enterprise');
+
+/**
+ * Enterprise awareness. Shown in every Community Edition rotation regardless of TrueNAS Connect state.
+ */
+export const enterpriseMarketingMessages: MarketingMessage[] = [
+  T('More Performance, More Protection'),
+  T('Boost Performance & Support'),
+  T('Unlock High Performance Solutions'),
+  T('Expert Support When You Need It'),
+  T('Achieve 99.999% Uptime with HA'),
+  T('Same trusted platform. Enterprise SLAs.'),
+  T('Validated Hardware. 24x7 Support.'),
+  T('From Evaluation to Enterprise, in one conversation.'),
+  T('Community Friendly. Enterprise Ready.'),
+  T('Trusted Software on Tested Hardware.'),
+].map((text) => ({ text, cta: exploreEnterpriseCta, href: exploreNasEnterpriseLink }));
+
+const tryTncCta = T('Try out TrueNAS Connect');
+
+/**
+ * Promote TrueNAS Connect. Shown when the system is not connected to TrueNAS Connect.
+ */
+export const promoteTncMarketingMessages: MarketingMessage[] = [
+  T('Centralized Visibility. Simplified Management.'),
+  T('Multiple Systems. Secure Browser Access. One URL.'),
+  T('Try out WebShare and Spotlight Support.'),
+  T('Get email alerts and reports. Free forever.'),
+].map((text) => ({ text, cta: tryTncCta, href: truenasConnectLink }));
+
+const upgradeTncCta = T('Upgrade to TrueNAS Connect Plus');
+
+/**
+ * Encourage upgrades. Shown when connected on the free Foundation tier.
+ */
+export const upgradeTncMarketingMessages: MarketingMessage[] = [
+  T('Create, Manage and Monitor Replication'),
+  T('Enable Custom Enclosure Support for Drive Monitoring'),
+  T('Get 30-day Extended Stats Retention'),
+  T('Inventory Control for Asset Management Across Systems'),
+  T('Three Managed Systems. One Low Price.'),
+].map((text) => ({ text, cta: upgradeTncCta, href: truenasConnectLink }));
+
+/**
+ * Thank-you. Shown when connected on a paid tier (Plus or Business). Non-clickable.
+ */
+export const thankYouMarketingMessage: MarketingMessage = {
+  text: T('Thanks for supporting TrueNAS!'),
+  cta: '',
+  href: null,
+};
+
+/**
+ * Enterprise awareness stays in rotation for every Community Edition system, joined by the
+ * TrueNAS Connect messages that match the system's current connection state.
+ */
+export function getMarketingMessages(config: TruenasConnectConfig | undefined): MarketingMessage[] {
+  const isConnected = config?.status === TruenasConnectStatus.Configured;
+  const tier = config?.tier;
+
+  if (isConnected && (tier === TruenasConnectTier.Plus || tier === TruenasConnectTier.Business)) {
+    return [...enterpriseMarketingMessages, thankYouMarketingMessage];
+  }
+
+  if (isConnected && tier === TruenasConnectTier.Foundation) {
+    return [...enterpriseMarketingMessages, ...upgradeTncMarketingMessages];
+  }
+
+  return [...enterpriseMarketingMessages, ...promoteTncMarketingMessages];
+}

--- a/src/app/constants/truenas-connect-link.constant.ts
+++ b/src/app/constants/truenas-connect-link.constant.ts
@@ -1,0 +1,1 @@
+export const truenasConnectLink = 'https://connect.truenas.com/';

--- a/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.html
+++ b/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.html
@@ -1,13 +1,30 @@
-<a
-  ixTest="use-enterprise-marketing-link"
-  target="_blank"
-  [href]="currentMessageHref()"
->
-  <span class="text-above">
-    {{ currentMessage() }}
-  </span>
+@let message = currentMessage();
+@let href = currentMessageHref();
 
-  <span>
-    {{ 'Explore TrueNAS Enterprise' | translate }}
-  </span>
-</a>
+@if (href) {
+  <a
+    ixTest="use-enterprise-marketing-link"
+    target="_blank"
+    [href]="href"
+  >
+    <span class="text-above">
+      {{ message.text | translate }}
+    </span>
+
+    <span>
+      {{ message.cta | translate }}
+    </span>
+  </a>
+} @else {
+  <div class="no-link" ixTest="use-enterprise-marketing-link">
+    <span class="text-above">
+      {{ message.text | translate }}
+    </span>
+
+    @if (message.cta) {
+      <span>
+        {{ message.cta | translate }}
+      </span>
+    }
+  </div>
+}

--- a/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.html
+++ b/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.html
@@ -5,6 +5,7 @@
   <a
     ixTest="use-enterprise-marketing-link"
     target="_blank"
+    rel="noopener noreferrer"
     [href]="href"
   >
     <span class="text-above">

--- a/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.scss
+++ b/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.scss
@@ -4,8 +4,8 @@
   margin: 0 auto;
 }
 
-a {
-  cursor: pointer;
+a,
+.no-link {
   display: block;
   margin-bottom: 2px;
   text-align: center;
@@ -20,4 +20,8 @@ a {
       margin-bottom: 10px;
     }
   }
+}
+
+a {
+  cursor: pointer;
 }

--- a/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.spec.ts
+++ b/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.spec.ts
@@ -1,20 +1,90 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { signal } from '@angular/core';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { exploreNasEnterpriseLink } from 'app/constants/explore-nas-enterprise-link.constant';
+import { getMarketingMessages } from 'app/constants/marketing-messages.constant';
+import { truenasConnectLink } from 'app/constants/truenas-connect-link.constant';
+import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
+import { TruenasConnectTier } from 'app/enums/truenas-connect-tier.enum';
 import { hashMessage } from 'app/helpers/hash-message';
-import { ignoreTranslation } from 'app/modules/translate/translate.helper';
+import { TruenasConnectConfig } from 'app/interfaces/truenas-connect-config.interface';
+import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
 import { UseEnterpriseMarketingLinkComponent } from './use-enterprise-marketing-link.component';
 
 const lastShownDate = 'marketingMessageLastShownDate';
 const lastMessageHash = 'marketingMessageLastHash';
 
+const firstEnterpriseMessage = 'More Performance, More Protection';
+const lastPromoteTncMessage = 'Get email alerts and reports. Free forever.';
+
+describe('getMarketingMessages', () => {
+  it('promotes TrueNAS Connect when the system is not connected', () => {
+    const messages = getMarketingMessages({
+      status: TruenasConnectStatus.Disabled,
+      tier: null,
+    } as TruenasConnectConfig);
+
+    expect(messages.some((message) => message.cta === 'Try out TrueNAS Connect')).toBe(true);
+    expect(messages.some((message) => message.text === lastPromoteTncMessage)).toBe(true);
+    expect(messages.every((message) => message.cta !== 'Upgrade to TrueNAS Connect Plus')).toBe(true);
+  });
+
+  it('promotes Plus when connected on the free Foundation tier', () => {
+    const messages = getMarketingMessages({
+      status: TruenasConnectStatus.Configured,
+      tier: TruenasConnectTier.Foundation,
+    } as TruenasConnectConfig);
+
+    expect(messages.some((message) => message.cta === 'Upgrade to TrueNAS Connect Plus')).toBe(true);
+    expect(messages.some((message) => message.text === 'Three Managed Systems. One Low Price.')).toBe(true);
+    expect(messages.every((message) => message.cta !== 'Try out TrueNAS Connect')).toBe(true);
+  });
+
+  it('shows a non-clickable thank-you on the paid Plus tier with no upsell CTAs', () => {
+    const messages = getMarketingMessages({
+      status: TruenasConnectStatus.Configured,
+      tier: TruenasConnectTier.Plus,
+    } as TruenasConnectConfig);
+
+    const thankYou = messages.find((message) => message.text === 'Thanks for supporting TrueNAS!');
+    expect(thankYou).toBeTruthy();
+    expect(thankYou.href).toBeNull();
+    expect(messages.every((message) => {
+      return message.cta !== 'Try out TrueNAS Connect' && message.cta !== 'Upgrade to TrueNAS Connect Plus';
+    })).toBe(true);
+  });
+
+  it('treats the Business tier as a paid supporter', () => {
+    const messages = getMarketingMessages({
+      status: TruenasConnectStatus.Configured,
+      tier: TruenasConnectTier.Business,
+    } as TruenasConnectConfig);
+
+    expect(messages.some((message) => message.text === 'Thanks for supporting TrueNAS!')).toBe(true);
+  });
+
+  it('always keeps enterprise awareness in the rotation', () => {
+    const messages = getMarketingMessages({
+      status: TruenasConnectStatus.Configured,
+      tier: TruenasConnectTier.Plus,
+    } as TruenasConnectConfig);
+
+    expect(messages.some((message) => message.cta === 'Explore TrueNAS Enterprise')).toBe(true);
+  });
+});
+
 describe('UseEnterpriseMarketingLinkComponent', () => {
   let spectator: Spectator<UseEnterpriseMarketingLinkComponent>;
+  const config = signal<TruenasConnectConfig | undefined>(undefined);
 
   const createComponent = createComponentFactory({
     component: UseEnterpriseMarketingLinkComponent,
+    providers: [
+      mockProvider(TruenasConnectService, { config }),
+    ],
   });
 
   beforeEach(() => {
-    spectator = createComponent();
+    config.set(undefined);
     jest.spyOn(global.Date.prototype, 'toDateString').mockReturnValue('2025-02-26');
     localStorage.clear();
   });
@@ -23,62 +93,78 @@ describe('UseEnterpriseMarketingLinkComponent', () => {
     jest.restoreAllMocks();
   });
 
-  it('should display the first message by default', () => {
-    const message = spectator.component.currentMessage();
-    expect(message).toBe('More Performance, More Protection');
+  it('shows the first enterprise tagline and its CTA by default', () => {
+    spectator = createComponent();
+
+    const link = spectator.query('a');
+    expect(link).toHaveText(firstEnterpriseMessage);
+    expect(link).toHaveText('Explore TrueNAS Enterprise');
+    expect(link?.getAttribute('href')).toBe(`${exploreNasEnterpriseLink}?m=${hashMessage(firstEnterpriseMessage)}`);
   });
 
-  it('should rotate to the next message on a new day', () => {
+  it('rotates to the next message on a new day', () => {
     localStorage.setItem(lastShownDate, '2025-02-25');
-    localStorage.setItem(lastMessageHash, hashMessage('Optimize Your Storage'));
+    localStorage.setItem(lastMessageHash, hashMessage(firstEnterpriseMessage));
+    spectator = createComponent();
 
-    const nextMessage = spectator.component.getTodaysMessage();
-    expect(nextMessage).toBe('More Performance, More Protection');
+    expect(spectator.query('a')).toHaveText('Boost Performance & Support');
   });
 
-  it('should loop to the first message after the last message', () => {
+  it('loops back to the first message after the last one', () => {
     localStorage.setItem(lastShownDate, '2025-02-25');
-    localStorage.setItem(lastMessageHash, hashMessage('5 Nines of Uptime with HA'));
+    localStorage.setItem(lastMessageHash, hashMessage(lastPromoteTncMessage));
+    spectator = createComponent();
 
-    const nextMessage = spectator.component.getTodaysMessage();
-    expect(nextMessage).toBe('More Performance, More Protection');
+    expect(spectator.query('a')).toHaveText(firstEnterpriseMessage);
   });
 
-  it('should update localStorage with new date and hash', () => {
-    spectator.component.getTodaysMessage();
+  it('persists the current date and message hash', () => {
+    spectator = createComponent();
 
     expect(localStorage.getItem(lastShownDate)).toBe('2025-02-26');
-    expect(localStorage.getItem(lastMessageHash)).toBe(hashMessage('More Performance, More Protection'));
+    expect(localStorage.getItem(lastMessageHash)).toBe(hashMessage(firstEnterpriseMessage));
   });
 
-  it('should maintain consistent message even if array order changes', () => {
-    const originalHash = hashMessage('Boost Performance & Support');
-    localStorage.setItem('marketingMessageLastShownDate', '2025-02-25');
-    localStorage.setItem('marketingMessageLastHash', originalHash);
+  it('does not change the message within the same day', () => {
+    localStorage.setItem(lastShownDate, '2025-02-26');
+    localStorage.setItem(lastMessageHash, hashMessage('Boost Performance & Support'));
+    spectator = createComponent();
 
-    spectator.component.messages = [
-      ignoreTranslation('Boost Performance & Support'),
-      ignoreTranslation('Optimize Your Storage'),
-      ignoreTranslation('More Performance, More Protection'),
-    ];
-
-    const nextMessage = spectator.component.getTodaysMessage();
-    expect(nextMessage).toBe('Optimize Your Storage');
+    expect(spectator.query('a')).toHaveText('Boost Performance & Support');
   });
 
-  it('should return the first message if hash is not found', () => {
+  it('falls back to the first message when the stored hash is unknown', () => {
     localStorage.setItem(lastShownDate, '2025-02-26');
     localStorage.setItem(lastMessageHash, 'unknownHash');
+    spectator = createComponent();
 
-    const currentMessage = spectator.component.getTodaysMessage();
-    expect(currentMessage).toBe('More Performance, More Protection');
+    expect(spectator.query('a')).toHaveText(firstEnterpriseMessage);
   });
 
-  it('should not change message within the same day', () => {
+  it('points TrueNAS Connect messages at connect.truenas.com', () => {
+    config.set({
+      status: TruenasConnectStatus.Configured,
+      tier: TruenasConnectTier.Foundation,
+    } as TruenasConnectConfig);
     localStorage.setItem(lastShownDate, '2025-02-26');
-    localStorage.setItem(lastMessageHash, hashMessage('More Performance, More Protection'));
+    localStorage.setItem(lastMessageHash, hashMessage('Three Managed Systems. One Low Price.'));
+    spectator = createComponent();
 
-    const currentMessage = spectator.component.getTodaysMessage();
-    expect(currentMessage).toBe('More Performance, More Protection');
+    expect(spectator.query('a')?.getAttribute('href')).toBe(
+      `${truenasConnectLink}?m=${hashMessage('Three Managed Systems. One Low Price.')}`,
+    );
+  });
+
+  it('renders the thank-you message as static text without a link', () => {
+    config.set({
+      status: TruenasConnectStatus.Configured,
+      tier: TruenasConnectTier.Plus,
+    } as TruenasConnectConfig);
+    localStorage.setItem(lastShownDate, '2025-02-26');
+    localStorage.setItem(lastMessageHash, hashMessage('Thanks for supporting TrueNAS!'));
+    spectator = createComponent();
+
+    expect(spectator.query('a')).toBeNull();
+    expect(spectator.query('.no-link')).toHaveText('Thanks for supporting TrueNAS!');
   });
 });

--- a/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.ts
+++ b/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, computed, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, effect, inject } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { MarketingMessage, getMarketingMessages } from 'app/constants/marketing-messages.constant';
 import { hashMessage } from 'app/helpers/hash-message';
@@ -21,9 +21,22 @@ const lastMessageHashKey = 'marketingMessageLastHash';
 export class UseEnterpriseMarketingLinkComponent {
   private tnConnect = inject(TruenasConnectService);
 
+  // Snapshot the rotation state once at construction so message selection stays a
+  // pure computed. The pool can still change when TrueNAS Connect config resolves
+  // asynchronously, but the "which slot to show today" decision is made against a
+  // stable pointer rather than being re-read (and advanced) on every recompute.
+  private readonly today = new Date().toDateString();
+  private readonly isNewDay = localStorage.getItem(lastShownDateKey) !== this.today;
+  private readonly storedMessageHash = localStorage.getItem(lastMessageHashKey);
+
   private messages = computed<MarketingMessage[]>(() => getMarketingMessages(this.tnConnect.config()));
 
-  protected currentMessage = computed<MarketingMessage>(() => this.getTodaysMessage(this.messages()));
+  protected currentMessage = computed<MarketingMessage>(() => {
+    const messages = this.messages();
+    return this.isNewDay
+      ? this.getNextMessage(messages, this.storedMessageHash)
+      : this.getCurrentMessage(messages, this.storedMessageHash);
+  });
 
   protected currentMessageHref = computed<string | null>(() => {
     const message = this.currentMessage();
@@ -33,21 +46,16 @@ export class UseEnterpriseMarketingLinkComponent {
     return `${message.href}?m=${hashMessage(message.text)}`;
   });
 
-  private getTodaysMessage(messages: MarketingMessage[]): MarketingMessage {
-    const today = new Date().toDateString();
-    const lastShownDate = localStorage.getItem(lastShownDateKey);
-    const lastMessageHash = localStorage.getItem(lastMessageHashKey);
-
-    if (lastShownDate !== today) {
-      const nextMessage = this.getNextMessage(messages, lastMessageHash);
-
-      localStorage.setItem(lastShownDateKey, today);
-      localStorage.setItem(lastMessageHashKey, hashMessage(nextMessage.text));
-
-      return nextMessage;
+  constructor() {
+    // Persist the day's selection as an explicit side-effect, keeping the computed
+    // pure. Re-runs if the resolved config swaps the pool after first render.
+    if (this.isNewDay) {
+      effect(() => {
+        const message = this.currentMessage();
+        localStorage.setItem(lastShownDateKey, this.today);
+        localStorage.setItem(lastMessageHashKey, hashMessage(message.text));
+      });
     }
-
-    return this.getCurrentMessage(messages, lastMessageHash);
   }
 
   private getNextMessage(messages: MarketingMessage[], lastMessageHash: string | null): MarketingMessage {

--- a/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.ts
+++ b/src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.ts
@@ -1,8 +1,12 @@
 import { Component, ChangeDetectionStrategy, computed, inject } from '@angular/core';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { exploreNasEnterpriseLink } from 'app/constants/explore-nas-enterprise-link.constant';
+import { TranslateModule } from '@ngx-translate/core';
+import { MarketingMessage, getMarketingMessages } from 'app/constants/marketing-messages.constant';
 import { hashMessage } from 'app/helpers/hash-message';
 import { TestDirective } from 'app/modules/test-id/test.directive';
+import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
+
+const lastShownDateKey = 'marketingMessageLastShownDate';
+const lastMessageHashKey = 'marketingMessageLastHash';
 
 @Component({
   selector: 'ix-use-enterprise-marketing-link',
@@ -15,44 +19,45 @@ import { TestDirective } from 'app/modules/test-id/test.directive';
   ],
 })
 export class UseEnterpriseMarketingLinkComponent {
-  private translate = inject(TranslateService);
+  private tnConnect = inject(TruenasConnectService);
 
-  messages = [
-    this.translate.instant('More Performance, More Protection'),
-    this.translate.instant('Boost Performance & Support'),
-    this.translate.instant('Unlock High Performance Solutions'),
-    this.translate.instant('Expert Support When You Need It'),
-    this.translate.instant('Achieve 99.999% Uptime with HA'),
-  ];
+  private messages = computed<MarketingMessage[]>(() => getMarketingMessages(this.tnConnect.config()));
 
-  currentMessage = computed(() => this.getTodaysMessage());
-  currentMessageHref = computed(() => `${exploreNasEnterpriseLink}?m=${hashMessage(this.currentMessage())}`);
+  protected currentMessage = computed<MarketingMessage>(() => this.getTodaysMessage(this.messages()));
 
-  getTodaysMessage(): string {
+  protected currentMessageHref = computed<string | null>(() => {
+    const message = this.currentMessage();
+    if (!message.href) {
+      return null;
+    }
+    return `${message.href}?m=${hashMessage(message.text)}`;
+  });
+
+  private getTodaysMessage(messages: MarketingMessage[]): MarketingMessage {
     const today = new Date().toDateString();
-    const lastShownDate = localStorage.getItem('marketingMessageLastShownDate');
-    const lastMessageHash = localStorage.getItem('marketingMessageLastHash');
+    const lastShownDate = localStorage.getItem(lastShownDateKey);
+    const lastMessageHash = localStorage.getItem(lastMessageHashKey);
 
     if (lastShownDate !== today) {
-      const nextMessage = this.getNextMessage(lastMessageHash);
+      const nextMessage = this.getNextMessage(messages, lastMessageHash);
 
-      localStorage.setItem('marketingMessageLastShownDate', today);
-      localStorage.setItem('marketingMessageLastHash', hashMessage(nextMessage));
+      localStorage.setItem(lastShownDateKey, today);
+      localStorage.setItem(lastMessageHashKey, hashMessage(nextMessage.text));
 
       return nextMessage;
     }
 
-    return this.getCurrentMessage(lastMessageHash);
+    return this.getCurrentMessage(messages, lastMessageHash);
   }
 
-  private getNextMessage(lastMessageHash: string | null): string {
-    const lastIndex = this.messages.findIndex((message) => hashMessage(message) === lastMessageHash);
-    const nextIndex = lastIndex >= 0 ? (lastIndex + 1) % this.messages.length : 0;
-    return this.messages[nextIndex];
+  private getNextMessage(messages: MarketingMessage[], lastMessageHash: string | null): MarketingMessage {
+    const lastIndex = messages.findIndex((message) => hashMessage(message.text) === lastMessageHash);
+    const nextIndex = lastIndex >= 0 ? (lastIndex + 1) % messages.length : 0;
+    return messages[nextIndex];
   }
 
-  private getCurrentMessage(lastMessageHash: string | null): string {
-    const currentIndex = this.messages.findIndex((message) => hashMessage(message) === lastMessageHash);
-    return currentIndex >= 0 ? this.messages[currentIndex] : this.messages[0];
+  private getCurrentMessage(messages: MarketingMessage[], lastMessageHash: string | null): MarketingMessage {
+    const currentIndex = messages.findIndex((message) => hashMessage(message.text) === lastMessageHash);
+    return currentIndex >= 0 ? messages[currentIndex] : messages[0];
   }
 }

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.scss
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.scss
@@ -26,9 +26,16 @@
 }
 
 .use-enterprise {
-  height: calc(48px * 2);
+  min-height: calc(48px * 2);
 
   @media (max-width: $breakpoint-sm) {
-    height: calc(48px * 1.2);
+    min-height: calc(48px * 1.2);
+  }
+
+  // tn-list-item truncates its primary text to a single line, but marketing messages are sentences.
+  ::ng-deep .tn-list-item__primary-text {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
   }
 }


### PR DESCRIPTION
 ## Summary

  Reworks the marketing call-to-action in the Dashboard's **System Information** card (Community Edition only) to serve targeted messaging based on TrueNAS Connect (TNC) state, per Marketing's request. Previously it rotated through "Explore TrueNAS Enterprise" taglines only; it now also promotes TrueNAS Connect and encourages tier upgrades.

  ## Message pools

  Enterprise-awareness messages stay in rotation for every CE system, joined by the TNC messages matching the current state:

  | System state | Extra pool | CTA |
  | --- | --- | --- |
  | Not connected to TNC | Promote TNC | `Try out TrueNAS Connect` |
  | Connected — Foundation (free) | Upgrade to Plus | `Upgrade to TrueNAS Connect Plus` |
  | Connected — Plus / Business (paid) | Thank-you (non-clickable) | `Thanks for supporting TrueNAS!` |

  Enterprise "Explore TrueNAS Enterprise" keeps its 5 taglines and adds 5 new ones. Hidden entirely on Enterprise systems.

  ## Changes

  - `marketing-messages.constant.ts` — `MarketingMessage` interface, the four pools, and `getMarketingMessages(config)` selecting by TNC `status`/`tier`.
  - `use-enterprise-marketing-link.component.ts` — derives messages from `TruenasConnectService.config()`; each message carries its own `cta`/`href`. Daily rotation unchanged.
  - `use-enterprise-marketing-link.component.html` — clickable `<a>` when `href` present, else non-clickable `.no-link` block; `text`own `cta`/`href`. Daily rotation unchanged.
- `use-enterprise-marketing-link.component.html` — clickable `<a>` when `href` present, else non-clickable `.no-link` block; `text` and `cta` both translated.
- `truenas-connect-link.constant.ts` *(new)* — `connect.truenas.com` link constant.
- `.scss` / `.spec.ts` — styling for both variants; expanded coverage of pool selection, rotation, links, and thank-you rendering.

## Testing

- `yarn test src/app/modules/use-enterprise-marketing-link/use-enterprise-marketing-link.component.spec.ts`
- Manual: verified pool switching in the sys-info card via mocked `tn_connect.config` / `system.product_type`.

## Notes

- Rotation is sequential with enterprise messages leading, so Connect messages arrive clustered (~10 enterprise messages before them). Flagging in case Marketing expected earlier TNC exposure.
- "Only in CE" gating lives in `widget-sys-info-active` and isn't covered by this spec.