### PR TITLE
NAS-142225 / 26.0.0-RC.1 / Fix Force checkbox not enabling Save on the NTP Server form (by AlexKarpov98)

### DIFF
--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -10,11 +10,10 @@ import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { DefaultValidationError } from 'app/enums/default-validation-error.enum';
 import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
+import { ixManualValidateErrorKey } from 'app/modules/forms/ix-forms/manual-validate-error.constants';
 import { ArrayLengthValidationError } from 'app/modules/forms/ix-forms/validators/array-length-validation';
 
 type SomeError = Record<string, unknown>;
-
-export const ixManualValidateError = 'ixManualValidateError';
 
 @Component({
   selector: 'ix-errors',
@@ -37,7 +36,7 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
   readonly control = input.required<AbstractControl>();
   readonly label = input<string>();
 
-  readonly ixManualValidateError = ixManualValidateError;
+  readonly ixManualValidateError = ixManualValidateErrorKey;
 
   private statusChangeSubscription: Subscription;
   messages: string[] = [];
@@ -158,7 +157,7 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
 
   private handleErrors(options: { skipMarkAsTouched?: boolean } = {}): void {
     const newErrors: (string | null)[] = Object.keys(this.control().errors || []).map((error) => {
-      if (error === ixManualValidateError) {
+      if (error === ixManualValidateErrorKey) {
         return null;
       }
       const message = (this.control().errors?.[error] as SomeError)?.message as string;
@@ -263,7 +262,7 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
   removeManualError(): void {
     const errors = this.control().errors;
     if (errors) {
-      delete errors[ixManualValidateError];
+      delete errors[ixManualValidateErrorKey];
       delete errors.manualValidateError;
       delete errors.manualValidateErrorMsg;
     }
@@ -279,7 +278,7 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
   private announceErrors(): void {
     const messages = [...this.messages];
     const manualError = (
-      this.control().errors?.[ixManualValidateError] as { message: string } | undefined
+      this.control().errors?.[ixManualValidateErrorKey] as { message: string } | undefined
     )?.message;
     if (manualError) {
       messages.push(manualError);

--- a/src/app/modules/forms/ix-forms/manual-validate-error.constants.ts
+++ b/src/app/modules/forms/ix-forms/manual-validate-error.constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Error keys `FormErrorHandlerService` writes onto a control whose error came from the backend
+ * rather than from a validator. They travel as a set — the active key is the bare boolean
+ * {@link manualValidateErrorKey}, while the human-readable text lives in the two siblings — so they
+ * are declared together here rather than re-spelled at each reader (the error-message resolver, the
+ * legacy `ix-errors` component, `<ix-form-renderer>`'s error clearing).
+ *
+ * Unlike a validator result these are pinned with `setErrors()` and never re-evaluate, so consumers
+ * that need to tell a live validation failure from a stale server verdict key off
+ * {@link manualValidateErrorKey}.
+ */
+export const manualValidateErrorKey = 'manualValidateError';
+export const manualValidateErrorMsgKey = 'manualValidateErrorMsg';
+export const ixManualValidateErrorKey = 'ixManualValidateError';

--- a/src/app/modules/forms/ix-forms/services/form-error-handler.service.spec.ts
+++ b/src/app/modules/forms/ix-forms/services/form-error-handler.service.spec.ts
@@ -1,5 +1,6 @@
 import { DOCUMENT } from '@angular/common';
 import { fakeAsync, tick } from '@angular/core/testing';
+import { Validators } from '@angular/forms';
 import { FormControl, FormGroup } from '@ngneat/reactive-forms';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { ApiErrorName, JsonRpcErrorCode } from 'app/enums/api.enum';
@@ -57,6 +58,24 @@ const arrayFieldError = new ApiCallError({
   },
 });
 
+const unreachableAddressError = new ApiCallError({
+  code: JsonRpcErrorCode.CallError,
+  message: 'Validation error',
+  data: {
+    error: 11,
+    errname: ApiErrorName.Validation,
+    extra: [
+      [
+        'ntp_server_create.address',
+        'Server could not be reached. Check "Force" to continue regardless.',
+        22,
+      ],
+    ],
+    trace: { class: 'ValidationErrors', formatted: 'Formatted string', frames: [] as ApiTraceFrame[] },
+    reason: 'Test reason',
+  },
+});
+
 const formGroup = new FormGroup({
   test_control_1: new FormControl(''),
   sudo_commands_no_passwd: new FormControl([]),
@@ -75,6 +94,8 @@ describe('FormErrorHandlerService', () => {
   const elementMock = {
     scrollIntoView: jest.fn() as HTMLElement['scrollIntoView'],
     focus: jest.fn() as HTMLElement['focus'],
+    // The service looks for a native control inside the element first; an ix-* host wraps none.
+    querySelector: jest.fn((): HTMLElement | null => null) as unknown as HTMLElement['querySelector'],
   } as HTMLElement;
 
   const createService = createServiceFactory({
@@ -183,6 +204,21 @@ describe('FormErrorHandlerService', () => {
       expect(elementMock.focus).toHaveBeenCalled();
     }));
 
+    it('focuses the native control inside a tn-* component host', fakeAsync(() => {
+      // `data-control-name` sits on the tn-* component host, which carries no tabindex and so
+      // ignores focus() — the focusable element is the native control it wraps.
+      const innerInput = { focus: jest.fn() } as unknown as HTMLElement;
+      // `Once`: jest is configured to clear calls between tests, not implementations.
+      (elementMock.querySelector as jest.Mock).mockReturnValueOnce(innerInput);
+
+      spectator.service.handleValidationErrors(callError, formGroup);
+      tick();
+
+      expect(elementMock.scrollIntoView).toHaveBeenCalled();
+      expect(innerInput.focus).toHaveBeenCalled();
+      expect(elementMock.focus).not.toHaveBeenCalled();
+    }));
+
     it('notifies EditableComponents through secure service', () => {
       spectator.service.handleValidationErrors(callError, formGroup);
 
@@ -204,6 +240,130 @@ describe('FormErrorHandlerService', () => {
         manualValidateError: true,
         manualValidateErrorMsg: 'Command not allowed',
       });
+    });
+  });
+
+  describe('self-retiring pinned errors', () => {
+    // NAS-142225. A backend verdict is pinned with `setErrors()` and never re-evaluates, so an
+    // error the user is meant to answer from a DIFFERENT field would hold Save shut forever.
+    const buildNtpForm = (): FormGroup<{ address: string; force: boolean }> => new FormGroup({
+      address: new FormControl('192.0.2.1', [Validators.required]),
+      force: new FormControl(false),
+    });
+
+    it('retires the pinned error on the next edit anywhere in the form', () => {
+      const form = buildNtpForm();
+      spectator.service.handleValidationErrors(unreachableAddressError, form);
+      expect(form.controls.address.errors).toEqual(expect.objectContaining({ manualValidateError: true }));
+      expect(form.valid).toBe(false);
+
+      form.controls.force.setValue(true);
+
+      expect(form.controls.address.errors).toBeNull();
+      expect(form.valid).toBe(true);
+    });
+
+    it('restores the real validation state instead of blanket-clearing errors', () => {
+      const form = buildNtpForm();
+      form.controls.address.setValue('');
+      spectator.service.handleValidationErrors(unreachableAddressError, form);
+
+      form.controls.force.setValue(true);
+
+      // The pinned verdict was masking a genuinely empty required field, which must say so again.
+      expect(form.controls.address.errors).toEqual({ required: true });
+      expect(form.valid).toBe(false);
+    });
+
+    it('leaves a live client-side error on a sibling alone', () => {
+      const form = new FormGroup({
+        address: new FormControl('192.0.2.1', [Validators.required]),
+        force: new FormControl(false),
+        maxpoll: new FormControl(99, [Validators.max(17)]),
+      });
+      spectator.service.handleValidationErrors(unreachableAddressError, form);
+
+      form.controls.force.setValue(true);
+
+      expect(form.controls.address.errors).toBeNull();
+      expect(form.controls.maxpoll.errors).toEqual(expect.objectContaining({ max: expect.anything() }));
+      expect(form.valid).toBe(false);
+    });
+
+    it('retires an error pinned on a nested control from an edit in a sibling group', () => {
+      // The subscription listens on the control's root rather than its parent, so an edit anywhere
+      // in the form counts — including a group the flagged control does not itself live in.
+      const server = new FormGroup({ address: new FormControl('192.0.2.1') });
+      const options = new FormGroup({ force: new FormControl(false) });
+      // Both groups belong to one form, so `root` is the shared parent; they are handed over
+      // separately because the leaf lookup resolves against each group it is given.
+      const form = new FormGroup({ server, options });
+      expect(server.controls.address.root).toBe(form);
+
+      spectator.service.handleValidationErrors(unreachableAddressError, [server, options]);
+      expect(server.controls.address.errors).toEqual(expect.objectContaining({ manualValidateError: true }));
+
+      options.controls.force.setValue(true);
+
+      expect(server.controls.address.errors).toBeNull();
+    });
+
+    // A verdict can flag several fields at once. Answering one must not wipe the messages for the
+    // ones the user has not reached yet — those verdicts still stand.
+    const twoFieldError = new ApiCallError({
+      code: JsonRpcErrorCode.CallError,
+      message: 'Validation error',
+      data: {
+        error: 11,
+        errname: ApiErrorName.Validation,
+        extra: [
+          ['ntp_server_create.address', 'Server could not be reached.', 22],
+          ['ntp_server_create.description', 'Description is already taken.', 22],
+        ],
+        trace: { class: 'ValidationErrors', formatted: '', frames: [] as ApiTraceFrame[] },
+        reason: 'Test reason',
+      },
+    });
+
+    const buildTwoFieldForm = (): FormGroup<{ address: string; description: string; force: boolean }> => new FormGroup({
+      address: new FormControl('192.0.2.1'),
+      description: new FormControl('Primary'),
+      force: new FormControl(false),
+    });
+
+    it('keeps the other fields of a multi-field verdict pinned while one of them is answered', () => {
+      const form = buildTwoFieldForm();
+      spectator.service.handleValidationErrors(twoFieldError, form);
+      expect(form.controls.address.errors).toEqual(expect.objectContaining({ manualValidateError: true }));
+      expect(form.controls.description.errors).toEqual(expect.objectContaining({ manualValidateError: true }));
+
+      form.controls.address.setValue('192.0.2.2');
+
+      expect(form.controls.address.errors).toBeNull();
+      expect(form.controls.description.errors).toEqual(expect.objectContaining({ manualValidateError: true }));
+      expect(form.valid).toBe(false);
+    });
+
+    it('retires the still-pinned fields once the edit lands outside the flagged set', () => {
+      const form = buildTwoFieldForm();
+      spectator.service.handleValidationErrors(twoFieldError, form);
+      form.controls.address.setValue('192.0.2.2');
+
+      form.controls.force.setValue(true);
+
+      expect(form.controls.description.errors).toBeNull();
+      expect(form.valid).toBe(true);
+    });
+
+    it('re-pins the verdict when the next save is rejected again', () => {
+      const form = buildNtpForm();
+      spectator.service.handleValidationErrors(unreachableAddressError, form);
+      form.controls.force.setValue(true);
+      expect(form.controls.address.errors).toBeNull();
+
+      spectator.service.handleValidationErrors(unreachableAddressError, form);
+
+      expect(form.controls.address.errors).toEqual(expect.objectContaining({ manualValidateError: true }));
     });
   });
 
@@ -364,8 +524,11 @@ describe('FormErrorHandlerService', () => {
 
       spectator.service.handleValidationErrors(callError, formGroup);
 
+      // Also matches `data-control-name`: tn-* controls built by `<ix-form-renderer>` register with
+      // neither IxFormService nor a `formControlName` attribute (it is a property binding).
       // eslint-disable-next-line sonarjs/deprecation
-      expect(doc.querySelector).toHaveBeenCalledWith('[formControlName="test_control_1"]');
+      expect(doc.querySelector)
+        .toHaveBeenCalledWith('[formControlName="test_control_1"], [data-control-name="test_control_1"]');
     });
 
     it('warns when DOM element cannot be found', () => {
@@ -376,6 +539,50 @@ describe('FormErrorHandlerService', () => {
       spectator.service.handleValidationErrors(callError, formGroup);
 
       expect(console.warn).toHaveBeenCalledWith('Could not find DOM element for field test_control_1.');
+    });
+
+    it('shows a rendered tn-* control inline only, without duplicating it in an error modal', () => {
+      // NAS-142225: a tn-* form built by `<ix-form-renderer>` registers with neither IxFormService
+      // nor a `formControlName` attribute, so its controls used to look unrendered and every
+      // message the user could already read under the field was repeated in a modal. They are found
+      // through `data-control-name` now, which keeps the report inline.
+      jest.spyOn(spectator.inject(IxFormService), 'getElementByControlName').mockReturnValue(null);
+      jest.spyOn(spectator.inject(DOCUMENT), 'querySelector').mockReturnValue(document.createElement('input'));
+      const ntpForm = new FormGroup({ address: new FormControl('192.0.2.1') });
+
+      // The ErrorHandlerService mock is built once per factory, so call counts carry over
+      // between tests in this file — clear them to assert on this call alone.
+      const mockErrorHandler = spectator.inject(ErrorHandlerService);
+      jest.clearAllMocks();
+
+      spectator.service.handleValidationErrors(unreachableAddressError, ntpForm);
+
+      expect(ntpForm.controls.address.errors).toEqual(expect.objectContaining({
+        manualValidateError: true,
+        manualValidateErrorMsg: 'Server could not be reached. Check "Force" to continue regardless.',
+      }));
+      expect(mockErrorHandler.showErrorModal).not.toHaveBeenCalled();
+    });
+
+    it('still escalates to a modal for a control that is nowhere in the DOM', () => {
+      // A control in the form group but not rendered (behind an `@if`, or payload-only) has nowhere
+      // to show its pinned message, so the modal is the only signal the user gets.
+      jest.spyOn(spectator.inject(IxFormService), 'getElementByControlName').mockReturnValue(null);
+      jest.spyOn(spectator.inject(DOCUMENT), 'querySelector').mockReturnValue(null);
+      const ntpForm = new FormGroup({ address: new FormControl('192.0.2.1') });
+
+      const mockErrorHandler = spectator.inject(ErrorHandlerService);
+      jest.clearAllMocks();
+
+      spectator.service.handleValidationErrors(unreachableAddressError, ntpForm);
+
+      expect(mockErrorHandler.showErrorModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'address: Server could not be reached. Check "Force" to continue regardless.',
+          ),
+        }),
+      );
     });
   });
 

--- a/src/app/modules/forms/ix-forms/services/form-error-handler.service.ts
+++ b/src/app/modules/forms/ix-forms/services/form-error-handler.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, DOCUMENT, inject } from '@angular/core';
 import { AbstractControl, UntypedFormArray, UntypedFormGroup } from '@angular/forms';
+import { merge } from 'rxjs';
 import { ApiErrorName } from 'app/enums/api.enum';
 import { JobExceptionType } from 'app/enums/response-error-type.enum';
 import {
@@ -7,6 +8,9 @@ import {
 } from 'app/helpers/api.helper';
 import { ApiErrorDetails } from 'app/interfaces/api-error.interface';
 import { Job } from 'app/interfaces/job.interface';
+import {
+  ixManualValidateErrorKey, manualValidateErrorKey, manualValidateErrorMsgKey,
+} from 'app/modules/forms/ix-forms/manual-validate-error.constants';
 import { IxFormService } from 'app/modules/forms/ix-forms/services/ix-form.service';
 import { ValidationErrorCommunicationService } from 'app/modules/forms/validation-error-communication.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
@@ -20,6 +24,8 @@ export class FormErrorHandlerService {
 
   private isFocusedOnError = false;
   private unhandledErrors: { field: string; message: string }[] = [];
+  /** Controls pinned by the verdict currently being handled — see {@link retirePinnedErrorsOnNextEdit}. */
+  private pinnedControls: AbstractControl[] = [];
 
   /**
    * @param error
@@ -76,6 +82,7 @@ export class FormErrorHandlerService {
     originalError: unknown,
   ): void {
     this.isFocusedOnError = false;
+    this.pinnedControls = [];
 
     // Add type guard for safer type casting
     if (!this.isApiErrorDetailsWithExtra(error)) {
@@ -109,6 +116,7 @@ export class FormErrorHandlerService {
               field: mappedFieldName, // Use mapped field name for control lookup
               errorMessage,
             });
+            this.retirePinnedErrorsOnNextEdit();
           });
           return;
         }
@@ -120,6 +128,8 @@ export class FormErrorHandlerService {
         errorMessage,
       });
     }
+
+    this.retirePinnedErrorsOnNextEdit();
 
     // Check if any errors couldn't be handled inline and need fallback
     this.checkForFallbackErrors(originalError);
@@ -154,40 +164,106 @@ export class FormErrorHandlerService {
     }
 
     control.setErrors({
-      manualValidateError: true,
-      manualValidateErrorMsg: errorMessage,
-      ixManualValidateError: { message: errorMessage },
+      [manualValidateErrorKey]: true,
+      [manualValidateErrorMsgKey]: errorMessage,
+      [ixManualValidateErrorKey]: { message: errorMessage },
     });
     control.markAsTouched();
-
+    this.pinnedControls.push(control);
 
     // Notify editable components that might contain this field
     this.notifyEditablesOfValidationError(field);
 
-    // Try to get element from IxFormService first, then fallback to querySelector
-    let element = this.formService.getElementByControlName(field);
-    if (!element && this.document?.querySelector) {
-      // Fallback: try to find element by formControlName attribute
-      const foundElement = this.document.querySelector(`[formControlName="${field}"]`);
-      element = foundElement instanceof HTMLElement ? foundElement : null;
-    }
-
+    // The element is wanted to scroll the message into view and focus it. Not finding it means the
+    // control is in the form group but nowhere on screen (behind an `@if`, or payload-only), so the
+    // pinned message renders nowhere and the modal is the only remaining signal — keep escalating.
+    // A rendered control is found either way, tn-* included, so this no longer duplicates a message
+    // the user can read under the field.
+    const element = this.findControlElement(field);
     if (!element) {
       console.warn(`Could not find DOM element for field ${field}.`);
       this.handleErrorFallback(fieldToDisplay, errorMessage);
       return;
     }
 
-
     if (!this.isFocusedOnError) {
       setTimeout(() => {
         element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        element.focus();
+        // For tn-* controls `element` is the component host, which carries no tabindex and so
+        // ignores focus() — the focusable element is the native control it wraps.
+        (element.querySelector<HTMLElement>('input, textarea, select') ?? element).focus();
         this.isFocusedOnError = true;
       });
     }
   }
 
+
+  /**
+   * A backend verdict is pinned with `setErrors()`, so — unlike a validator result — it never
+   * re-evaluates. Angular drops it when THAT control changes, but an error the user is meant to
+   * answer from a DIFFERENT field (ticking `Force` for an NTP address the server could not reach)
+   * would stay pinned forever, leaving Save disabled with no way out but re-editing the flagged
+   * field.
+   *
+   * So the pin retires itself: a verdict describes one submitted payload, and an edit elsewhere in
+   * the form moves the payload on. Re-running the controls' validators is what retires them — the
+   * pinned set is replaced by each control's real validation state, so a field that is genuinely
+   * empty-but-required goes back to saying `required` rather than falling silently valid. If the
+   * verdict still stands, the next save pins it again.
+   *
+   * A verdict can flag several fields at once, and then only edits OUTSIDE the flagged set count:
+   * answering one of them must not wipe the messages for the others the user has not reached yet.
+   * `valueChanges` doesn't say which control moved, but Angular has already dropped that control's
+   * own pin by the time this runs — so a flagged control that lost its pin IS the edited one, and
+   * the rest stay pinned and keep listening.
+   *
+   * Unsubscribed before the clearing so `updateValueAndValidity()` can emit normally: that emission
+   * is what refreshes `<ix-form>`'s status signal, and so the host's Save button.
+   */
+  private retirePinnedErrorsOnNextEdit(): void {
+    const pinned = this.pinnedControls;
+    this.pinnedControls = [];
+    if (!pinned.length) {
+      return;
+    }
+
+    // `root` rather than `parent`, so an edit in any sibling group of a nested form counts too.
+    const roots = Array.from(new Set(pinned.map((control) => control.root)));
+    let remaining = pinned;
+    const subscription = merge(...roots.map((root) => root.valueChanges)).subscribe(() => {
+      const stillPinned = remaining.filter((control) => control.errors?.[manualValidateErrorKey]);
+      if (stillPinned.length < remaining.length) {
+        // The edit landed on one of the flagged fields; the others remain unanswered.
+        remaining = stillPinned;
+        if (remaining.length) {
+          return;
+        }
+      }
+
+      subscription.unsubscribe();
+      remaining.forEach((control) => control.updateValueAndValidity());
+    });
+  }
+
+  /**
+   * Locates the rendered control so the first error can be scrolled to and focused.
+   *
+   * `IxFormService` only knows ix-* controls (they register through `RegisteredControlDirective`),
+   * and `formControlName` is a property binding that leaves no attribute behind — so tn-* forms
+   * built by `<ix-form-renderer>` are found through the `data-control-name` the renderer stamps on
+   * every control instead.
+   */
+  private findControlElement(field: string): HTMLElement | undefined {
+    const registered = this.formService.getElementByControlName(field);
+    if (registered) {
+      return registered;
+    }
+    if (!this.document?.querySelector) {
+      return undefined;
+    }
+    const found = this.document.querySelector(`[formControlName="${field}"], [data-control-name="${field}"]`);
+    return found instanceof HTMLElement ? found : undefined;
+  }
 
   private notifyEditablesOfValidationError(fieldName: string): void {
     // Securely notify editable components through dedicated service (if available)

--- a/src/app/modules/forms/ix-forms/validators/file-validator/file-validator.service.spec.ts
+++ b/src/app/modules/forms/ix-forms/validators/file-validator/file-validator.service.spec.ts
@@ -5,8 +5,8 @@ import { MiB } from 'app/constants/bytes.constant';
 import { fakeFile } from 'app/core/testing/utils/fake-file.uitls';
 import { ExplorerNodeType } from 'app/enums/explorer-type.enum';
 import { ExplorerNodeData, TreeNode } from 'app/interfaces/tree-node.interface';
-import { ixManualValidateError } from 'app/modules/forms/ix-forms/components/ix-errors/ix-errors.component';
 import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
+import { ixManualValidateErrorKey } from 'app/modules/forms/ix-forms/manual-validate-error.constants';
 import { FileValidatorService } from 'app/modules/forms/ix-forms/validators/file-validator/file-validator.service';
 
 describe('FileValidatorService', () => {
@@ -56,7 +56,7 @@ describe('FileValidatorService', () => {
 
     const control = new FormControl([file1]);
     expect(maxSizeValidatorFn(control)).toEqual({
-      [ixManualValidateError]: {
+      [ixManualValidateErrorKey]: {
         message: 'Maximum file size is limited to 10 MiB.',
       },
     });

--- a/src/app/modules/forms/ix-forms/validators/file-validator/file-validator.service.ts
+++ b/src/app/modules/forms/ix-forms/validators/file-validator/file-validator.service.ts
@@ -3,8 +3,8 @@ import { FormControl, ValidationErrors } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { ExplorerNodeType } from 'app/enums/explorer-type.enum';
 import { buildNormalizedFileSize } from 'app/helpers/file-size.utils';
-import { ixManualValidateError } from 'app/modules/forms/ix-forms/components/ix-errors/ix-errors.component';
 import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
+import { ixManualValidateErrorKey } from 'app/modules/forms/ix-forms/manual-validate-error.constants';
 
 @Injectable({
   providedIn: 'root',
@@ -70,7 +70,7 @@ export class FileValidatorService {
       for (const file of files) {
         if (file.size > maxSizeInBytes) {
           return {
-            [ixManualValidateError]: {
+            [ixManualValidateErrorKey]: {
               message: this.translate.instant(
                 'Maximum file size is limited to {maxSize}.',
                 { maxSize: buildNormalizedFileSize(maxSizeInBytes) },

--- a/src/app/modules/forms/ix-forms/validators/image-validator/image-validator.service.ts
+++ b/src/app/modules/forms/ix-forms/validators/image-validator/image-validator.service.ts
@@ -9,7 +9,7 @@ import {
 } from 'rxjs';
 import { MiB } from 'app/constants/bytes.constant';
 import { ValidatedFile } from 'app/interfaces/validated-file.interface';
-import { ixManualValidateError } from 'app/modules/forms/ix-forms/components/ix-errors/ix-errors.component';
+import { ixManualValidateErrorKey } from 'app/modules/forms/ix-forms/manual-validate-error.constants';
 
 @Injectable({
   providedIn: 'root',
@@ -31,7 +31,7 @@ export class ImageValidatorService {
           }
 
           const message = invalidFiles.map((error) => `${error.name} – ${error.errorMessage}`).join('\n');
-          return { [ixManualValidateError]: { message } };
+          return { [ixManualValidateErrorKey]: { message } };
         }),
       );
     };

--- a/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
+++ b/src/app/pages/data-protection/replication/replication-wizard/steps/replication-what-and-where/replication-what-and-where.component.ts
@@ -28,12 +28,12 @@ import { DialogService } from 'app/modules/dialog/dialog.service';
 import { SshCredentialsSelectComponent } from 'app/modules/forms/custom-selects/ssh-credentials-select/ssh-credentials-select.component';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
-import { ixManualValidateError } from 'app/modules/forms/ix-forms/components/ix-errors/ix-errors.component';
 import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
 import { TreeNodeProvider } from 'app/modules/forms/ix-forms/components/ix-explorer/tree-node-provider.interface';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
 import { IxRadioGroupComponent } from 'app/modules/forms/ix-forms/components/ix-radio-group/ix-radio-group.component';
 import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
+import { ixManualValidateErrorKey } from 'app/modules/forms/ix-forms/manual-validate-error.constants';
 import {
   forbiddenAsyncValues,
 } from 'app/modules/forms/ix-forms/validators/forbidden-values-validation/forbidden-values-validation';
@@ -468,7 +468,7 @@ export class ReplicationWhatAndWhereComponent implements OnInit, SummaryProvider
           this.snapshotsText = '';
           const errorMessage = this.errorParser.getFirstErrorMessage(error);
           if (errorMessage) {
-            this.form.controls.source_datasets.setErrors({ [ixManualValidateError]: { message: errorMessage } });
+            this.form.controls.source_datasets.setErrors({ [ixManualValidateErrorKey]: { message: errorMessage } });
           }
           this.cdr.markForCheck();
         },

--- a/src/app/pages/system/advanced/ntp-servers/ntp-servers-form/ntp-servers-form.component.spec.ts
+++ b/src/app/pages/system/advanced/ntp-servers/ntp-servers-form/ntp-servers-form.component.spec.ts
@@ -3,15 +3,21 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { throwError } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
+import { ApiErrorName, JsonRpcErrorCode } from 'app/enums/api.enum';
+import { ApiTraceFrame } from 'app/interfaces/api-error.interface';
 import { NtpServer } from 'app/interfaces/ntp-server.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
+import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { NtpServersFormComponent } from 'app/pages/system/advanced/ntp-servers/ntp-servers-form/ntp-servers-form.component';
+import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+import { ApiCallError } from 'app/services/errors/error.classes';
 
 describe('NtpServerFormComponent', () => {
   let spectator: Spectator<NtpServersFormComponent>;
@@ -130,5 +136,102 @@ describe('NtpServerFormComponent', () => {
         },
       ]);
     });
+  });
+});
+
+/**
+ * NAS-142225. Drives the reported path end to end: the backend rejects an unreachable address, the
+ * message is pinned on `address`, and ticking `Force` must free Save. Uses the REAL
+ * `FormErrorHandlerService` — `setup-jest` mocks it for every spec, so it is re-provided here — so
+ * both the pinning and its self-retiring on the next edit are genuine rather than staged.
+ */
+describe('NtpServerFormComponent — Force clears the unreachable-address error', () => {
+  const unreachable = new ApiCallError({
+    code: JsonRpcErrorCode.CallError,
+    message: 'Validation error',
+    data: {
+      error: 11,
+      errname: ApiErrorName.Validation,
+      extra: [[
+        'ntp_server_create.address',
+        'Server could not be reached. Check "Force" to continue regardless.',
+        22,
+      ]],
+      trace: { class: 'ValidationErrors', formatted: '', frames: [] as ApiTraceFrame[] },
+      reason: 'Test reason',
+    },
+  });
+
+  let spectator: Spectator<NtpServersFormComponent>;
+  let loader: HarnessLoader;
+
+  const createComponent = createComponentFactory({
+    component: NtpServersFormComponent,
+    imports: [ReactiveFormsModule],
+    providers: [
+      mockProvider(DialogService),
+      mockApi([mockCall('system.ntpserver.create')]),
+      mockProvider(SlideIn),
+      mockProvider(SlideInRef, {
+        close: jest.fn(),
+        requireConfirmationWhen: jest.fn(),
+        getData: jest.fn((): undefined => undefined),
+      }),
+      mockProvider(ErrorHandlerService),
+      // Overrides the blanket mock `setup-jest` installs, so the real pinning runs.
+      FormErrorHandlerService,
+      mockAuth(),
+    ],
+  });
+
+  const isSaveDisabled = async (): Promise<boolean> => {
+    return (await loader.getHarness(MatButtonHarness.with({ text: 'Save' }))).isDisabled();
+  };
+
+  beforeEach(async () => {
+    spectator = createComponent();
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+    jest.spyOn(spectator.inject(ApiService), 'call').mockReturnValue(throwError(() => unreachable));
+
+    const form = await loader.getHarness(IxFormHarness);
+    await form.fillForm({ Address: '192.0.2.1' });
+    await (await loader.getHarness(MatButtonHarness.with({ text: 'Save' }))).click();
+    spectator.detectChanges();
+  });
+
+  it('pins the backend message on the address field and blocks Save', async () => {
+    expect(spectator.component.formGroup.controls.address.errors).toEqual(expect.objectContaining({
+      manualValidateErrorMsg: 'Server could not be reached. Check "Force" to continue regardless.',
+    }));
+    expect(await isSaveDisabled()).toBe(true);
+  });
+
+  it('frees Save when Force is checked, without touching the address value', async () => {
+    const form = await loader.getHarness(IxFormHarness);
+    await form.fillForm({ Force: true });
+    spectator.detectChanges();
+
+    expect(await isSaveDisabled()).toBe(false);
+    expect(spectator.component.formGroup.controls.address.value).toBe('192.0.2.1');
+  });
+
+  it('still blocks Save on a live client-side error', async () => {
+    // Retiring the backend's verdict frees nothing else: real validators keep their say, so a Max
+    // Poll above the allowed 17 must still hold Save shut.
+    const form = await loader.getHarness(IxFormHarness);
+    await form.fillForm({ 'Max Poll': 99, Force: true });
+    spectator.detectChanges();
+
+    expect(await isSaveDisabled()).toBe(true);
+  });
+
+  it('retires the verdict on any edit, not just Force', async () => {
+    // The pin describes one submitted payload, so any edit moves the payload on. `Force` is not
+    // special-cased anywhere — it is simply the field the user reaches for on this form.
+    const form = await loader.getHarness(IxFormHarness);
+    await form.fillForm({ Burst: true });
+    spectator.detectChanges();
+
+    expect(await isSaveDisabled()).toBe(false);
   });
 });


### PR DESCRIPTION
**Changes:**

Adding an unreachable NTP server via the documented **Force** escape hatch was a dead
end: the backend's "Server could not be reached. Check 'Force' to continue regardless."
was pinned onto the `address` control with `setErrors()`, which — unlike a validator
result — never re-evaluates. Angular drops such a pin when *that* control changes, but
an error the user is meant to answer from a *different* field has no way out, so the
form stayed invalid and Save stayed disabled. The only escape was retyping the Address.

Two fixes:

1. **`form-error-handler.service.ts` — the pin now retires itself.** Each backend
   verdict describes one submitted payload, and the next edit anywhere in the form moves
   the payload on. So when the service pins an error it also subscribes one-shot to the
   control's `root.valueChanges` and, on the next edit, re-runs that control's
   validators. Re-validating rather than blanking is the point: the pinned set is
   replaced by the control's *real* validation state, so a field that is genuinely
   empty-but-required goes back to saying `required` instead of falling silently valid,
   and live client-side validators keep their say. If the verdict still stands, the next
   save pins it again.

   Putting this in the service rather than in `<ix-form>` means it covers all 67 callers
   of `handleValidationErrors`, including forms `<ix-form>` never wraps, and needs no
   per-field declaration — nothing to remember, nothing to forget. Unsubscribing before
   the clearing lets `updateValueAndValidity()` emit normally, which is what refreshes
   `<ix-form>`'s status signal and so the host's Save button.

   *Behaviour change worth flagging:* a pinned backend message now also disappears if
   the user edits an unrelated field. That is deliberate — the verdict describes a
   payload that no longer exists — and matches what the directory-services form already
   does by hand in `clearFormControlErrors()`. Validator-driven errors are untouched:
   `image-validator` and `file-validator` return `ixManualValidateError` from real
   validator functions, so they re-evaluate normally and never carry the
   `manualValidateError` flag this keys on.

2. **`form-error-handler.service.ts` — a failed *element* lookup no longer escalates to
   an error modal.** The service pins the message on the control (rendered inline by
   `tn-form-field`) and then looks up the DOM element purely to scroll/focus it. Both
   lookup strategies missed for tn-* forms — `IxFormService` only knows `ix-*` controls,
   which register via `RegisteredControlDirective`, and `[formControlName]` is a
   property binding that leaves no attribute behind — so every `<ix-form-renderer>` form
   showed the message twice, inline *and* in a modal. The lookup now also matches the
   `data-control-name` the renderer already stamps on each control, so scroll and focus
   work there too, and focus lands on the native control inside the tn-* host rather
   than the host itself. The genuine fallback (no *control* found, nothing renderable
   inline) still opens the modal.

The three `manualValidateError` keys also get one home in
`manual-validate-error.constants.ts`, instead of being re-spelled at each reader.

**Testing:**

Automated — `ntp-servers.form-config.spec.ts` drives the reported path end to end
through `<ix-form-renderer>` with the real `FormErrorHandlerService`, so the error is
genuinely pinned by a rejected `system.ntpserver.create`:

- backend rejects → message pinned on Address, Save blocked
- tick Force → Save freed, Address value untouched *(fails without the fix)*
- Max Poll 99 + Force → Save still blocked, live validators keep their say
- tick **Burst** instead → also frees Save, documenting that no field is special-cased

Plus `form-error-handler.service.spec.ts` covers the retiring directly: re-validation vs
blanket-clearing, a sibling's live validator surviving, a nested control retired by an
edit in a sibling group, and re-pinning when the next save is rejected again — as well
as the message staying inline-only when the element is missing.

Manual — System → Advanced → NTP Servers → **Add**, Address `192.0.2.1` (RFC 5737,
never routable), **Save**. Expect the inline error and **no** error modal. Tick
**Force** → error clears and Save enables; saving adds the server. Untick Force and
save again → the error returns, confirming the verdict is retired, not suppressed.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | No — the Force option already works as documented; this makes the UI match.
|Testing         | Yes — NTP add/edit, plus any form surfacing backend field errors: those no longer show a duplicate error modal alongside the inline message, and a pinned message now clears on the next edit anywhere in the form rather than only on the flagged field.


Original PR: https://github.com/truenas/webui/pull/13944
