### PR TITLE
NAS-142667 / 25.10.7 / Send the required gpu_type field when adding a GPU device to a container

### DIFF
--- a/src/app/pages/instances/components/all-instances/instance-details/instance-devices/add-device-menu/add-device-menu.component.spec.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-devices/add-device-menu/add-device-menu.component.spec.ts
@@ -6,7 +6,9 @@ import { MatMenuHarness } from '@angular/material/menu/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
-import { VirtualizationDeviceType, VirtualizationStatus, VirtualizationType } from 'app/enums/virtualization.enum';
+import {
+  VirtualizationDeviceType, VirtualizationGpuType, VirtualizationStatus, VirtualizationType,
+} from 'app/enums/virtualization.enum';
 import { AvailableGpu, AvailableUsb, VirtualizationDevice } from 'app/interfaces/virtualization.interface';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -116,6 +118,7 @@ describe('AddDeviceMenuComponent', () => {
 
     expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('virt.instance.device_add', ['my-instance', {
       dev_type: VirtualizationDeviceType.Gpu,
+      gpu_type: VirtualizationGpuType.Physical,
       pci: 'pci_0000_01_00_1',
     } as VirtualizationDevice]);
     expect(spectator.inject(VirtualizationDevicesStore).loadDevices).toHaveBeenCalled();

--- a/src/app/pages/instances/components/all-instances/instance-details/instance-devices/add-device-menu/add-device-menu.component.ts
+++ b/src/app/pages/instances/components/all-instances/instance-details/instance-devices/add-device-menu/add-device-menu.component.ts
@@ -116,6 +116,7 @@ export class AddDeviceMenuComponent {
   protected addGpu(gpuPci: string): void {
     this.addDevice({
       dev_type: VirtualizationDeviceType.Gpu,
+      gpu_type: VirtualizationGpuType.Physical,
       pci: gpuPci,
     } as VirtualizationGpu);
   }


### PR DESCRIPTION
**Changes:**

The add device menu sent a GPU payload without the gpu_type field. The middleware requires that field and rejected every request with a validation error. This menu only ever offers physical GPUs because it loads its choices with the physical type. The payload now includes the physical GPU type in the same way the instance wizard already does.

**Testing:**

<!-- If necessary provide testing instructions or refer reviewer to ticket. -->

### Downstream
<!--- Note downstream areas that can be affected with a brief reasoning after "|" of each -->

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |
|Testing         |
