### PR TITLE
NAS-141822 / 26.0.0-RC.1 / Fix TrueCloud Backup label overlap and inconsistent link color in Backup Tasks widget (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-actions/backup-task-actions.component.scss
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-actions/backup-task-actions.component.scss
@@ -1,4 +1,5 @@
 .backup-action {
+  color: var(--primary);
   cursor: pointer;
   display: inline-block;
   text-decoration: underline;

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-tile/backup-task-tile.component.scss
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/backup-task-tile/backup-task-tile.component.scss
@@ -107,7 +107,9 @@ ul {
     .title {
       font-size: 20px;
       margin: 0;
-      white-space: nowrap;
+      // Let long labels (e.g. "TrueCloud Backup") wrap within the 25%-wide
+      // caption column instead of overflowing into the task-counts column.
+      overflow-wrap: break-word;
     }
 
     .backup-actions {


### PR DESCRIPTION
Preview:

<img width="569" height="436" alt="Screenshot 2026-07-22 at 11 10 47" src="https://github.com/user-attachments/assets/ac85746f-d5bd-49fb-b75c-0e196dc20720" />


Original PR: https://github.com/truenas/webui/pull/13846
