### PR TITLE
NAS-142728 / 26.0.0-RC.1 / Fix dataset tree column layout and details panel sizing

### DIFF
--- a/src/app/directives/details-height/details-height.directive.spec.ts
+++ b/src/app/directives/details-height/details-height.directive.spec.ts
@@ -1,0 +1,68 @@
+import { createDirectiveFactory, mockProvider, SpectatorDirective } from '@ngneat/spectator/jest';
+import { DetailsHeightDirective } from 'app/directives/details-height/details-height.directive';
+import { LayoutService } from 'app/modules/layout/layout.service';
+
+interface Box {
+  top: number;
+  bottom: number;
+}
+
+describe('DetailsHeightDirective', () => {
+  let spectator: SpectatorDirective<DetailsHeightDirective>;
+
+  const createDirective = createDirectiveFactory({
+    directive: DetailsHeightDirective,
+    providers: [
+      mockProvider(LayoutService),
+    ],
+  });
+
+  /**
+   * The scroll container is 900px of screen below a 48px topbar, padded by 16px.
+   */
+  const scrollContainer = { top: 48, bottom: 948 } as Box;
+  const containerPadding = 16;
+
+  function setup(row: Box): HTMLElement {
+    const container = document.createElement('div');
+    container.style.paddingTop = `${containerPadding}px`;
+    container.style.paddingBottom = `${containerPadding}px`;
+    container.getBoundingClientRect = () => scrollContainer as DOMRect;
+
+    spectator = createDirective('<div class="container"><div ixDetailsHeight></div></div>', {
+      providers: [
+        mockProvider(LayoutService, { getContentContainer: () => container }),
+      ],
+    });
+
+    const details = spectator.element as HTMLElement;
+    details.parentElement!.getBoundingClientRect = () => row as DOMRect;
+    spectator.directive.applyHeight();
+
+    return details;
+  }
+
+  it('fills the screen below the row when the page is not scrolled', () => {
+    // Row starts 177px down (page heading above it) and its content runs well past the screen.
+    const details = setup({ top: 177, bottom: 1400 });
+
+    // Down to the container's padded bottom: 948 - 16 - 177.
+    expect(details.style.height).toBe('755px');
+  });
+
+  it('grows as the page heading scrolls away, stopping where the block sticks', () => {
+    // Same row scrolled up past the top of the scroll container, still running past the screen.
+    const details = setup({ top: -300, bottom: 1100 });
+
+    // Measured from where the block sticks (48 + 16), not from the row's off-screen top.
+    expect(details.style.height).toBe('868px');
+  });
+
+  it('does not shrink itself when the row it sits in is the one it sizes', () => {
+    // The row is as tall as this block, so its bottom moves with whatever height is set here.
+    // Reading it would ratchet the height down a pass at a time.
+    const details = setup({ top: 177, bottom: 177 + 400 });
+
+    expect(details.style.height).toBe('755px');
+  });
+});

--- a/src/app/directives/details-height/details-height.directive.ts
+++ b/src/app/directives/details-height/details-height.directive.ts
@@ -1,155 +1,90 @@
-import { DestroyRef, Directive, ElementRef, OnDestroy, OnInit, OnChanges, inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Store } from '@ngrx/store';
+import { Directive, ElementRef, OnDestroy, OnInit, inject } from '@angular/core';
 import { WINDOW } from 'app/helpers/window.helper';
-import { IxSimpleChanges } from 'app/interfaces/simple-changes.interface';
-import { headerHeight, footerHeight } from 'app/modules/layout/admin-layout/admin-layout.component.const';
 import { LayoutService } from 'app/modules/layout/layout.service';
-import { AppState } from 'app/store';
-import { waitForAdvancedConfig } from 'app/store/system-config/system-config.selectors';
 
 /**
  * This directive is used to dynamically adjust height of the "details" block in a "master-details" layout
  * to fill the bottom space, which becomes available when user scrolls the page down,
- * so the page's heading is shifted off the screen
+ * so the page's heading is shifted off the screen.
+ *
+ * The block is `position: sticky`, so the space available to it runs from wherever its row has
+ * scrolled to - bounded below by the top of the scroll container, where it sticks - down to the
+ * bottom of the screen. The top is measured off the row rather than off the block itself, because
+ * the block's own position is a function of the height being set here (it sticks, so
+ * `getBoundingClientRect()` reports where it is pinned, not where it sits in the document), and
+ * measuring it would feed the height back into itself.
  */
 @Directive({
   selector: '[ixDetailsHeight]',
   host: {
-    '(window:resize)': 'onResize()',
+    '(window:resize)': 'applyHeight()',
   },
 })
