### PR TITLE
NAS-141778 / 27.0.0-BETA.1 / Expose force_topology option for vdevs on Community Edition

### DIFF
--- a/src/app/interfaces/pool.interface.ts
+++ b/src/app/interfaces/pool.interface.ts
@@ -92,6 +92,9 @@ export interface CreatePool {
   dedup_table_quota?: NewDeduplicationQuotaSetting;
   deduplication?: DeduplicationSetting;
   allow_duplicate_serials?: boolean;
+  // Community Edition only: bypasses topology policy checks (equal data-vdev width,
+  // RAIDZ/mirror width caps, special/dedup redundancy rule). Rejected on Enterprise.
+  force_topology?: boolean;
 }
 
 export interface UpdatePool {
@@ -101,6 +104,9 @@ export interface UpdatePool {
   all_sed?: boolean;
   dedup_table_quota?: NewDeduplicationQuotaSetting;
   dedup_table_quota_value?: number;
+  // Community Edition only: bypasses topology policy checks (equal data-vdev width,
+  // RAIDZ/mirror width caps, special/dedup redundancy rule). Rejected on Enterprise.
+  force_topology?: boolean;
 }
 
 // TODO: Maybe replace first 5 keys with VDevType enum once old pool manager is removed.

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.spec.ts
@@ -258,5 +258,18 @@ describe('PoolManagerWizardComponent', () => {
         data: createdPool,
       });
     });
