### PR TITLE
NAS-141773 / 26.0.0-RC.1 / Show files in TrueCloud restore snapshot path selectors (by AlexKarpov98)

### DIFF
--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.html
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.html
@@ -45,7 +45,7 @@
             formControlName="subFolder"
             [required]="true"
             [label]="'Subfolder' | translate"
-            [nodeProvider]="snapshotNodeProvider"
+            [nodeProvider]="subFolderNodeProvider"
             [rootNodes]="data?.backup.absolute_paths ? [rootDatasetNode] : [slashRootNode]"
             [tooltip]="helptext.tooltips.subFolder | translate"
           ></ix-explorer>

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.spec.ts
@@ -141,6 +141,31 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
       ]);
     });
 
+    it('forwards a selected file path as-is through include params', async () => {
+      const form = await loader.getHarness(IxFormHarness);
+      await form.fillForm({
+        Target: '/mnt/bulldozer',
+        'Include/Exclude': 'Include from subfolder',
+        Subfolder: '/mnt/dozer',
+        'Included Paths': '/mnt/dozer/file.txt',
+      });
+
+      const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await saveButton.click();
+
+      expect(spectator.inject(ApiService).job).toHaveBeenCalledWith('cloud_backup.restore', [
+        1,
+        1,
+        '/mnt/dozer',
+        '/mnt/bulldozer',
+        {
+          include: [
+            '/file.txt',
+          ],
+        },
+      ]);
+    });
+
     it('submits backup restore from snapshot with `Include from subfolder` matches paths', async () => {
       const form = await loader.getHarness(IxFormHarness);
       await form.fillForm({
@@ -203,6 +228,15 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
       expect(nodes).toEqual([
         expect.objectContaining({ path: '/sub', type: ExplorerNodeType.Directory, hasChildren: true }),
         expect.objectContaining({ path: '/file.txt', type: ExplorerNodeType.File, hasChildren: false }),
+      ]);
+    });
+
+    it('lists only directories for the subfolder selector', async () => {
+      const node = { data: { path: '/' } } as TreeNode<ExplorerNodeData>;
+      const nodes = await firstValueFrom(spectator.component.subFolderNodeProvider(node));
+
+      expect(nodes).toEqual([
+        expect.objectContaining({ path: '/sub', type: ExplorerNodeType.Directory, hasChildren: true }),
       ]);
     });
   });

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.spec.ts
@@ -4,10 +4,17 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
-import { of } from 'rxjs';
-import { mockJob, mockApi } from 'app/core/testing/utils/mock-api.utils';
+import { firstValueFrom, of } from 'rxjs';
+import { mockCall, mockJob, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { CloudBackup, CloudBackupSnapshot } from 'app/interfaces/cloud-backup.interface';
+import { ExplorerNodeType } from 'app/enums/explorer-type.enum';
+import {
+  CloudBackup,
+  CloudBackupSnapshot,
+  CloudBackupSnapshotDirectoryFileType,
+  CloudBackupSnapshotDirectoryListing,
+} from 'app/interfaces/cloud-backup.interface';
+import { ExplorerNodeData, TreeNode } from 'app/interfaces/tree-node.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import {
   ExplorerCreateDatasetComponent,
@@ -49,6 +56,10 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
       }),
       mockApi([
         mockJob('cloud_backup.restore'),
+        mockCall('cloud_backup.list_snapshot_directory', [
+          { name: 'sub', path: '/sub', type: CloudBackupSnapshotDirectoryFileType.Dir },
+          { name: 'file.txt', path: '/file.txt', type: CloudBackupSnapshotDirectoryFileType.File },
+        ] as CloudBackupSnapshotDirectoryListing[]),
       ]),
       mockProvider(SlideIn, {
         open: jest.fn(() => of()),
@@ -176,6 +187,22 @@ describe('CloudBackupRestoreFromSnapshotFormComponent', () => {
             'pattern',
           ],
         },
+      ]);
+    });
+  });
+
+  describe('snapshot node provider', () => {
+    beforeEach(() => {
+      spectator = createComponent();
+    });
+
+    it('lists both directories and files from a snapshot directory', async () => {
+      const node = { data: { path: '/' } } as TreeNode<ExplorerNodeData>;
+      const nodes = await firstValueFrom(spectator.component.snapshotNodeProvider(node));
+
+      expect(nodes).toEqual([
+        expect.objectContaining({ path: '/sub', type: ExplorerNodeType.Directory, hasChildren: true }),
+        expect.objectContaining({ path: '/file.txt', type: ExplorerNodeType.File, hasChildren: false }),
       ]);
     });
   });

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.ts
@@ -186,14 +186,18 @@ export class CloudBackupRestoreFromSnapshotFormComponent implements OnInit {
           const nodes: ExplorerNodeData[] = [];
 
           listing.forEach((file) => {
-            if (file.type === CloudBackupSnapshotDirectoryFileType.Dir && file.path !== node.data.path) {
-              nodes.push({
-                path: file.path,
-                name: file.name,
-                type: ExplorerNodeType.Directory,
-                hasChildren: true,
-              });
+            if (file.path === node.data.path) {
+              return;
             }
+
+            const isDirectory = file.type === CloudBackupSnapshotDirectoryFileType.Dir;
+
+            nodes.push({
+              path: file.path,
+              name: file.name,
+              type: isDirectory ? ExplorerNodeType.Directory : ExplorerNodeType.File,
+              hasChildren: isDirectory,
+            });
           });
 
           return nodes;

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-details/cloud-backup-restore-form-snapshot-form/cloud-backup-restore-from-snapshot-form.component.ts
@@ -86,6 +86,7 @@ export class CloudBackupRestoreFromSnapshotFormComponent implements OnInit {
 
   fileNodeProvider: TreeNodeProvider;
   snapshotNodeProvider: TreeNodeProvider;
+  subFolderNodeProvider: TreeNodeProvider;
 
   readonly includeExcludeOptions$ = of(mapToOptions(snapshotIncludeExcludeOptions, this.translate));
 
@@ -176,7 +177,7 @@ export class CloudBackupRestoreFromSnapshotFormComponent implements OnInit {
       });
   }
 
-  private getSnapshotNodeProvider(): TreeNodeProvider {
+  private getSnapshotNodeProvider(directoriesOnly = false): TreeNodeProvider {
     return (node: TreeNode<ExplorerNodeData>) => {
       return this.api.call(
         'cloud_backup.list_snapshot_directory',
@@ -191,6 +192,10 @@ export class CloudBackupRestoreFromSnapshotFormComponent implements OnInit {
             }
 
             const isDirectory = file.type === CloudBackupSnapshotDirectoryFileType.Dir;
+
+            if (directoriesOnly && !isDirectory) {
+              return;
+            }
 
             nodes.push({
               path: file.path,
@@ -263,6 +268,7 @@ export class CloudBackupRestoreFromSnapshotFormComponent implements OnInit {
 
   private setSnapshotNodeProvider(): void {
     this.snapshotNodeProvider = this.getSnapshotNodeProvider();
+    this.subFolderNodeProvider = this.getSnapshotNodeProvider(true);
   }
 
   private disableHiddenFields(): void {


### PR DESCRIPTION
### Problem
In the TrueCloud "Restore from Snapshot" form, the **Included Paths** and **Excluded Paths** tree selectors only displayed folders, even though the tooltip states files and directories can be selected. Users could not select individual files to restore.

### Cause
`getSnapshotNodeProvider()` only mapped directory entries into tree nodes; file entries returned by `cloud_backup.list_snapshot_directory` were silently discarded.

### Fix
Map both files and directories into explorer nodes — files as selectable leaf nodes (`type: File`, `hasChildren: false`), directories unchanged. The `ix-explorer` already supports file selection, and the restore params pass selected paths through as-is, so no backend change is needed.

### Testing
- Added a spec asserting the node provider returns both file and directory nodes.
- All specs pass; lint clean.

Original PR: https://github.com/truenas/webui/pull/13845