-export class DetailsHeightDirective implements OnInit, OnDestroy, OnChanges {
-  private readonly destroyRef = inject(DestroyRef);
+export class DetailsHeightDirective implements OnInit, OnDestroy {
   private window = inject<Window>(WINDOW);
   private element = inject<ElementRef<HTMLElement>>(ElementRef);
   private layoutService = inject(LayoutService);
-  private store$ = inject<Store<AppState>>(Store);
-
-  private hasConsoleFooter = false;
-  private headerHeight = headerHeight;
-  private footerHeight = footerHeight;
-
-  private parentPadding = 0;
-  private heightBaseOffset = 0;
-  private scrollBreakingPoint = 0;
-  private heightCssValue = '';
 
   private resizeObserver: ResizeObserver | null = null;
   private scrollAnimationFrame: number | null = null;
 
   ngOnInit(): void {
     this.setupResizeObserver();
-    this.listenForConsoleFooterChanges();
-    this.precalculateHeights();
     this.applyHeight();
     this.window.addEventListener('scroll', this.onScroll, true);
-    setTimeout(() => this.onResize());
-  }
-
-  ngOnChanges(changes: IxSimpleChanges<this>): void {
-    if ('hasConsoleFooter' in changes) {
-      this.precalculateHeights();
-      this.applyHeight();
-    }
   }
 
   ngOnDestroy(): void {
-    if (this.resizeObserver) {
-      this.resizeObserver.disconnect();
-    }
+    this.resizeObserver?.disconnect();
     if (this.scrollAnimationFrame) {
       cancelAnimationFrame(this.scrollAnimationFrame);
     }
     this.window.removeEventListener('scroll', this.onScroll, true);
   }
 
-  onResize(): void {
-    this.precalculateHeights();
-    this.applyHeight();
+  applyHeight(): void {
+    const container = this.layoutService.getContentContainer();
+    const row = this.element.nativeElement.parentElement;
+    if (!container || !row) {
+      return;
+    }
+
+    const containerBox = container.getBoundingClientRect();
+    const rowBox = row.getBoundingClientRect();
+    const padding = this.getPadding(container);
+
+    const top = Math.max(rowBox.top, containerBox.top + padding.top);
+    // The scroll container shrinks to make room for the console footer, so its own bottom
+    // already accounts for one being shown.
+    const bottom = containerBox.bottom - padding.bottom;
+
+    this.element.nativeElement.style.height = `${Math.floor(Math.max(bottom - top, 0))}px`;
   }
 
-  onScroll = (): void => {
+  private onScroll = (): void => {
     if (this.scrollAnimationFrame) {
       cancelAnimationFrame(this.scrollAnimationFrame);
     }
 
-    this.scrollAnimationFrame = requestAnimationFrame(() => {
-      const parentElement = this.layoutService.getContentContainer();
-      if (!parentElement) {
-        return;
-      }
-
-      const scrollTop = parentElement.scrollTop;
-
-      if (scrollTop < this.scrollBreakingPoint) {
-        this.heightCssValue = `calc(100vh - ${this.heightBaseOffset + 18}px + ${scrollTop}px)`;
-      } else {
-        this.heightCssValue = `calc(100vh - ${this.heightBaseOffset}px + ${this.scrollBreakingPoint}px)`;
-      }
-
-      this.element.nativeElement.style.height = this.heightCssValue;
-    });
+    this.scrollAnimationFrame = requestAnimationFrame(() => this.applyHeight());
   };
 
   private setupResizeObserver(): void {
-    this.resizeObserver = new ResizeObserver(() => {
-      this.precalculateHeights();
-      this.applyHeight();
-    });
-
-    const parentElement = this.layoutService.getContentContainer();
-    if (parentElement) {
-      this.resizeObserver.observe(parentElement);
-    }
-  }
-
-  private precalculateHeights(): void {
-    const parentElement = this.layoutService.getContentContainer();
-    if (!parentElement) {
+    const container = this.layoutService.getContentContainer();
+    if (!container) {
       return;
     }
 
-    this.parentPadding = parseFloat(
-      this.window.getComputedStyle(parentElement, null).getPropertyValue('padding-bottom'),
-    ) || 0;
-
-    this.heightBaseOffset = this.calculateBaseOffset();
-    this.scrollBreakingPoint = this.calculateScrollBreakingPoint();
-    this.heightCssValue = `calc(100vh - ${this.heightBaseOffset}px)`;
+    this.resizeObserver = new ResizeObserver(() => this.applyHeight());
+    this.resizeObserver.observe(container);
   }
 
-  private applyHeight(): void {
-    this.element.nativeElement.style.height = this.heightCssValue;
-  }
+  private getPadding(element: HTMLElement): { top: number; bottom: number } {
+    const style = this.window.getComputedStyle(element, null);
 
-  private calculateBaseOffset(): number {
-    let result = this.getInitialTopPosition(this.element.nativeElement);
-    result += this.parentPadding;
-    if (this.hasConsoleFooter) {
-      result += this.footerHeight;
-    }
-    return Math.floor(result);
-  }
-
-  private calculateScrollBreakingPoint(): number {
-    let result = this.getInitialTopPosition(this.element.nativeElement);
-    result -= this.parentPadding;
-    result -= this.headerHeight;
-    return Math.max(Math.floor(result), 0);
-  }
-
-  private getInitialTopPosition(element: HTMLElement): number {
-    return Math.floor(element.getBoundingClientRect().top);
-  }
-
-  private listenForConsoleFooterChanges(): void {
-    this.store$
-      .pipe(waitForAdvancedConfig, takeUntilDestroyed(this.destroyRef))
-      .subscribe((advancedConfig) => {
-        this.hasConsoleFooter = advancedConfig.consolemsg;
-        this.precalculateHeights();
-        this.applyHeight();
-      });
+    return {
+      top: parseFloat(style.getPropertyValue('padding-top')) || 0,
+      bottom: parseFloat(style.getPropertyValue('padding-bottom')) || 0,
+    };
   }
 }

--- a/src/app/enums/default-validation-error.enum.ts
+++ b/src/app/enums/default-validation-error.enum.ts
@@ -5,6 +5,7 @@ export enum DefaultValidationError {
   Email = 'email',
   Cpu = 'cpu',
   MaxLength = 'maxlength',
+  ParentPathTooLong = 'parentPathTooLong',
   Range = 'range',
   MinLength = 'minlength',
   Pattern = 'pattern',

--- a/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-errors/ix-errors.component.ts
@@ -66,6 +66,10 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
         : T('The length of the field should be no more than {maxLength}'),
       { field: this.label(), maxLength },
     ),
+    parentPathTooLong: (maxPathLength: number) => this.translate.instant(
+      'The parent path already fills the {maxPathLength} character limit for a dataset path, so nothing can be created under it.',
+      { maxPathLength },
+    ),
     pattern: () => this.translate.instant('Invalid format or character'),
     forbidden: (value: string) => this.translate.instant('The name "{value}" is already in use.', { value }),
     range: (min: number, max: number) => this.translate.instant(
@@ -206,6 +210,10 @@ export class IxErrorsComponent implements OnChanges, OnDestroy {
         return this.defaultErrMessages.minlength((errors.minlength as SomeError).requiredLength as number);
       case DefaultValidationError.MaxLength:
         return this.defaultErrMessages.maxlength((errors.maxlength as SomeError).requiredLength as number);
+      case DefaultValidationError.ParentPathTooLong:
+        return this.defaultErrMessages.parentPathTooLong(
+          (errors.parentPathTooLong as SomeError).maxPathLength as number,
+        );
       case DefaultValidationError.Range:
         return this.defaultErrMessages.range(
           (errors.rangeValue as SomeError).min as number,

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
@@ -3,15 +3,39 @@ import { maxDatasetPath } from 'app/constants/dataset.constants';
 import { datasetNameTooLong } from 'app/pages/datasets/components/dataset-form/utils/name-length-validation';
 
 describe('datasetNameTooLong', () => {
+  const parentPath = '/mnt/tank';
+  // The longest name for which `${parentPath}/${name}` still fits within maxDatasetPath.
+  const longestAllowed = maxDatasetPath - parentPath.length - 2;
+
   it('takes path and returns a validator that makes sure that dataset path is less than maximum', () => {
-    const parentPath = '/mnt/tank';
     const validator = datasetNameTooLong(parentPath);
 
     expect(validator(new FormControl(''))).toBeNull();
     expect(validator(new FormControl('a'))).toBeNull();
-    expect(validator(new FormControl('a'.repeat(maxDatasetPath - parentPath.length - 1)))).toEqual({
+    expect(validator(new FormControl('a'.repeat(longestAllowed)))).toBeNull();
+    expect(validator(new FormControl('a'.repeat(longestAllowed + 1)))).toEqual({
       maxlength: {
-        requiredLength: 191,
+        requiredLength: longestAllowed,
+      },
+    });
+  });
+
+  it('reports a length the field can actually satisfy', () => {
+    const validator = datasetNameTooLong(parentPath);
+
+    const error = validator(new FormControl('a'.repeat(maxDatasetPath)));
+    const reportedLength = (error as { maxlength: { requiredLength: number } }).maxlength.requiredLength;
+
+    expect(validator(new FormControl('a'.repeat(reportedLength)))).toBeNull();
+  });
+
+  it('blames the parent path when it leaves no room for a name at all', () => {
+    const validator = datasetNameTooLong('a'.repeat(maxDatasetPath));
+
+    expect(validator(new FormControl(''))).toBeNull();
+    expect(validator(new FormControl('a'))).toEqual({
+      parentPathTooLong: {
+        maxPathLength: maxDatasetPath,
       },
     });
   });

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
@@ -3,16 +3,27 @@ import { maxDatasetPath } from 'app/constants/dataset.constants';
 import { DefaultValidationError } from 'app/enums/default-validation-error.enum';
 
 export function datasetNameTooLong(parentPath: string): ValidatorFn {
-  const maxLengthAllowed = maxDatasetPath;
+  // Two characters shorter than what is left of the budget: one goes to the `/` separator, and
+  // `maxDatasetPath` is the first length that is already too long (it is compared with `>=`,
+  // same as in DatasetFormService.checkAndWarnForLengthAndDepth).
+  const maxNameLength = maxDatasetPath - parentPath.length - 2;
 
   return function datasetNameTooLongValidate(control: FormControl<string>) {
     if (!control.value || !parentPath) {
       return null;
     }
 
-    if (parentPath.length + 1 + control.value.length >= maxLengthAllowed) {
+    // "no more than 0 characters" is a limit no name can meet - the parent path itself is the
+    // problem, so say that instead.
+    if (maxNameLength <= 0) {
       return {
-        [DefaultValidationError.MaxLength]: { requiredLength: maxLengthAllowed - parentPath.length },
+        [DefaultValidationError.ParentPathTooLong]: { maxPathLength: maxDatasetPath },
+      };
+    }
+
+    if (control.value.length > maxNameLength) {
+      return {
+        [DefaultValidationError.MaxLength]: { requiredLength: maxNameLength },
       };
     }
 

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.html
@@ -42,6 +42,7 @@
       <div
         #ixTree
         class="tree-wrapper"
+        (scroll)="treeScrolled()"
       >
         <div class="tree-inner">
 

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
@@ -28,20 +28,29 @@ ix-dataset-details-panel {
 }
 
 .tree-header {
-  grid-template-columns: auto 125px 125px 125px 125px 40px;
+  // Value columns are kept narrow (and must match .tree-node-grid exactly, so the labels
+  // stay above their values) to leave the dataset name as much of the table as possible.
+  // The name column's floor is what makes a deeply nested tree scroll horizontally instead
+  // of truncating the name down to a few characters.
+  grid-template-columns: minmax(280px, 1fr) 85px 90px 95px 55px 40px;
 
   @media (max-width: $breakpoint-tablet) {
-    grid-template-columns: auto 0 0 0 0 0;
+    grid-template-columns: minmax(0, 1fr) 0 0 0 0 0;
   }
 
   @media (min-width: $breakpoint-singlecolumn) {
-    grid-template-columns: auto 125px 125px 125px 125px;
+    grid-template-columns: minmax(280px, 1fr) 85px 90px 95px 55px;
   }
 
   .available-header {
     display: flex;
     flex-direction: column;
     line-height: 1.2;
+
+    // This rule outranks the `> div { display: none }` every other value header falls under.
+    @media (max-width: $breakpoint-tablet) {
+      display: none;
+    }
 
     .tier-subtitle {
       color: var(--fg2);

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -238,6 +238,14 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit, OnDes
     this.scrollSubject.next(scrollLeft);
   }
 
+  /**
+   * The header sits outside the tree's scroll container, so it has to be scrolled in code
+   * to stay above the columns it labels.
+   */
+  protected treeScrolled(): void {
+    this.scrollSubject.next(this.ixTree()?.nativeElement?.scrollLeft || 0);
+  }
+
   protected datasetTreeWidthChanged(event: ResizedEvent): void {
     this.treeWidthChange$.next(event);
   }

--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
@@ -15,12 +15,12 @@
   background-color: var(--bg2);
   display: grid;
   grid-gap: 8px;
-  grid-template-columns: auto 125px 125px 125px 125px;
+  grid-template-columns: minmax(280px, 1fr) 85px 90px 95px 55px;
   min-width: fit-content;
   width: 100%;
 
   @media (max-width: $breakpoint-tablet) {
-    grid-template-columns: auto 0 0 0 0;
+    grid-template-columns: minmax(0, 1fr) 0 0 0 0;
     width: 100%;
   }
 
@@ -29,6 +29,7 @@
     box-sizing: border-box;
     display: inline-flex;
     min-height: 44px;
+    min-width: 0;
 
     @media (max-width: $breakpoint-tablet) {
       display: none;
@@ -36,8 +37,6 @@
 
     &:first-child {
       align-items: center;
-      left: 15px;
-      position: sticky;
 
       @media (max-width: $breakpoint-tablet) {
         display: inline-flex;
@@ -50,6 +49,10 @@
     // margin: 0 0 0 -10px;
     // padding: 0 0 0 10px;
     z-index: 1;
+  }
+
+  .cell-name .name {
+    display: block;
   }
 
   .cell-used span,

--- a/src/app/pages/storage/modules/vdevs/components/topology-item-node/topology-item-node.component.scss
+++ b/src/app/pages/storage/modules/vdevs/components/topology-item-node/topology-item-node.component.scss
@@ -13,12 +13,12 @@
   align-items: center;
   display: grid;
   grid-gap: 8px;
-  grid-template-columns: auto 125px 125px 125px;
+  grid-template-columns: minmax(200px, 1fr) 125px 125px 125px;
   min-width: fit-content;
   width: 100%;
 
   @media (max-width: $breakpoint-tablet) {
-    grid-template-columns: auto 0 0 0;
+    grid-template-columns: minmax(0, 1fr) 0 0 0;
     width: 100%;
   }
 
@@ -26,15 +26,13 @@
     align-items: center;
     display: inline-flex;
     min-height: 48px;
+    min-width: 0;
 
     @media (max-width: $breakpoint-tablet) {
       display: none;
     }
 
     &:first-child {
-      left: 15px;
-      position: sticky;
-
       @media (max-width: $breakpoint-tablet) {
         display: inline-flex;
       }
@@ -55,7 +53,14 @@
       align-items: center;
       display: inline-flex;
       gap: 6px;
+      min-width: 0;
       padding-right: 15px;
+
+      span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
 
     .descendant-warning-icon {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -5254,6 +5254,7 @@
   "The NVMe Qualified Name (NQN) is used to identify the subsystem. Leave blank to generate NQN using the base NQN from global settings.": "",
   "The operation timed out. The requested resource might be offline. Check the network connection.": "",
   "The parent of this dataset has an Access Control List (ACL). Do you want to set an ACL for this dataset using the ACL Manager? ": "",
+  "The parent path already fills the {maxPathLength} character limit for a dataset path, so nothing can be created under it.": "",
   "The password for the user account that will obtain the kerberos ticket.": "",
   "The path <i>{path}</i> is in a locked dataset.": "",
   "The pool <i>{pool}</i>is in the database but not connected to the machine. If it was exported by     mistake, reconnect the hardware and use <b>Import Pool</b>.<br /><br />": "",

--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -15,8 +15,13 @@
   }
 
   .scroll-window {
-    columns: calc(50vw / 2.7);
-    gap: 8px;
+    // A fixed column width, not a slice of the viewport: the old `calc(50vw / 2.7)` grew the
+    // cards with the screen (711px columns at 2560px), so a card holding "Type: Built-In" was
+    // mostly empty space. The width is the ideal, and the browser stretches the columns to
+    // fill the panel, so the card size is really capped by the details panel's own max-width
+    // (see tree-node-with-details-container in mixins/layout.scss).
+    columns: $card-width-slim;
+    gap: $gap;
 
     @media (max-width: $breakpoint-tablet) {
       columns: 1;
@@ -24,7 +29,6 @@
     }
 
     @media (min-width: $breakpoint-tablet) and (max-width: $breakpoint-md) {
-      columns: calc(50vw / 1.5);
       padding: 0 16px;
     }
 

--- a/src/assets/styles/mixins/layout.scss
+++ b/src/assets/styles/mixins/layout.scss
@@ -4,6 +4,9 @@ $scrollbar-offset: 20px;
 
 @mixin tree-node-with-details-container() {
   .container {
+    // Each side keeps its own height: stretching would give the table a tall empty area below
+    // its last row whenever the details panel is the taller of the two.
+    align-items: flex-start;
     display: flex;
     flex-direction: row;
     gap: 16px;
@@ -63,14 +66,11 @@ $scrollbar-offset: 20px;
       max-width: $singlecolumn-max-width;
     }
 
-    // Two Cards Columns
-    @media (min-width: $breakpoint-dualcolumn-slim) and (max-width: calc($breakpoint-dualcolumn - 1px)) {
+    // Two Cards Columns. This is as wide as the details panel ever gets: the cards hold
+    // short label/value rows, so past two slim columns they only get emptier. Every extra
+    // pixel goes to the master table instead.
+    @media (min-width: $breakpoint-dualcolumn-slim) {
       max-width: ($dualcolumn-slim-max-width + $scrollbar-offset);
-    }
-
-    // Two Cards Columns
-    @media (min-width: $breakpoint-dualcolumn) {
-      max-width: 70%;
     }
   }
 
@@ -142,20 +142,19 @@ $scrollbar-offset: 20px;
     color: var(--fg2);
     display: grid;
     grid-gap: 8px;
-    grid-template-columns: auto 125px 125px 125px 40px;
+    grid-template-columns: minmax(200px, 1fr) 125px 125px 125px 40px;
     min-height: 40px;
-    min-width: fit-content;
     min-width: 100%;
     padding-left: 25px;
     width: 100%;
 
     @media (max-width: $breakpoint-tablet) {
-      grid-template-columns: auto 0 0 0 0;
+      grid-template-columns: minmax(0, 1fr) 0 0 0 0;
       width: auto;
     }
 
     @media (min-width: $breakpoint-singlecolumn) {
-      grid-template-columns: auto 125px 125px 125px;
+      grid-template-columns: minmax(200px, 1fr) 125px 125px 125px;
     }
 
     > div {
@@ -167,9 +166,6 @@ $scrollbar-offset: 20px;
       }
 
       &:first-child {
-        left: 0;
-        position: sticky;
-
         @media (max-width: $breakpoint-tablet) {
           display: block;
         }
@@ -178,23 +174,28 @@ $scrollbar-offset: 20px;
   }
 
   .sticky-header {
-    overflow: visible;
+    // `overflow: hidden` is what lets the header be scrolled sideways in step with the tree,
+    // but it also drops the flex item's automatic minimum size, hence the explicit shrink/height.
+    flex-shrink: 0;
+    min-height: 40px;
+    overflow: hidden;
     position: sticky;
     top: 51px;
     z-index: 1;
   }
 
+  // Lines up with the row's toggle/spacer, which the name sits after.
   .name-header {
     align-items: center;
-    background: linear-gradient(90deg, var(--bg1) 0%, var(--bg1) 0, transparent 80%);
     display: flex;
-    left: 15px;
     padding-left: 15px;
     padding-right: 0;
-    position: sticky;
   }
 
   .tree-wrapper {
+    // The tree paints its own background, but only over its content box - which scrolls away
+    // with the rows. The scroll container keeps the empty area below them filled.
+    background: var(--bg2);
     display: flex;
     flex: 1;
     flex-direction: column;
@@ -220,10 +221,15 @@ $scrollbar-offset: 20px;
           display: flex;
         }
 
+        // No width cap: the name is shown in full wherever the name column has room for it,
+        // and only truncates once it doesn't. The column is `minmax(<floor>, 1fr)`, so on a
+        // wide table that is everything the value columns don't take, and on a narrow or
+        // deeply indented one the floor pushes the tree past the wrapper, which scrolls.
+        // `display` is intentionally left to each tree's own node styles: a plain text name
+        // needs a block box for `text-overflow` to apply, a name with trailing icons doesn't.
         .name {
-          align-items: center;
-          display: inline-flex;
-          max-width: calc(100vw - 80vw);
+          flex: 0 1 auto;
+          min-width: 0;
           overflow: hidden;
           padding-right: 15px;
           text-overflow: ellipsis;
@@ -239,8 +245,12 @@ $scrollbar-offset: 20px;
     }
   }
 
+  // Rows stretch to the full (content-driven) tree width rather than each sizing to its own
+  // content, so that every row's value columns end on the same right edge as the header's -
+  // otherwise each nesting level would shift them by its indent.
   ix-tree-node {
     color: var(--fg1);
+    min-width: 100%;
   }
 
   .nested-tree-root-node {
@@ -313,26 +323,11 @@ $scrollbar-offset: 20px;
       min-width: calc($table-min-width + 0px);
     }
 
-    // Two Cards Slim Columns
-    @media (min-width: $breakpoint-dualcolumn-slim) and (max-width: calc($breakpoint-dualcolumn - 1px)) {
+    // Two Cards Slim Columns. The details panel stops growing here, so the table takes
+    // the whole remainder no matter how wide the screen gets.
+    @media (min-width: $breakpoint-dualcolumn-slim) {
       max-width: calc(100% - $dualcolumn-slim-max-width - 16px - $scrollbar-offset);
       min-width: calc($table-min-width + 0px);
-    }
-
-    // Two Cards Columns
-    @media (min-width: $breakpoint-dualcolumn) and (max-width: calc($breakpoint-flex - 1px)) {
-      min-width: calc(98% - 2 * ($card-width + $gap));
-    }
-
-    // Three Cards Columns
-    @media (min-width: $breakpoint-triplecolumn) and (max-width: calc($breakpoint-flex - 1px)) {
-      min-width: calc(98% - 3 * ($card-width + $gap));
-    }
-
-    // Cards spill to the right
-    @media (min-width: $breakpoint-flex) {
-      max-width: 1200px;
-      width: 50%;
     }
   }
 }

--- a/src/assets/styles/scss-imports/variables.scss
+++ b/src/assets/styles/scss-imports/variables.scss
@@ -3,7 +3,6 @@
 // TreeTable - Cards split view breakpoints & other variables
 $table-min-width: 620px;
 $table-width: 700px;
-$card-width: 455px;
 $card-width-slim: 356px;
 $gap: 8px;
 $breakpoint-min-mobile: 320px;
@@ -15,7 +14,6 @@ $breakpoint-tablet: 767px;
 $breakpoint-singlecolumn: $breakpoint-md;
 $breakpoint-dualcolumn-slim: 1680px;
 $breakpoint-dualcolumn: $breakpoint-lg;
-$breakpoint-triplecolumn: 2500px;
 $breakpoint-flex: 3132px;
 $breakpoint-hidden: calc($breakpoint-singlecolumn - 1px);
 


### PR DESCRIPTION
Layout fixes for the Datasets master-detail page (and the two other pages that share the same
mixin: Storage > VDEVs and the generic `master-detail-view`), plus a validation message fix found
along the way.

Everything below was verified in the browser against a real NAS at 760 / 1300 / 1440 / 1740 / 1920 /
2560 / 3840 CSS px.

## Dataset name column

Long names ran outside the table and collided with the `Used` value, with no ellipsis:

- The name was capped at `calc(100vw - 80vw)` — a slice of the *viewport*, unrelated to the space
  the column actually had — and its `padding-right` pushed the text 15px past the column into the
  next one.
- `.name` was `display: inline-flex`, so `text-overflow: ellipsis` never applied and the text was
  hard-cut mid-glyph.

The name column is now `minmax(<floor>, 1fr)` in both the header and the row, so it takes whatever
the value columns don't and truncates with a real ellipsis (the full name is still on hover). The
floor is what makes a deeply indented tree scroll horizontally instead of squeezing the name down to
a few characters. Value columns were trimmed to what they actually hold (125px → 85/90/95/55), which
hands ~150px back to the name at every width.

## Header alignment and horizontal scrolling

- Row and header grids now use identical tracks, and rows stretch to the full tree width
  (`min-width: 100%` instead of `fit-content`), so every row's value columns end on the same right
  edge as the header's — previously each nesting level shifted them by its indent.
- The header follows the tree sideways. `.sticky-header` was `overflow: visible`, so the existing
  `scrollLeft` sync in `dataset-management.component.ts` could never take effect; it is now
  `overflow: hidden` with a `(scroll)` handler on the tree feeding the existing subject.
- Dropped the frozen first column. It kept its full width while pinned, so the columns you scroll
  right to reach ended up *behind* it — measured on a 625px table, the pinned 360px name cell
  spanned x 271–631 while `Used` had scrolled to 531–616, and `Used`'s opaque background painted
  over the name's ellipsis. It could not work here regardless: the whole scroll range (173px) is
  smaller than the name column.

## Master-detail card sizing

The details panel was sized off the viewport rather than off its content, so it got *more* room as
the screen got wider (or as you zoomed out):

- `.scroll-window { columns: calc(50vw / 2.7) }` → `columns: $card-width-slim`.
- `.details-container { max-width: 70% }` above 1920 → stops at two slim columns (748px) from
  `$breakpoint-dualcolumn-slim` up; every extra pixel goes to the master table.

| viewport | details panel | card | master table |
|---|---|---|---|
| 1920 | 917 → **748** | 447 → **370** | 700 → **869** |
| 2560 | 1418 → **748** | 705 → **370** | 839 → **1509** |
| 3840 | — → **748** | — → **370** | — → **2789** |

This lets the `$breakpoint-dualcolumn` / `$breakpoint-triplecolumn` / `$breakpoint-flex` table-width
rules go, along with the now-unused `$card-width` and `$breakpoint-triplecolumn`. They only existed
to reserve room for card columns the panel no longer grows into — and the `$breakpoint-flex` rule
(`max-width: 1200px; width: 50%`) was what made zooming out give the cards more room, not less.

## Details panel height (page scrolled far past its content)

`DetailsHeightDirective` cached a "distance from the top of the screen to the panel" offset and
recomputed it from `getBoundingClientRect().top` — a *scrolled* position. The dataset tree dispatches
a window resize on every scroll, so each scroll re-measured it from a smaller (eventually negative)
top and set `height: calc(100vh - <negative>)`. At 1740x930 the panel grew 737px → **1320px**, the
row stretched to match, and the page became scrollable well past anything to show.

The panel is `position: sticky`, so neither `getBoundingClientRect().top` (clamps: 177 → 64) nor
`offsetTop` (tracks the stuck position: 129 → 537) is scroll-invariant. The height is now measured
off the panel's *row* instead, which does not depend on the height being set:

```
top    = max(row.top, container.top + paddingTop)   // where the block sticks
bottom = container.bottom - paddingBottom           // bottom of the screen
```

That also removes the two derived offsets, the `scrollBreakingPoint` clamp, the `+18px` fudge, and
the console-footer subscription (the scroll container already shrinks for the footer, and the
`ResizeObserver` on it catches the change). `scrollHeight` is now constant across repeated
scroll-to-bottom, and the panel fills the screen at every scroll position.

Also `align-items: flex-start` on `.container`, so a short tree no longer gets a table card stretched
to the height of the details panel.

The directive had no spec; it has one now.

## Dataset name length message

Unrelated to the layout, but reported while testing. `datasetNameTooLong` rejected when
`parentPath.length + 1 + name.length >= 200` but reported the limit as `200 - parentPath.length`,
counting neither the `/` separator nor the `>=`. Under a 198-character parent it said
*"The length of Name should be no more than 2"* and then rejected a 2-character name.

The limit is computed once now and both the check and the message read from it, so the number it
reports is always a length the field can satisfy. Behaviour is otherwise unchanged — it is the same
boundary, algebraically. When nothing fits at all, "no more than 0" is a limit no input can meet, so
that case gets its own error naming the real problem:

> The parent path already fills the 200 character limit for a dataset path, so nothing can be created
> under it.

Applies to Add Dataset, Add Zvol, and the create-dataset dialog in the path explorer.