+
+    it('adds force_topology to the payload when forceTopology is set in the store', async () => {
+      state$.next({ ...state, forceTopology: true });
+
+      await wizard.selectStep((await wizard.getStepLabels()).indexOf('Review'));
+      spectator.query(ReviewWizardStepComponent)!.createPool.emit();
+
+      expect(spectator.inject(ApiService, true).job).toHaveBeenCalledWith('pool.create', [
+        expect.objectContaining({ force_topology: true }),
+      ]);
+
+      state$.next(state);
+    });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.spec.ts
@@ -94,6 +94,7 @@ describe('PoolManagerWizardComponent', () => {
   } as PoolManagerState;
   const state$ = new BehaviorSubject(state);
   const createdPool = {} as Pool;
+  const existingPool$ = new BehaviorSubject<Pool | null>(null);
 
   const createComponent = createComponentFactory({
     component: PoolManagerWizardComponent,
@@ -122,6 +123,7 @@ describe('PoolManagerWizardComponent', () => {
       mockApi([
         mockCall('pool.query', []),
         mockJob('pool.create', fakeSuccessfulJob(createdPool)),
+        mockJob('pool.update', fakeSuccessfulJob(createdPool)),
       ]),
       mockProvider(ActivatedRoute, {
         params: of({}),
@@ -147,7 +149,7 @@ describe('PoolManagerWizardComponent', () => {
         ],
       }),
       mockProvider(AddVdevsStore, {
-        pool$: of(null),
+        pool$: existingPool$,
         isLoading$: of(false),
       }),
       mockProvider(Router),
@@ -266,6 +268,35 @@ describe('PoolManagerWizardComponent', () => {
       spectator.query(ReviewWizardStepComponent)!.createPool.emit();
 
       expect(spectator.inject(ApiService, true).job).toHaveBeenCalledWith('pool.create', [
+        expect.objectContaining({ force_topology: true }),
+      ]);
+
+      state$.next(state);
+    });
+  });
+
+  describe('updating an existing pool', () => {
+    const existingPool = { id: 42 } as Pool;
+
+    beforeEach(async () => {
+      existingPool$.next(existingPool);
+      spectator = createComponent();
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+      wizard = await loader.getHarness(TnStepperHarness);
+    });
+
+    afterEach(() => {
+      existingPool$.next(null);
+    });
+
+    it('adds force_topology to the pool.update payload when forceTopology is set in the store', async () => {
+      state$.next({ ...state, forceTopology: true });
+
+      await wizard.selectStep((await wizard.getStepLabels()).indexOf('Review'));
+      spectator.query(ReviewWizardStepComponent)!.createPool.emit();
+
+      expect(spectator.inject(ApiService, true).job).toHaveBeenCalledWith('pool.update', [
+        existingPool.id,
         expect.objectContaining({ force_topology: true }),
       ]);
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/pool-manager-wizard.component.ts
@@ -275,6 +275,12 @@ export class PoolManagerWizardComponent implements OnInit, OnDestroy {
       payload.all_sed = true;
     }
 
+    // Community Edition only. The flag is gated to CE in the UI, so state.forceTopology
+    // is never true on Enterprise, where middleware rejects it outright.
+    if (this.state.forceTopology) {
+      payload.force_topology = true;
+    }
+
     return payload;
   }
 
@@ -283,6 +289,10 @@ export class PoolManagerWizardComponent implements OnInit, OnDestroy {
       topology: topologyToPayload(this.state.topology),
       allow_duplicate_serials: this.state.diskSettings.allowNonUniqueSerialDisks,
     };
+
+    if (this.state.forceTopology) {
+      payload.force_topology = true;
+    }
 
     this.dialogService.jobDialog(
       this.api.job('pool.update', [this.existingPool.id, payload]),

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.html
@@ -77,6 +77,20 @@
   }
 </div>
 
+@if (!isEnterprise()) {
+  <div class="force-topology">
+    <tn-form-field
+      [tooltip]="'Bypass topology recommendation checks (equal data VDEV width, RAIDZ/mirror width limits, and special/dedup redundancy). Not recommended.' | translate"
+    >
+      <tn-checkbox
+        [formControl]="forceTopologyControl"
+        [testId]="'force-topology'"
+        [label]="'Force' | translate"
+      ></tn-checkbox>
+    </tn-form-field>
+  </div>
+}
+
 <ix-form-actions>
   <tn-button
     tnStepperPrevious

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.scss
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.force-topology {
+  margin-bottom: 24px;
+}
+
 .summary-item {
   display: flex;
   justify-content: space-between;

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.spec.ts
@@ -3,7 +3,10 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import {
   byTextContent, createComponentFactory, mockProvider, Spectator,
 } from '@ngneat/spectator/jest';
-import { TnButtonHarness, TnDialog, TnStepperComponent } from '@truenas/ui-components';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import {
+  TnButtonHarness, TnCheckboxHarness, TnDialog, TnStepperComponent,
+} from '@truenas/ui-components';
 import { BehaviorSubject, of } from 'rxjs';
 import { GiB } from 'app/constants/bytes.constant';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
@@ -30,6 +33,7 @@ import {
   PoolManagerState,
   PoolManagerStore,
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
+import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors';
 
 describe('ReviewWizardStepComponent', () => {
   let spectator: Spectator<ReviewWizardStepComponent>;
@@ -84,6 +88,11 @@ describe('ReviewWizardStepComponent', () => {
         totalUsableCapacity$: of(2 * GiB),
       }),
       mockProvider(TnDialog),
+      provideMockStore({
+        selectors: [
+          { selector: selectIsEnterprise, value: false },
+        ],
+      }),
       mockAuth(),
     ],
   });
@@ -273,6 +282,35 @@ describe('ReviewWizardStepComponent', () => {
     it('disables pool creation button once there are errors', async () => {
       const createPool = await loader.getHarness(TnButtonHarness.with({ label: 'Create Pool' }));
       expect(await createPool.isDisabled()).toBe(true);
+    });
+  });
+
+  describe('force topology (Community Edition)', () => {
+    beforeEach(() => {
+      spectator = createComponent();
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+    });
+
+    it('shows the Force checkbox on non-Enterprise systems', async () => {
+      const checkbox = await loader.getHarnessOrNull(TnCheckboxHarness.with({ label: 'Force' }));
+      expect(checkbox).not.toBeNull();
+    });
+
+    it('updates the store when the Force checkbox is toggled', async () => {
+      const checkbox = await loader.getHarness(TnCheckboxHarness.with({ label: 'Force' }));
+      await checkbox.check();
+
+      expect(spectator.inject(PoolManagerStore).setForceTopology).toHaveBeenLastCalledWith(true);
+    });
+
+    it('hides the Force checkbox on Enterprise systems', async () => {
+      const store$ = spectator.inject(MockStore);
+      store$.overrideSelector(selectIsEnterprise, true);
+      store$.refreshState();
+      spectator.detectChanges();
+
+      const checkbox = await loader.getHarnessOrNull(TnCheckboxHarness.with({ label: 'Force' }));
+      expect(checkbox).toBeNull();
     });
   });
 });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.spec.ts
@@ -67,6 +67,7 @@ describe('ReviewWizardStepComponent', () => {
     },
   } as PoolManagerState;
   const state$ = new BehaviorSubject(state);
+  const forceTopology$ = new BehaviorSubject(false);
 
   const createComponent = createComponentFactory({
     component: ReviewWizardStepComponent,
@@ -85,6 +86,7 @@ describe('ReviewWizardStepComponent', () => {
       }),
       mockProvider(PoolManagerStore, {
         state$,
+        forceTopology$,
         totalUsableCapacity$: of(2 * GiB),
       }),
       mockProvider(TnDialog),
@@ -248,6 +250,7 @@ describe('ReviewWizardStepComponent', () => {
         providers: [
           mockProvider(PoolManagerStore, {
             state$,
+            forceTopology$,
             totalUsableCapacity$: of(2 * GiB),
           }),
           mockProvider(PoolManagerValidationService, {
@@ -291,6 +294,10 @@ describe('ReviewWizardStepComponent', () => {
       loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     });
 
+    afterEach(() => {
+      forceTopology$.next(false);
+    });
+
     it('shows the Force checkbox on non-Enterprise systems', async () => {
       const checkbox = await loader.getHarnessOrNull(TnCheckboxHarness.with({ label: 'Force' }));
       expect(checkbox).not.toBeNull();
@@ -301,6 +308,17 @@ describe('ReviewWizardStepComponent', () => {
       await checkbox.check();
 
       expect(spectator.inject(PoolManagerStore).setForceTopology).toHaveBeenLastCalledWith(true);
+    });
+
+    it('unchecks the Force checkbox when the store resets forceTopology (e.g. Start Over)', async () => {
+      forceTopology$.next(true);
+      spectator.detectChanges();
+      const checkbox = await loader.getHarness(TnCheckboxHarness.with({ label: 'Force' }));
+      expect(await checkbox.isChecked()).toBe(true);
+
+      forceTopology$.next(false);
+      spectator.detectChanges();
+      expect(await checkbox.isChecked()).toBe(false);
     });
 
     it('hides the Force checkbox on Enterprise systems', async () => {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
@@ -125,6 +125,14 @@ export class ReviewWizardStepComponent implements OnInit {
     this.forceTopologyControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((forceTopology) => {
       this.store.setForceTopology(forceTopology);
     });
+
+    // Keep the checkbox in sync with the store so a reset/Start Over (which sets
+    // forceTopology back to false) unchecks it, instead of leaving a checked box
+    // whose value is no longer reflected in the payload. emitEvent: false avoids
+    // looping back through the valueChanges subscription above.
+    this.store.forceTopology$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((forceTopology) => {
+      this.forceTopologyControl.setValue(forceTopology, { emitEvent: false });
+    });
   }
 
   onInspectVdevsPressed(): void {

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
@@ -2,9 +2,13 @@ import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, input, OnInit, output, inject,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { TnButtonComponent, TnDialog, TnStepperPreviousDirective } from '@truenas/ui-components';
+import {
+  TnButtonComponent, TnCheckboxComponent, TnDialog, TnFormFieldComponent, TnStepperPreviousDirective,
+} from '@truenas/ui-components';
 import { filter } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
@@ -27,6 +31,8 @@ import {
   PoolManagerStore,
   PoolManagerTopology, PoolManagerTopologyCategory,
 } from 'app/pages/storage/modules/pool-manager/store/pool-manager.store';
+import { AppState } from 'app/store';
+import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-review-wizard-step',
@@ -37,6 +43,9 @@ import {
     TnButtonComponent,
     TnStepperPreviousDirective,
     RequiresRolesDirective,
+    ReactiveFormsModule,
+    TnFormFieldComponent,
+    TnCheckboxComponent,
     TranslateModule,
     FileSizePipe,
     MapValuePipe,
@@ -48,6 +57,7 @@ import {
 export class ReviewWizardStepComponent implements OnInit {
   private tnDialog = inject(TnDialog);
   private store = inject(PoolManagerStore);
+  private systemStore$ = inject<Store<AppState>>(Store);
   private cdr = inject(ChangeDetectorRef);
   private dialogService = inject(DialogService);
   private translate = inject(TranslateService);
@@ -58,6 +68,10 @@ export class ReviewWizardStepComponent implements OnInit {
 
   readonly vDevType = VDevType;
   readonly createPool = output();
+
+  // force_topology is a Community Edition escape hatch; middleware rejects it on Enterprise.
+  protected readonly isEnterprise = toSignal(this.systemStore$.select(selectIsEnterprise));
+  protected readonly forceTopologyControl = new FormControl(false, { nonNullable: true });
 
   state: PoolManagerState;
   nonEmptyTopologyCategories: [VDevType, PoolManagerTopologyCategory][] = [];
@@ -106,6 +120,10 @@ export class ReviewWizardStepComponent implements OnInit {
     this.poolManagerValidation.getPoolCreationErrors().pipe(takeUntilDestroyed(this.destroyRef)).subscribe((errors) => {
       this.poolCreationErrors = errors;
       this.isCreateDisabled = !!errors.filter((error) => error.severity === PoolCreationSeverity.Error).length;
+    });
+
+    this.forceTopologyControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((forceTopology) => {
+      this.store.setForceTopology(forceTopology);
     });
   }
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/9-review-wizard-step/review-wizard-step.component.ts
@@ -70,7 +70,7 @@ export class ReviewWizardStepComponent implements OnInit {
   readonly createPool = output();
 
   // force_topology is a Community Edition escape hatch; middleware rejects it on Enterprise.
-  protected readonly isEnterprise = toSignal(this.systemStore$.select(selectIsEnterprise));
+  protected readonly isEnterprise = toSignal(this.systemStore$.select(selectIsEnterprise), { requireSync: true });
   protected readonly forceTopologyControl = new FormControl(false, { nonNullable: true });
 
   state: PoolManagerState;

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -76,7 +76,7 @@ export interface PoolManagerState {
   enclosureSettings: PoolManagerEnclosureSettings;
   topology: PoolManagerTopology;
   categorySequence: VDevType[];
-  // Community Edition only: forces the pool through topology policy checks. Never set on Enterprise.
+  // Community Edition only: bypasses topology policy checks. Never set on Enterprise.
   forceTopology: boolean;
 }
 

--- a/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
+++ b/src/app/pages/storage/modules/pool-manager/store/pool-manager.store.ts
@@ -76,6 +76,8 @@ export interface PoolManagerState {
   enclosureSettings: PoolManagerEnclosureSettings;
   topology: PoolManagerTopology;
   categorySequence: VDevType[];
+  // Community Edition only: forces the pool through topology policy checks. Never set on Enterprise.
+  forceTopology: boolean;
 }
 
 type TopologyCategoryUpdate = Partial<Omit<PoolManagerTopologyCategory, 'vdevs' | 'hasCustomDiskSelection'>>;
@@ -129,6 +131,8 @@ export const initialState: PoolManagerState = {
     VDevType.Special,
     VDevType.Dedup,
   ],
+
+  forceTopology: false,
 };
 
 @Injectable()
@@ -153,6 +157,7 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
   readonly topology$ = this.select((state) => state.topology);
   readonly diskSettings$ = this.select((state) => state.diskSettings);
   readonly enclosureSettings$ = this.select((state) => state.enclosureSettings);
+  readonly forceTopology$ = this.select((state) => state.forceTopology);
   readonly totalUsableCapacity$ = this.select(
     this.topology$,
     (topology) => categoryCapacity(topology[VDevType.Data]),
@@ -322,6 +327,10 @@ export class PoolManagerStore extends ComponentStore<PoolManagerState> {
     });
 
     this.resetTopologyIfNotEnoughDisks();
+  }
+
+  setForceTopology(forceTopology: boolean): void {
+    this.patchState({ forceTopology });
   }
 
   setEnclosureOptions(enclosureOptions: PoolManagerEnclosureSettings): void {


### PR DESCRIPTION
<img width="931" height="499" alt="Screenshot 2026-07-23 at 13 21 28" src="https://github.com/user-attachments/assets/16d2a127-3b4c-4bcf-bc90-4e10adbffbd8" />

Adds a CE-only **Force** checkbox to the pool wizard's Review step that sends `force_topology` to `pool.create` / `pool.update`, bypassing the topology policy checks added in [middleware#19282](https://github.com/truenas/middleware/pull/19282) (equal data-vdev width, RAIDZ/mirror width caps, special/dedup redundancy). Hidden on Enterprise, where middleware rejects the flag.