### PR TITLE
NAS-142532 / 27.0.0-BETA.1 / Refresh No WebShare users notice when users change

### DIFF
--- a/src/app/pages/sharing/webshare/webshare.service.spec.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.spec.ts
@@ -2,7 +2,7 @@ import { signal } from '@angular/core';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
 import { TranslateService } from '@ngx-translate/core';
-import { firstValueFrom, of } from 'rxjs';
+import { firstValueFrom, of, throwError } from 'rxjs';
 import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { CollectionChangeType } from 'app/enums/api.enum';
@@ -249,6 +249,54 @@ describe('WebShareService', () => {
       expect(emissions).toEqual([false, true]);
       subscription.unsubscribe();
     });
+  });
+});
+
+describe('WebShareService - user.query subscription error', () => {
+  let spectator: SpectatorService<WebShareService>;
+
+  const createService = createServiceFactory({
+    service: WebShareService,
+    providers: [
+      mockProvider(ApiService, {
+        subscribe: jest.fn(() => throwError(() => new Error('subscription failed'))),
+        call: jest.fn(() => of([])),
+      }),
+      mockProvider(SnackbarService),
+      mockProvider(TranslateService),
+      mockProvider(LicenseService),
+      mockProvider(FormSidePanelService),
+      mockProvider(TruenasConnectService, {
+        config: signal(mockConfiguredTncConfig),
+      }),
+      mockStoreWithRunningService,
+      {
+        provide: WINDOW,
+        useValue: {
+          location: {
+            protocol: 'https:',
+            hostname: 'mynas.truenas.direct',
+          },
+          open: jest.fn(),
+        },
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+  });
+
+  it('emits false instead of erroring when the user.query subscription errors', () => {
+    const emissions: boolean[] = [];
+    let streamError: unknown;
+    spectator.service.hasWebshareUsers$.subscribe({
+      next: (value) => emissions.push(value),
+      error: (error: unknown) => streamError = error,
+    });
+
+    expect(streamError).toBeUndefined();
+    expect(emissions.at(-1)).toBe(false);
   });
 });
 

--- a/src/app/pages/sharing/webshare/webshare.service.spec.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.spec.ts
@@ -5,7 +5,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { firstValueFrom, of, throwError } from 'rxjs';
 import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
-import { CollectionChangeType } from 'app/enums/api.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { ServiceStatus } from 'app/enums/service-status.enum';
 import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
@@ -229,74 +228,36 @@ describe('WebShareService', () => {
   });
 
   describe('hasWebshareUsers$', () => {
-    it('re-queries webshare users when a user.query collection event arrives', () => {
+    it('re-runs the query on every subscription so each screen re-checks on open', () => {
       const api = spectator.inject(MockApiService);
       api.mockCall('user.query', []);
 
-      const emissions: boolean[] = [];
-      const subscription = spectator.service.hasWebshareUsers$.subscribe((value) => emissions.push(value));
-
+      let firstResult: boolean | undefined;
+      spectator.service.hasWebshareUsers$.subscribe((value) => firstResult = value);
+      expect(firstResult).toBe(false);
       expect(api.call).toHaveBeenCalledWith('user.query', [[['webshare', '=', true], ['local', '=', true]]]);
 
       api.mockCall('user.query', [{ id: 1, username: 'bob', webshare: true } as User]);
-      api.emitSubscribeEvent({
-        id: 'test-id-1',
-        msg: CollectionChangeType.Added,
-        collection: 'user.query',
-        fields: null,
+
+      let secondResult: boolean | undefined;
+      spectator.service.hasWebshareUsers$.subscribe((value) => secondResult = value);
+      expect(secondResult).toBe(true);
+    });
+
+    it('emits false instead of erroring when the query fails', () => {
+      const api = spectator.inject(MockApiService);
+      jest.spyOn(api, 'call').mockReturnValue(throwError(() => new Error('query failed')));
+
+      let result: boolean | undefined;
+      let streamError: unknown;
+      spectator.service.hasWebshareUsers$.subscribe({
+        next: (value) => result = value,
+        error: (error: unknown) => streamError = error,
       });
 
-      expect(emissions).toEqual([false, true]);
-      subscription.unsubscribe();
+      expect(streamError).toBeUndefined();
+      expect(result).toBe(false);
     });
-  });
-});
-
-describe('WebShareService - user.query subscription error', () => {
-  let spectator: SpectatorService<WebShareService>;
-
-  const createService = createServiceFactory({
-    service: WebShareService,
-    providers: [
-      mockProvider(ApiService, {
-        subscribe: jest.fn(() => throwError(() => new Error('subscription failed'))),
-        call: jest.fn(() => of([])),
-      }),
-      mockProvider(SnackbarService),
-      mockProvider(TranslateService),
-      mockProvider(LicenseService),
-      mockProvider(FormSidePanelService),
-      mockProvider(TruenasConnectService, {
-        config: signal(mockConfiguredTncConfig),
-      }),
-      mockStoreWithRunningService,
-      {
-        provide: WINDOW,
-        useValue: {
-          location: {
-            protocol: 'https:',
-            hostname: 'mynas.truenas.direct',
-          },
-          open: jest.fn(),
-        },
-      },
-    ],
-  });
-
-  beforeEach(() => {
-    spectator = createService();
-  });
-
-  it('emits false instead of erroring when the user.query subscription errors', () => {
-    const emissions: boolean[] = [];
-    let streamError: unknown;
-    spectator.service.hasWebshareUsers$.subscribe({
-      next: (value) => emissions.push(value),
-      error: (error: unknown) => streamError = error,
-    });
-
-    expect(streamError).toBeUndefined();
-    expect(emissions.at(-1)).toBe(false);
   });
 });
 

--- a/src/app/pages/sharing/webshare/webshare.service.spec.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.spec.ts
@@ -3,13 +3,16 @@ import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/sp
 import { provideMockStore } from '@ngrx/store/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { firstValueFrom, of } from 'rxjs';
+import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
+import { CollectionChangeType } from 'app/enums/api.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { ServiceStatus } from 'app/enums/service-status.enum';
 import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { Service } from 'app/interfaces/service.interface';
 import { TruenasConnectConfig } from 'app/interfaces/truenas-connect-config.interface';
+import { User } from 'app/interfaces/user.interface';
 import { WebShare } from 'app/interfaces/webshare-config.interface';
 import { FormSidePanelService } from 'app/modules/slide-ins/form-side-panel/form-side-panel.service';
 import { SlideInResult } from 'app/modules/slide-ins/slide-in-result';
@@ -222,6 +225,29 @@ describe('WebShareService', () => {
     it('should return empty array for empty input', () => {
       const result = spectator.service.transformToTableRows([]);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('hasWebshareUsers$', () => {
+    it('re-queries webshare users when a user.query collection event arrives', () => {
+      const api = spectator.inject(MockApiService);
+      api.mockCall('user.query', []);
+
+      const emissions: boolean[] = [];
+      const subscription = spectator.service.hasWebshareUsers$.subscribe((value) => emissions.push(value));
+
+      expect(api.call).toHaveBeenCalledWith('user.query', [[['webshare', '=', true], ['local', '=', true]]]);
+
+      api.mockCall('user.query', [{ id: 1, username: 'bob', webshare: true } as User]);
+      api.emitSubscribeEvent({
+        id: 'test-id-1',
+        msg: CollectionChangeType.Added,
+        collection: 'user.query',
+        fields: null,
+      });
+
+      expect(emissions).toEqual([false, true]);
+      subscription.unsubscribe();
     });
   });
 });

--- a/src/app/pages/sharing/webshare/webshare.service.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.ts
@@ -5,10 +5,10 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  Observable, of, forkJoin,
+  Observable, defer, of, forkJoin,
 } from 'rxjs';
 import {
-  defaultIfEmpty, switchMap, take, map, catchError, shareReplay, startWith, tap,
+  defaultIfEmpty, switchMap, take, map, catchError, shareReplay, tap,
 } from 'rxjs/operators';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { ServiceStatus } from 'app/enums/service-status.enum';
@@ -157,20 +157,15 @@ export class WebShareService {
   /**
    * Observable that checks if there are any local users configured with WebShare access.
    * Returns true if at least one local user has webshare=true, false otherwise.
-   * Re-queries on `user.query` collection events so creating, editing or deleting a
-   * user updates the "No WebShare users" notice without a page refresh.
+   * Deliberately uncached: every subscription issues a fresh query, so each screen
+   * showing the "No WebShare users" notice re-checks when it opens instead of
+   * replaying a session-long cached value.
    */
-  readonly hasWebshareUsers$ = this.api.subscribe('user.query').pipe(
-    startWith(null),
-    switchMap(() => this.api.call('user.query', [[['webshare', '=', true], ['local', '=', true]]]).pipe(
-      map((users) => users.length > 0),
-      // Inner catch: a failed query degrades to `false` without killing the event stream.
-      catchError(() => of(false)),
-    )),
-    // Outer catch: an error from the `user.query` subscription itself must also
-    // degrade to `false` instead of propagating into consumers.
+  readonly hasWebshareUsers$ = defer(() => {
+    return this.api.call('user.query', [[['webshare', '=', true], ['local', '=', true]]]);
+  }).pipe(
+    map((users) => users.length > 0),
     catchError(() => of(false)),
-    shareReplay({ bufferSize: 1, refCount: true }),
   );
 
   /**

--- a/src/app/pages/sharing/webshare/webshare.service.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.ts
@@ -164,8 +164,12 @@ export class WebShareService {
     startWith(null),
     switchMap(() => this.api.call('user.query', [[['webshare', '=', true], ['local', '=', true]]]).pipe(
       map((users) => users.length > 0),
+      // Inner catch: a failed query degrades to `false` without killing the event stream.
       catchError(() => of(false)),
     )),
+    // Outer catch: an error from the `user.query` subscription itself must also
+    // degrade to `false` instead of propagating into consumers.
+    catchError(() => of(false)),
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 

--- a/src/app/pages/sharing/webshare/webshare.service.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.ts
@@ -8,7 +8,7 @@ import {
   Observable, of, forkJoin,
 } from 'rxjs';
 import {
-  defaultIfEmpty, switchMap, take, map, catchError, shareReplay, tap,
+  defaultIfEmpty, switchMap, take, map, catchError, shareReplay, startWith, tap,
 } from 'rxjs/operators';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { ServiceStatus } from 'app/enums/service-status.enum';
@@ -157,10 +157,15 @@ export class WebShareService {
   /**
    * Observable that checks if there are any local users configured with WebShare access.
    * Returns true if at least one local user has webshare=true, false otherwise.
+   * Re-queries on `user.query` collection events so creating, editing or deleting a
+   * user updates the "No WebShare users" notice without a page refresh.
    */
-  readonly hasWebshareUsers$ = this.api.call('user.query', [[['webshare', '=', true], ['local', '=', true]]]).pipe(
-    map((users) => users.length > 0),
-    catchError(() => of(false)),
+  readonly hasWebshareUsers$ = this.api.subscribe('user.query').pipe(
+    startWith(null),
+    switchMap(() => this.api.call('user.query', [[['webshare', '=', true], ['local', '=', true]]]).pipe(
+      map((users) => users.length > 0),
+      catchError(() => of(false)),
+    )),
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 


### PR DESCRIPTION
<!--
Pull request title must reference a ticket, for example:
  NAS-12345: Fix broken thing
  NAS-12345 / 27.0.0-BETA.1 / Fix broken thing
-->

**Changes:**

<img width="1603" height="393" alt="image" src="https://github.com/user-attachments/assets/0e6fdc0d-afb9-43ef-8fc3-5118758b55cb" />

**Testing:**

Add webshare user and see that banner vanishes.