### PR TITLE
NAS-142168 / 26.0.0-RC.1 / Make pool usage severity consistent across dashboards (by AlexKarpov98)

### DIFF
--- a/src/app/constants/pool-capacity.constant.spec.ts
+++ b/src/app/constants/pool-capacity.constant.spec.ts
@@ -1,0 +1,46 @@
+import {
+  getPoolCapacityGaugeFill, getPoolCapacityGaugeLabelStyle, getPoolCapacityLevel,
+} from 'app/constants/pool-capacity.constant';
+import { PoolCapacityLevel } from 'app/enums/pool-capacity-level.enum';
+
+describe('getPoolCapacityLevel', () => {
+  it('treats usage below 80% as safe', () => {
+    expect(getPoolCapacityLevel(0)).toBe(PoolCapacityLevel.Safe);
+    expect(getPoolCapacityLevel(79.99)).toBe(PoolCapacityLevel.Safe);
+  });
+
+  it('treats usage from 80% up to 90% as a warning', () => {
+    expect(getPoolCapacityLevel(80)).toBe(PoolCapacityLevel.Warning);
+    expect(getPoolCapacityLevel(83.9)).toBe(PoolCapacityLevel.Warning);
+    expect(getPoolCapacityLevel(89.99)).toBe(PoolCapacityLevel.Warning);
+  });
+
+  it('treats usage from 90% as critical', () => {
+    expect(getPoolCapacityLevel(90)).toBe(PoolCapacityLevel.Critical);
+    expect(getPoolCapacityLevel(100)).toBe(PoolCapacityLevel.Critical);
+  });
+});
+
+describe('getPoolCapacityGaugeFill', () => {
+  const colors = {
+    blank: 'blank', fill: 'fill', warning: 'warning', critical: 'critical',
+  };
+
+  it('returns the blank color when nothing is used', () => {
+    expect(getPoolCapacityGaugeFill(0, colors)).toBe('blank');
+  });
+
+  it('returns a color matching the capacity level', () => {
+    expect(getPoolCapacityGaugeFill(79.99, colors)).toBe('fill');
+    expect(getPoolCapacityGaugeFill(80, colors)).toBe('warning');
+    expect(getPoolCapacityGaugeFill(90, colors)).toBe('critical');
+  });
+});
+
+describe('getPoolCapacityGaugeLabelStyle', () => {
+  it('tints the label to match the capacity level', () => {
+    expect(getPoolCapacityGaugeLabelStyle(79.99)).toBe('');
+    expect(getPoolCapacityGaugeLabelStyle(80)).toBe('color: var(--orange);');
+    expect(getPoolCapacityGaugeLabelStyle(90)).toBe('color: var(--red);');
+  });
+});

--- a/src/app/constants/pool-capacity.constant.ts
+++ b/src/app/constants/pool-capacity.constant.ts
@@ -1,7 +1,85 @@
+import { PoolCapacityLevel } from 'app/enums/pool-capacity-level.enum';
+
 /**
- * Pool capacity threshold (percent) at which the UI flags a pool as "low
- * capacity" and tier rewrite jobs default to triggering. Shared between the
- * pools-dashboard pool-usage-card, the storage widget pool-usage-gauge, and
- * the tier-config-form's default for `max_used_percentage`.
+ * Percent of used space at which pool capacity stops being safe and starts
+ * warning. Also the point at which tier rewrite jobs default to triggering.
  */
 export const poolLowCapacityPercent = 80;
