### PR TITLE
NAS-142095 / 27.0.0-BETA.1 : Call the shared check-ticket workflow instead of a local copy

### DIFF
--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -1,22 +1,14 @@
-# The rule lives in iXsystems/ux-github-workflows. What stays here is only what a
-# reusable workflow cannot own for its caller: the trigger, the token ceiling and
-# the concurrency policy — don't drop them assuming the shared copy covers it.
+# The rule lives in iXsystems/ux-github-workflows, which owns the concurrency policy
+# too. Only the trigger and the token ceiling are here — a reusable workflow cannot
+# declare either on its caller's behalf.
 #
-# NOTE: if this is made a required status check, remember that PRs opened with the
-# default GITHUB_TOKEN never fire pull_request events, so it never runs and never
-# reports — such a PR is unmergeable with no way to unblock it from the PR side.
-# PRs opened by automation must use a PAT/app token (see update-translations.yml).
+# Automation opening PRs here must use a PAT/app token (see update-translations.yml):
+# GITHUB_TOKEN does not fire pull_request, so this would never report on such a PR.
 name: Check Ticket
 
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-
-# Must not collide with the group the shared workflow declares for itself: a caller
-# sharing a concurrency group with its own callee can cancel or deadlock the run.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 jobs:
   check-ticket:

--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -1,3 +1,9 @@
+# Automation opening PRs here must use a PAT/app token (see update-translations.yml):
+# GITHUB_TOKEN does not fire pull_request, so this would never report on such a PR.
+#
+# Reports as "check-ticket / <job name in ux-github-workflows>". Branch protection
+# matches that whole string, so the shared workflow's job name is API — renaming it
+# there silently stops this check reporting here.
 name: Check Ticket
 on:
   pull_request:

--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -12,8 +12,10 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+# Must not collide with the group the shared workflow declares for itself: a caller
+# sharing a concurrency group with its own callee can cancel or deadlock the run.
 concurrency:
-  group: check-ticket-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -1,49 +1,18 @@
+# The rule lives in iXsystems/ux-github-workflows, so truenas-ui-components and
+# truenas-connect/ui can share one copy instead of forking it. Only the trigger
+# stays here — a reusable workflow has no say in what triggers its caller.
+#
+# The shared workflow keeps the note that used to live here: if this is made a
+# required status check, remember that PRs opened with the default GITHUB_TOKEN
+# never fire pull_request events, so it never runs and never reports — such a PR
+# is unmergeable with no way to unblock it from the PR side. PRs opened by
+# automation must use a PAT/app token (see update-translations.yml).
 name: Check Ticket
 
-# NOTE: if this is made a required status check, remember that PRs opened with the
-# default GITHUB_TOKEN never fire pull_request events, so this workflow never runs and
-# never reports — such a PR is unmergeable with no way to unblock it from the PR side.
-# PRs opened by automation must use a PAT/app token (see update-translations.yml).
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  contents: read
-
-concurrency:
-  group: check-ticket-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   check-ticket:
-    name: Check PR references a ticket
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check ticket reference in PR title
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Case-sensitive on purpose: bugclerk only links the Jira ticket for uppercase NAS-.
-            const TICKET_PATTERN = /\bNAS-\d+\b/;
-            const WRONG_CASE_PATTERN = new RegExp(TICKET_PATTERN.source, 'i');
-
-            // Every pull request needs a ticket — no bot or label exemptions.
-            const title = context.payload.pull_request.title || '';
-
-            if (TICKET_PATTERN.test(title)) {
-              core.info(`Found ticket ${title.match(TICKET_PATTERN)[0]} in PR title.`);
-              return;
-            }
-
-            const wrongCase = title.match(WRONG_CASE_PATTERN);
-
-            core.setFailed(
-              (wrongCase
-                ? `This pull request references "${wrongCase[0]}", but the ticket must be uppercase (NAS-).\n\n`
-                : `This pull request does not reference a ticket.\n\n`) +
-              `Current title: "${title}"\n\n` +
-              `Add the ticket number to the pull request title, for example:\n` +
-              `  NAS-12345: Fix broken thing\n` +
-              `  NAS-12345 / 27.0.0-BETA.1 / Fix broken thing`
-            );
+    uses: iXsystems/ux-github-workflows/.github/workflows/check-ticket.yml@v1

