### PR TITLE
NAS-138641 / 25.10.6 / Fix validation errors not displaying on form init (by william-gr)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.html
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.html
@@ -1,4 +1,4 @@
-@if (control().touched || control().dirty) {
+@if (control().touched || control().dirty || showErrorsForUntouched) {
   <div class="form-error" role="alert" aria-live="polite">
     @for (message of messages; track trackMessage(message)) {
       <mat-error>

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.spec.ts
@@ -42,4 +42,65 @@ describe('IxErrorsComponent', () => {
 
     expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: Custom error');
   });
+
+  it('displays errors immediately when control has errors on init', () => {
+    const invalidControl = new FormControl(5, [Validators.min(10)]);
+
+    spectator.setHostInput('control', invalidControl);
+    spectator.detectComponentChanges();
+
+    expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: Minimum value is 10');
+    expect(spectator.query('.form-error')).toExist();
+    expect(spectator.query('mat-error')).toHaveText('Minimum value is 10');
+  });
+
+  it('does not announce errors when control is in PENDING state', () => {
+    jest.clearAllMocks();
+
+    const asyncControl = new FormControl('', {
+      asyncValidators: () => new Promise(() => {}),
+    });
+
+    spectator.setHostInput('control', asyncControl);
+    spectator.detectComponentChanges();
+
+    expect(spectator.inject(LiveAnnouncer).announce).not.toHaveBeenCalled();
+  });
+
+  it('clears errors when control becomes valid', () => {
+    const dynamicControl = new FormControl('invalid', [Validators.minLength(10)]);
+
+    spectator.setHostInput('control', dynamicControl);
+    spectator.detectComponentChanges();
+
+    expect(spectator.inject(LiveAnnouncer).announce).toHaveBeenCalledWith('Errors in Name: The length of Name should be at least 10');
+
+    jest.clearAllMocks();
+
+    dynamicControl.setValue('valid value with length');
+    spectator.detectComponentChanges();
+
+    expect(spectator.component.messages).toEqual([]);
+  });
+
+  it('does not display errors for empty required fields on init (new form scenario)', () => {
+    jest.clearAllMocks();
+
+    const emptyRequiredControl = new FormControl('', [Validators.required]);
+
+    spectator.setHostInput('control', emptyRequiredControl);
+    spectator.detectComponentChanges();
+
+    expect(spectator.query('.form-error')).not.toExist();
+    expect(spectator.inject(LiveAnnouncer).announce).not.toHaveBeenCalled();
+  });
+
+  it('does not mark control as touched when displaying initial errors', () => {
+    const invalidControl = new FormControl(5, [Validators.min(10)]);
+
+    spectator.setHostInput('control', invalidControl);
+    spectator.detectComponentChanges();
+
+    expect(invalidControl.touched).toBe(false);
+  });
 });

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -41,6 +41,7 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
 
   private statusChangeSubscription: Subscription;
   messages: string[] = [];
+  protected showErrorsForUntouched = false;
 
   readonly defaultErrMessages = {
     min: (min: number) => this.translate.instant('Minimum value is {min}', { min }),
@@ -94,15 +95,44 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
     this.statusChangeSubscription?.unsubscribe();
   }
 
+  /**
+   * Subscribes to control status changes to update error messages.
+   *
+   * This manually works around Angular issue where statusChanges doesn't emit
+   * on initial control setup: https://github.com/angular/angular/issues/10816
+   *
+   * We also handle errors immediately on subscription if the control is not
+   * in PENDING state, ensuring validation errors present at initialization
+   * (e.g., when a form is populated with invalid data from the backend)
+   * are displayed right away without requiring user interaction.
+   */
   private subscribeToControlStatusChanges(): void {
-    // This manually works around: https://github.com/angular/angular/issues/10816
     this.statusChangeSubscription?.unsubscribe();
+
+    // Check status before subscription to avoid race condition where status
+    // might change between subscription setup and the check.
+    const shouldHandleImmediately = this.control().status !== 'PENDING';
+
     this.statusChangeSubscription = this.control().statusChanges.pipe(
       filter((status) => status !== 'PENDING'),
       untilDestroyed(this),
     ).subscribe(() => {
       this.handleErrors();
     });
+
+    // Handle errors immediately if control is not in PENDING state.
+    if (shouldHandleImmediately) {
+      // Only show errors for untouched controls if the control has a value.
+      // This handles edit forms with invalid data from API, while not showing
+      // errors for empty required fields in new forms.
+      const controlValue = this.control().value;
+      const hasValue = controlValue !== null && controlValue !== undefined && controlValue !== '';
+
+      if (this.control().errors && hasValue) {
+        this.showErrorsForUntouched = true;
+        this.handleErrors();
+      }
+    }
   }
 
   private handleErrors(): void {
@@ -122,8 +152,8 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
 
     this.cdr.markForCheck();
 
-    // Only announce errors if the control has been touched or is dirty
-    if (this.control().touched || this.control().dirty) {
+    // Only announce errors if the control has been touched, is dirty, or we're showing errors for untouched controls
+    if (this.control().touched || this.control().dirty || this.showErrorsForUntouched) {
       this.announceErrors();
     }
   }

--- a/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/directory-services-form.component.ts
@@ -92,25 +92,14 @@ export class DirectoryServicesFormComponent implements OnInit {
   protected readonly DirectoryServiceType = DirectoryServiceType;
 
   protected readonly isFormValid = computed(() => {
-    const mainFormValid = this.mainFormValid();
-    const validationState = this.validationService.validationState();
-    const serviceType = this.form.controls.service_type.value;
-
-    let configValid = false;
-    if (serviceType === DirectoryServiceType.ActiveDirectory) {
-      configValid = validationState.isActiveDirectoryValid;
-    } else if (serviceType === DirectoryServiceType.Ldap) {
-      configValid = validationState.isLdapValid;
-    } else if (serviceType === DirectoryServiceType.Ipa) {
-      configValid = validationState.isIpaValid;
-    }
-
-    return configValid && validationState.isCredentialValid && mainFormValid;
+    return this.validationService.calculateFormValidity(
+      this.mainFormValid(),
+      this.form.controls.service_type.value,
+    );
   });
 
   private updateFormValidity(): void {
     this.mainFormValid.set(this.form.valid);
-    this.cdr.markForCheck();
   }
 
   protected readonly form = this.fb.group({
@@ -313,8 +302,8 @@ export class DirectoryServicesFormComponent implements OnInit {
   }
 
   private setupFormWatchers(): void {
-    // Watch for main form changes
-    this.form.valueChanges.pipe(
+    // Watch for main form status changes (validity)
+    this.form.statusChanges.pipe(
       untilDestroyed(this),
     ).subscribe(() => {
       this.updateFormValidity();

--- a/src/app/pages/directory-service/components/directory-services-form/services/directory-service-validation.service.spec.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/services/directory-service-validation.service.spec.ts
@@ -56,7 +56,7 @@ describe('DirectoryServiceValidationService', () => {
   describe('calculateFormValidity', () => {
     it('should return false when no service type is selected', () => {
       testForm.patchValue({ service_type: null });
-      const isValid = service.calculateFormValidity(testForm, null);
+      const isValid = service.calculateFormValidity(testForm.valid, null);
       expect(isValid).toBe(false);
     });
 
@@ -69,7 +69,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setActiveDirectoryValid(true);
       service.setCredentialValid(true);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.ActiveDirectory);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.ActiveDirectory);
       expect(isValid).toBe(true);
     });
 
@@ -82,7 +82,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setActiveDirectoryValid(false);
       service.setCredentialValid(true);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.ActiveDirectory);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.ActiveDirectory);
       expect(isValid).toBe(false);
     });
 
@@ -95,7 +95,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setActiveDirectoryValid(true);
       service.setCredentialValid(false);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.ActiveDirectory);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.ActiveDirectory);
       expect(isValid).toBe(false);
     });
 
@@ -108,7 +108,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setActiveDirectoryValid(true);
       service.setCredentialValid(true);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.ActiveDirectory);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.ActiveDirectory);
       expect(isValid).toBe(false);
     });
 
