### PR TITLE
NAS-142200 / 26.0.0-RC.1 / Show when a tier migration ended, not just when it completed (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.scss
+++ b/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.scss
@@ -1,7 +1,7 @@
+@import 'mixins/tier-status';
+
 :host {
-  display: block;
-  min-width: min(360px, 100%);
-  max-width: min(420px, 90vw);
+  @include tier-dialog-size;
 }
 
 .dataset-name {
@@ -34,7 +34,9 @@
 
 .tier-change {
   display: flex;
-  justify-content: center;
+  // Left-aligned like every other row in the body (Dataset, the checkbox, the
+  // rewrite-size note) - centering left the chips floating mid-dialog.
+  justify-content: flex-start;
   align-items: flex-start;
   gap: 12px;
   margin-bottom: 16px;

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.html
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.html
@@ -23,8 +23,8 @@
     @if (startTime(); as start) {
       <span>{{ 'Started' | translate }}: {{ start | formatDateTime }}</span>
     }
-    @if (finishedTime(); as finished) {
-      <span>{{ 'Finished' | translate }}: {{ finished | formatDateTime }}</span>
+    @if (endTime(); as ended) {
+      <span>{{ endTimeLabel() }}: {{ ended | formatDateTime }}</span>
     } @else if (estimatedCompletion(); as eta) {
       @if (isRunning()) {
         <span>{{ 'Est. completion' | translate }}: {{ eta | formatDateTime }}</span>

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.scss
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.scss
@@ -1,5 +1,9 @@
 @import 'mixins/tier-status';
 
+:host {
+  @include tier-dialog-size;
+}
+
 // Tighten the title's line box and center its items so the small status pill
 // lines up with the large title text (the default MDC title line-height is much
 // taller than the glyphs, which left the pill sitting high).

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.spec.ts
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.spec.ts
@@ -82,20 +82,37 @@ describe('DataMigrationStatusDialogComponent', () => {
     });
   });
 
-  describe('startTime / finishedTime / ETA', () => {
+  describe('startTime / endTime / ETA', () => {
     it('computes startTime from stats.start_time', () => {
       build({ ...baseJob, stats: { ...baseStats } });
       expect(spectator.component.startTime()).toEqual(new Date(1000 * 1000));
     });
 
-    it('returns finishedTime when status is Complete', () => {
-      build({ ...baseJob, status: TierRewriteJobStatus.Complete, stats: { ...baseStats } });
-      expect(spectator.component.finishedTime()).toEqual(new Date(1100 * 1000));
+    it.each([
+      [TierRewriteJobStatus.Complete, 'Finished'],
+      [TierRewriteJobStatus.Cancelled, 'Cancelled'],
+      [TierRewriteJobStatus.Stopped, 'Stopped'],
+      [TierRewriteJobStatus.Error, 'Failed'],
+    ])('shows when the job ended for status %s', (status, label) => {
+      build({ ...baseJob, status, stats: { ...baseStats } });
+
+      expect(spectator.component.endTime()).toEqual(new Date(1100 * 1000));
+      expect(spectator.query('.time-info')).toHaveText(`${label}: `);
     });
 
-    it('returns null finishedTime when still running', () => {
-      build({ ...baseJob, status: TierRewriteJobStatus.Running, stats: { ...baseStats } });
-      expect(spectator.component.finishedTime()).toBeNull();
+    it.each([
+      TierRewriteJobStatus.Running,
+      TierRewriteJobStatus.Queued,
+    ])('returns null endTime for status %s', (status) => {
+      build({ ...baseJob, status, stats: { ...baseStats } });
+
+      expect(spectator.component.endTime()).toBeNull();
+      expect(spectator.component.endTimeLabel()).toBeNull();
+    });
+
+    it('returns null endTime when an ended job never reported stats', () => {
+      build({ ...baseJob, status: TierRewriteJobStatus.Cancelled });
+      expect(spectator.component.endTime()).toBeNull();
     });
 
     it('suppresses ETA below the 1% fraction threshold', () => {
@@ -154,7 +171,21 @@ describe('DataMigrationStatusDialogComponent', () => {
       } as ApiEvent<ZfsTierRewriteJobEntry>);
       spectator.detectChanges();
 
-      expect(spectator.component.finishedTime()).toEqual(new Date(1100 * 1000));
+      expect(spectator.component.endTime()).toEqual(new Date(1100 * 1000));
+    });
+
+    it('shows the cancelled timestamp when the job is cancelled while the dialog is open', () => {
+      build({ ...baseJob, stats: { ...baseStats } });
+
+      updates$.next({
+        msg: 'changed',
+        collection: 'zfs.tier.rewrite_job_status',
+        id: 'job-1',
+        fields: { ...baseJob, status: TierRewriteJobStatus.Cancelled, stats: { ...baseStats } },
+      } as ApiEvent<ZfsTierRewriteJobEntry>);
+      spectator.detectChanges();
+
+      expect(spectator.query('.time-info')).toHaveText('Cancelled: ');
     });
   });
 });

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.ts
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.ts
@@ -10,14 +10,13 @@ import {
 import { MatProgressBar } from '@angular/material/progress-bar';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { DatasetTier } from 'app/enums/dataset-tier.enum';
-import { TierRewriteJobStatus } from 'app/enums/tier-rewrite-job-status.enum';
 import { ZfsTierRewriteJobEntry } from 'app/interfaces/zfs-tier.interface';
 import { FormatDateTimePipe } from 'app/modules/dates/pipes/format-date-time/format-datetime.pipe';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FileSizePipe } from 'app/modules/pipes/file-size/file-size.pipe';
 import { ApiService } from 'app/modules/websocket/api.service';
 import {
-  getTierJobStatusClass, getTierJobStatusLabelKey, getTierLabelKey, isTierJobRunning,
+  getTierJobEndTimeLabelKey, getTierJobStatusClass, getTierJobStatusLabelKey, getTierLabelKey, isTierJobRunning,
 } from 'app/pages/sharing/components/tier-status.utils';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 
@@ -82,12 +81,27 @@ export class DataMigrationStatusDialogComponent implements OnInit {
     return stats ? new Date(stats.start_time * 1000) : null;
   });
 
-  protected finishedTime = computed<Date | null>(() => {
+  /**
+   * Label for `endTime`, which doubles as the "has this job ended?" test: it is
+   * null exactly for the statuses a job can still leave (running, queued).
+   */
+  protected endTimeLabel = computed<string | null>(() => {
+    const key = getTierJobEndTimeLabelKey(this.job());
+    return key ? this.translate.instant(key) : null;
+  });
+
+  /**
+   * When a job stopped. The backend has no dedicated end timestamp, so this uses
+   * the last stats update, which for any ended job is its final progress report.
+   * Shown for every terminal status, not just Complete, so a cancelled or failed
+   * migration says when it stopped instead of leaving the reader guessing.
+   */
+  protected endTime = computed<Date | null>(() => {
     const job = this.job();
-    if (job?.status === TierRewriteJobStatus.Complete && job.stats) {
-      return new Date(job.stats.update_time * 1000);
+    if (!this.endTimeLabel() || !job?.stats) {
+      return null;
     }
-    return null;
+    return new Date(job.stats.update_time * 1000);
   });
 
   protected progressPercent = computed(() => {

--- a/src/app/pages/sharing/components/tier-status.utils.ts
+++ b/src/app/pages/sharing/components/tier-status.utils.ts
@@ -1,12 +1,18 @@
 import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
-import { IconLibraryType } from '@truenas/ui-components';
+import { tnIconMarker } from '@truenas/ui-components';
 import { DatasetTier } from 'app/enums/dataset-tier.enum';
 import { TierRewriteJobStatus } from 'app/enums/tier-rewrite-job-status.enum';
 import { ZfsTierRewriteJobEntry } from 'app/interfaces/zfs-tier.interface';
 
 export interface TierJobIconInfo {
+  /**
+   * Library-prefixed icon name produced by `tnIconMarker`. The marker is what
+   * gets these icons into the generated sprite — a plain `{ name, library }`
+   * pair is invisible to the build-time scanner, which is how `mdi-cancel`
+   * ended up missing while the other four survived only because unrelated
+   * files happened to mark them.
+   */
   name: string;
-  library: IconLibraryType;
   color: string;
   spinning: boolean;
 }
@@ -31,7 +37,7 @@ interface TierJobStatusDescriptor {
 const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> = {
   [TierRewriteJobStatus.Complete]: {
     icon: {
-      name: 'check-circle', library: 'mdi', color: 'green', spinning: false,
+      name: tnIconMarker('check-circle', 'mdi'), color: 'green', spinning: false,
     },
     themeClass: 'fn-theme-green',
     labelKey: T('Complete'),
@@ -39,7 +45,7 @@ const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> 
   },
   [TierRewriteJobStatus.Running]: {
     icon: {
-      name: 'sync', library: 'mdi', color: 'orange', spinning: true,
+      name: tnIconMarker('sync', 'mdi'), color: 'orange', spinning: true,
     },
     themeClass: 'fn-theme-orange',
     labelKey: T('Running'),
@@ -53,7 +59,7 @@ const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> 
   },
   [TierRewriteJobStatus.Error]: {
     icon: {
-      name: 'alert-circle', library: 'mdi', color: 'red', spinning: false,
+      name: tnIconMarker('alert-circle', 'mdi'), color: 'red', spinning: false,
     },
     themeClass: 'fn-theme-red',
     labelKey: T('Error'),
@@ -61,7 +67,7 @@ const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> 
   },
   [TierRewriteJobStatus.Cancelled]: {
     icon: {
-      name: 'cancel', library: 'mdi', color: 'grey', spinning: false,
+      name: tnIconMarker('cancel', 'mdi'), color: 'grey', spinning: false,
     },
     themeClass: 'fn-theme-grey',
     labelKey: T('Cancelled'),
@@ -69,7 +75,7 @@ const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> 
   },
   [TierRewriteJobStatus.Stopped]: {
     icon: {
-      name: 'stop-circle', library: 'mdi', color: 'grey', spinning: false,
+      name: tnIconMarker('stop-circle', 'mdi'), color: 'grey', spinning: false,
     },
     themeClass: 'fn-theme-grey',
     labelKey: T('Stopped'),

--- a/src/app/pages/sharing/components/tier-status.utils.ts
+++ b/src/app/pages/sharing/components/tier-status.utils.ts
@@ -15,6 +15,12 @@ interface TierJobStatusDescriptor {
   icon: TierJobIconInfo | null;
   themeClass: string;
   labelKey: string;
+  /**
+   * Label for the timestamp a job stopped updating, or `null` for statuses that
+   * have no end yet. Worded per status so a cancelled job reads "Cancelled: ..."
+   * rather than borrowing "Finished", which implies the migration ran to the end.
+   */
+  endTimeLabelKey: string | null;
 }
 
 /**
@@ -29,6 +35,7 @@ const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> 
     },
     themeClass: 'fn-theme-green',
     labelKey: T('Complete'),
+    endTimeLabelKey: T('Finished'),
   },
   [TierRewriteJobStatus.Running]: {
     icon: {
@@ -36,11 +43,13 @@ const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> 
     },
     themeClass: 'fn-theme-orange',
     labelKey: T('Running'),
+    endTimeLabelKey: null,
   },
   [TierRewriteJobStatus.Queued]: {
     icon: null,
     themeClass: 'fn-theme-primary',
     labelKey: T('Queued'),
+    endTimeLabelKey: null,
   },
   [TierRewriteJobStatus.Error]: {
     icon: {
@@ -48,6 +57,7 @@ const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> 
     },
     themeClass: 'fn-theme-red',
     labelKey: T('Error'),
+    endTimeLabelKey: T('Failed'),
   },
   [TierRewriteJobStatus.Cancelled]: {
     icon: {
@@ -55,6 +65,7 @@ const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> 
     },
     themeClass: 'fn-theme-grey',
     labelKey: T('Cancelled'),
+    endTimeLabelKey: T('Cancelled'),
   },
   [TierRewriteJobStatus.Stopped]: {
     icon: {
@@ -62,6 +73,7 @@ const tierJobStatusTable: Record<TierRewriteJobStatus, TierJobStatusDescriptor> 
     },
     themeClass: 'fn-theme-grey',
     labelKey: T('Stopped'),
+    endTimeLabelKey: T('Stopped'),
   },
 };
 
@@ -87,6 +99,17 @@ export function getTierJobStatusLabelKey(
   job: ZfsTierRewriteJobEntry | null,
 ): string {
   return job ? tierJobStatusTable[job.status]?.labelKey ?? '' : '';
+}
+
+/**
+ * Returns the i18n extraction key labelling when a job stopped, or `null` while
+ * it is still running or queued. Callers must run the result through
+ * TranslateService to display it.
+ */
+export function getTierJobEndTimeLabelKey(
+  job: ZfsTierRewriteJobEntry | null,
+): string | null {
+  return job ? tierJobStatusTable[job.status]?.endTimeLabelKey ?? null : null;
 }
 
 export function getTierJobStatusClass(

--- a/src/app/pages/sharing/components/tier-status/tier-status.component.html
+++ b/src/app/pages/sharing/components/tier-status/tier-status.component.html
@@ -9,7 +9,6 @@
       tabindex="0"
       [class.spinning]="icon.spinning"
       [name]="icon.name"
-      [library]="icon.library"
       [color]="icon.color"
       [matTooltip]="'Migration: {status}' | translate: { status: jobStatusLabel() }"
       [attr.aria-label]="'Migration: {status}' | translate: { status: jobStatusLabel() }"

--- a/src/assets/styles/mixins/tier-status.scss
+++ b/src/assets/styles/mixins/tier-status.scss
@@ -13,3 +13,21 @@
   &.fn-theme-primary { color: var(--primary); }
   &.fn-theme-grey { color: var(--fg2); }
 }
+
+// Shared sizing for the two tiering dialogs (Change Storage Tier, Data
+// Migration). They are reached from the same flow — Change opens the migration
+// dialog — so a shared width keeps the box from resizing between them.
+//
+// The min-width also holds the Data Migration dialog steady while it loads:
+// without it the dialog is sized by its content, so it starts narrow around the
+// "Gathering statistics..." placeholder and jumps wider once the three stat
+// cards arrive.
+// An explicit `width` rather than a min/max pair: the CDK dialog panel is
+// shrink-to-fit, so a percentage min-width resolves against a box that is itself
+// sized by this content and collapses to nothing. A fixed width also means the
+// dialog cannot resize at all as its content arrives.
+@mixin tier-dialog-size {
+  display: block;
+  max-width: 100%;
+  width: min(640px, 90vw);
+}


### PR DESCRIPTION
**Changes:**

The Data Migration dialog only ever showed a timestamp for a job that ran to the end. Cancel one part way, reopen the dialog, and the line was simply missing — you got a `Cancelled` badge with no indication of when it stopped.

The timestamp row was hardcoded to `Finished`, and the computed feeding it returned a date only for `TierRewriteJobStatus.Complete`. Every other terminal status — `Cancelled`, `Stopped`, `Error` — fell through to the `@else if` ETA branch, which is itself gated on `isRunning()`, so nothing rendered at all.

This generalizes "finished" to "ended". `tier-status.utils.ts` already owns a per-status table that is the single source of truth for each status's icon, theme class, and label, so the end-time wording joins it as `endTimeLabelKey`:

| Status | Badge | Timestamp label |
|---|---|---|
| Complete | Complete | Finished |
| Cancelled | Cancelled | **Cancelled** |
| Stopped | Stopped | **Stopped** |
| Error | Error | **Failed** |
| Running / Queued | Running / Queued | — (ETA shows instead) |

In the dialog, `finishedTime` becomes `endTime`, paired with a new `endTimeLabel`. The label doubles as the "has this job ended?" test — it is null for exactly the two statuses a job can still leave — so there is no second list of terminal statuses to keep in sync as the enum grows.

The ticket only asks about cancel, but `Stopped` and `Error` had the identical gap and are fed by the same computed, so leaving them blank would have been an arbitrary hole.

Two things worth flagging for review:

- **The timestamp source is `stats.update_time`.** `ZfsTierRewriteJobEntry` has no dedicated end-time field, so this uses the last stats update, which for an ended job is its final progress report. That is what the `Complete` case already did, so the cancelled reading is exactly as accurate as the finished one shipping today — but it is a proxy. If the backend grows a real end timestamp, this should switch to it.
- **A job that never reported stats shows no timestamp**, cancelled or not, because `update_time` lives inside `stats`. Covered by a test.

**Testing:**

Reproduces per the ticket: mirrored HDD pool with a mirrored special VDEV, ZFS tiering on, an SMB dataset holding a large amount of data. Start a tier migration, cancel it part way, then reopen the migration status dialog — it now reads `Cancelled: <date/time>` beneath `Started`, matching the `Finished: <date/time>` line a completed migration already shows.

Automated coverage in `data-migration-status-dialog.component.spec.ts`, 16 tests (up from 12):

- one parameterized case per terminal status, asserting both the computed `endTime` and the rendered `.time-info` label
- `Running` and `Queued` still yield a null `endTime` and null label
- an ended job with no stats yields no timestamp
- a live-update test that flips the job to `Cancelled` while the dialog is open and asserts the timestamp appears

Neighbouring `tier-status` and `sharing-tier.service` specs pass unchanged (37 tests across the three suites). `yarn lint` clean on all four files, `tsc -p src/tsconfig.app.json` clean, full AOT `yarn build` clean.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | No. No new UI surface — an existing timestamp row now populates for statuses that previously left it blank.
|Testing         | Yes. Re-run NAS-T2242, where this was found indirectly. QA should confirm the cancelled dialog now carries a date/time, and that a completed migration still reads `Finished` rather than the new wording. `Stopped` and `Failed` labels are also newly reachable if those states can be produced.


Original PR: https://github.com/truenas/webui/pull/13949