+
+/**
+ * Percent of used space at which pool capacity stops being a warning and
+ * becomes critical.
+ */
+export const poolCriticalCapacityPercent = 90;
+
+/**
+ * Single source of truth for how used space maps to a severity, so the same
+ * percentage never reads as healthy in one place and critical in another.
+ * Consumers should go through this rather than comparing to the constants
+ * directly. Note that the tier-config-form still hardcodes its own 80 default
+ * for `max_used_percentage`; pointing it here is a worthwhile follow-up.
+ *
+ * @param usedPercent Used space as a percentage (0-100), not a fraction.
+ */
+export function getPoolCapacityLevel(usedPercent: number): PoolCapacityLevel {
+  if (usedPercent >= poolCriticalCapacityPercent) {
+    return PoolCapacityLevel.Critical;
+  }
+
+  if (usedPercent >= poolLowCapacityPercent) {
+    return PoolCapacityLevel.Warning;
+  }
+
+  return PoolCapacityLevel.Safe;
+}
+
+/**
+ * Theme colors a pool usage gauge picks from, supplied by the consuming
+ * component since each pulls slightly different values off the current theme.
+ */
+export interface PoolCapacityGaugeColors {
+  blank: string;
+  fill: string;
+  warning: string;
+  critical: string;
+}
+
+/**
+ * Gauge fill color for a used percentage, so the gauge can never disagree with
+ * the severity the rest of the card reports. Note that a gauge only honors this
+ * fill when it is not segmented - `GaugeChartComponent` colors a segmented gauge
+ * from the segments alone - so consumers passing segments must drop or tint them
+ * once capacity leaves `PoolCapacityLevel.Safe`.
+ *
+ * @param usedPercent Used space as a percentage (0-100), not a fraction.
+ */
+export function getPoolCapacityGaugeFill(usedPercent: number, colors: PoolCapacityGaugeColors): string {
+  if (usedPercent === 0) {
+    return colors.blank;
+  }
+
+  switch (getPoolCapacityLevel(usedPercent)) {
+    case PoolCapacityLevel.Critical:
+      return colors.critical;
+    case PoolCapacityLevel.Warning:
+      return colors.warning;
+    default:
+      return colors.fill;
+  }
+}
+
+/**
+ * Inline style that tints the gauge's label to match its fill.
+ *
+ * @param usedPercent Used space as a percentage (0-100), not a fraction.
+ */
+export function getPoolCapacityGaugeLabelStyle(usedPercent: number): string {
+  switch (getPoolCapacityLevel(usedPercent)) {
+    case PoolCapacityLevel.Critical:
+      return 'color: var(--red);';
+    case PoolCapacityLevel.Warning:
+      return 'color: var(--orange);';
+    default:
+      return '';
+  }
+}