@@ -122,7 +122,7 @@ describe('DirectoryServiceValidationService', () => {
       service.setLdapValid(true);
       service.setCredentialValid(true);
 
-      const isValid = service.calculateFormValidity(testForm, DirectoryServiceType.Ldap);
+      const isValid = service.calculateFormValidity(testForm.valid, DirectoryServiceType.Ldap);
       expect(isValid).toBe(true);
     });
   });

--- a/src/app/pages/directory-service/components/directory-services-form/services/directory-service-validation.service.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/services/directory-service-validation.service.ts
@@ -38,11 +38,10 @@ export class DirectoryServiceValidationService {
    * Calculate overall form validity based on selected service type and component validities
    */
   calculateFormValidity(
-    mainForm: FormGroup,
+    mainFormValid: boolean,
     selectedServiceType: DirectoryServiceType | null,
   ): boolean {
     const credentialValid = this.credentialValid();
-    const formValid = mainForm.valid;
 
     // Only validate the configuration component for the selected service type
     // If no service type is selected, form should be invalid
@@ -55,7 +54,7 @@ export class DirectoryServiceValidationService {
       configValid = this.ipaValid();
     }
 
-    return configValid && credentialValid && formValid;
+    return configValid && credentialValid && mainFormValid;
   }
 
   /**


### PR DESCRIPTION
- Handle errors immediately in ix-errors when control already has errors
- Update directory services timeout validation to 5-60 seconds

**Changes:**

<img width="466" height="534" alt="Screenshot 2025-12-03 at 10 18 48 AM" src="https://github.com/user-attachments/assets/aee8b0df-4217-4bb9-a93b-aaa2cd4312ba" />

**Testing:**

Use a form (in this case directory services) and mock the API response to return a value outside the validation, in this case we saw the issue on directory services.


Original PR: https://github.com/truenas/webui/pull/12900
