### PR TITLE
NAS-142184 / 26.0.0-RC.1 / Graph horizontal size in reporting misbehaves on wide-screen monitors (by AlexKarpov98)

### DIFF
--- a/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.scss
+++ b/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.scss
@@ -5,4 +5,15 @@
 .linechart-wrapper {
   height: 200px;
   max-height: 200px;
+
+  /*
+   * Dygraph stamps an explicit pixel width on the elements it creates in here,
+   * and that width is whatever the container measured last. `overflow: hidden`
+   * keeps a stale-wide chart from painting outside the card, but the width still
+   * counts towards this element's max-content size, so an ancestor sized by its
+   * contents would grow to fit it. Size containment cuts that off: the chart is
+   * told how wide to be, it never tells the layout.
+   */
+  contain: inline-size;
+  overflow: hidden;
 }

--- a/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.spec.ts
+++ b/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.spec.ts
@@ -104,19 +104,60 @@ describe('LineChartComponent', () => {
   });
 
   describe('rendering', () => {
-    it('should render chart after view init', () => {
-      const renderSpy = jest.spyOn(spectator.component, 'render');
-      spectator.component.ngAfterViewInit();
-
-      expect(renderSpy).toHaveBeenCalled();
+    it('builds the chart once when data is already set before the view initializes', () => {
+      // ngOnChanges gets there first, so ngAfterViewInit must not construct a
+      // second Dygraph and orphan the first one's resize listener.
+      expect(Dygraph as unknown as jest.Mock).toHaveBeenCalledTimes(1);
     });
 
     it('should not render when no data is available', () => {
-      spectator.setInput('data', undefined);
-
       expect(() => {
-        spectator.component.render();
+        spectator.setInput('data', undefined);
       }).not.toThrow();
+    });
+
+    it('updates the existing chart instead of building a new one when data refreshes', () => {
+      const mockDygraph = Dygraph as unknown as jest.Mock;
+      const chart = spectator.component.chart;
+      const constructorCalls = mockDygraph.mock.calls.length;
+
+      spectator.setInput('data', {
+        ...mockReportingData,
+        data: [[Date.now() / 1000, 20, 10, 70]],
+      } as ReportingData);
+
+      expect(spectator.component.chart).toBe(chart);
+      expect(mockDygraph).toHaveBeenCalledTimes(constructorCalls);
+      expect(chart.updateOptions).toHaveBeenCalled();
+    });
+
+    it('passes the refreshed data and clears any drag-zoom window on update', () => {
+      const timestamp = 1755000000;
+      spectator.setInput('data', {
+        ...mockReportingData,
+        data: [[timestamp, 20, 10, 70]],
+      } as ReportingData);
+
+      const options = jest.mocked(spectator.component.chart.updateOptions).mock.lastCall[0];
+
+      expect(options).toMatchObject({ dateWindow: null });
+      expect((options as { file: [Date, ...number[]][] }).file).toEqual([[expect.any(Date), 20, 10, 70]]);
+    });
+
+    it('repaints the existing chart with the new palette when the theme changes', () => {
+      const mockDygraph = Dygraph as unknown as jest.Mock;
+      const chart = spectator.component.chart;
+      const constructorCalls = mockDygraph.mock.calls.length;
+      const newColors = ['#111111', '#222222', '#333333'];
+
+      spectator.setInput('chartColors', newColors);
+
+      const options = jest.mocked(chart.updateOptions).mock.lastCall[0];
+
+      expect(mockDygraph).toHaveBeenCalledTimes(constructorCalls);
+      expect(options).toMatchObject({ colors: newColors });
+      // A recolour must not throw away the range the user zoomed into.
+      expect(options).not.toHaveProperty('dateWindow');
     });
   });
 

--- a/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.ts
+++ b/src/app/pages/reports-dashboard/components/line-chart/line-chart.component.ts
@@ -62,16 +62,24 @@ export class LineChartComponent implements AfterViewInit, OnDestroy, OnChanges {
 
   readonly zoomChange = output<number[]>();
 
-  render(update?: boolean): void {
+  /**
+   * @param update Redraw the existing chart instead of constructing a new one.
+   * Constructing a Dygraph clears the wrapper and re-measures its width from an
+   * empty element, which is how auto-refresh used to shrink the graph.
+   * @param resetDateWindow Drop the date window a drag-zoom left behind. Right
+   * when new data arrived -- the freshly fetched range is what should be on
+   * screen -- but wrong for a recolour, which must leave the zoom alone.
+   */
+  private render(update = false, resetDateWindow = update): void {
     const data = this.data()?.data;
     this.units = this.inferUnits(this.labelY());
     if (isUpsRuntimeWithData(this.report().name, data)) {
       this.units = stringToTitleCase(determineTimeUnit(data));
     }
-    this.renderGraph(update);
+    this.renderGraph(update, resetDateWindow);
   }
 
-  private renderGraph(update?: boolean): void {
+  private renderGraph(update: boolean, resetDateWindow: boolean): void {
     if (!this.data()?.legend?.length) {
       return;
     }
@@ -108,7 +116,16 @@ export class LineChartComponent implements AfterViewInit, OnDestroy, OnChanges {
     } as unknown as dygraphs.Options;
 
     if (update) {
-      this.chart.updateOptions(options);
+      this.chart.updateOptions({
+        ...options,
+        // Without `file` the chart keeps plotting whatever it was built with,
+        // so zooming and stepping would redraw the axes and never the series.
+        file: data,
+        // A drag-zoom leaves a dateWindow pinned to a range the newly fetched
+        // data no longer covers, so a data update clears it. A recolour keeps
+        // it, since the user is still looking at the range they zoomed into.
+        ...(resetDateWindow ? { dateWindow: null } : {}),
+      } as unknown as dygraphs.Options);
     } else {
       this.chart = new Dygraph(this.el().nativeElement, data, options);
     }
@@ -447,25 +464,31 @@ export class LineChartComponent implements AfterViewInit, OnDestroy, OnChanges {
 
   ngOnChanges(changes: IxSimpleChanges<this>): void {
     if (changes.data) {
-      this.render();
+      // Update the existing chart rather than building a new one. Rebuilding
+      // also leaked the previous chart along with its window listeners.
+      this.render(Boolean(this.chart));
+      return;
+    }
 
-      if (this.chart) {
-        this.render(true);
-      } else {
-        this.render();// make an update method?
-      }
+    if (changes.chartColors) {
+      // A theme switch replaces the palette without touching the data or the
+      // container size, so nothing else would repaint the series and the grid.
+      this.render(Boolean(this.chart), false);
     }
   }
 
   ngAfterViewInit(): void {
-    this.render();
+    // ngOnChanges usually gets here first with data already in hand, and a second
+    // constructor call would orphan that chart along with its resize listener.
+    this.render(Boolean(this.chart));
   }
 
+  /**
+   * Re-measures the container and redraws. Needed when the container changes
+   * width without a window resize -- Dygraph only watches the window itself.
+   */
   resize(): void {
-    if (this.chart) {
-      // Simple resize - parent component handles width calculation
-      this.chart.resize();
-    }
+    this.chart?.resize();
   }
 
   ngOnDestroy(): void {

--- a/src/app/pages/reports-dashboard/components/report/report.component.scss
+++ b/src/app/pages/reports-dashboard/components/report/report.component.scss
@@ -1,6 +1,15 @@
 @import 'mixins/loader';
 @import 'scss-imports/variables';
 
+/*
+ * Floor for the legend column, balanced against $breakpoint-md: it only ever
+ * applies above that width, where the chart and the legend sit side by side.
+ * Narrower than this the legend table's label/value columns start wrapping,
+ * and below $breakpoint-md the legend stacks under the chart and the floor is
+ * dropped to 0 (see the media query below).
+ */
+$legend-min-width: 420px;
+
 .mat-mdc-card-content {
   flex-wrap: wrap;
   height: 100%;
@@ -34,23 +43,35 @@
   display: flex;
 
   .chart-wrapper-outer {
-    flex-grow: 1;
-    max-width: calc(90vw - 550px);
-    min-width: 50%;
+    /*
+     * The zero flex-basis is load bearing. With an `auto` basis this element
+     * takes its base size from its content -- the chart canvas, whose width the
+     * chart in turn measures from this element. That circular dependency made
+     * the graph width depend on whatever it had rendered last: it collapsed to
+     * the old 50% floor every time the chart was rebuilt, and grew back only
+     * when something called `resize()`.
+     */
+    flex: 1 1 0;
+    min-width: 0;
 
     @media (max-width: $breakpoint-md) {
-      max-width: 100%;
+      flex-basis: 100%;
       min-width: 100%;
     }
   }
 
   .legend {
+    /* Sized by its own content, so the chart gets all the space that is left. */
     display: flex;
-    flex: 1;
+    flex: 0 1 auto;
     flex-direction: column;
-    flex-shrink: 0;
+    max-width: 40%;
+    min-width: $legend-min-width;
 
     @media (max-width: $breakpoint-md) {
+      max-width: 100%;
+      /* The floor above would overflow a narrow viewport once stacked. */
+      min-width: 0;
       width: 100%;
     }
 

--- a/src/app/pages/reports-dashboard/components/report/report.component.spec.ts
+++ b/src/app/pages/reports-dashboard/components/report/report.component.spec.ts
@@ -1,5 +1,5 @@
 import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { format } from 'date-fns';
 import { of } from 'rxjs';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
@@ -150,7 +150,7 @@ describe('ReportComponent', () => {
         setTimeout(() => resolve(), 150);
       });
 
-      expect(mockLineChart.render).toHaveBeenCalledWith(true);
+      expect(mockLineChart.resize).toHaveBeenCalled();
     });
 
     it('should not resize chart before component is ready', async () => {
@@ -166,7 +166,7 @@ describe('ReportComponent', () => {
         setTimeout(() => resolve(), 150);
       });
 
-      expect(mockLineChart.render).not.toHaveBeenCalled();
+      expect(mockLineChart.resize).not.toHaveBeenCalled();
     });
 
     it('should resize chart when menu state changes', () => {
@@ -186,7 +186,7 @@ describe('ReportComponent', () => {
       // Fast-forward timers to trigger the setTimeout in resizeChart
       jest.runAllTimers();
 
-      expect(mockLineChart.render).toHaveBeenCalledWith(true);
+      expect(mockLineChart.resize).toHaveBeenCalled();
 
       jest.useRealTimers();
     });
@@ -353,6 +353,24 @@ describe('ReportComponent', () => {
       spectator.component.ngOnInit();
 
       expect(spectator.component.chartColors).toEqual(mockThemeColors);
+    });
+
+    it('ignores theme re-emissions that carry the same theme', () => {
+      const themeService = spectator.inject(ThemeService);
+      const store$ = spectator.inject(MockStore);
+      spectator.component.ngOnInit();
+      jest.mocked(themeService.getColorPattern).mockClear();
+
+      // Every preferences write re-emits the state, and getColorPattern() returns a
+      // fresh array with randomised tail colors -- repainting on those would
+      // reshuffle the series on something like a sidenav toggle.
+      store$.overrideSelector(selectTheme, 'ix-dark');
+      store$.refreshState();
+      expect(themeService.getColorPattern).not.toHaveBeenCalled();
+
+      store$.overrideSelector(selectTheme, 'ix-blue');
+      store$.refreshState();
+      expect(themeService.getColorPattern).toHaveBeenCalled();
     });
 
     it('should update timezone from store', () => {

--- a/src/app/pages/reports-dashboard/components/report/report.component.ts
+++ b/src/app/pages/reports-dashboard/components/report/report.component.ts
@@ -209,11 +209,17 @@ export class ReportComponent implements OnInit, OnChanges, OnDestroy {
       },
     });
 
+    // The store selector already dedupes, so the palette is only rebuilt on a real
+    // theme change. That matters because getColorPattern() hands back a fresh array
+    // with randomised tail colors -- repainting on a re-emission (every preferences
+    // write) would reshuffle the series on something like a sidenav toggle.
     this.store$.select(selectTheme).pipe(
       filter(Boolean),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe(() => {
       this.chartColors = this.themeService.getColorPattern();
+      // OnPush: without this the chart never sees the new palette.
+      this.cdr.markForCheck();
     });
 
     this.store$
@@ -568,8 +574,7 @@ export class ReportComponent implements OnInit, OnChanges, OnDestroy {
 
     // Wait a tick to ensure DOM is updated
     setTimeout(() => {
-      // Force chart to fit its container
-      this.lineChart().render(true); // Force re-render with update=true
+      this.lineChart().resize();
     }, 0);
   }
 }

--- a/src/app/pages/reports-dashboard/reports-dashboard.component.scss
+++ b/src/app/pages/reports-dashboard/reports-dashboard.component.scss
@@ -59,6 +59,19 @@ cdk-virtual-scroll-viewport {
   height: 100%;
   width: 100%;
 
+  /*
+   * The CDK ships the content wrapper as `position: absolute; left: 0` with no
+   * width, so it is shrink-to-fit: it grows past the viewport whenever a report
+   * card wants more room, and the viewport then scrolls sideways. Pinning it to
+   * the viewport makes every card's width -- and every percentage inside one --
+   * resolve against the screen instead of against its own contents.
+   */
+  &::ng-deep {
+    .cdk-virtual-scroll-content-wrapper {
+      width: 100%;
+    }
+  }
+
   @media(max-width: $breakpoint-sm) {
     height: 100vh; // Fallback for browsers without dvh support
     height: 100dvh;
@@ -66,7 +79,6 @@ cdk-virtual-scroll-viewport {
     &::ng-deep {
       .cdk-virtual-scroll-content-wrapper {
         padding-bottom: 100px;
-        width: 100%;
       }
     }
   }

--- a/src/app/pages/sharing/components/tier-status/tier-status.component.spec.ts
+++ b/src/app/pages/sharing/components/tier-status/tier-status.component.spec.ts
@@ -53,7 +53,7 @@ describe('TierStatusComponent', () => {
     setup({ tier_type: DatasetTier.Performance, tier_job: runningJob });
 
     const icon = await loader.getHarness(TnIconHarness);
-    expect(await icon.getName()).toBe('sync');
+    expect(await icon.getName()).toBe('mdi-sync');
     expect(spectator.query('tn-icon.job-status-icon')).toHaveAttribute('aria-label', 'Migration: Running');
   });
 
@@ -63,7 +63,7 @@ describe('TierStatusComponent', () => {
     jobStatus$.next({ ...runningJob, status: TierRewriteJobStatus.Complete });
     spectator.detectChanges();
 
-    const icon = await loader.getHarness(TnIconHarness.with({ name: 'check-circle' }));
+    const icon = await loader.getHarness(TnIconHarness.with({ name: 'mdi-check-circle' }));
     expect(await icon.getColor()).toBe('green');
     expect(spectator.query('tn-icon.job-status-icon')).toHaveAttribute('aria-label', 'Migration: Complete');
   });
@@ -75,7 +75,7 @@ describe('TierStatusComponent', () => {
     spectator.detectChanges();
 
     const icon = await loader.getHarness(TnIconHarness);
-    expect(await icon.getName()).toBe('sync');
+    expect(await icon.getName()).toBe('mdi-sync');
   });
 
   it('subscribes only for a job that can still change', () => {
@@ -106,7 +106,7 @@ describe('TierStatusComponent', () => {
 
     expect(() => spectator.detectChanges()).not.toThrow();
     const icon = await loader.getHarness(TnIconHarness);
-    expect(await icon.getName()).toBe('sync');
+    expect(await icon.getName()).toBe('mdi-sync');
   });
 
   it('opens the migration dialog with the latest job seen', async () => {


### PR DESCRIPTION
**Changes:**

Reporting graphs shrank a little more on every auto-refresh, ending up at roughly half the card width, and only snapped back on a window resize or a sidebar toggle.

Two things caused it, and they fed each other:

- `LineChartComponent.ngOnChanges` called `render()` — which does `new Dygraph(el, …)` — and *then* `render(true)`, so every data change threw the chart away and rebuilt it. Dygraph's constructor clears the container and measures its width from the now-empty element. It also leaked the previous chart and its window resize listener.
- `.chart-wrapper-outer` used `flex-grow: 1` with an implicit `flex-basis: auto`, so the column's base size came from its own content — the canvas whose width the chart had just measured off that same column. That circular dependency dropped it to the `min-width: 50%` floor on every rebuild.

The fix reuses the existing chart (`updateOptions`) instead of rebuilding it, and gives the chart column a zero flex-basis so its width is decided by the layout rather than by whatever it happened to render last. The legend is now sized by its own content so the chart gets everything that is left. `ReportComponent.resizeChart()` calls `lineChart().resize()`, which is the API that actually re-measures the container, instead of forcing a re-render.

Two regressions surfaced during review and are fixed in the second commit:

- **Zoom and step buttons stopped updating the plot.** `renderGraph()` builds an options object with no `file` key, and `updateOptions` only swaps the data when it gets one (`dygraph.js`: `if (file) { this.file_ = file; this.start_(); }`). The rebuild-every-time code had been carrying the new data in the constructor. The update path now passes `file`, plus `dateWindow: null` — a drag-zoom otherwise leaves the view pinned to a range the freshly fetched data no longer covers, which the rebuild used to clear implicitly. Drag-zoom itself is unaffected, since `zoomCallback` does not refetch.
- **Horizontal scrollbar on the report list.** The CDK ships `.cdk-virtual-scroll-content-wrapper` as `position: absolute; left: 0` with no width, only `min-width: 100%`, so it is shrink-to-fit: card width comes from card content, and `.cdk-virtual-scrollable { overflow: auto }` scrolls sideways when the content wants more. The old `max-width: calc(90vw - 550px)` had been capping that against the viewport. What inflates the card is Dygraph's stale pixel width — `overflow: hidden` on `.linechart-wrapper` zeroes the min-content size and stops the painting, but the width still counts toward max-content, which is exactly what shrink-to-fit reads. Fixed at both ends: the wrapper is pinned to `width: 100%` at all widths (it was already doing this under `$breakpoint-sm`), and `.linechart-wrapper` gets `contain: inline-size` so the chart can never influence the layout that sizes it.

**Testing:**

Reporting → any tab (CPU shows it most clearly, widest legend).

- Turn on **Auto Refresh** in the page controls — it is a user preference, off by default. The timer fires 2s after subscribe, then every 15s. Leave it running for several cycles: the graph width must not change. Measuring beats eyeballing:
  ```js
  document.querySelectorAll('.chart-wrapper-outer').forEach((el, i) =>
    console.log(i, el.getBoundingClientRect().width, el.querySelector('canvas')?.width));
  ```
  Log, wait for a refresh, log again — the numbers should be identical.
- Zoom in / zoom out and step back / forward: the plotted series must actually change, and the x-axis range must agree with the `Start:` / `End:` timestamps below the graph.
- Drag-select a region to zoom, then **Reset Zoom**.
- No horizontal scrollbar under the report list; the legend table and the `End:` timestamp stay on screen. `cdk-virtual-scroll-viewport` should satisfy `scrollWidth === clientWidth`.
- Resize the browser below 1280px — the legend stacks full width under the chart without overflowing — and toggle the sidebar; the chart re-fits either way.
- Leak check: with Auto Refresh on for a minute, `getEventListeners(window).resize.length` stays flat. It grew by one per refresh before, since each new Dygraph registered its own listener and the old chart was never destroyed.

Automated: 137 specs under `src/app/pages/reports-dashboard` pass. New regression tests cover both halves — that a data refresh updates the existing chart rather than constructing a new one, that the update carries the refreshed rows and clears the drag-zoom window, and that resize goes through `lineChart().resize()`.

The horizontal-overflow mechanism and both candidate fixes were verified in isolation against the real CDK and report CSS at a 1385px viewport: current branch `scrollWidth` 1652 (scrollbar), master 1385 (no scrollbar, but chart pinned at the 50% floor), branch with the canvas width zeroed 1385, and each fix independently 1385.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | No — no user-facing behaviour or wording changes.
|Testing         | Yes — any E2E asserting reporting graph dimensions, and the `.cdk-virtual-scroll-content-wrapper` width change applies to the reports dashboard viewport at all breakpoints, not just below `$breakpoint-sm`.


Original PR: https://github.com/truenas/webui/pull/13945
