### PR TITLE
NAS-142532 / 26.0.0-RC.1 / Refresh No WebShare users notice when users change (by william-gr)

### DIFF
--- a/src/app/pages/sharing/webshare/webshare.service.spec.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.spec.ts
@@ -1,11 +1,13 @@
 import { signal } from '@angular/core';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { TranslateService } from '@ngx-translate/core';
-import { firstValueFrom, of } from 'rxjs';
+import { firstValueFrom, of, throwError } from 'rxjs';
+import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { TruenasConnectConfig } from 'app/interfaces/truenas-connect-config.interface';
+import { User } from 'app/interfaces/user.interface';
 import { WebShare } from 'app/interfaces/webshare-config.interface';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
@@ -202,6 +204,39 @@ describe('WebShareService', () => {
     it('should return empty array for empty input', () => {
       const result = spectator.service.transformToTableRows([]);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('hasWebshareUsers$', () => {
+    it('re-runs the query on every subscription so each screen re-checks on open', () => {
+      const api = spectator.inject(MockApiService);
+      api.mockCall('user.query', []);
+
+      let firstResult: boolean | undefined;
+      spectator.service.hasWebshareUsers$.subscribe((value) => firstResult = value);
+      expect(firstResult).toBe(false);
+      expect(api.call).toHaveBeenCalledWith('user.query', [[['webshare', '=', true], ['local', '=', true]]]);
+
+      api.mockCall('user.query', [{ id: 1, username: 'bob', webshare: true } as User]);
+
+      let secondResult: boolean | undefined;
+      spectator.service.hasWebshareUsers$.subscribe((value) => secondResult = value);
+      expect(secondResult).toBe(true);
+    });
+
+    it('emits false instead of erroring when the query fails', () => {
+      const api = spectator.inject(MockApiService);
+      jest.spyOn(api, 'call').mockReturnValue(throwError(() => new Error('query failed')));
+
+      let result: boolean | undefined;
+      let streamError: unknown;
+      spectator.service.hasWebshareUsers$.subscribe({
+        next: (value) => result = value,
+        error: (error: unknown) => streamError = error,
+      });
+
+      expect(streamError).toBeUndefined();
+      expect(result).toBe(false);
     });
   });
 });

--- a/src/app/pages/sharing/webshare/webshare.service.ts
+++ b/src/app/pages/sharing/webshare/webshare.service.ts
@@ -4,7 +4,7 @@ import {
 import { toObservable } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  Observable, of, forkJoin,
+  Observable, defer, of, forkJoin,
 } from 'rxjs';
 import {
   switchMap, take, map, catchError, shareReplay, tap,
@@ -126,11 +126,15 @@ export class WebShareService {
   /**
    * Observable that checks if there are any local users configured with WebShare access.
    * Returns true if at least one local user has webshare=true, false otherwise.
+   * Deliberately uncached: every subscription issues a fresh query, so each screen
+   * showing the "No WebShare users" notice re-checks when it opens instead of
+   * replaying a session-long cached value.
    */
-  readonly hasWebshareUsers$ = this.api.call('user.query', [[['webshare', '=', true], ['local', '=', true]]]).pipe(
+  readonly hasWebshareUsers$ = defer(() => {
+    return this.api.call('user.query', [[['webshare', '=', true], ['local', '=', true]]]);
+  }).pipe(
     map((users) => users.length > 0),
     catchError(() => of(false)),
-    shareReplay({ bufferSize: 1, refCount: true }),
   );
 
   /**


### PR DESCRIPTION
<!--
Pull request title must reference a ticket, for example:
  NAS-12345: Fix broken thing
  NAS-12345 / 27.0.0-BETA.1 / Fix broken thing
-->

**Changes:**

<img width="1603" height="393" alt="image" src="https://github.com/user-attachments/assets/0e6fdc0d-afb9-43ef-8fc3-5118758b55cb" />

**Testing:**

Add webshare user and see that banner vanishes.

Original PR: https://github.com/truenas/webui/pull/13959
