### PR TITLE
NAS-142267 / 26.0.0-RC.1 / Show nav badges and page banners for ZFS tiering alerts (by AlexKarpov98)

### DIFF
--- a/src/app/enums/alert-class-name.enum.ts
+++ b/src/app/enums/alert-class-name.enum.ts
@@ -115,6 +115,8 @@ export enum AlertClassName {
   PoolUsbDisks = 'PoolUSBDisks',
   QuotaWarning = 'QuotaWarning',
   ScrubPaused = 'ScrubPaused',
+  TierSpecialVdevWarning = 'TierSpecialVdevWarning',
+  TierSpecialVdevCritical = 'TierSpecialVdevCritical',
   SnapshotTotalCount = 'SnapshotTotalCount',
   SnapshotCount = 'SnapshotCount',
 
@@ -155,6 +157,8 @@ export enum AlertClassName {
   ScrubStarted = 'ScrubStarted',
   SnapshotFailed = 'SnapshotFailed',
   TaskLocked = 'TaskLocked',
+  TierJobError = 'TierJobError',
+  TierJobComplete = 'TierJobComplete',
   VmwareLoginFailed = 'VMWareLoginFailed',
   VmwareSnapshotDeleteFailed = 'VMWareSnapshotDeleteFailed',
 

--- a/src/app/interfaces/smart-alert.interface.ts
+++ b/src/app/interfaces/smart-alert.interface.ts
@@ -52,15 +52,25 @@ export interface SmartAlertEnhancement {
   detailedHelp?: string;
   documentationUrl?: string;
 
-  // Navigation integration.
-  // Drives the nav badge (badge shows on this path and every parent path).
+  // Navigation integration. The primary feature area of the alert.
+  // Drives the nav badge (badge shows on this path and every parent path) and,
+  // unless bannerMenuPath overrides it, the page-level banner.
   relatedMenuPath?: string[];
 
-  // Restricts the page-level alert banner to routes at or below this path.
-  // Use when the banner should be scoped more narrowly than the nav badge
-  // (e.g. an alert relevant only to a sub-page that has no menu item of its own).
-  // Falls back to relatedMenuPath when omitted.
+  // Overrides relatedMenuPath *for the banner only*, restricting it to routes at or
+  // below this path. Use when the banner should be scoped more narrowly than the nav
+  // badge (e.g. an alert relevant only to a sub-page that has no menu item of its own).
+  // Falls back to relatedMenuPath when omitted, and never applies to extraMenuPaths.
   bannerMenuPath?: string[];
+
+  // Secondary feature areas of the alert. Each path surfaces both the badge and the
+  // banner in full, unaffected by any bannerMenuPath narrowing of the primary path.
+  // Use for alerts that span two feature areas, e.g. ZFS tiering alerts are raised
+  // against a pool (Storage) but are acted on per-dataset (Datasets).
+  // Resulting scopes: badge = relatedMenuPath + extraMenuPaths,
+  // banner = (bannerMenuPath ?? relatedMenuPath) + extraMenuPaths.
+  // See getAlertBadgeMenuPaths / getAlertBannerMenuPaths.
+  extraMenuPaths?: string[][];
 
   // Visual enhancements
   customIcon?: string;
@@ -152,12 +162,15 @@ export interface EnhancedAlert {
   documentationUrl?: string;
   relatedMenuPath?: string[];
   bannerMenuPath?: string[];
+  extraMenuPaths?: string[][];
   customIcon?: string;
   severityScore?: number;
 }
 
 /**
- * Alert decorated with the count and ids of every alert sharing the same key.
+ * Alert decorated with the count and ids of every alert sharing the same duplicate key,
+ * i.e. the same alert class *and* the same key (see `getAlertDuplicateKey`) - two different
+ * classes raised against the same object are not duplicates of each other.
  * Dispatchers carry `allIds` so dismiss/reopen actions act on every duplicate
  * without re-querying post-reducer state.
  */

--- a/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.spec.ts
+++ b/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.spec.ts
@@ -5,6 +5,7 @@ import { MockComponent } from 'ng-mocks';
 import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { AlertClassName } from 'app/enums/alert-class-name.enum';
 import { AlertLevel } from 'app/enums/alert-level.enum';
 import { CollectionChangeType } from 'app/enums/api.enum';
 import { ProductType } from 'app/enums/product-type.enum';
@@ -204,6 +205,39 @@ describe('AlertsPanelComponent', () => {
       ['dup-a', 'dup-b'],
       ['dup-a', 'dup-b'],
     ]);
+  });
+
+  // Regression for NAS-142267: middleware builds `key` from the alert arguments alone, so
+  // TierSpecialVdevWarning and TierSpecialVdevCritical for the same pool share a key. They are
+  // separate alerts and must not be counted as duplicates of one another (nor dismissed together).
+  it('does not treat different alert classes sharing a key as duplicates', () => {
+    const sameKeyAlerts = [
+      {
+        id: 'tier-warning',
+        klass: AlertClassName.TierSpecialVdevWarning,
+        key: '"hddpool"',
+        dismissed: false,
+        datetime: { $date: 1641811015 },
+        level: AlertLevel.Warning,
+      },
+      {
+        id: 'tier-critical',
+        klass: AlertClassName.TierSpecialVdevCritical,
+        key: '"hddpool"',
+        dismissed: false,
+        datetime: { $date: 1641811020 },
+        level: AlertLevel.Critical,
+      },
+    ] as Alert[];
+    spectator.inject(Store).dispatch(alertsLoaded({ alerts: sameKeyAlerts }));
+    spectator.detectChanges();
+
+    const rendered = alertPanel.unreadAlertComponents.map(
+      (component) => alertPanel.getAlertData(component),
+    );
+
+    expect(rendered.map((alert) => alert?.allIds)).toEqual([['tier-critical'], ['tier-warning']]);
+    expect(rendered.map((alert) => alert?.duplicateCount)).toEqual([1, 1]);
   });
 
   it('dismisses all alerts when Dismiss All Alerts is pressed', () => {

--- a/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.ts
+++ b/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.ts
@@ -29,6 +29,7 @@ import {
   selectDismissedAlerts,
   selectUnreadAlerts,
 } from 'app/modules/alerts/store/alert.selectors';
+import { getAlertDuplicateKey } from 'app/modules/alerts/utils/alert-duplicate-key.utils';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { EmailFormComponent } from 'app/pages/system/general-settings/email/email-form/email-form.component';
@@ -167,13 +168,14 @@ export class AlertsPanelComponent implements OnInit {
   ): (T & { duplicateCount: number; allIds: string[] })[] {
     const idsByKey = new Map<string, string[]>();
     const idsForAlert = alerts.map((alert) => {
-      const existing = idsByKey.get(alert.key);
+      const duplicateKey = getAlertDuplicateKey(alert);
+      const existing = idsByKey.get(duplicateKey);
       if (existing) {
         existing.push(alert.id);
         return existing;
       }
       const ids = [alert.id];
-      idsByKey.set(alert.key, ids);
+      idsByKey.set(duplicateKey, ids);
       return ids;
     });
 

--- a/src/app/modules/alerts/services/alert-enhancement.registry.spec.ts
+++ b/src/app/modules/alerts/services/alert-enhancement.registry.spec.ts
@@ -1,6 +1,6 @@
 import { AlertClassName } from 'app/enums/alert-class-name.enum';
 import { Alert } from 'app/interfaces/alert.interface';
-import { SmartAlertActionType } from 'app/interfaces/smart-alert.interface';
+import { SmartAlertActionType, SmartAlertCategory } from 'app/interfaces/smart-alert.interface';
 import { getAlertEnhancement } from 'app/modules/alerts/services/alert-enhancement.registry';
 
 describe('alert-enhancement.registry route fixes (NAS-140943)', () => {
@@ -109,6 +109,50 @@ describe('alert-enhancement.registry route fixes (NAS-140943)', () => {
         expect(action?.route).toEqual(['/credentials', 'users', 'api-keys']);
       },
     );
+  });
+
+  describe('ZFS tiering alerts (NAS-142267)', () => {
+    it.each([
+      AlertClassName.TierSpecialVdevWarning,
+      AlertClassName.TierSpecialVdevCritical,
+    ])('badges both Storage and Datasets for %s', (klass) => {
+      const enhancement = getAlertEnhancement(
+        '',
+        klass,
+        'Pool hddpool: special allocation class usage exceeds 70%.',
+        buildAlert(klass),
+      );
+
+      expect(enhancement?.category).toBe(SmartAlertCategory.Storage);
+      expect(enhancement?.relatedMenuPath).toEqual(['storage']);
+      expect(enhancement?.extraMenuPaths).toEqual([['datasets']]);
+      expect(enhancement?.actions?.map((action) => action.route)).toEqual([['/storage'], ['/datasets']]);
+    });
+
+    it('badges Datasets for a failed tier migration job', () => {
+      const enhancement = getAlertEnhancement(
+        '',
+        AlertClassName.TierJobError,
+        'Tier migration job tank/data@uuid encountered an error: boom',
+        buildAlert(AlertClassName.TierJobError),
+      );
+
+      expect(enhancement?.category).toBe(SmartAlertCategory.Tasks);
+      expect(enhancement?.relatedMenuPath).toEqual(['datasets']);
+    });
+
+    it('does not badge any menu for a completed tier migration job', () => {
+      const enhancement = getAlertEnhancement(
+        '',
+        AlertClassName.TierJobComplete,
+        'Tier migration job tank/data@uuid completed successfully.',
+        buildAlert(AlertClassName.TierJobComplete),
+      );
+
+      expect(enhancement?.category).toBe(SmartAlertCategory.Tasks);
+      expect(enhancement?.relatedMenuPath).toBeUndefined();
+      expect(enhancement?.extraMenuPaths).toBeUndefined();
+    });
   });
 
   describe('Scrub finished/not started alerts', () => {

--- a/src/app/modules/alerts/services/alert-enhancement.registry.ts
+++ b/src/app/modules/alerts/services/alert-enhancement.registry.ts
@@ -1117,6 +1117,73 @@ export const smartAlertRegistry: SmartAlertConfig = {
       }],
     },
 
+    // ZFS Tiering
+    // Special allocation class (special vdev) capacity is a pool-level condition, but it is
+    // resolved from Datasets by moving datasets back to the Regular tier — badge both menus.
+    [AlertClassName.TierSpecialVdevCritical]: {
+      category: SmartAlertCategory.Storage,
+      relatedMenuPath: ['storage'],
+      extraMenuPaths: [['datasets']],
+      contextualHelp: T('The special allocation class of this pool is nearly full. Tier rewrites will abort and new Performance tier writes will overflow into the Regular tier. Free space by moving datasets back to the Regular tier, or expand the special vdev.'),
+      actions: [{
+        label: T('Go to Storage'),
+        type: SmartAlertActionType.Navigate,
+        icon: tnIconMarker('dns', 'material'),
+        route: ['/storage'],
+        primary: true,
+      }, {
+        label: T('Go to Datasets'),
+        type: SmartAlertActionType.Navigate,
+        icon: tnIconMarker('database', 'mdi'),
+        route: ['/datasets'],
+      }],
+    },
+
+    [AlertClassName.TierSpecialVdevWarning]: {
+      category: SmartAlertCategory.Storage,
+      relatedMenuPath: ['storage'],
+      extraMenuPaths: [['datasets']],
+      contextualHelp: T('The special allocation class of this pool is approaching the configured critical cap. Review the tier assignments of your datasets or expand the special vdev before tier rewrites start to fail.'),
+      actions: [{
+        label: T('Go to Storage'),
+        type: SmartAlertActionType.Navigate,
+        icon: tnIconMarker('dns', 'material'),
+        route: ['/storage'],
+        primary: true,
+      }, {
+        label: T('Go to Datasets'),
+        type: SmartAlertActionType.Navigate,
+        icon: tnIconMarker('database', 'mdi'),
+        route: ['/datasets'],
+      }],
+    },
+
+    [AlertClassName.TierJobError]: {
+      category: SmartAlertCategory.Tasks,
+      relatedMenuPath: ['datasets'],
+      contextualHelp: T('A tier migration job did not finish. The dataset keeps its previous tier placement until the migration is retried.'),
+      actions: [{
+        label: T('Go to Datasets'),
+        type: SmartAlertActionType.Navigate,
+        icon: tnIconMarker('database', 'mdi'),
+        route: ['/datasets'],
+        primary: true,
+      }],
+    },
+
+    // Informational only, so it carries no menu path and never badges a menu.
+    // (Notice-level alerts are filtered out of the badge and banner surfaces upstream.)
+    [AlertClassName.TierJobComplete]: {
+      category: SmartAlertCategory.Tasks,
+      actions: [{
+        label: T('Go to Datasets'),
+        type: SmartAlertActionType.Navigate,
+        icon: tnIconMarker('database', 'mdi'),
+        route: ['/datasets'],
+        primary: true,
+      }],
+    },
+
     // Storage/Pools
     PoolUpgraded: {
       category: SmartAlertCategory.Storage,

--- a/src/app/modules/alerts/services/smart-alert.service.spec.ts
+++ b/src/app/modules/alerts/services/smart-alert.service.spec.ts
@@ -51,6 +51,28 @@ describe('SmartAlertService', () => {
     dismissed: false,
   } as unknown as Alert;
 
+  const tierSpecialVdevCriticalAlert = {
+    id: '44',
+    klass: AlertClassName.TierSpecialVdevCritical,
+    source: '',
+    level: AlertLevel.Critical,
+    formatted: 'Pool hddpool: special allocation class usage exceeds 70%.',
+    text: 'Pool hddpool: special allocation class usage exceeds 70%.',
+    args: { pool_name: 'hddpool', threshold: 70 },
+    dismissed: false,
+  } as unknown as Alert;
+
+  const tierSpecialVdevWarningAlert = {
+    id: '45',
+    klass: AlertClassName.TierSpecialVdevWarning,
+    source: '',
+    level: AlertLevel.Warning,
+    formatted: 'Pool hddpool: special allocation class usage exceeds 60%.',
+    text: 'Pool hddpool: special allocation class usage exceeds 60%.',
+    args: { pool_name: 'hddpool', threshold: 60 },
+    dismissed: false,
+  } as unknown as Alert;
+
   const createService = createServiceFactory({
     service: SmartAlertService,
     providers: [
@@ -214,6 +236,28 @@ describe('SmartAlertService', () => {
 
       expect(counts.get('data-protection')?.critical).toBe(1);
       expect(counts.get('data-protection.cloud-backup')?.critical).toBe(1);
+    });
+
+    it('counts alerts under their extra menu paths as well', () => {
+      const tierCritical = spectator.service.enhanceAlert(tierSpecialVdevCriticalAlert);
+      const tierWarning = spectator.service.enhanceAlert(tierSpecialVdevWarningAlert);
+
+      const counts = spectator.service.getAlertCountsByMenuPath([tierCritical, tierWarning]);
+
+      expect(counts.get('storage')).toEqual({ critical: 1, warning: 1, info: 0 });
+      expect(counts.get('datasets')).toEqual({ critical: 1, warning: 1, info: 0 });
+    });
+
+    it('does not count an alert twice when its menu paths overlap', () => {
+      const alert = {
+        ...spectator.service.enhanceAlert(tierSpecialVdevCriticalAlert),
+        relatedMenuPath: ['storage'],
+        extraMenuPaths: [['storage']],
+      };
+
+      const counts = spectator.service.getAlertCountsByMenuPath([alert]);
+
+      expect(counts.get('storage')?.critical).toBe(1);
     });
   });
 });

--- a/src/app/modules/alerts/services/smart-alert.service.ts
+++ b/src/app/modules/alerts/services/smart-alert.service.ts
@@ -12,6 +12,7 @@ import { Alert } from 'app/interfaces/alert.interface';
 import { EnhancedAlert, SmartAlertAction, SmartAlertActionType, SmartAlertCategory } from 'app/interfaces/smart-alert.interface';
 import { isRoutePlaceholder, routePlaceholders } from 'app/modules/alerts/constants/route-placeholders.const';
 import { criticalLevels } from 'app/modules/alerts/store/alert.selectors';
+import { getAlertBadgeMenuPaths } from 'app/modules/alerts/utils/alert-menu-path.utils';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { searchDelayConst } from 'app/modules/global-search/constants/delay.const';
 import { UiSearchDirectivesService } from 'app/modules/global-search/services/ui-search-directives.service';
@@ -149,6 +150,7 @@ export class SmartAlertService {
       documentationUrl: enhancement.documentationUrl,
       relatedMenuPath: enhancement.relatedMenuPath,
       bannerMenuPath: enhancement.bannerMenuPath,
+      extraMenuPaths: enhancement.extraMenuPaths,
       customIcon: enhancement.customIcon,
       severityScore: enhancement.severityScore,
     };
@@ -396,6 +398,9 @@ export class SmartAlertService {
    * Example: alert with path ['data-protection', 'cloud-backup']
    * increments counts for both 'data-protection' and 'data-protection.cloud-backup'
    *
+   * Alerts that declare `extraMenuPaths` are counted under those paths too, so an
+   * alert spanning two feature areas badges both (e.g. tiering: Storage + Datasets).
+   *
    * Counts all alert instances to match what users see in the alert panel.
    * For example, if there are 2 instances of the same alert, it counts as 2.
    */
@@ -406,10 +411,10 @@ export class SmartAlertService {
 
     // Count all alert instances by path
     alerts
-      .filter((alert) => !alert.dismissed && alert.relatedMenuPath)
+      .filter((alert) => !alert.dismissed)
       .forEach((alert) => {
-        const menuPath = alert.relatedMenuPath;
-        if (!menuPath) return;
+        const menuPaths = getAlertBadgeMenuPaths(alert);
+        if (!menuPaths.length) return;
 
         const isCritical = criticalLevels.includes(alert.level);
         const isWarning = [AlertLevel.Warning].includes(alert.level);
@@ -419,21 +424,27 @@ export class SmartAlertService {
         // Example: ['data-protection', 'cloud-backup'] creates entries for:
         // - 'data-protection'
         // - 'data-protection.cloud-backup'
-        for (let i = 1; i <= menuPath.length; i++) {
-          const pathSegments = menuPath.slice(0, i);
-          const path = pathSegments.join('.');
-          const current = counts.get(path) || { critical: 0, warning: 0, info: 0 };
+        const countedPaths = new Set<string>();
+        menuPaths.forEach((menuPath) => {
+          for (let i = 1; i <= menuPath.length; i++) {
+            const path = menuPath.slice(0, i).join('.');
+            // A path shared by two of the alert's menu paths must only be counted once.
+            if (countedPaths.has(path)) continue;
+            countedPaths.add(path);
 
-          if (isCritical) {
-            current.critical++;
-          } else if (isWarning) {
-            current.warning++;
-          } else if (isInfo) {
-            current.info++;
+            const current = counts.get(path) || { critical: 0, warning: 0, info: 0 };
+
+            if (isCritical) {
+              current.critical++;
+            } else if (isWarning) {
+              current.warning++;
+            } else if (isInfo) {
+              current.info++;
+            }
+
+            counts.set(path, current);
           }
-
-          counts.set(path, current);
-        }
+        });
       });
 
     return counts;

--- a/src/app/modules/alerts/utils/alert-duplicate-key.utils.ts
+++ b/src/app/modules/alerts/utils/alert-duplicate-key.utils.ts
@@ -1,0 +1,17 @@
+import { Alert } from 'app/interfaces/alert.interface';
+
+/**
+ * Builds the key used to group duplicate instances of the same alert.
+ *
+ * Middleware derives `alert.key` from the alert arguments alone
+ * (`json.dumps(key_from_args(args))`), so two *different* alert classes raised
+ * against the same object share a key — e.g. `TierSpecialVdevWarning` and
+ * `TierSpecialVdevCritical` both key on the pool name, which made a single
+ * warning and a single critical alert each report a duplicate count of 2 and
+ * dismiss each other. Qualifying the key with the alert class keeps unrelated
+ * alerts apart while still grouping the genuine duplicates (e.g. the same alert
+ * reported by both controllers of an HA pair).
+ */
+export function getAlertDuplicateKey(alert: Pick<Alert, 'klass' | 'key'>): string {
+  return `${alert.klass}:${alert.key}`;
+}

--- a/src/app/modules/alerts/utils/alert-menu-path.utils.ts
+++ b/src/app/modules/alerts/utils/alert-menu-path.utils.ts
@@ -1,0 +1,34 @@
+import { EnhancedAlert } from 'app/interfaces/smart-alert.interface';
+
+/**
+ * Menu paths that should show a navigation badge for this alert.
+ * `extraMenuPaths` lets an alert that spans two feature areas badge both of them.
+ */
+export function getAlertBadgeMenuPaths(alert: EnhancedAlert): string[][] {
+  return [
+    ...(alert.relatedMenuPath ? [alert.relatedMenuPath] : []),
+    ...(alert.extraMenuPaths || []),
+  ];
+}
+
+/**
+ * Menu paths whose pages should show the alert banner.
+ * `bannerMenuPath` narrows the primary scope (see SmartAlertEnhancement), while
+ * `extraMenuPaths` widens it to the alert's secondary feature areas.
+ */
+export function getAlertBannerMenuPaths(alert: EnhancedAlert): string[][] {
+  const primaryPath = alert.bannerMenuPath ?? alert.relatedMenuPath;
+  return [
+    ...(primaryPath ? [primaryPath] : []),
+    ...(alert.extraMenuPaths || []),
+  ];
+}
+
+/**
+ * True when the current route is at or below the given menu path.
+ * Dataset routes use /datasets/:datasetId, so ['datasets'] still matches /datasets/tank.
+ */
+export function isRouteUnderMenuPath(menuPath: string[], pathSegments: string[]): boolean {
+  return menuPath.length <= pathSegments.length
+    && menuPath.every((segment, index) => pathSegments[index] === segment);
+}

--- a/src/app/modules/page-header/page-alerts/page-alerts.component.spec.ts
+++ b/src/app/modules/page-header/page-alerts/page-alerts.component.spec.ts
@@ -2,6 +2,7 @@ import { signal } from '@angular/core';
 import { provideRouter, Router } from '@angular/router';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
+import { AlertClassName } from 'app/enums/alert-class-name.enum';
 import { AlertLevel } from 'app/enums/alert-level.enum';
 import { Alert } from 'app/interfaces/alert.interface';
 import { EnhancedAlert } from 'app/interfaces/smart-alert.interface';
@@ -68,13 +69,42 @@ describe('PageAlertsComponent', () => {
     bannerMenuPath: ['credentials', 'users', 'api-keys'],
   } as unknown as Alert & EnhancedAlert;
 
-  const alertsSignal = signal([
+  const tierWarningAlert = {
+    id: 'tier-warning',
+    uuid: 'tier-warning',
+    // Middleware keys both tier alerts on the pool name alone.
+    key: '"hddpool"',
+    klass: AlertClassName.TierSpecialVdevWarning,
+    level: AlertLevel.Warning,
+    formatted: 'Pool hddpool: special allocation class usage exceeds 60%.',
+    dismissed: false,
+    datetime: { $date: 1 },
+    relatedMenuPath: ['storage'],
+    extraMenuPaths: [['datasets']],
+  } as unknown as Alert & EnhancedAlert;
+
+  const tierCriticalAlert = {
+    id: 'tier-critical',
+    uuid: 'tier-critical',
+    key: '"hddpool"',
+    klass: AlertClassName.TierSpecialVdevCritical,
+    level: AlertLevel.Critical,
+    formatted: 'Pool hddpool: special allocation class usage exceeds 70%.',
+    dismissed: false,
+    datetime: { $date: 2 },
+    relatedMenuPath: ['storage'],
+    extraMenuPaths: [['datasets']],
+  } as unknown as Alert & EnhancedAlert;
+
+  const defaultAlerts = [
     lockedShareAlert,
     rootLoginAlert,
     dismissedDatasetAlert,
     storageAlert,
     apiKeyAlert,
-  ]);
+  ];
+
+  const alertsSignal = signal(defaultAlerts);
 
   const createComponent = createComponentFactory({
     component: PageAlertsComponent,
@@ -96,6 +126,7 @@ describe('PageAlertsComponent', () => {
   }
 
   beforeEach(() => {
+    alertsSignal.set(defaultAlerts);
     spectator = createComponent();
     router = spectator.inject(Router);
   });
@@ -168,5 +199,31 @@ describe('PageAlertsComponent', () => {
 
     const messages = renderedMessages();
     expect(messages.some((message) => message.includes('API key has been revoked'))).toBe(false);
+  });
+
+  describe('alerts spanning several feature areas (NAS-142267)', () => {
+    beforeEach(() => {
+      alertsSignal.set([tierWarningAlert, tierCriticalAlert]);
+    });
+
+    it.each(['/storage', '/datasets'])('shows a tiering alert on %s', async (url) => {
+      await setUrl(url);
+
+      const messages = renderedMessages();
+      expect(messages.some((message) => message.includes('special allocation class'))).toBe(true);
+    });
+
+    it('does not show a tiering alert on an unrelated route', async () => {
+      await setUrl('/credentials/users');
+
+      expect(renderedMessages()).toEqual([]);
+    });
+
+    it('keeps alert classes that share a middleware key apart instead of counting them as duplicates', async () => {
+      await setUrl('/storage');
+
+      expect(renderedMessages()).toHaveLength(2);
+      expect(spectator.queryAll('.duplicate-count-badge')).toEqual([]);
+    });
   });
 });

--- a/src/app/modules/page-header/page-alerts/page-alerts.component.ts
+++ b/src/app/modules/page-header/page-alerts/page-alerts.component.ts
@@ -13,6 +13,8 @@ import { maxAlertMessageLength } from 'app/modules/alerts/constants/alert-displa
 import { AlertNavBadgeService } from 'app/modules/alerts/services/alert-nav-badge.service';
 import { dismissAlertPressed } from 'app/modules/alerts/store/alert.actions';
 import { criticalLevels } from 'app/modules/alerts/store/alert.selectors';
+import { getAlertDuplicateKey } from 'app/modules/alerts/utils/alert-duplicate-key.utils';
+import { getAlertBannerMenuPaths, isRouteUnderMenuPath } from 'app/modules/alerts/utils/alert-menu-path.utils';
 import { AppState } from 'app/store';
 
 /**
@@ -55,7 +57,8 @@ export class PageAlertsComponent {
 
   /**
    * Memoized duplicate info map that only recomputes when alerts change
-   * Maps alert key -> { count, allIds } for all unread alerts system-wide
+   * Maps the duplicate key (alert class + key, see `getAlertDuplicateKey`) ->
+   * { count, allIds } for all unread alerts system-wide
    */
   private duplicateInfoMap = computed(() => {
     const alerts = this.allAlerts();
@@ -65,12 +68,13 @@ export class PageAlertsComponent {
     alerts.forEach((alert) => {
       if (alert.dismissed) return;
 
-      const existing = duplicateInfo.get(alert.key);
+      const duplicateKey = getAlertDuplicateKey(alert);
+      const existing = duplicateInfo.get(duplicateKey);
       if (existing) {
         existing.count++;
         existing.allIds.push(alert.id);
       } else {
-        duplicateInfo.set(alert.key, {
+        duplicateInfo.set(duplicateKey, {
           count: 1,
           allIds: [alert.id],
         });
@@ -105,27 +109,26 @@ export class PageAlertsComponent {
     const alertsByKey = new Map<string, (Alert & EnhancedAlert)[]>();
 
     for (const alert of alerts) {
-      // Scope the banner by bannerMenuPath when provided, otherwise fall back to relatedMenuPath.
-      // This lets the banner target a narrower route than the nav badge (e.g. API keys live under
-      // /credentials/users/api-keys but the badge stays on the Credentials menu).
-      const menuPath = alert.bannerMenuPath ?? alert.relatedMenuPath;
+      // Scope the banner by bannerMenuPath when provided, otherwise fall back to relatedMenuPath,
+      // plus any extraMenuPaths. This lets the banner target a narrower route than the nav badge
+      // (e.g. API keys live under /credentials/users/api-keys but the badge stays on the
+      // Credentials menu), or a wider one for alerts that span two feature areas.
+      const menuPaths = getAlertBannerMenuPaths(alert);
 
       // Skip dismissed or alerts without a page scope
-      if (!menuPath || alert.dismissed) continue;
+      if (!menuPaths.length || alert.dismissed) continue;
 
-      // Match if current URL is at or below the alert's menu path.
-      // Dataset routes use /datasets/:datasetId, so ['datasets'] must still match /datasets/tank.
-      const isMatch = menuPath.length <= pathSegments.length
-        && menuPath.every((segment, index) => pathSegments[index] === segment);
+      const isMatch = menuPaths.some((menuPath) => isRouteUnderMenuPath(menuPath, pathSegments));
 
       if (!isMatch) continue;
 
-      // Group by key
-      const group = alertsByKey.get(alert.key);
+      // Group by class + key
+      const duplicateKey = getAlertDuplicateKey(alert);
+      const group = alertsByKey.get(duplicateKey);
       if (group) {
         group.push(alert);
       } else {
-        alertsByKey.set(alert.key, [alert]);
+        alertsByKey.set(duplicateKey, [alert]);
       }
     }
 
@@ -179,7 +182,7 @@ export class PageAlertsComponent {
   protected hasAlerts = computed(() => this.pageAlerts().length > 0);
 
   /**
-   * Dismiss an alert (and all its duplicates with the same key)
+   * Dismiss an alert (and all its duplicates - alerts of the same class sharing the same key)
    */
   protected onDismiss(alert: Alert & { allIds: string[] }): void {
     this.store$.dispatch(dismissAlertPressed({ ids: alert.allIds }));


### PR DESCRIPTION


https://github.com/user-attachments/assets/00cedf92-d834-4cf5-950b-1a7298286f06


Register the middleware Tier* alert classes in the smart alert registry so special-vdev capacity warnings/criticals badge both the Storage and Datasets menu items and raise a banner at the top of those pages.

Alerts can now declare `extraMenuPaths` for conditions that span two feature areas: the special allocation class belongs to a pool (Storage) but is freed by re-tiering datasets (Datasets).

Also group duplicate alerts by class + key. Middleware derives `alert.key` from the alert arguments alone, so TierSpecialVdevWarning and TierSpecialVdevCritical for the same pool share a key and were reported as 2 duplicates of each other (and dismissed together).


<!--
Pull request title must reference a ticket, for example:
  NAS-12345: Fix broken thing
  NAS-12345 / 27.0.0-BETA.1 / Fix broken thing
-->

**Changes:**

<!-- Briefly describe what changed. -->

**Testing:**

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |


Original PR: https://github.com/truenas/webui/pull/13952
