### PR TITLE
NAS-142223 / 26.0.0-RC.1 / Warn that cancelling a data migration does not undo the tier change (by AlexKarpov98)

### DIFF
--- a/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.html
+++ b/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.html
@@ -80,6 +80,15 @@
       }
     }
   </form>
+
+  <tn-banner
+    class="tier-warning"
+    type="warning"
+    [heading]="'Changing the tier takes effect immediately' | translate"
+    [message]="form.value.moveExistingData
+      ? ('Data migration can be cancelled while it runs, but cancelling does not undo the tier change: the dataset stays on the new tier.' | translate)
+      : ''"
+  ></tn-banner>
 </div>
 
 <mat-dialog-actions align="end">

--- a/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.scss
+++ b/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.scss
@@ -50,7 +50,10 @@
 .tier-column {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  // Left-aligned, not centered: the chip is narrower than its "N GiB
+  // available" caption, and centering pushed it off the left edge every other
+  // row in the dialog body shares.
+  align-items: flex-start;
   gap: 4px;
 }
 
@@ -84,4 +87,10 @@
   margin-bottom: 8px;
   font-size: 13px;
   color: var(--orange);
+}
+
+// Sits directly above the dialog actions, so the user reads it before Apply.
+.tier-warning {
+  display: block;
+  margin-top: 16px;
 }

--- a/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.spec.ts
+++ b/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.spec.ts
@@ -3,12 +3,14 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { TnBannerHarness } from '@truenas/ui-components';
 import {
   EMPTY, Observable, catchError, of, throwError,
 } from 'rxjs';
 import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { DatasetTier } from 'app/enums/dataset-tier.enum';
+import { IxCheckboxHarness } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.harness';
 import { ApiService } from 'app/modules/websocket/api.service';
 import {
   ChangeTierDialogComponent, ChangeTierDialogData,
@@ -211,5 +213,58 @@ describe('ChangeTierDialogComponent — loadDetails parsing', () => {
     await spectator.fixture.whenStable();
 
     expect(spectator.component.hasSnapshots()).toBe(true);
+  });
+});
+
+describe('ChangeTierDialogComponent — tier change warning', () => {
+  let spectator: Spectator<ChangeTierDialogComponent>;
+  let loader: HarnessLoader;
+
+  const dialogData: ChangeTierDialogData = {
+    datasetName: 'tank/SHARE',
+    currentTier: DatasetTier.Regular,
+    poolName: 'tank',
+  };
+
+  const createComponent = createComponentFactory({
+    component: ChangeTierDialogComponent,
+    providers: [
+      mockApi([
+        mockCall('zpool.query', []),
+        mockCall('pool.dataset.query', []),
+        mockCall('sharing.smb.query', []),
+        mockCall('sharing.nfs.query', []),
+        mockCall('sharing.webshare.query', []),
+      ]),
+      { provide: MAT_DIALOG_DATA, useValue: dialogData },
+      mockProvider(MatDialogRef),
+    ],
+  });
+
+  beforeEach(async () => {
+    spectator = createComponent({ detectChanges: false });
+    spectator.detectChanges();
+    await spectator.fixture.whenStable();
+    spectator.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+  });
+
+  it('warns that the tier takes effect immediately, and that cancelling the migration does not undo it', async () => {
+    const banner = await loader.getHarness(TnBannerHarness);
+
+    expect(await banner.getText()).toContain('Changing the tier takes effect immediately');
+    expect(await banner.getText()).toContain(
+      'Data migration can be cancelled while it runs, but cancelling does not undo the tier change',
+    );
+  });
+
+  it('drops the migration half of the warning when existing data is not moved', async () => {
+    const moveExistingData = await loader.getHarness(IxCheckboxHarness.with({ label: 'Move existing data' }));
+    await moveExistingData.setValue(false);
+
+    const banner = await loader.getHarness(TnBannerHarness);
+
+    expect(await banner.getText()).toContain('Changing the tier takes effect immediately');
+    expect(await banner.getText()).not.toContain('Data migration can be cancelled');
   });
 });

--- a/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.ts
+++ b/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.ts
@@ -8,6 +8,7 @@ import {
   MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle,
 } from '@angular/material/dialog';
 import { TranslateModule } from '@ngx-translate/core';
