### PR TITLE
NAS-142142 / 26.0.0-RC.1 / The Search and Sort funtion are inactive in the Fibre Channel Ports screen (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/iscsi/fibre-channel-ports/build-ports-table-row.utils.spec.ts
+++ b/src/app/pages/sharing/iscsi/fibre-channel-ports/build-ports-table-row.utils.spec.ts
@@ -129,4 +129,22 @@ describe('buildPortsTableRow', () => {
       },
     ]);
   });
+
+  it('falls back to the host WWPNs for a physical port that has no fcport record', () => {
+    const hosts = [
+      {
+        alias: 'fc0', npiv: 1, wwpn: 'naa.220034800d75aec4', wwpn_b: 'naa.220034800d75aec5',
+      },
+    ] as FibreChannelHost[];
+
+    const result = buildPortsTableRow(hosts, [], []);
+
+    expect(result[0]).toMatchObject({
+      name: 'fc0',
+      wwpn: 'naa.220034800d75aec4',
+      wwpn_b: 'naa.220034800d75aec5',
+    });
+    // A virtual port has no host of its own to fall back to.
+    expect(result[1]).toMatchObject({ name: 'fc0/1', wwpn: undefined, wwpn_b: undefined });
+  });
 });

--- a/src/app/pages/sharing/iscsi/fibre-channel-ports/build-ports-table-row.utils.ts
+++ b/src/app/pages/sharing/iscsi/fibre-channel-ports/build-ports-table-row.utils.ts
@@ -30,8 +30,11 @@ export function buildPortsTableRow(
     rows.push({
       name: host.alias,
       target: indexedPorts[host.alias]?.target,
-      wwpn: indexedPorts[host.alias]?.wwpn || undefined,
-      wwpn_b: indexedPorts[host.alias]?.wwpn_b || undefined,
+      // A physical port only has an `fcport` record once it is mapped to a target, so fall back to
+      // the host's own WWPNs. Resolved here rather than in the template so the value the user sees
+      // is also the value the table searches and sorts by.
+      wwpn: indexedPorts[host.alias]?.wwpn || host.wwpn || undefined,
+      wwpn_b: indexedPorts[host.alias]?.wwpn_b || host.wwpn_b || undefined,
       aPortState: indexedStatuses[host.alias]?.A?.port_state,
       bPortState: indexedStatuses[host.alias]?.B?.port_state,
       isPhysical: true,

--- a/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.spec.ts
+++ b/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.spec.ts
@@ -4,16 +4,23 @@ import { MatDialog } from '@angular/material/dialog';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TnIconHarness } from '@truenas/ui-components';
-import { of } from 'rxjs';
+import {
+  EMPTY, Observable, of, throwError,
+} from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { EmptyType } from 'app/enums/empty-type.enum';
 import { FibreChannelHost, FibreChannelPort, FibreChannelStatus } from 'app/interfaces/fibre-channel.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EmptyService } from 'app/modules/empty/empty.service';
+import { BasicSearchHarness } from 'app/modules/forms/search-input/components/basic-search/basic-search.harness';
 import { IxTableHarness } from 'app/modules/ix-table/components/ix-table/ix-table.harness';
+import { ApiService } from 'app/modules/websocket/api.service';
 import {
   VirtualPortsNumberDialog,
 } from 'app/pages/sharing/iscsi/fibre-channel-ports/virtual-ports-number-dialog/virtual-ports-number-dialog.component';
+import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import { FibreChannelPortsComponent } from './fibre-channel-ports.component';
 
@@ -97,6 +104,14 @@ describe('FibreChannelPortsComponent', () => {
         confirm: jest.fn(() => of(true)),
       }),
       mockProvider(EmptyService),
+      // The global mock passes errors straight through; this one behaves like the real operator, so
+      // a failed load reaches `showErrorModal` the way it does in the app.
+      mockProvider(ErrorHandlerService, {
+        withErrorHandler: <T>() => (source$: Observable<T>) => source$.pipe(catchError((error: unknown) => {
+          spectator.inject(ErrorHandlerService).showErrorModal(error);
+          return EMPTY;
+        })),
+      }),
       provideMockStore({
         selectors: [{
           selector: selectIsHaLicensed,
@@ -105,6 +120,12 @@ describe('FibreChannelPortsComponent', () => {
       }),
     ],
   });
+
+  async function clickSortHeader(title: string): Promise<void> {
+    const index = (await table.getHeaderTexts()).indexOf(title);
+    spectator.click(spectator.queryAll('th')[index]);
+    spectator.detectChanges();
+  }
 
   beforeEach(async () => {
     spectator = createComponent();
@@ -152,6 +173,67 @@ describe('FibreChannelPortsComponent', () => {
 
     expect(spectator.inject(MatDialog).open)
       .toHaveBeenCalledWith(VirtualPortsNumberDialog, { data: hosts[0] });
+  });
+
+  it('searches ports by name, target and WWPN', async () => {
+    const search = await loader.getHarness(BasicSearchHarness);
+
+    await search.setValue('target1');
+    spectator.detectChanges();
+    expect((await table.getCellTexts()).slice(1)).toEqual([
+      ['fc0', 'target1', 'naa.220034800d75aec4', 'naa.220034800d75aec5', 'A: Online B: Offline', ''],
+    ]);
+
+    await search.setValue('naa.220034800d75aec8');
+    spectator.detectChanges();
+    expect((await table.getCellTexts()).slice(1)).toEqual([
+      ['– fc0/1 (virtual)', 'target2', 'naa.220034800d75aec8', 'naa.220034800d75aec9', 'A: – B: –', ''],
+    ]);
+
+    await search.setValue('fc1');
+    spectator.detectChanges();
+    expect((await table.getCellTexts()).slice(1)).toEqual([
+      ['fc1', 'target2', 'naa.220034800d75aec6', 'naa.220034800d75aec7', 'A: Online B: Online', ''],
+      ['– fc1/1 (virtual)', '-', '-', '-', 'A: – B: –', ''],
+    ]);
+
+    await search.setValue('');
+    spectator.detectChanges();
+    expect(await table.getRowCount()).toBe(5);
+  });
+
+  it('sorts by a derived column', async () => {
+    await clickSortHeader('Target');
+
+    // Rows with no target sort first, then target1, then the two target2 ports.
+    expect((await table.getCellTexts()).slice(1).map((row) => row[1])).toEqual([
+      '-', '-', 'target1', 'target2', 'target2',
+    ]);
+
+    await clickSortHeader('Target');
+
+    expect((await table.getCellTexts()).slice(1).map((row) => row[1])).toEqual([
+      'target2', 'target2', 'target1', '-', '-',
+    ]);
+  });
+
+  it('sorts port names so a host is followed by its own virtual ports', async () => {
+    await clickSortHeader('Port');
+
+    expect((await table.getCellTexts()).slice(1).map((row) => row[0])).toEqual([
+      'fc0', '– fc0/1 (virtual)', '– fc0/2 (virtual)', 'fc1', '– fc1/1 (virtual)',
+    ]);
+  });
+
+  it('reports a failed load and shows the error empty state', () => {
+    const error = new Error('Failed to query ports');
+    spectator = createComponent({ detectChanges: false });
+    jest.spyOn(spectator.inject(ApiService), 'call').mockReturnValue(throwError(() => error));
+
+    spectator.detectChanges();
+
+    expect(spectator.inject(ErrorHandlerService).showErrorModal).toHaveBeenCalledWith(error);
+    expect(spectator.inject(EmptyService).defaultEmptyConfig).toHaveBeenLastCalledWith(EmptyType.Errors);
   });
 
   it('should show/hide WWPN (B) column based on HA status', async () => {

--- a/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.ts
+++ b/src/app/pages/sharing/iscsi/fibre-channel-ports/fibre-channel-ports.component.ts
@@ -8,11 +8,9 @@ import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { tnIconMarker } from '@truenas/ui-components';
 import { finalize, forkJoin, of } from 'rxjs';
-import {
-  catchError,
-  filter, tap,
-} from 'rxjs/operators';
+import { filter, tap } from 'rxjs/operators';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
+import { EmptyType } from 'app/enums/empty-type.enum';
 import { FibreChannelHost, FibreChannelPort, FibreChannelStatus } from 'app/interfaces/fibre-channel.interface';
 import { EmptyService } from 'app/modules/empty/empty.service';
 import { BasicSearchComponent } from 'app/modules/forms/search-input/components/basic-search/basic-search.component';
@@ -89,36 +87,30 @@ export class FibreChannelPortsComponent implements OnInit {
 
           return ` – ${this.translate.instant('{port} (virtual)', { port: row.name })}`;
         },
-        disableSorting: true,
+        // Sorts by the port name itself rather than the rendered label, which carries a leading
+        // dash on virtual ports and would clump them all together away from their host.
+        sortBy: (row) => portNameSortKey(row.name),
       }),
       textColumn({
         title: this.translate.instant('Target'),
         propertyName: 'target',
-        getValue: (row) => {
-          return row.target?.iscsi_target_name || '-';
-        },
-        disableSorting: true,
+        getValue: (row) => this.targetLabel(row),
       }),
       textColumn({
         title: this.translate.instant('WWPN'),
         propertyName: 'wwpn',
-        getValue: (row) => this.resolveWwpn(row, 'wwpn'),
-        disableSorting: true,
+        getValue: (row) => this.wwpnLabel(row, 'wwpn'),
       }),
       textColumn({
         title: this.translate.instant('WWPN (B)'),
         propertyName: 'wwpn_b',
-        getValue: (row) => this.resolveWwpn(row, 'wwpn_b'),
+        getValue: (row) => this.wwpnLabel(row, 'wwpn_b'),
         hidden: !this.isHa(),
-        disableSorting: true,
       }),
       textColumn({
         title: this.translate.instant('State'),
-        getValue: (row) => {
-          return `A: ${row.aPortState || '–'} B: ${row.bPortState || '–'}`;
-        },
+        getValue: (row) => this.stateLabel(row),
         hidden: !this.isHa(),
-        disableSorting: true,
       }),
       actionsWithMenuColumn({
         disableSorting: true,
@@ -153,44 +145,77 @@ export class FibreChannelPortsComponent implements OnInit {
 
   protected onListFiltered(query: string): void {
     this.searchQuery.set(query);
-    this.dataProvider.setFilter({
-      query,
-      // TODO: This should be fixed in dataprovider
-      list: this.rows(),
-      columnKeys: ['name', 'wwpn', 'wwpn_b'],
-    });
+    this.applyFilter();
+  }
+
+  private targetLabel(row: FibreChannelPortRow): string {
+    return row.target?.iscsi_target_name || '-';
+  }
+
+  private wwpnLabel(row: FibreChannelPortRow, key: 'wwpn' | 'wwpn_b'): string {
+    return row[key] || '-';
+  }
+
+  private stateLabel(row: FibreChannelPortRow): string {
+    return `A: ${row.aPortState || '–'} B: ${row.bPortState || '–'}`;
+  }
+
+  /**
+   * Re-applies the current search to the loaded rows. Called on reload too, so editing a port
+   * doesn't silently drop the filter the user is looking through.
+   */
+  private applyFilter(): void {
+    const query = this.searchQuery();
+
+    if (query) {
+      this.dataProvider.setFilter({
+        query,
+        // TODO: This should be fixed in dataprovider
+        list: this.rows(),
+        columnKeys: ['name', 'target', 'wwpn', 'wwpn_b'],
+        // The Target cell renders a name off a nested object, which the filter can't reach on its own.
+        preprocessMap: {
+          target: (target) => target?.iscsi_target_name || '',
+        },
+      });
+    } else {
+      this.dataProvider.setRows(this.rows());
+    }
+
+    // ArrayDataProvider never resolves its own empty type, so without this the table shows the
+    // loading placeholder in place of "No Search Results" whenever a search matches nothing.
+    this.dataProvider.setEmptyType(this.rows().length ? EmptyType.NoSearchResults : EmptyType.NoPageData);
   }
 
   private loadTable(): void {
     this.isLoading.set(true);
+    this.dataProvider.setEmptyType(EmptyType.Loading);
     forkJoin([
       this.api.call('fc.fc_host.query'),
       this.api.call('fcport.query'),
       this.api.call('fcport.status'),
     ])
       .pipe(
+        // `withErrorHandler()` is an operator, not a `catchError` selector — handed to `catchError`
+        // it was called with the error itself and threw `error.pipe is not a function`, so a failed
+        // query left the page on its loading placeholder with no error dialog.
+        tap({ error: () => this.dataProvider.setEmptyType(EmptyType.Errors) }),
+        this.errorHandler.withErrorHandler(),
         finalize(() => this.isLoading.set(false)),
-        catchError(this.errorHandler.withErrorHandler()),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(([hosts, ports, statuses]: [FibreChannelHost[], FibreChannelPort[], FibreChannelStatus[]]) => {
         this.rows.set(buildPortsTableRow(hosts, ports, statuses));
-        this.dataProvider.setRows(this.rows());
+        this.applyFilter();
       });
   }
+}
 
-  private resolveWwpn(row: FibreChannelPortRow, key: 'wwpn' | 'wwpn_b'): string {
-    if (row?.[key]) {
-      return row[key];
-    }
-
-    const aliasPrefix = row?.host?.alias?.split?.('/')?.[0];
-    const isPhysical = row?.name === aliasPrefix;
-
-    if (isPhysical && row?.host?.[key]) {
-      return row.host[key];
-    }
-
-    return '-';
-  }
+/**
+ * Orders port names the way they read: `fc2` before `fc10`. Plain string comparison orders
+ * digit runs lexically and gets that wrong, so every digit run is zero-padded to a fixed width
+ * first. Virtual ports stay grouped under their host either way — `/` sorts below every digit.
+ */
+function portNameSortKey(name: string): string {
+  return name.replace(/\d+/g, (digits) => digits.padStart(6, '0'));
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/0597116d-6d8c-4c5a-bee8-aa30598c4c18


You can use `WebSocket Debug Panel` mock to test it live:

[mock-configs-2026-08-13.json](https://github.com/user-attachments/files/31022327/mock-configs-2026-08-13.json)


Original PR: https://github.com/truenas/webui/pull/13923
