### PR TITLE
NAS-142246 / 27.0.0-BETA.1 / Map the Claude Code OAuth token for PR review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,6 +47,13 @@ jobs:
       pull-requests: write
       id-token: write
     secrets:
+      # Both are mapped on purpose, and the shared workflow prefers the token.
+      # `UX_CLAUDE_CODE_OAUTH_TOKEN` is an org secret granted per repository:
+      # where the grant is missing it resolves to the empty string rather than
+      # failing, so the API key below covers that case and this repo moves to
+      # subscription billing on its own once the grant lands. Drop the key line
+      # when API billing is retired, not before.
+      claude-code-oauth-token: ${{ secrets.UX_CLAUDE_CODE_OAUTH_TOKEN }}
       # Named rather than inherited, because the repos call it different things
       # — truenas-connect/ui calls the same secret CLAUDE_TOKEN.
       anthropic-api-key: ${{ secrets.CLAUDE_API_KEY }}


### PR DESCRIPTION
The shared review workflow now prefers claude-code-oauth-token over anthropic-api-key. Map both: UX_CLAUDE_CODE_OAUTH_TOKEN is an org secret granted per repository and arrives as the empty string where the grant is missing, so the API key stays as the fallback and this repo moves to subscription billing on its own once the grant lands.

Depends on the shared workflow change being merged first. Until then its old exactly-one guard fails the job on both secrets being mapped.