+import { TnBannerComponent } from '@truenas/ui-components';
 import { forkJoin, tap } from 'rxjs';
 import { DatasetTier } from 'app/enums/dataset-tier.enum';
 import { mntPath } from 'app/enums/mnt-path.enum';
@@ -40,6 +41,7 @@ export interface ChangeTierDialogData {
     ReactiveFormsModule,
     IxCheckboxComponent,
     TestDirective,
+    TnBannerComponent,
   ],
 })
 export class ChangeTierDialogComponent implements OnInit {

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.html
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.html
@@ -33,14 +33,18 @@
   </div>
 
   @if (job().stats; as stats) {
-    <mat-progress-bar
-      mode="determinate"
-      [value]="progressPercent()"
-    />
+    @if (hasIndeterminateProgress()) {
+      <mat-progress-bar mode="indeterminate" />
+    } @else {
+      <mat-progress-bar
+        mode="determinate"
+        [value]="progressPercent()"
+      />
+    }
 
     <div class="stats-cards">
       <div class="stat-card">
-        <div class="stat-label">{{ 'Data Transferred' | translate }}</div>
+        <div class="stat-label">{{ 'Data Scanned' | translate }}</div>
         <div class="stat-value">
           {{ stats.count_bytes | ixFileSize }}
           /
@@ -49,7 +53,7 @@
       </div>
 
       <div class="stat-card">
-        <div class="stat-label">{{ 'Items Completed' | translate }}</div>
+        <div class="stat-label">{{ 'Items Succeeded' | translate }}</div>
         <div class="stat-value">{{ stats.success }} / {{ stats.total_items }}</div>
       </div>
 

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.scss
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.scss
@@ -69,12 +69,11 @@ mat-progress-bar {
   gap: 16px;
 }
 
+// Not a card any more - the stats read as plain columns aligned with the rest
+// of the dialog body, so the box went with the padding.
 .stat-card {
   flex: 1;
   min-width: 120px;
-  padding: 12px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
 
   .stat-label {
     font-size: 12px;

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.spec.ts
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.spec.ts
@@ -69,16 +69,68 @@ describe('DataMigrationStatusDialogComponent', () => {
   }
 
   describe('progress math', () => {
-    it('renders progressPercent as 50 when half the bytes have been transferred', () => {
+    it('renders progressPercent as 50 when half the items are done', () => {
       build({ ...baseJob, stats: { ...baseStats } });
 
       const bar = spectator.query('mat-progress-bar')!;
       expect(bar.getAttribute('aria-valuenow') || bar.getAttribute('ng-reflect-value')).toBe('50');
     });
 
-    it('emits 0 when total_bytes is 0', () => {
-      build({ ...baseJob, stats: { ...baseStats, total_bytes: 0, count_bytes: 0 } });
+    it('emits 0 when total_items is 0', () => {
+      build({ ...baseJob, stats: { ...baseStats, total_items: 0, success: 0 } });
       expect(spectator.component.progressPercent()).toBe(0);
+    });
+
+    it('ignores byte counts, which reach the total before anything is rewritten', () => {
+      build({
+        ...baseJob,
+        stats: {
+          ...baseStats, count_bytes: 4_000_000, total_bytes: 4_000_000, success: 0, total_items: 10,
+        },
+      });
+
+      expect(spectator.component.progressPercent()).toBe(0);
+    });
+
+    it('clamps an item count that overshoots its total', () => {
+      build({ ...baseJob, stats: { ...baseStats, success: 12, total_items: 10 } });
+
+      expect(spectator.component.progressPercent()).toBe(100);
+    });
+
+    it('floors the percentage, so a nearly-done job does not read 100 while it runs', () => {
+      build({ ...baseJob, stats: { ...baseStats, success: 999, total_items: 1000 } });
+
+      expect(spectator.component.progressPercent()).toBe(99);
+    });
+
+    it('counts failed items as processed, so a terminal job reaches 100%', () => {
+      build({
+        ...baseJob,
+        status: TierRewriteJobStatus.Complete,
+        stats: {
+          ...baseStats, total_items: 10, success: 9, failures: 1,
+        },
+      });
+
+      expect(spectator.component.progressPercent()).toBe(100);
+    });
+
+    it('runs the bar indeterminate while a single-item job is in flight', () => {
+      build({ ...baseJob, stats: { ...baseStats, total_items: 1, success: 0 } });
+
+      expect(spectator.query('mat-progress-bar')).toHaveAttribute('mode', 'indeterminate');
+    });
+
+    it('settles a single-item job back to a determinate bar once it ends', () => {
+      build({
+        ...baseJob,
+        status: TierRewriteJobStatus.Complete,
+        stats: { ...baseStats, total_items: 1, success: 1 },
+      });
+
+      expect(spectator.query('mat-progress-bar')).toHaveAttribute('mode', 'determinate');
+      expect(spectator.component.progressPercent()).toBe(100);
     });
   });
 
@@ -118,8 +170,23 @@ describe('DataMigrationStatusDialogComponent', () => {
     it('suppresses ETA below the 1% fraction threshold', () => {
       build({
         ...baseJob,
-        stats: { ...baseStats, count_bytes: 1, total_bytes: 1_000_000 },
+        stats: { ...baseStats, success: 1, total_items: 1000 },
       });
+      expect(spectator.component.estimatedCompletion()).toBeNull();
+    });
+
+    it('suppresses ETA once every item is done, instead of extrapolating to the start time', () => {
+      build({
+        ...baseJob,
+        stats: { ...baseStats, success: 10, total_items: 10 },
+      });
+
+      expect(spectator.component.estimatedCompletion()).toBeNull();
+    });
+
+    it('suppresses ETA when the first tick lands in the same second the job started', () => {
+      build({ ...baseJob, stats: { ...baseStats, update_time: 1000 } });
+
       expect(spectator.component.estimatedCompletion()).toBeNull();
     });
 
@@ -156,6 +223,17 @@ describe('DataMigrationStatusDialogComponent', () => {
         [{ tier_job_id: 'job-1' }],
       );
       expect(spectator.inject(MatDialogRef).close).toHaveBeenCalledWith(true);
+    });
+
+    it('warns in the confirmation that the tier change itself is not reverted', async () => {
+      build({ ...baseJob, stats: { ...baseStats } });
+
+      const cancelButton = await loader.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
+      await cancelButton.click();
+
+      expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining('The storage tier change has already been applied and is not reverted by cancelling.'),
+      }));
     });
   });
 

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.ts
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.ts
@@ -106,10 +106,39 @@ export class DataMigrationStatusDialogComponent implements OnInit {
     return new Date(job.stats.update_time * 1000);
   });
 
-  protected progressPercent = computed(() => {
+  /**
+   * Progress is measured in items, not bytes. `count_bytes` is the byte count
+   * the job has *claimed*, not written — it reaches `total_bytes` as soon as
+   * the job has enumerated the dataset, and can even exceed it, so a byte-based
+   * bar reads 100% on a job that has rewritten nothing.
+   *
+   * Items *processed*, not items succeeded: `failures` is a counter disjoint
+   * from `success` (the Failures card reports it separately), so a job that
+   * ends having failed an item would otherwise stall the bar short of full
+   * next to a terminal status badge. A failed item is finished work either way.
+   */
+  protected progressFraction = computed(() => {
     const stats = this.job()?.stats;
-    if (!stats || stats.total_bytes <= 0) return 0;
-    return Math.round((stats.count_bytes / stats.total_bytes) * 100);
+    if (!stats || stats.total_items <= 0) return 0;
+    return Math.min(1, Math.max(0, (stats.success + stats.failures) / stats.total_items));
+  });
+
+  /**
+   * Floor, not round: at 999 of 1000 items `Math.round` reads 100 while the job
+   * is still running and still showing an ETA, so the bar would claim to be
+   * done ahead of every other element on screen. `progressFraction` is clamped,
+   * so flooring can only reach 100 when the job genuinely is.
+   */
+  protected progressPercent = computed(() => Math.floor(this.progressFraction() * 100));
+
+  /**
+   * A single-item job has no expressible middle: `success` is 0 until the one
+   * file lands, then 1. Rather than pin the bar at 0% for the whole rewrite,
+   * show motion without a false number while it runs.
+   */
+  protected hasIndeterminateProgress = computed(() => {
+    const stats = this.job()?.stats;
+    return !!stats && this.isRunning() && stats.total_items <= 1;
   });
 
   /**
@@ -122,15 +151,22 @@ export class DataMigrationStatusDialogComponent implements OnInit {
   protected estimatedCompletion = computed<Date | null>(() => {
     const job = this.job();
     const start = this.startTime();
-    if (!start || !job?.stats || job.stats.count_bytes <= 0 || job.stats.total_bytes <= 0) {
+    if (!start || !job?.stats) {
       return null;
     }
-    const fractionDone = job.stats.count_bytes / job.stats.total_bytes;
-    if (fractionDone < DataMigrationStatusDialogComponent.minFractionForEta) {
+    const fractionDone = this.progressFraction();
+    // At >=100% there is nothing left to estimate, and extrapolating from a
+    // fraction of 1 just returns the elapsed time — which is how the ETA used
+    // to render as the start time itself.
+    if (fractionDone < DataMigrationStatusDialogComponent.minFractionForEta || fractionDone >= 1) {
       return null;
     }
     const now = job.stats.update_time * 1000;
     const elapsed = now - start.getTime();
+    // The first status tick can land in the same second the job started.
+    if (elapsed <= 0) {
+      return null;
+    }
     const estimatedTotal = elapsed / fractionDone;
     return new Date(start.getTime() + estimatedTotal);
   });
@@ -141,7 +177,9 @@ export class DataMigrationStatusDialogComponent implements OnInit {
 
   protected onCancel(): void {
     this.dialogService.confirm({
-      message: this.translate.instant('Are you sure you want to cancel this data migration? Data already transferred will remain at its destination.'),
+      message: this.translate.instant(
+        'Are you sure you want to cancel this data migration? The storage tier change has already been applied and is not reverted by cancelling. Data already transferred will remain at its destination.',
+      ),
       buttonText: this.translate.instant('Stop migration'),
       buttonColor: 'warn',
     }).pipe(


### PR DESCRIPTION
**Changes:**

Users reasonably assume that cancelling a dual action cancels both halves of it. A data migration *can* be cancelled (`zfs.tier.rewrite_job_cancel`), but cancelling only stops the rewrite — `dataset_set_tier` has already been applied and is not reverted, so the dataset stays on the new tier. Nothing in the UI said so.

This takes option (a) from the ticket: warn up front, rather than adding a "cancel Tiering and Migration / Migration only" choice. Option (b) needs middleware support to actually revert a tier, so it isn't something the UI can deliver alone.

- **Change Storage Tier dialog** — warning banner directly above Cancel/Apply: *"Changing the tier takes effect immediately"*. When **Move existing data** is checked it adds *"Data migration can be cancelled while it runs, but cancelling does not undo the tier change: the dataset stays on the new tier."*
- **Cancel-migration confirmation** — second sentence: *"The storage tier change has already been applied and is not reverted by cancelling."*

The heading was originally taken almost verbatim from the ticket ("Tiering change cannot be cancelled once started") — out of that context it read as "there is no abort button", which is wrong. Reworded in ec5f8cac2c to say what the ticket is actually after.

Two defects found while testing the above against a real migration, both pre-existing since NAS-139979:

- **Migration progress was measured in bytes.** `count_bytes` is the byte count the job has *claimed*, not written — it reaches `total_bytes` as soon as the dataset is enumerated, and can overshoot it (the ticket's own screenshot shows `2.08 GiB / 1.66 GiB`). A 4 GiB single-file rewrite therefore rendered a full progress bar with `0 / 1` items done. Progress now comes from `(success + failures) / total_items` — items *processed*, so a job that ends having failed an item still reaches 100% next to its terminal badge — clamped, and floored rather than rounded so 999 of 1000 reads 99, not a premature 100.
- **The ETA rendered as the start time.** It extrapolated from that same byte fraction: fraction 1.0 × 0s elapsed → ETA = start. It's now derived from item progress and suppressed when it can't say anything — at >=100%, or when the first status tick lands in the same second the job started. A single-item job has no expressible middle (`success` is 0, then 1), so it runs the bar indeterminate instead of pinning it at 0%.

Since the bar deliberately ignores `count_bytes`, the two stat cards were relabelled so they don't contradict it on screen: **Data Transferred → Data Scanned** (claim-shaped, matching what the counter actually reports) and **Items Completed → Items Succeeded** (the card counts `success` only, while the bar counts processed).

Also: left-aligned the tier chips (they were centered over their "N GiB available" captions, so they sat indented from every other row in the dialog), and dropped the box on the migration stat cards — padding, border and radius — so they read as plain columns aligned with the rest of the dialog body.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | Tier-change docs should state that a tier change is not reversible and that cancelling stops only the data migration.
|Testing         | .


Original PR: https://github.com/truenas/webui/pull/13954