--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -1,6 +1,11 @@
 # The rule lives in iXsystems/ux-github-workflows. What stays here is only what a
 # reusable workflow cannot own for its caller: the trigger, the token ceiling and
 # the concurrency policy — don't drop them assuming the shared copy covers it.
+#
+# NOTE: if this is made a required status check, remember that PRs opened with the
+# default GITHUB_TOKEN never fire pull_request events, so it never runs and never
+# reports — such a PR is unmergeable with no way to unblock it from the PR side.
+# PRs opened by automation must use a PAT/app token (see update-translations.yml).
 name: Check Ticket
 
 on:

--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -1,18 +1,9 @@
-# The rule lives in iXsystems/ux-github-workflows, which owns the concurrency policy
-# too. Only the trigger and the token ceiling are here — a reusable workflow cannot
-# declare either on its caller's behalf.
-#
-# Automation opening PRs here must use a PAT/app token (see update-translations.yml):
-# GITHUB_TOKEN does not fire pull_request, so this would never report on such a PR.
 name: Check Ticket
-
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-
 jobs:
   check-ticket:
-    name: Check PR references a ticket
     permissions:
       contents: read
     uses: iXsystems/ux-github-workflows/.github/workflows/check-ticket.yml@v1

--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -1,18 +1,19 @@
-# The rule lives in iXsystems/ux-github-workflows, so truenas-ui-components and
-# truenas-connect/ui can share one copy instead of forking it. Only the trigger
-# stays here — a reusable workflow has no say in what triggers its caller.
-#
-# The shared workflow keeps the note that used to live here: if this is made a
-# required status check, remember that PRs opened with the default GITHUB_TOKEN
-# never fire pull_request events, so it never runs and never reports — such a PR
-# is unmergeable with no way to unblock it from the PR side. PRs opened by
-# automation must use a PAT/app token (see update-translations.yml).
+# The rule lives in iXsystems/ux-github-workflows. What stays here is only what a
+# reusable workflow cannot own for its caller: the trigger, the token ceiling and
+# the concurrency policy — don't drop them assuming the shared copy covers it.
 name: Check Ticket
 
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+concurrency:
+  group: check-ticket-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-ticket:
+    name: Check PR references a ticket
+    permissions:
+      contents: read
     uses: iXsystems/ux-github-workflows/.github/workflows/check-ticket.yml@v1

--- a/.github/workflows/check-ticket.yml
+++ b/.github/workflows/check-ticket.yml
@@ -12,4 +12,4 @@ jobs:
   check-ticket:
     permissions:
       contents: read
-    uses: iXsystems/ux-github-workflows/.github/workflows/check-ticket.yml@v1
+    uses: iXsystems/ux-github-workflows/.github/workflows/check-ticket.yml@master


### PR DESCRIPTION
Moves the PR ticket-reference rule to
[iXsystems/ux-github-workflows](https://github.com/iXsystems/ux-github-workflows) and
calls it from here, so `truenas-ui-components` and `truenas-connect/ui` can share one
copy instead of forking it.

`check-ticket.yml` goes from 49 lines to 9 — the trigger, the token ceiling, the job,
and the reference. Nothing else can live caller-side. Behaviour is unchanged: the shared
version takes a `ticket-prefixes` input defaulting to `NAS`.

**⚠️ The status check name changes** to `check-ticket / Check PR references a ticket`
(was `Check PR references a ticket`). If the old name is a required check on `master`,
it must be updated when this merges or every PR becomes unmergeable.

CodeQL's missing-`permissions` flag is a false positive — `contents: read` is set at job
level, which is correct for a `uses:` job.