--- a/src/app/enums/pool-capacity-level.enum.ts
+++ b/src/app/enums/pool-capacity-level.enum.ts
@@ -1,0 +1,5 @@
+export enum PoolCapacityLevel {
+  Safe = 'safe',
+  Warning = 'warning',
+  Critical = 'critical',
+}

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.html
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.html
@@ -81,13 +81,13 @@
       <ix-widget-stale-data-notice></ix-widget-stale-data-notice>
     } @else if (!isDatasetLoading()) {
       <ix-gauge-chart
-        [colorFill]="usedPercentage() === 0 ? chartBlankColor : isLowCapacity() ? chartLowCapacityColor : chartFillColor"
-        [colorBlank]="chartBlankColor"
+        [colorFill]="gaugeFill()"
+        [colorBlank]="gaugeBlankColor()"
         [width]="size()"
         [height]="size()"
         [label]="(usedPercentage() / 100 | percent: '1.0-1') || ('Unknown' | translate)"
         [value]="usedPercentage() > 100 ? 100 : usedPercentage()"
-        [style]="isLowCapacity() ? 'color: var(--red);' : ''"
+        [style]="gaugeLabelStyle()"
       ></ix-gauge-chart>
     } @else {
       <ngx-skeleton-loader

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.spec.ts
@@ -71,6 +71,7 @@ describe('PoolUsageGaugeComponent', () => {
         currentTheme: jest.fn(() => ({
           bg1: 'bg1',
           primary: 'primary',
+          orange: 'orange',
           red: 'red',
         })),
       }),
@@ -127,11 +128,11 @@ describe('PoolUsageGaugeComponent', () => {
     expect(spectator.query('ix-gauge-chart')).toBeTruthy();
   });
 
-  it('shows chart', () => {
+  it('shows chart in warning color when usage is between 80% and 90%', () => {
     expect(spectator.query(GaugeChartComponent)!.label).toBe('80.2%');
     const value = spectator.query(GaugeChartComponent)!.value;
     expect(value).toBeCloseTo(80, 0);
-    expect(spectator.query(GaugeChartComponent)!.colorFill).toBe('red');
+    expect(spectator.query(GaugeChartComponent)!.colorFill).toBe('orange');
   });
 
   it('should display skeleton loader when pool is loading', () => {

--- a/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.ts
+++ b/src/app/pages/dashboard/widgets/storage/widget-pool/common/pool-usage-gauge/pool-usage-gauge.component.ts
@@ -1,11 +1,13 @@
 import { PercentPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, input, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, inject } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { formatDuration } from 'date-fns';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { filter, switchMap } from 'rxjs';
-import { poolLowCapacityPercent } from 'app/constants/pool-capacity.constant';
+import {
+  getPoolCapacityGaugeFill, getPoolCapacityGaugeLabelStyle, PoolCapacityGaugeColors,
+} from 'app/constants/pool-capacity.constant';
 import { PoolStatus } from 'app/enums/pool-status.enum';
 import { TopologyWarning, VDevType } from 'app/enums/v-dev-type.enum';
 import { buildNormalizedFileSize } from 'app/helpers/file-size.utils';
@@ -35,7 +37,7 @@ import { StorageService } from 'app/services/storage.service';
     WidgetStaleDataNoticeComponent,
   ],
 })
-export class PoolUsageGaugeComponent implements OnInit {
+export class PoolUsageGaugeComponent {
   private resources = inject(WidgetResourcesService);
   private translate = inject(TranslateService);
   private storageService = inject(StorageService);
@@ -44,9 +46,25 @@ export class PoolUsageGaugeComponent implements OnInit {
   readonly pool = input<Pool>();
   readonly size = input<number>(150);
 
-  protected chartLowCapacityColor: string;
-  protected chartFillColor: string;
-  protected chartBlankColor: string;
+  private gaugeColors = computed<PoolCapacityGaugeColors>(() => {
+    const theme = this.themeService.currentTheme();
+    return {
+      blank: theme.bg2,
+      fill: theme.primary,
+      warning: theme.orange,
+      critical: theme.red,
+    };
+  });
+
+  protected gaugeFill = computed(() => {
+    return getPoolCapacityGaugeFill(this.usedPercentage(), this.gaugeColors());
+  });
+
+  protected gaugeLabelStyle = computed(() => {
+    return getPoolCapacityGaugeLabelStyle(this.usedPercentage());
+  });
+
+  protected gaugeBlankColor = computed(() => this.gaugeColors().blank);
 
   protected poolDataState = toSignal(
     this.resources.poolUpdatesWithStaleDetection().pipe(takeUntilDestroyed()),
@@ -73,10 +91,6 @@ export class PoolUsageGaugeComponent implements OnInit {
     return this.poolStats()?.used / this.capacity() * 100;
   });
 
-  protected isLowCapacity = computed(() => {
-    return this.usedPercentage() >= poolLowCapacityPercent;
-  });
-
   protected dataTopology = computed(() => {
     if (this.pool()?.status === PoolStatus.Offline) {
       return this.translate.instant('Offline VDEVs');
@@ -94,12 +108,6 @@ export class PoolUsageGaugeComponent implements OnInit {
     const seconds = secondsToDuration((scan.end_time.$date - scan.start_time.$date) / 1000);
     return formatDuration(seconds);
   });
-
-  ngOnInit(): void {
-    this.chartBlankColor = this.themeService.currentTheme().bg2;
-    this.chartFillColor = this.themeService.currentTheme().primary;
-    this.chartLowCapacityColor = this.themeService.currentTheme().red;
-  }
 
   private parseTopologyData(): string {
     const vdevs = this.pool()?.topology?.data;

--- a/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.spec.ts
@@ -110,6 +110,8 @@ describe('WidgetStorageComponent', () => {
   let spectator: Spectator<WidgetStorageComponent>;
   const pools$ = new BehaviorSubject<Pool[]>([]);
   const scans$ = new BehaviorSubject<PoolScan>(null);
+  // Mutable so individual tests can dial the usage up before creating the component.
+  let poolStats: Record<string, { available: number; used: number; total: number }>;
   const createComponent = createComponentFactory({
     component: WidgetStorageComponent,
     imports: [
@@ -125,15 +127,7 @@ describe('WidgetStorageComponent', () => {
         {
           pools$,
           poolUpdatesWithStaleDetection: () => of({
-            value: {
-              // since we only ever check the size values of the pool with a finished scrub,
-              // we only define the size for the pool with a finished scrub.
-              poolWithFinishedScrub: {
-                available: totalData - usedData,
-                used: usedData,
-                total: totalData,
-              },
-            },
+            value: poolStats,
             isStale: false,
           }),
           scans$,
@@ -151,6 +145,18 @@ describe('WidgetStorageComponent', () => {
       mockProvider(PercentPipe),
       mockAuth(),
     ],
+  });
+
+  beforeEach(() => {
+    // since we only ever check the size values of the pool with a finished scrub,
+    // we only define the size for the pool with a finished scrub.
+    poolStats = {
+      poolWithFinishedScrub: {
+        available: totalData - usedData,
+        used: usedData,
+        total: totalData,
+      },
+    };
   });
 
   describe('Single Pool Configuration', () => {
@@ -183,7 +189,7 @@ describe('WidgetStorageComponent', () => {
           value: '58.25%',
         },
         disksWithError: {
-          icon: 'mat-error',
+          icon: 'mdi-alert',
           label: 'Disks with Errors',
           level: 'warn',
           value: '1 of 2',
@@ -244,6 +250,49 @@ describe('WidgetStorageComponent', () => {
           ],
         },
       );
+    });
+  });
+
+  describe('Used Space Thresholds', () => {
+    function createWithUsage(usedPercent: number): void {
+      poolStats.poolWithFinishedScrub = {
+        available: totalData - (totalData * usedPercent) / 100,
+        used: (totalData * usedPercent) / 100,
+        total: totalData,
+      };
+      pools$.next([poolWithFinishedScrub]);
+      spectator = createComponent({
+        props: {
+          size: SlotSize.Full,
+        },
+      });
+    }
+
+    it('reports used space as safe below 80%', () => {
+      createWithUsage(79);
+
+      expect(spectator.component.poolsInfo()[0].usedSpace).toMatchObject({
+        level: 'safe',
+        icon: 'mat-check_circle',
+      });
+    });
+
+    it('warns when used space is at or above 80%', () => {
+      createWithUsage(83.9);
+
+      expect(spectator.component.poolsInfo()[0].usedSpace).toMatchObject({
+        level: 'warn',
+        icon: 'mdi-alert',
+      });
+    });
+
+    it('errors when used space is at or above 90%', () => {
+      createWithUsage(91);
+
+      expect(spectator.component.poolsInfo()[0].usedSpace).toMatchObject({
+        level: 'error',
+        icon: 'mat-error',
+      });
     });
   });
 

--- a/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.ts
+++ b/src/app/pages/dashboard/widgets/storage/widget-storage/widget-storage.component.ts
@@ -9,7 +9,9 @@ import { RouterLink } from '@angular/router';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { TnIconComponent, TnTooltipDirective } from '@truenas/ui-components';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { getPoolCapacityLevel } from 'app/constants/pool-capacity.constant';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
+import { PoolCapacityLevel } from 'app/enums/pool-capacity-level.enum';
 import { PoolScanFunction } from 'app/enums/pool-scan-function.enum';
 import { PoolScanState } from 'app/enums/pool-scan-state.enum';
 import { PoolStatus } from 'app/enums/pool-status.enum';
@@ -152,7 +154,7 @@ export class WidgetStorageComponent {
       case PoolStatus.Offline:
       case PoolStatus.Degraded:
         level = StatusLevel.Warn;
-        icon = statusIcons.error;
+        icon = statusIcons.mdiAlert;
         break;
 
       case PoolStatus.Faulted:
@@ -174,17 +176,17 @@ export class WidgetStorageComponent {
   private getUsedSpaceItemInfo(pool: Pool): ItemInfo {
     const usedSpace = Number(this.poolStats()?.[pool.name]?.used);
     const totalSpace = Number(this.poolStats()?.[pool.name]?.total);
-    const usedSpacePercent = usedSpace / totalSpace;
+    const usedSpaceFraction = usedSpace / totalSpace;
     let level = StatusLevel.Safe;
     let icon = statusIcons.checkCircle;
-    let value = this.percentPipe.transform(usedSpacePercent, '1.2-2') || '?';
+    let value = this.percentPipe.transform(usedSpaceFraction, '1.2-2') || '?';
 
     if (!usedSpace) {
       return {
         label: this.translate.instant('Used Space'),
         value: this.translate.instant('Unknown'),
         level: StatusLevel.Warn,
-        icon: statusIcons.error,
+        icon: statusIcons.mdiAlert,
       };
     }
 
@@ -196,12 +198,17 @@ export class WidgetStorageComponent {
       });
     }
 
-    if (usedSpacePercent >= 90) {
-      level = StatusLevel.Error;
-      icon = statusIcons.error;
-    } else if (usedSpacePercent >= 80) {
-      level = StatusLevel.Warn;
-      icon = statusIcons.error;
+    switch (getPoolCapacityLevel(usedSpaceFraction * 100)) {
+      case PoolCapacityLevel.Critical:
+        level = StatusLevel.Error;
+        icon = statusIcons.error;
+        break;
+      case PoolCapacityLevel.Warning:
+        level = StatusLevel.Warn;
+        icon = statusIcons.mdiAlert;
+        break;
+      case PoolCapacityLevel.Safe:
+        break;
     }
 
     return {
@@ -214,7 +221,7 @@ export class WidgetStorageComponent {
 
   private getDiskWithErrorsItemInfo(pool: Pool): ItemInfo {
     let level = StatusLevel.Warn;
-    let icon = statusIcons.error;
+    let icon = statusIcons.mdiAlert;
     let unhealthyCount: number | null = null;
     let value: string = this.translate.instant('Unknown');
 
@@ -243,7 +250,7 @@ export class WidgetStorageComponent {
         icon = statusIcons.checkCircle;
       } else {
         level = StatusLevel.Warn;
-        icon = statusIcons.error;
+        icon = statusIcons.mdiAlert;
         unhealthyCount = unhealthy.length;
       }
 
@@ -294,7 +301,7 @@ export class WidgetStorageComponent {
       value = this.formatScanPercentage(scan);
     } else if (endTime && !isScanInProgress) {
       // case: scan is finished.
-      icon = isScanFinished ? statusIcons.checkCircle : statusIcons.error;
+      icon = isScanFinished ? statusIcons.checkCircle : statusIcons.mdiAlert;
       level = isScanFinished ? StatusLevel.Safe : StatusLevel.Warn;
       value = this.formatDateTimePipe.transform(endTime);
     } else {

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.html
@@ -19,20 +19,25 @@
       <div>
         <ix-gauge-chart
           class="gauge"
-          [colorFill]="usedPercentage() === 0 ? chartBlankColor : isLowCapacity() ? chartLowCapacityColor : chartFillColor"
-          [colorBlank]="chartBlankColor"
+          [colorFill]="gaugeFill()"
+          [colorBlank]="gaugeBlankColor()"
           [segments]="chartSegments()"
           [sublabel]="showTierBreakdown() ? ('Used' | translate) : ''"
           [width]="150"
           [height]="150"
           [label]="(usedPercentage() / 100 | percent: '1.0-1') || ''"
           [value]="usedPercentage() > 100 ? 100 : usedPercentage()"
-          [style]="isLowCapacity() ? 'color: var(--red);' : ''"
+          [style]="gaugeLabelStyle()"
         ></ix-gauge-chart>
         @if (isLowCapacity()) {
-          <div class="warning-container">
+          <div class="warning-container" [class.critical]="isCriticalCapacity()">
             <span>
-              <b>{{ 'Warning' | translate }}:</b> {{ 'Low Capacity' | translate }}
+              @if (isCriticalCapacity()) {
+                <b>{{ 'Critical' | translate }}:</b>
+              } @else {
+                <b>{{ 'Warning' | translate }}:</b>
+              }
+              {{ 'Low Capacity' | translate }}
             </span>
           </div>
         }

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.scss
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.scss
@@ -181,6 +181,14 @@
   }
 }
 
+// Matches the header icon and the gauge: orange for a warning, red once critical.
+.warning-container {
+  color: var(--orange);
+
+  &.critical {
+    color: var(--red);
+  }
+}
 
 .link {
   color: var(--primary);

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.spec.ts
@@ -57,6 +57,11 @@ describe('PoolUsageCardComponent', () => {
           getItem: jest.fn(),
           setItem: jest.fn(),
         },
+        matchMedia: jest.fn().mockReturnValue({
+          matches: false,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        }),
       }),
     ],
   });
@@ -120,6 +125,27 @@ describe('PoolUsageCardComponent', () => {
     expect(spectator.query('.warning-container')).toHaveText('Warning: Low Capacity');
     expect(spectator.query(GaugeChartComponent)!.label).toBe('81%');
     expect(spectator.query(GaugeChartComponent)!.value).toBeCloseTo(81, 0);
+    expect(spectator.query(GaugeChartComponent)!.colorFill).toBe('#E68D37');
+  });
+
+  it('renders component values when usage is above 90%', () => {
+    spectator.setInput('poolState', {
+      healthy: true,
+      name: 'bingo',
+      status: 'ONLINE',
+      used: 2199792913690,
+      available: 109989645684,
+
+      topology: {
+        data: [{
+          disk: 'sda',
+          type: TopologyItemType.Disk,
+        }],
+      },
+    } as Pool);
+
+    expect(spectator.query('.warning-container')).toHaveText('Critical: Low Capacity');
+    expect(spectator.query(GaugeChartComponent)!.label).toBe('95.2%');
     expect(spectator.query(GaugeChartComponent)!.colorFill).toBe('#CE2929');
   });
 
@@ -144,6 +170,24 @@ describe('PoolUsageCardComponent', () => {
 
     expect(spectator.query(PoolCardIconComponent)!.type).toBe(PoolCardIconType.Warn);
     expect(spectator.query(PoolCardIconComponent)!.tooltip).toBe('Pool is using more than 80% of available space');
+
+    spectator.setInput('poolState', {
+      healthy: true,
+      name: 'bingo',
+      status: 'ONLINE',
+      used: 2199792913690,
+      available: 109989645684,
+
+      topology: {
+        data: [{
+          disk: 'sda',
+          type: TopologyItemType.Disk,
+        }],
+      },
+    } as Pool);
+
+    expect(spectator.query(PoolCardIconComponent)!.type).toBe(PoolCardIconType.Error);
+    expect(spectator.query(PoolCardIconComponent)!.tooltip).toBe('Pool is using more than 90% of available space');
   });
 
   it('should pre-select disks when user click "View Disk Reports" link', () => {
@@ -195,7 +239,6 @@ describe('PoolUsageCardComponent', () => {
       },
     } as Pool);
 
-    spectator.component.ngOnInit();
     spectator.detectChanges();
 
     expect(spectator.query('.list-caption')).not.toExist();
@@ -216,6 +259,41 @@ describe('PoolUsageCardComponent', () => {
     expect(regularStatItems).toHaveLength(2);
     expect(regularStatItems[0]).toHaveText('3.15 GiB Used');
     expect(regularStatItems[1]).toHaveText('2.34 GiB Available');
+
+    expect(spectator.query(GaugeChartComponent)!.segments).toHaveLength(2);
+  });
+
+  it('drops the gauge tier segments so the gauge matches the severity when capacity is low', () => {
+    tierEnabled.set(true);
+    metadataReservePct.set(0);
+
+    spectator.setInput('poolState', {
+      healthy: true,
+      name: 'bingo',
+      status: 'ONLINE',
+      used: 2199792913690,
+      available: 109989645684,
+      special_class_used: 536870912,
+      special_class_available: 0,
+      special_class_usable: 536870912,
+      topology: {
+        data: [{
+          disk: 'sda',
+          type: TopologyItemType.Disk,
+        }],
+        special: [{
+          disk: 'nvme0',
+          type: TopologyItemType.Disk,
+        }],
+      },
+    } as Pool);
+
+    spectator.detectChanges();
+
+    expect(spectator.query('.warning-container')).toHaveText('Critical: Low Capacity');
+    expect(spectator.query('.tier-breakdown')).toExist();
+    expect(spectator.query(GaugeChartComponent)!.segments).toBeUndefined();
+    expect(spectator.query(GaugeChartComponent)!.colorFill).toBe('#CE2929');
   });
 
   it('shows used eating into the reserve when usage crosses the threshold', () => {
@@ -245,7 +323,6 @@ describe('PoolUsageCardComponent', () => {
       },
     } as Pool);
 
-    spectator.component.ngOnInit();
     spectator.detectChanges();
 
     // Reserve zone is a fixed-width striped overlay (25% of usable). The Used bar

--- a/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.ts
+++ b/src/app/pages/storage/components/dashboard-pool/pool-usage-card/pool-usage-card.component.ts
@@ -1,6 +1,6 @@
 import { PercentPipe } from '@angular/common';
 import {
-  ChangeDetectionStrategy, Component, computed, inject, input, OnInit,
+  ChangeDetectionStrategy, Component, computed, inject, input,
 } from '@angular/core';
 import { MatAnchor } from '@angular/material/button';
 import {
@@ -8,8 +8,12 @@ import {
 } from '@angular/material/card';
 import { RouterLink } from '@angular/router';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { poolLowCapacityPercent } from 'app/constants/pool-capacity.constant';
+import {
+  getPoolCapacityGaugeFill, getPoolCapacityGaugeLabelStyle, getPoolCapacityLevel, PoolCapacityGaugeColors,
+  poolCriticalCapacityPercent, poolLowCapacityPercent,
+} from 'app/constants/pool-capacity.constant';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
+import { PoolCapacityLevel } from 'app/enums/pool-capacity-level.enum';
 import { PoolCardIconType } from 'app/enums/pool-card-icon-type.enum';
 import { Pool } from 'app/interfaces/pool.interface';
 import { GaugeChartComponent, GaugeSegment } from 'app/modules/charts/gauge-chart/gauge-chart.component';
@@ -43,8 +47,8 @@ import { getPoolDisks } from 'app/pages/storage/modules/disks/utils/get-pool-dis
     PercentPipe,
   ],
 })
-export class PoolUsageCardComponent implements OnInit {
-  themeService = inject(ThemeService);
+export class PoolUsageCardComponent {
+  private themeService = inject(ThemeService);
   private translate = inject(TranslateService);
   private tierService = inject(SharingTierService);
 
@@ -53,20 +57,38 @@ export class PoolUsageCardComponent implements OnInit {
   protected readonly tierEnabled = this.tierService.tierEnabled;
   protected readonly reservePct = this.tierService.metadataReservePct;
 
-  chartLowCapacityColor: string;
-  chartFillColor: string;
-  chartBlankColor: string;
-
   protected readonly searchableElements = usageCardElements;
 
-  ngOnInit(): void {
-    this.chartBlankColor = this.themeService.currentTheme().bg1;
-    this.chartFillColor = this.themeService.currentTheme().primary;
-    this.chartLowCapacityColor = this.themeService.currentTheme().red;
-  }
+  private gaugeColors = computed<PoolCapacityGaugeColors>(() => {
+    const theme = this.themeService.currentTheme();
+    return {
+      blank: theme.bg1,
+      fill: theme.primary,
+      warning: theme.orange,
+      critical: theme.red,
+    };
+  });
+
+  protected gaugeFill = computed(() => {
+    return getPoolCapacityGaugeFill(this.usedPercentage(), this.gaugeColors());
+  });
+
+  protected gaugeLabelStyle = computed(() => {
+    return getPoolCapacityGaugeLabelStyle(this.usedPercentage());
+  });
+
+  protected gaugeBlankColor = computed(() => this.gaugeColors().blank);
+
+  private capacityLevel = computed(() => {
+    return getPoolCapacityLevel(this.usedPercentage());
+  });
 
   protected isLowCapacity = computed(() => {
-    return this.usedPercentage() >= poolLowCapacityPercent;
+    return this.capacityLevel() !== PoolCapacityLevel.Safe;
+  });
+
+  protected isCriticalCapacity = computed(() => {
+    return this.capacityLevel() === PoolCapacityLevel.Critical;
   });
 
   protected disks = computed(() => {
@@ -94,17 +116,25 @@ export class PoolUsageCardComponent implements OnInit {
   });
 
   protected iconType = computed(() => {
-    if (this.isLowCapacity()) {
-      return PoolCardIconType.Warn;
+    switch (this.capacityLevel()) {
+      case PoolCapacityLevel.Critical:
+        return PoolCardIconType.Error;
+      case PoolCapacityLevel.Warning:
+        return PoolCardIconType.Warn;
+      default:
+        return PoolCardIconType.Safe;
     }
-    return PoolCardIconType.Safe;
   });
 
   protected iconTooltip = computed(() => {
-    if (this.isLowCapacity()) {
-      return this.translate.instant('Pool is using more than {maxPct}% of available space', { maxPct: poolLowCapacityPercent });
+    switch (this.capacityLevel()) {
+      case PoolCapacityLevel.Critical:
+        return this.translate.instant('Pool is using more than {maxPct}% of available space', { maxPct: poolCriticalCapacityPercent });
+      case PoolCapacityLevel.Warning:
+        return this.translate.instant('Pool is using more than {maxPct}% of available space', { maxPct: poolLowCapacityPercent });
+      default:
+        return this.translate.instant('Everything is fine');
     }
-    return this.translate.instant('Everything is fine');
   });
 
   protected hasSpecialVdev = computed(() => {
@@ -116,7 +146,13 @@ export class PoolUsageCardComponent implements OnInit {
   });
 
   protected chartSegments = computed<GaugeSegment[] | undefined>(() => {
-    if (!this.showTierBreakdown()) {
+    // Severity wins over the tier split: GaugeChartComponent ignores colorFill
+    // whenever segments are set, so a segmented gauge would keep drawing green /
+    // primary while the header icon and the "Critical: Low Capacity" caption go
+    // red. Drop the segments once capacity leaves Safe and let the single
+    // severity-colored fill through; the tier split is still spelled out by the
+    // breakdown bars below.
+    if (!this.showTierBreakdown() || this.capacityLevel() !== PoolCapacityLevel.Safe) {
       return undefined;
     }
     const cap = this.capacity();


### PR DESCRIPTION

https://github.com/user-attachments/assets/35c4afa9-e48b-412a-937e-6fc297d2f15e

 **Changes:**

  The same pool usage percentage was reported at three different severities depending on
  where you looked. At 83.9% a pool showed as healthy on the Dashboard, as a warning on the
  Storage Dashboard's Usage card icon, and as critical on that card's gauge.

  Two causes:

  - `WidgetStorageComponent.getUsedSpaceItemInfo()` computed `used / total` — a fraction
    (0.839) — and compared it against `90` and `80`. Those branches could never fire, so the
    Dashboard's Storage widget showed a green check for every pool regardless of usage.
  - The Storage Dashboard's Usage card and the Pool / Pool Usage gauges had a single
    threshold at 80% and painted it red, with no distinct warning colour, so anything over
    80% read as critical.

  Both now go through one shared helper, `getPoolCapacityLevel()`, with the thresholds in
  `pool-capacity.constant.ts`: below 80% is safe, 80–90% is a warning, 90% and above is
  critical.

  - `src/app/constants/pool-capacity.constant.ts` — adds `poolCriticalCapacityPercent = 90`
    and `getPoolCapacityLevel()`, returning the new `PoolCapacityLevel` enum.
  - `widget-storage.component.ts` — fixes the fraction/percent mismatch; a warning now uses
    the alert icon rather than the error icon.
  - `pool-usage-card.component.*` — 80–90% is orange (icon, gauge ring, percentage label,
    banner) and only 90%+ is red with the error icon and a `Critical: Low Capacity` banner.
    The header tooltip quotes the threshold actually crossed instead of always saying 80%.
  - `pool-usage-gauge.component.*` — same orange/red split for the Pool and Pool Usage
    dashboard widgets.

  No API or i18n changes; `Critical` was already in the translation catalogue.

  **Testing:**

  Unit tests added for the thresholds (`pool-capacity.constant.spec.ts`, plus safe/warn/
  critical cases in `widget-storage.component.spec.ts` and a 90%+ case in
  `pool-usage-card.component.spec.ts`). Two existing assertions that expected red in the
  80–90% band were updated to orange.

  Manually verified against a live system at 50%, 85% and 95% on all four surfaces:
  Storage Dashboard Usage card, Dashboard Storage widget, Pool widget, Pool Usage widget.

  Note for reviewers: the Usage card's gauge draws tier `segments` when a pool has a special
  vdev with tiering enabled, and segments take precedence over `colorFill`. On such a pool
  the ring keeps its tier colours and severity shows through the icon, the percentage label
  and the banner. That is pre-existing behaviour, not changed here.
the ring keeps its tier colours and severity shows through the icon, the percentage label
and the banner. That is pre-existing behaviour, not changed here.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Yes — pool capacity now has two documented bands (warning at 80%, critical at 90%) instead of one "low capacity" state at 80%.
|Testing         | Yes — any test asserting a red gauge or the `Warning: Low Capacity` banner in the 80–90% range needs updating to orange / the `Critical:` prefix above 90%.

Original PR: https://github.com/truenas/webui/pull/13934
