### PR TITLE
NAS-141792 / 26.0.0-RC.1 / Preserve explicit dataset Case Sensitivity when preset changes (by AlexKarpov98)

### DIFF
--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
@@ -259,6 +259,14 @@ describe('OtherOptionsSectionComponent', () => {
     form = await loader.getHarness(IxFieldsetHarness);
   });
 
+  function getSelect(formControlName: string): Promise<IxSelectHarness> {
+    return loader.getHarness(IxSelectHarness.with({ selector: `[formControlName="${formControlName}"]` }));
+  }
+
+  async function getSelectValue(formControlName: string): Promise<string> {
+    return (await getSelect(formControlName)).getValue() as Promise<string>;
+  }
+
   describe('basic options', () => {
     it('hides section in Basic mode', async () => {
       spectator.setInput('advancedMode', false);
@@ -434,7 +442,7 @@ describe('OtherOptionsSectionComponent', () => {
       spectator.setInput({ parent: parentDataset });
       spectator.setInput({ datasetPreset: DatasetPreset.Apps });
 
-      await (await getSelect('casesensitivity')).selectOption('Insensitive');
+      await (await getSelect('casesensitivity')).setValue('Insensitive');
 
       // Changing the preset must not silently discard the user's explicit choice.
       spectator.setInput({ datasetPreset: DatasetPreset.Multiprotocol });
@@ -458,7 +466,7 @@ describe('OtherOptionsSectionComponent', () => {
       spectator.setInput({ parent: parentDataset });
       spectator.setInput({ datasetPreset: DatasetPreset.Apps });
 
-      await (await getSelect('aclmode')).selectOption('Restricted');
+      await (await getSelect('aclmode')).setValue('Restricted');
 
       // Changing the preset must not silently discard the user's explicit choice.
       spectator.setInput({ datasetPreset: DatasetPreset.Multiprotocol });

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
@@ -454,6 +454,29 @@ describe('OtherOptionsSectionComponent', () => {
       expect(await getSelectValue('casesensitivity')).toBe('Sensitive');
     });
 
+    it('preserves an explicit ACL Mode choice when the dataset preset is changed', async () => {
+      spectator.setInput({ parent: parentDataset });
+      spectator.setInput({ datasetPreset: DatasetPreset.Apps });
+
+      await (await getSelect('aclmode')).selectOption('Restricted');
+
+      // Changing the preset must not silently discard the user's explicit choice.
+      spectator.setInput({ datasetPreset: DatasetPreset.Multiprotocol });
+
+      expect(await getSelectValue('aclmode')).toBe('Restricted');
+    });
+
+    it('applies the preset ACL Mode default when the user has not changed it', async () => {
+      spectator.setInput({ parent: parentDataset });
+
+      // SMB forces Restricted; switching to a non-SMB preset restores the Passthrough default.
+      spectator.setInput({ datasetPreset: DatasetPreset.Smb });
+      expect(await getSelectValue('aclmode')).toBe('Restricted');
+
+      spectator.setInput({ datasetPreset: DatasetPreset.Apps });
+      expect(await getSelectValue('aclmode')).toBe('Passthrough');
+    });
+
     it('shows warning if user selects "Sync" as Disabled', async () => {
       spectator.setInput({
         parent: parentDataset,

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.spec.ts
@@ -10,7 +10,7 @@ import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { AclMode } from 'app/enums/acl-type.enum';
 import {
   DatasetAclType,
-  DatasetCaseSensitivity, DatasetRecordSize,
+  DatasetCaseSensitivity, DatasetPreset, DatasetRecordSize,
   DatasetSnapdev,
   DatasetSnapdir,
   DatasetSync,
@@ -428,6 +428,30 @@ describe('OtherOptionsSectionComponent', () => {
         Snapdev: 'Inherit (Hidden)',
         'Snapshot Directory': 'Inherit (Hidden)',
       });
+    });
+
+    it('preserves an explicit Case Sensitivity choice when the dataset preset is changed', async () => {
+      spectator.setInput({ parent: parentDataset });
+      spectator.setInput({ datasetPreset: DatasetPreset.Apps });
+
+      await (await getSelect('casesensitivity')).selectOption('Insensitive');
+
+      // Changing the preset must not silently discard the user's explicit choice.
+      spectator.setInput({ datasetPreset: DatasetPreset.Multiprotocol });
+
+      expect(await getSelectValue('casesensitivity')).toBe('Insensitive');
+      expect(spectator.component.getPayload().casesensitivity).toBe(DatasetCaseSensitivity.Insensitive);
+    });
+
+    it('applies the preset Case Sensitivity default when the user has not changed it', async () => {
+      spectator.setInput({ parent: parentDataset });
+
+      // SMB forces case-insensitive; switching to a non-SMB preset restores the Sensitive default.
+      spectator.setInput({ datasetPreset: DatasetPreset.Smb });
+      expect(await getSelectValue('casesensitivity')).toBe('Insensitive');
+
+      spectator.setInput({ datasetPreset: DatasetPreset.Apps });
+      expect(await getSelectValue('casesensitivity')).toBe('Sensitive');
     });
 
     it('shows warning if user selects "Sync" as Disabled', async () => {

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
@@ -436,12 +436,16 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
       this.form.controls.aclmode.disable();
       this.form.controls.casesensitivity.disable();
     } else {
-      this.form.patchValue({
-        aclmode: AclMode.Passthrough,
-        casesensitivity: DatasetCaseSensitivity.Sensitive,
-      });
       this.form.controls.aclmode.enable();
       this.form.controls.casesensitivity.enable();
+
+      this.form.patchValue({ aclmode: AclMode.Passthrough });
+
+      // Only apply the preset's case-sensitivity default when the user hasn't explicitly
+      // chosen a value; otherwise a preset change would silently discard their selection.
+      if (!this.form.controls.casesensitivity.dirty) {
+        this.form.patchValue({ casesensitivity: DatasetCaseSensitivity.Sensitive });
+      }
     }
   }
 

--- a/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/other-options-section/other-options-section.component.ts
@@ -439,10 +439,11 @@ export class OtherOptionsSectionComponent implements OnInit, OnChanges {
       this.form.controls.aclmode.enable();
       this.form.controls.casesensitivity.enable();
 
-      this.form.patchValue({ aclmode: AclMode.Passthrough });
-
-      // Only apply the preset's case-sensitivity default when the user hasn't explicitly
-      // chosen a value; otherwise a preset change would silently discard their selection.
+      // Only apply the preset's defaults when the user hasn't explicitly chosen a value;
+      // otherwise a preset change would silently discard their selection.
+      if (!this.form.controls.aclmode.dirty) {
+        this.form.patchValue({ aclmode: AclMode.Passthrough });
+      }
       if (!this.form.controls.casesensitivity.dirty) {
         this.form.patchValue({ casesensitivity: DatasetCaseSensitivity.Sensitive });
       }


### PR DESCRIPTION
When switching `Dataset Preset` now we preserve Case Sensitivity value if it was changed instead of always silently overriding it to `Sensitive`.

Original PR: https://github.com/truenas/webui/pull/13835
