### PR TITLE
NAS-141753 / 26.0.0-RC.1 / Fix Disk Health panel hidden when a pool device lacks SMART temperature (by AlexKarpov98)

### DIFF
--- a/src/app/interfaces/storage.interface.ts
+++ b/src/app/interfaces/storage.interface.ts
@@ -123,7 +123,7 @@ export interface ZfsProperties {
 }
 
 export interface TemperatureAgg {
-  min: number;
-  max: number;
-  avg: number;
+  min: number | null;
+  max: number | null;
+  avg: number | null;
 }

--- a/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.spec.ts
@@ -115,5 +115,28 @@ describe('DiskHealthCardComponent', () => {
         .toHaveText('30 °C');
       expect(spectator.query(byText('No disk temperature is available.'))).toBeNull();
     });
+
+    it('recomputes extremes without retaining stale values when disks input changes', () => {
+      spectator.setInput('disks', [
+        {
+          ...disks[0], devname: 'sda', name: 'sda', tempAggregates: { min: 10, max: 50, avg: 30 },
+        },
+        {
+          ...disks[0], devname: 'sdb', name: 'sdb', tempAggregates: { min: 20, max: 40, avg: 30 },
+        },
+      ] as StorageDashboardDisk[]);
+
+      // Remove the disk holding both extremes (10/50) — the panel must reflect the survivor (20/40).
+      spectator.setInput('disks', [
+        {
+          ...disks[0], devname: 'sdb', name: 'sdb', tempAggregates: { min: 20, max: 40, avg: 30 },
+        },
+      ] as StorageDashboardDisk[]);
+
+      expect(spectator.query(byText('Highest Temperature:'))!.parentElement!.querySelector('.value'))
+        .toHaveText('40 °C');
+      expect(spectator.query(byText('Lowest Temperature:'))!.parentElement!.querySelector('.value'))
+        .toHaveText('20 °C');
+    });
   });
 });

--- a/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.spec.ts
@@ -95,5 +95,25 @@ describe('DiskHealthCardComponent', () => {
       const detailsItem = spectator.query(byText('Average Disk Temperature:'))!.parentElement!;
       expect(detailsItem.querySelector('.value')).toHaveText('30 °C');
     });
+
+    it('ignores devices without SMART temperature values when aggregating', () => {
+      spectator.setInput('disks', [
+        ...disks,
+        {
+          ...disks[0],
+          devname: 'pmem0',
+          name: 'pmem0',
+          tempAggregates: { min: null, max: null, avg: null },
+        } as StorageDashboardDisk,
+      ]);
+
+      expect(spectator.query(byText('Highest Temperature:'))!.parentElement!.querySelector('.value'))
+        .toHaveText('50 °C');
+      expect(spectator.query(byText('Lowest Temperature:'))!.parentElement!.querySelector('.value'))
+        .toHaveText('10 °C');
+      expect(spectator.query(byText('Average Disk Temperature:'))!.parentElement!.querySelector('.value'))
+        .toHaveText('30 °C');
+      expect(spectator.query(byText('No disk temperature is available.'))).toBeNull();
+    });
   });
 });

--- a/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.ts
@@ -56,9 +56,7 @@ export class DiskHealthCardComponent implements OnInit, OnChanges {
   }
 
   get isTemperatureDataAvailable(): boolean {
-    return Boolean(
-      this.diskState.highestTemperature && this.diskState.lowestTemperature && this.diskState.averageTemperature,
-    );
+    return this.isHighestTempReady || this.isLowestTempReady || this.isAverageTempReady;
   }
 
   diskState: DiskState = {
@@ -116,22 +114,26 @@ export class DiskHealthCardComponent implements OnInit, OnChanges {
         return;
       }
 
-      if (this.diskState.highestTemperature === null) {
-        this.diskState.highestTemperature = disk.tempAggregates.max;
-      } else {
-        this.diskState.highestTemperature = Math.max(this.diskState.highestTemperature, disk.tempAggregates.max);
+      const { min, max, avg } = disk.tempAggregates;
+
+      if (max != null) {
+        this.diskState.highestTemperature = this.diskState.highestTemperature === null
+          ? max
+          : Math.max(this.diskState.highestTemperature, max);
       }
 
-      if (this.diskState.lowestTemperature === null) {
-        this.diskState.lowestTemperature = disk.tempAggregates.min;
-      } else {
-        this.diskState.lowestTemperature = Math.min(this.diskState.lowestTemperature, disk.tempAggregates.min);
+      if (min != null) {
+        this.diskState.lowestTemperature = this.diskState.lowestTemperature === null
+          ? min
+          : Math.min(this.diskState.lowestTemperature, min);
       }
 
-      avgSum += disk.tempAggregates.avg;
-      avgCounter++;
+      if (avg != null) {
+        avgSum += avg;
+        avgCounter++;
+      }
     });
 
-    this.diskState.averageTemperature = avgSum / avgCounter;
+    this.diskState.averageTemperature = avgCounter ? avgSum / avgCounter : null;
   }
 }

--- a/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/disk-health-card/disk-health-card.component.ts
@@ -107,6 +107,8 @@ export class DiskHealthCardComponent implements OnInit, OnChanges {
   }
 
   private loadTemperatures(): void {
+    this.diskState.highestTemperature = null;
+    this.diskState.lowestTemperature = null;
     let avgSum = 0;
     let avgCounter = 0;
     this.disks().forEach((disk) => {


### PR DESCRIPTION
<img width="475" height="268" alt="Screenshot 2026-07-23 at 12 46 36" src="https://github.com/user-attachments/assets/a7513c1c-ec17-4933-a820-88e1438aa21a" />

### Problem
Adding a device that doesn't report SMART temperature to a pool (e.g. an Intel Optane
PMEM used as a SLOG) blanked the entire **Disk Health** panel on the storage dashboard —
it showed only *"No disk temperature is available"* even though other disks in the pool
were reporting temperatures. Removing the device restored the panel.

### Cause
The backend returns `tempAggregates: { min: null, max: null, avg: null }` for such a
device. In `DiskHealthCardComponent.loadTemperatures()` the per-disk skip guard only
checked whether the `tempAggregates` object was *missing*, not whether its values were
null. So the null-valued device poisoned the aggregate:
- `avgSum += null` counted the device as 0 °C, halving the average
- `Math.min(x, null)` coerced Lowest Temperature to `0`
- the truthiness-based `isTemperatureDataAvailable` gate then collapsed the whole panel

### Fix
- `loadTemperatures()` now validates each of `min`/`max`/`avg` individually before folding
  it into the aggregate, and yields `null` (not `NaN`) when no disk reports a temperature.
- `isTemperatureDataAvailable` reuses the existing null/NaN-safe `*Ready` getters instead
  of truthiness, so a legitimate `0 °C` no longer hides the panel.
- `TemperatureAgg.min/max/avg` typed as `number | null` to model non-SMART devices.

### Testing
- Added a spec covering a healthy disk + a null-aggregate device — panel still shows temps.
- Verified live on a running instance: a pool mixing reporting disks with a null-aggregate
  PMEM SLOG now shows Highest/Lowest/Average correctly instead of collapsing.

Original PR: https://github.com/truenas/webui/pull/13856
