### PR TITLE
NAS-142379 / 27.0.0-BETA.1 / Migrate datasets quota, unlock, encryption and ACL editors to the shared ix-form wrapper

### DIFF
--- a/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.scss
+++ b/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.scss
@@ -4,10 +4,20 @@
   padding: 16px;
 
   .controls {
-    padding-top: 10px;
+    display: flex;
+    flex-direction: column;
+    padding-top: 16px;
 
-    ix-input {
-      margin: 0;
+    // `tn-form-section`'s body spaces only its DIRECT children, and this whole block is one of
+    // them — so the fields inside it have to space themselves. Anything but a pair of related
+    // checkboxes gets the section's own rhythm, so the SMB Name label isn't glued to the
+    // checkbox above it.
+    tn-form-field + tn-form-field {
+      margin-top: 1.25rem;
+    }
+
+    tn-form-field:has(tn-checkbox) + tn-form-field:has(tn-checkbox) {
+      margin-top: 8px;
     }
   }
 

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.html
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.html
@@ -1,86 +1,104 @@
 <tn-card class="form-card">
-  <form class="ix-form-container" [formGroup]="form" (submit)="onSave()">
-      @if (!hideFileInput) {
-        <ix-radio-group
+  <ix-form
+    [formGroup]="form"
+    [requiredRoles]="requiredRoles"
+    [submitHandler]="handleSubmit"
+    [suppressSuccessSnackbar]="true"
+  >
+    @if (!hideFileInput) {
+      <tn-form-field
+        [label]="helptext.keyFileLabel | translate"
+        [tooltip]="helptext.keyFileTooltip | translate"
+      >
+        <tn-radio-group
           formControlName="use_file"
-          [label]="helptext.keyFileLabel | translate"
-          [tooltip]="helptext.keyFileTooltip | translate"
-          [options]="useFileOptions$"
-        ></ix-radio-group>
-      }
+          [options]="useFileOptions"
+        ></tn-radio-group>
+      </tn-form-field>
+    }
 
-      @if (useFile) {
-        <ix-checkbox
+    @if (useFile) {
+      <tn-form-field [tooltip]="helptext.unlockChildrenTooltip | translate">
+        <tn-checkbox
           formControlName="unlock_children"
           [label]="helptext.unlockChildrenLabel | translate"
-          [tooltip]="helptext.unlockChildrenTooltip | translate"
-        ></ix-checkbox>
-        <ix-file-input
-          formControlName="file"
-          [label]="helptext.uploadKeyFileLabel | translate"
-          [tooltip]="helptext.uploadKeyFileTooltip | translate"
-          [required]="true"
-        ></ix-file-input>
-      } @else {
-        <ix-list
-          formArrayName="datasets"
-          [empty]="form.controls.datasets.controls.length === 0"
-          [label]="'Datasets' | translate"
-          [canAdd]="false"
-          [formArray]="form.controls.datasets"
-        >
-          @for (dataset of form.controls.datasets.controls; track dataset; let i = $index) {
-            <ix-list-item
-              [formGroupName]="i"
-              [canDelete]="false"
-            >
-              <div>
-                <strong> {{'Dataset' | translate }}: </strong>
-                {{ dataset.value.name }}
-              </div>
-              @if (dataset.value.is_passphrase) {
-                <ix-input
-                  formControlName="passphrase"
-                  type="password"
-                  [label]="helptext.datasetPassphraseLabel | translate"
-                  [tooltip]="helptext.datasetPassphraseTooltip | translate"
-                ></ix-input>
-              } @else {
-                <ix-textarea
-                  formControlName="key"
-                  [label]="helptext.datasetKeyLabel | translate"
-                  [tooltip]="helptext.datasetKeyLabel | translate"
-                ></ix-textarea>
-                <ix-file-input
-                  formControlName="file"
-                  [acceptedFiles]="'.json'"
-                ></ix-file-input>
-              }
-            </ix-list-item>
-          }
-        </ix-list>
-      }
+        ></tn-checkbox>
+      </tn-form-field>
 
-      <ix-checkbox
+      <ix-file-input
+        formControlName="file"
+        [label]="helptext.uploadKeyFileLabel | translate"
+        [tooltip]="helptext.uploadKeyFileTooltip | translate"
+        [required]="true"
+      ></ix-file-input>
+    } @else {
+      <ix-list
+        formArrayName="datasets"
+        [empty]="form.controls.datasets.controls.length === 0"
+        [label]="'Datasets' | translate"
+        [canAdd]="false"
+        [formArray]="form.controls.datasets"
+      >
+        @for (dataset of form.controls.datasets.controls; track dataset; let i = $index) {
+          <ix-list-item
+            [formGroupName]="i"
+            [canDelete]="false"
+          >
+            <div>
+              <strong> {{'Dataset' | translate }}: </strong>
+              {{ dataset.value.name }}
+            </div>
+            @if (dataset.value.is_passphrase) {
+              <tn-form-field
+                [label]="helptext.datasetPassphraseLabel | translate"
+                [tooltip]="helptext.datasetPassphraseTooltip | translate"
+              >
+                <tn-input
+                  formControlName="passphrase"
+                  [inputType]="InputType.Password"
+                ></tn-input>
+              </tn-form-field>
+            } @else {
+              <tn-form-field
+                [label]="helptext.datasetKeyLabel | translate"
+                [tooltip]="helptext.datasetKeyLabel | translate"
+              >
+                <tn-input
+                  formControlName="key"
+                  [multiline]="true"
+                ></tn-input>
+              </tn-form-field>
+              <ix-file-input
+                formControlName="file"
+                [acceptedFiles]="'.json'"
+              ></ix-file-input>
+            }
+          </ix-list-item>
+        }
+      </ix-list>
+    }
+
+    <tn-form-field [tooltip]="helptext.datasetForceTooltip | translate">
+      <tn-checkbox
         formControlName="force"
         [label]="'Force' | translate"
-        [tooltip]="helptext.datasetForceTooltip | translate"
-      ></ix-checkbox>
+      ></tn-checkbox>
+    </tn-form-field>
 
-      <div class="form-actions">
-        <tn-button
-          *ixRequiresRoles="requiredRoles"
-          type="submit"
-          color="primary"
-          [testId]="'unlock'"
-          [label]="'Unlock' | translate"
-          [disabled]="form.invalid || isFormLoading"
-        ></tn-button>
-        <tn-button
-          [testId]="'cancel'"
-          [label]="'Cancel' | translate"
-          (onClick)="goBack()"
-        ></tn-button>
-      </div>
-  </form>
+    <ix-form-actions>
+      <tn-button
+        *ixRequiresRoles="requiredRoles"
+        type="submit"
+        color="primary"
+        [testId]="'unlock'"
+        [label]="'Unlock' | translate"
+        [disabled]="!canSubmit()"
+      ></tn-button>
+      <tn-button
+        [testId]="'cancel'"
+        [label]="'Cancel' | translate"
+        (onClick)="goBack()"
+      ></tn-button>
+    </ix-form-actions>
+  </ix-form>
 </tn-card>

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.html
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.html
@@ -1,91 +1,93 @@
-<tn-card class="form-card">
+<tn-card class="card" [padContent]="false" [fillHeight]="false">
   <ix-form
     [formGroup]="form"
     [requiredRoles]="requiredRoles"
     [submitHandler]="handleSubmit"
     [suppressSuccessSnackbar]="true"
   >
-    @if (!hideFileInput) {
-      <tn-form-field
-        [label]="helptext.keyFileLabel | translate"
-        [tooltip]="helptext.keyFileTooltip | translate"
-      >
-        <tn-radio-group
-          formControlName="use_file"
-          [options]="useFileOptions"
-        ></tn-radio-group>
-      </tn-form-field>
-    }
+    <div class="fields">
+      @if (!hideFileInput) {
+        <tn-form-field
+          [label]="helptext.keyFileLabel | translate"
+          [tooltip]="helptext.keyFileTooltip | translate"
+        >
+          <tn-radio-group
+            formControlName="use_file"
+            [options]="useFileOptions"
+          ></tn-radio-group>
+        </tn-form-field>
+      }
 
-    @if (useFile) {
-      <tn-form-field [tooltip]="helptext.unlockChildrenTooltip | translate">
+      @if (useFile) {
+        <tn-form-field [tooltip]="helptext.unlockChildrenTooltip | translate">
+          <tn-checkbox
+            formControlName="unlock_children"
+            [label]="helptext.unlockChildrenLabel | translate"
+          ></tn-checkbox>
+        </tn-form-field>
+
+        <ix-file-input
+          formControlName="file"
+          [label]="helptext.uploadKeyFileLabel | translate"
+          [tooltip]="helptext.uploadKeyFileTooltip | translate"
+          [required]="true"
+        ></ix-file-input>
+      } @else {
+        <ix-list
+          formArrayName="datasets"
+          [empty]="form.controls.datasets.controls.length === 0"
+          [label]="'Datasets' | translate"
+          [canAdd]="false"
+          [formArray]="form.controls.datasets"
+        >
+          @for (dataset of form.controls.datasets.controls; track dataset; let i = $index) {
+            <ix-list-item
+              [formGroupName]="i"
+              [canDelete]="false"
+            >
+              <div>
+                <strong> {{'Dataset' | translate }}: </strong>
+                {{ dataset.value.name }}
+              </div>
+              @if (dataset.value.is_passphrase) {
+                <tn-form-field
+                  [label]="helptext.datasetPassphraseLabel | translate"
+                  [tooltip]="helptext.datasetPassphraseTooltip | translate"
+                >
+                  <tn-input
+                    formControlName="passphrase"
+                    [inputType]="InputType.Password"
+                  ></tn-input>
+                </tn-form-field>
+              } @else {
+                <tn-form-field
+                  [label]="helptext.datasetKeyLabel | translate"
+                  [tooltip]="helptext.datasetKeyLabel | translate"
+                >
+                  <tn-input
+                    formControlName="key"
+                    [multiline]="true"
+                  ></tn-input>
+                </tn-form-field>
+                <ix-file-input
+                  formControlName="file"
+                  [acceptedFiles]="'.json'"
+                ></ix-file-input>
+              }
+            </ix-list-item>
+          }
+        </ix-list>
+      }
+
+      <tn-form-field [tooltip]="helptext.datasetForceTooltip | translate">
         <tn-checkbox
-          formControlName="unlock_children"
-          [label]="helptext.unlockChildrenLabel | translate"
+          formControlName="force"
+          [label]="'Force' | translate"
         ></tn-checkbox>
       </tn-form-field>
+    </div>
 
-      <ix-file-input
-        formControlName="file"
-        [label]="helptext.uploadKeyFileLabel | translate"
-        [tooltip]="helptext.uploadKeyFileTooltip | translate"
-        [required]="true"
-      ></ix-file-input>
-    } @else {
-      <ix-list
-        formArrayName="datasets"
-        [empty]="form.controls.datasets.controls.length === 0"
-        [label]="'Datasets' | translate"
-        [canAdd]="false"
-        [formArray]="form.controls.datasets"
-      >
-        @for (dataset of form.controls.datasets.controls; track dataset; let i = $index) {
-          <ix-list-item
-            [formGroupName]="i"
-            [canDelete]="false"
-          >
-            <div>
-              <strong> {{'Dataset' | translate }}: </strong>
-              {{ dataset.value.name }}
-            </div>
-            @if (dataset.value.is_passphrase) {
-              <tn-form-field
-                [label]="helptext.datasetPassphraseLabel | translate"
-                [tooltip]="helptext.datasetPassphraseTooltip | translate"
-              >
-                <tn-input
-                  formControlName="passphrase"
-                  [inputType]="InputType.Password"
-                ></tn-input>
-              </tn-form-field>
-            } @else {
-              <tn-form-field
-                [label]="helptext.datasetKeyLabel | translate"
-                [tooltip]="helptext.datasetKeyLabel | translate"
-              >
-                <tn-input
-                  formControlName="key"
-                  [multiline]="true"
-                ></tn-input>
-              </tn-form-field>
-              <ix-file-input
-                formControlName="file"
-                [acceptedFiles]="'.json'"
-              ></ix-file-input>
-            }
-          </ix-list-item>
-        }
-      </ix-list>
-    }
-
-    <tn-form-field [tooltip]="helptext.datasetForceTooltip | translate">
-      <tn-checkbox
-        formControlName="force"
-        [label]="'Force' | translate"
-      ></tn-checkbox>
-    </tn-form-field>
-
-    <ix-form-actions>
+    <div class="form-actions">
       <tn-button
         *ixRequiresRoles="requiredRoles"
         type="submit"
@@ -99,6 +101,6 @@
         [label]="'Cancel' | translate"
         (onClick)="goBack()"
       ></tn-button>
-    </ix-form-actions>
+    </div>
   </ix-form>
 </tn-card>

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.scss
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.scss
@@ -1,8 +1,31 @@
-// The `<ix-form>` wrapper renders the form element itself, so the page owns only the
-// gutter between the card edge and the fields.
-ix-form {
-  display: block;
-  padding: 20px;
+.card {
+  margin: 0 auto;
+  max-width: 850px;
+}
+
+// The `<ix-form>` wrapper renders the form element itself, so the card's padding lives on the
+// two rows it projects: the fields and the footer actions.
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 24px;
+
+  // These ix-* controls ship their own vertical margins, which would stack on the column gap
+  // above. The gap owns the rhythm here.
+  > ix-file-input,
+  > ix-list {
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+}
+
+.form-actions {
+  border-top: 1px solid var(--lines);
+  column-gap: 10px;
+  display: flex;
+  justify-content: flex-end;
+  padding: 24px;
 }
 
 ix-list-item {

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.scss
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.scss
@@ -1,15 +1,10 @@
-.ix-form-container {
+// The `<ix-form>` wrapper renders the form element itself, so the page owns only the
+// gutter between the card edge and the fields.
+ix-form {
+  display: block;
   padding: 20px;
 }
 
 ix-list-item {
   padding: 10px;
-}
-
-.form-actions {
-  margin: 8px 10px;
-
-  tn-button {
-    margin-right: 8px;
-  }
 }

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.spec.ts
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.spec.ts
@@ -14,7 +14,8 @@ import { DatasetEncryptionType } from 'app/enums/dataset.enum';
 import { DatasetEncryptionSummary } from 'app/interfaces/dataset-encryption-summary.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxFileInputHarness } from 'app/modules/forms/ix-forms/components/ix-file-input/ix-file-input.harness';
-import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
+import { fillControlValues, indexFormControls } from 'app/modules/forms/ix-forms/testing/control-harnesses.helpers';
+import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { DatasetUnlockComponent } from 'app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component';
 import { UploadService } from 'app/services/upload.service';
@@ -34,6 +35,7 @@ describe('DatasetUnlockComponent', () => {
       ReactiveFormsModule,
     ],
     providers: [
+      ixFormTestingProviders(),
       mockAuth(),
       mockProvider(Router),
       mockProvider(ActivatedRoute, {
@@ -80,16 +82,15 @@ describe('DatasetUnlockComponent', () => {
   });
 
   it('saves when set key manually', async () => {
-    const form = await loader.getHarness(IxFormHarness);
+    await fillControlValues(await indexFormControls(loader), {
+      'Unlock with Key file': 'Provide keys/passphrases manually',
+    });
 
-    await form.fillForm(
-      {
-        'Unlock with Key file': 'Provide keys/passphrases manually',
-        Force: true,
-        'Dataset Key': '0123456789012345678901234567890123456789012345678901234567890123',
-        'Dataset Passphrase': '12345678',
-      },
-    );
+    await fillControlValues(await indexFormControls(loader), {
+      Force: true,
+      'Dataset Key': '0123456789012345678901234567890123456789012345678901234567890123',
+      'Dataset Passphrase': '12345678',
+    });
 
     const unlockButton = await loader.getHarness(TnButtonHarness.with({ label: 'Unlock' }));
     await unlockButton.click();

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.ts
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.ts
@@ -1,31 +1,33 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, viewChild,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   FormControl, FormGroup, NonNullableFormBuilder, ReactiveFormsModule, Validators,
 } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { TnButtonComponent, TnCardComponent, TnDialog } from '@truenas/ui-components';
 import {
-  Observable,
-  from, of, switchMap,
-} from 'rxjs';
+  InputType, TnButtonComponent, TnCardComponent, TnCheckboxComponent, TnDialog,
+  TnFormFieldComponent, TnInputComponent, TnRadioGroupComponent,
+} from '@truenas/ui-components';
+import { from, of, switchMap } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { DatasetEncryptionType } from 'app/enums/dataset.enum';
 import { Role } from 'app/enums/role.enum';
 import { helptextUnlock } from 'app/helptext/storage/volumes/datasets/dataset-unlock';
 import { DatasetEncryptionSummary, DatasetEncryptionSummaryQueryParams, DatasetEncryptionSummaryQueryParamsDataset } from 'app/interfaces/dataset-encryption-summary.interface';
 import { DatasetUnlockParams, DatasetUnlockResult } from 'app/interfaces/dataset-lock.interface';
+import { Job } from 'app/interfaces/job.interface';
 import { RadioOption } from 'app/interfaces/option.interface';
-import { AuthService } from 'app/modules/auth/auth.service';
 import { DialogService } from 'app/modules/dialog/dialog.service';
-import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
+import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFileInputComponent } from 'app/modules/forms/ix-forms/components/ix-file-input/ix-file-input.component';
-import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
+import {
+  IxFormComponent, SubmitResult,
+} from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
 import { IxListItemComponent } from 'app/modules/forms/ix-forms/components/ix-list/ix-list-item/ix-list-item.component';
 import { IxListComponent } from 'app/modules/forms/ix-forms/components/ix-list/ix-list.component';
-import { IxRadioGroupComponent } from 'app/modules/forms/ix-forms/components/ix-radio-group/ix-radio-group.component';
-import { IxTextareaComponent } from 'app/modules/forms/ix-forms/components/ix-textarea/ix-textarea.component';
 import { exactLength } from 'app/modules/forms/ix-forms/validators/validators';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { UnlockSummaryDialog } from 'app/pages/datasets/modules/encryption/components/unlock-summary-dialog/unlock-summary-dialog.component';
@@ -47,15 +49,17 @@ interface DatasetFormGroup {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     TnCardComponent,
-    IxRadioGroupComponent,
     ReactiveFormsModule,
-    IxCheckboxComponent,
+    IxFormComponent,
+    TnFormFieldComponent,
+    TnRadioGroupComponent,
+    TnCheckboxComponent,
+    TnInputComponent,
     IxFileInputComponent,
     IxListComponent,
     IxListItemComponent,
     TranslateModule,
-    IxInputComponent,
-    IxTextareaComponent,
+    FormActionsComponent,
     TnButtonComponent,
     RequiresRolesDirective,
   ],
@@ -64,7 +68,6 @@ export class DatasetUnlockComponent implements OnInit {
   private api = inject(ApiService);
   private formBuilder = inject(NonNullableFormBuilder);
   private aroute = inject(ActivatedRoute);
-  private authService = inject(AuthService);
   private dialogService = inject(DialogService);
   private errorHandler = inject(ErrorHandlerService);
   private tnDialog = inject(TnDialog);
@@ -73,11 +76,18 @@ export class DatasetUnlockComponent implements OnInit {
   private upload = inject(UploadService);
   private destroyRef = inject(DestroyRef);
 
+  /**
+   * The shared form wrapper owns the submit lifecycle (loading, validation-error mapping). The
+   * action row's button submits natively (`type="submit"` inside the wrapper's own `<form>`), so
+   * only its disabled state is read back from here.
+   */
+  private readonly ixForm = viewChild(IxFormComponent);
+
   protected readonly requiredRoles = [Role.DatasetWrite];
+  protected readonly InputType = InputType;
 
   pk: string;
   dialogOpen = false;
-  isFormLoading = false;
   hideFileInput = false;
 
   form = this.formBuilder.group({
@@ -89,13 +99,13 @@ export class DatasetUnlockComponent implements OnInit {
     force: [false],
   });
 
-  useFileOptions$: Observable<RadioOption[]> = of([{
+  protected readonly useFileOptions: RadioOption[] = [{
     value: true,
     label: this.translate.instant('From a key file'),
   }, {
     value: false,
     label: this.translate.instant('Provide keys/passphrases manually'),
-  }]);
+  }];
 
   readonly helptext = helptextUnlock;
 
@@ -211,7 +221,16 @@ export class DatasetUnlockComponent implements OnInit {
       });
   }
 
-  protected onSave(): void {
+  protected canSubmit(): boolean {
+    return this.ixForm()?.canSubmit() ?? false;
+  }
+
+  /**
+   * "Unlock" fetches an encryption summary rather than saving anything: success is reported by
+   * the summary dialog it opens, which is also where the actual unlock is confirmed — hence
+   * `suppressSuccessSnackbar` and a `null` success message.
+   */
+  protected handleSubmit = (): SubmitResult<boolean, Job<DatasetEncryptionSummary[]>> => {
     const values = this.form.getRawValue();
     const datasets: DatasetEncryptionSummaryQueryParamsDataset[] = [];
 
@@ -240,19 +259,17 @@ export class DatasetUnlockComponent implements OnInit {
         })
       : this.api.job('pool.dataset.encryption_summary', [this.pk, payload]);
 
-    this.dialogService.jobDialog(job$, {
-      title: this.translate.instant(helptextUnlock.fetchingEncryptionSummaryTitle),
-      description: this.translate.instant(helptextUnlock.fetchingEncryptionSummaryMessage, { dataset: this.pk }),
-    })
-      .afterClosed()
-      .pipe(
-        this.errorHandler.withErrorHandler(),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe((job) => {
-        this.openSummaryDialog(payload as DatasetUnlockParams, job.result);
-      });
-  }
+    return {
+      request$: this.dialogService.jobDialog(job$, {
+        title: this.translate.instant(helptextUnlock.fetchingEncryptionSummaryTitle),
+        description: this.translate.instant(helptextUnlock.fetchingEncryptionSummaryMessage, { dataset: this.pk }),
+      })
+        .afterClosed()
+        .pipe(this.errorHandler.withErrorHandler()),
+      successMessage: null,
+      onSuccess: (job) => this.openSummaryDialog(payload as DatasetUnlockParams, job.result),
+    };
+  };
 
   private openUnlockDialog(payload: DatasetUnlockParams, unlockResult: DatasetUnlockResult): void {
     const errors: { name: string; unlock_error: string }[] = [];

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.ts
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.ts
@@ -21,7 +21,6 @@ import { DatasetUnlockParams, DatasetUnlockResult } from 'app/interfaces/dataset
 import { Job } from 'app/interfaces/job.interface';
 import { RadioOption } from 'app/interfaces/option.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
-import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxFileInputComponent } from 'app/modules/forms/ix-forms/components/ix-file-input/ix-file-input.component';
 import {
   IxFormComponent, SubmitResult,
@@ -59,7 +58,6 @@ interface DatasetFormGroup {
     IxListComponent,
     IxListItemComponent,
     TranslateModule,
-    FormActionsComponent,
     TnButtonComponent,
     RequiresRolesDirective,
   ],

--- a/src/app/pages/datasets/modules/encryption/components/encryption-options-dialog/encryption-options-dialog.component.html
+++ b/src/app/pages/datasets/modules/encryption/components/encryption-options-dialog/encryption-options-dialog.component.html
@@ -1,84 +1,105 @@
 <tn-dialog-shell testId="encryption-options" [title]="'Edit Encryption Options for {dataset}' | translate: { dataset: data.dataset.id }">
-<form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
-  @if (canInherit) {
-    <tn-form-field>
-      <tn-checkbox
-        testId="inherit-encryption"
-        formControlName="inherit_encryption"
-        [label]="'Inherit encryption properties from parent' | translate"
-      ></tn-checkbox>
-    </tn-form-field>
-  }
-
-  @if (!(isInheriting$ | async)) {
-    <tn-form-field [label]="'Encryption Type' | translate" [tooltip]="tooltips.encryption_type | translate" [required]="true">
-      <tn-select
-        testId="encryption-type"
-        formControlName="encryption_type"
-        [options]="(encryptionTypeOptions$ | async) ?? []"
-      ></tn-select>
-    </tn-form-field>
-    @if (isKey$ | async) {
-      <tn-form-field [tooltip]="tooltips.generate_key | translate">
+  <ix-form
+    [formGroup]="form"
+    [requiredRoles]="requiredRoles"
+    [submitHandler]="handleSubmit"
+    (closed)="dialogRef.close($event)"
+  >
+    @if (canInherit) {
+      <tn-form-field>
         <tn-checkbox
-          testId="generate-key"
-          formControlName="generate_key"
-          [label]="'Generate Key' | translate"
+          testId="inherit-encryption"
+          formControlName="inherit_encryption"
+          [label]="'Inherit encryption properties from parent' | translate"
         ></tn-checkbox>
       </tn-form-field>
-
-      @if (!(isSetToGenerateKey$ | async)) {
-        <ix-textarea
-          formControlName="key"
-          [label]="'Key' | translate"
-          [required]="true"
-        ></ix-textarea>
-      }
-    } @else {
-      <ix-input
-        formControlName="passphrase"
-        type="password"
-        [label]="'Passphrase' | translate"
-        [tooltip]="tooltips.passphrase | translate"
-      ></ix-input>
-
-      <ix-input
-        formControlName="confirm_passphrase"
-        type="password"
-        [label]="'Confirm Passphrase' | translate"
-      ></ix-input>
-
-      <ix-input
-        formControlName="pbkdf2iters"
-        type="number"
-        [label]="'pbkdf2iters' | translate"
-        [tooltip]="tooltips.pbkdf2iters | translate"
-      ></ix-input>
     }
-  }
-  <tn-form-field>
-    <tn-checkbox
-      testId="confirm"
-      formControlName="confirm"
-      [label]="'Confirm' | translate"
-    ></tn-checkbox>
-  </tn-form-field>
-</form>
-<ix-form-actions tnDialogAction>
-  <tn-button
-    variant="outline"
-    testId="cancel"
-    [label]="'Cancel' | translate"
-    (onClick)="dialogRef.close(false)"
-  ></tn-button>
 
-  <tn-button
-    *ixRequiresRoles="[Role.DatasetWrite]"
-    color="primary"
-    testId="save"
-    [label]="'Save' | translate"
-    [disabled]="form.invalid"
-    (onClick)="onSubmit()"
-  ></tn-button>
-</ix-form-actions>
+    @if (!isInheriting()) {
+      <tn-form-field
+        [label]="'Encryption Type' | translate"
+        [tooltip]="tooltips.encryption_type | translate"
+        [required]="true"
+      >
+        <tn-select
+          testId="encryption-type"
+          formControlName="encryption_type"
+          [options]="encryptionTypeOptions"
+        ></tn-select>
+      </tn-form-field>
+
+      @if (isKeyEncryption()) {
+        <tn-form-field [tooltip]="tooltips.generate_key | translate">
+          <tn-checkbox
+            testId="generate-key"
+            formControlName="generate_key"
+            [label]="'Generate Key' | translate"
+          ></tn-checkbox>
+        </tn-form-field>
+
+        @if (!isGeneratingKey()) {
+          <tn-form-field [label]="'Key' | translate" [required]="true">
+            <tn-input
+              formControlName="key"
+              [multiline]="true"
+            ></tn-input>
+          </tn-form-field>
+        }
+      } @else {
+        <tn-form-field
+          [label]="'Passphrase' | translate"
+          [tooltip]="tooltips.passphrase | translate"
+        >
+          <tn-input
+            formControlName="passphrase"
+            [inputType]="InputType.Password"
+          ></tn-input>
+        </tn-form-field>
+
+        <tn-form-field [label]="'Confirm Passphrase' | translate">
+          <tn-input
+            formControlName="confirm_passphrase"
+            [inputType]="InputType.Password"
+          ></tn-input>
+        </tn-form-field>
+
+        <tn-form-field
+          [label]="'pbkdf2iters' | translate"
+          [tooltip]="tooltips.pbkdf2iters | translate"
+        >
+          <tn-input
+            testId="pbkdf-2-iters"
+            formControlName="pbkdf2iters"
+            [inputType]="InputType.Number"
+          ></tn-input>
+        </tn-form-field>
+      }
+    }
+
+    <tn-form-field>
+      <tn-checkbox
+        testId="confirm"
+        formControlName="confirm"
+        [label]="'Confirm' | translate"
+      ></tn-checkbox>
+    </tn-form-field>
+  </ix-form>
+
+  <ix-form-actions tnDialogAction>
+    <tn-button
+      variant="outline"
+      testId="cancel"
+      [label]="'Cancel' | translate"
+      (onClick)="dialogRef.close(false)"
+    ></tn-button>
+
+    <tn-button
+      *ixRequiresRoles="requiredRoles"
+      color="primary"
+      testId="save"
+      [label]="'Save' | translate"
+      [disabled]="!canSubmit()"
+      (onClick)="submit()"
+    ></tn-button>
+  </ix-form-actions>
 </tn-dialog-shell>

--- a/src/app/pages/datasets/modules/encryption/components/encryption-options-dialog/encryption-options-dialog.component.spec.ts
+++ b/src/app/pages/datasets/modules/encryption/components/encryption-options-dialog/encryption-options-dialog.component.spec.ts
@@ -1,16 +1,19 @@
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
-import { HarnessLoader, parallel } from '@angular/cdk/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnButtonHarness, TnCheckboxHarness, TnSelectHarness } from '@truenas/ui-components';
+import {
+  TnButtonHarness, TnCheckboxHarness, TnInputHarness, TnSelectHarness,
+} from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { mockCall, mockJob, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { EncryptionKeyFormat } from 'app/enums/encryption-key-format.enum';
 import { Dataset, DatasetDetails } from 'app/interfaces/dataset.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
-import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
+import { indexFormControls } from 'app/modules/forms/ix-forms/testing/control-harnesses.helpers';
+import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { EncryptionOptionsDialog } from 'app/pages/datasets/modules/encryption/components/encryption-options-dialog/encryption-options-dialog.component';
 import { EncryptionOptionsDialogData } from './encryption-options-dialog-data.interface';
@@ -19,7 +22,6 @@ describe('EncryptionOptionsDialogComponent', () => {
   let spectator: Spectator<EncryptionOptionsDialog>;
   let api: ApiService;
   let loader: HarnessLoader;
-  let form: IxFormHarness;
   let dialogRef: DialogRef;
   const createComponent = createComponentFactory({
     component: EncryptionOptionsDialog,
@@ -27,6 +29,7 @@ describe('EncryptionOptionsDialogComponent', () => {
       ReactiveFormsModule,
     ],
     providers: [
+      ixFormTestingProviders(),
       { provide: DIALOG_DATA, useValue: {} },
       mockProvider(DialogRef),
       mockProvider(DialogService, {
@@ -62,7 +65,7 @@ describe('EncryptionOptionsDialogComponent', () => {
     },
   } as EncryptionOptionsDialogData;
 
-  async function setupTest(dialogData: EncryptionOptionsDialogData = defaultDialogData): Promise<void> {
+  function setupTest(dialogData: EncryptionOptionsDialogData = defaultDialogData): void {
     spectator = createComponent({
       providers: [
         { provide: DIALOG_DATA, useValue: dialogData },
@@ -71,7 +74,6 @@ describe('EncryptionOptionsDialogComponent', () => {
     api = spectator.inject(ApiService);
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     dialogRef = spectator.inject(DialogRef);
-    form = await loader.getHarness(IxFormHarness);
   }
 
   async function setCheckbox(label: string, checked: boolean): Promise<void> {
@@ -79,36 +81,46 @@ describe('EncryptionOptionsDialogComponent', () => {
     await (checked ? checkbox.check() : checkbox.uncheck());
   }
 
+  async function setInput(controlName: string, value: string): Promise<void> {
+    const input = await loader.getHarness(TnInputHarness.with({ selector: `[formControlName="${controlName}"]` }));
+    await input.setValue(value);
+  }
+
   async function selectEncryptionType(option: string): Promise<void> {
     const encryptionTypeSelect = await loader.getHarness(TnSelectHarness);
     await encryptionTypeSelect.selectOption(option);
   }
 
+  async function clickSave(): Promise<void> {
+    const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
+    await saveButton.click();
+  }
+
   it('loads dataset pbkdf2iters when dialog is opened', async () => {
-    await setupTest();
+    setupTest();
     expect(api.call)
       .toHaveBeenCalledWith('pool.dataset.query', [[['id', '=', 'pool/parent/child']]]);
-    spectator.component.ngOnInit();
 
-    const pbkdf2iters = await form.getControl('pbkdf2iters');
+    const pbkdf2iters = await loader.getHarness(
+      TnInputHarness.with({ selector: '[formControlName="pbkdf2iters"]' }),
+    );
     expect(await pbkdf2iters.getValue()).toBe('1300000');
   });
 
   it('allows to inherit when there is an encrypted parent', async () => {
-    await setupTest();
+    setupTest();
 
     await setCheckbox('Inherit encryption properties from parent', true);
     await setCheckbox('Confirm', true);
 
-    const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
-    await saveButton.click();
+    await clickSave();
 
     expect(api.call).toHaveBeenCalledWith('pool.dataset.inherit_parent_encryption_properties', ['pool/parent/child']);
-    expect(dialogRef.close).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
   });
 
   it('does not make the API call when set to Inherit, but dataset is already not an encryption root', async () => {
-    await setupTest({
+    setupTest({
       dataset: {
         id: 'pool/parent/child',
         encryption_root: 'pool',
@@ -122,104 +134,93 @@ describe('EncryptionOptionsDialogComponent', () => {
     await setCheckbox('Inherit encryption properties from parent', true);
     await setCheckbox('Confirm', true);
 
-    const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
-    await saveButton.click();
+    await clickSave();
 
     expect(api.call).not.toHaveBeenCalledWith('pool.dataset.inherit_parent_encryption_properties');
-    expect(dialogRef.close).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalledWith(false);
   });
 
   it('hides other controls when Inherit checkbox is ticked', async () => {
-    await setupTest();
+    setupTest();
 
-    expect(await form.getLabels()).toEqual(['Passphrase', 'Confirm Passphrase', 'pbkdf2iters']);
-    expect(await loader.getAllHarnesses(TnSelectHarness)).toHaveLength(1);
+    expect(Object.keys(await indexFormControls(loader))).toEqual([
+      'Inherit encryption properties from parent',
+      'Encryption Type',
+      'Passphrase',
+      'Confirm Passphrase',
+      'pbkdf2iters',
+      'Confirm',
+    ]);
 
     await setCheckbox('Inherit encryption properties from parent', true);
 
-    // Only Inherit and Confirm survive; they are tn-checkbox, so the remaining
-    // ix-form controls and the tn-select disappear entirely.
-    expect(await form.getLabels()).toEqual([]);
-    expect(await loader.getAllHarnesses(TnSelectHarness)).toHaveLength(0);
-
-    const checkboxes = await loader.getAllHarnesses(TnCheckboxHarness);
-    expect(await parallel(() => checkboxes.map((checkbox) => checkbox.getLabelText()))).toEqual([
+    expect(Object.keys(await indexFormControls(loader))).toEqual([
       'Inherit encryption properties from parent',
       'Confirm',
     ]);
+    expect(await loader.getAllHarnesses(TnSelectHarness)).toHaveLength(0);
   });
 
   it('allows to set encryption to key', async () => {
-    await setupTest();
+    setupTest();
 
     const key = 'k'.repeat(64);
     await selectEncryptionType('Key');
-    await form.fillForm({
-      Key: 'k'.repeat(64),
-    });
+    await setInput('key', key);
     await setCheckbox('Confirm', true);
 
-    const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
-    await saveButton.click();
+    await clickSave();
 
     expect(api.job).toHaveBeenCalledWith(
       'pool.dataset.change_key',
       ['pool/parent/child', { key, generate_key: false }],
     );
-    expect(dialogRef.close).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
   });
 
   it('allows key to be generated for when encryption type is key', async () => {
-    await setupTest();
+    setupTest();
 
     await selectEncryptionType('Key');
     await setCheckbox('Generate Key', true);
     await setCheckbox('Confirm', true);
 
-    const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
-    await saveButton.click();
+    await clickSave();
 
     expect(api.job).toHaveBeenCalledWith(
       'pool.dataset.change_key',
       ['pool/parent/child', { generate_key: true }],
     );
-    expect(dialogRef.close).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
   });
 
   it('allows to set encryption to passphrase', async () => {
-    await setupTest();
+    setupTest();
 
     await selectEncryptionType('Passphrase');
-    await form.fillForm({
-      Passphrase: '12345678',
-      'Confirm Passphrase': '12345678',
-      pbkdf2iters: '1300001',
-    });
+    await setInput('passphrase', '12345678');
+    await setInput('confirm_passphrase', '12345678');
+    await setInput('pbkdf2iters', '1300001');
     await setCheckbox('Confirm', true);
 
-    const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
-    await saveButton.click();
+    await clickSave();
 
     expect(api.job).toHaveBeenCalledWith(
       'pool.dataset.change_key',
       ['pool/parent/child', { passphrase: '12345678', pbkdf2iters: 1300001 }],
     );
-    expect(dialogRef.close).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
   });
 
   it('allows saving when switching from passphrase to key with mismatched passphrase fields', async () => {
-    await setupTest();
+    setupTest();
 
     await selectEncryptionType('Passphrase');
-    await form.fillForm({
-      Passphrase: '12345678',
-    });
+    await setInput('passphrase', '12345678');
 
     const key = 'k'.repeat(64);
     await selectEncryptionType('Key');
-    await form.fillForm({
-      Key: key,
-    });
+    await setInput('key', key);
     await setCheckbox('Confirm', true);
 
     const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save' }));
@@ -234,7 +235,7 @@ describe('EncryptionOptionsDialogComponent', () => {
   });
 
   it('only allows key encryption when dataset has a key-encrypted child', async () => {
-    await setupTest({
+    setupTest({
       ...defaultDialogData,
       dataset: {
         ...defaultDialogData.dataset,
@@ -255,7 +256,7 @@ describe('EncryptionOptionsDialogComponent', () => {
   });
 
   it('only allows passphrase encryption when dataset has a passphrase-encrypted parent', async () => {
-    await setupTest({
+    setupTest({
       ...defaultDialogData,
       parent: {
         key_format: {

--- a/src/app/pages/datasets/modules/encryption/components/encryption-options-dialog/encryption-options-dialog.component.ts
+++ b/src/app/pages/datasets/modules/encryption/components/encryption-options-dialog/encryption-options-dialog.component.ts
@@ -1,35 +1,33 @@
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
-import { AsyncPipe } from '@angular/common';
 import {
-  ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, OnInit, inject,
+  ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, signal, viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ReactiveFormsModule, Validators } from '@angular/forms';
-import { FormBuilder, FormControl } from '@ngneat/reactive-forms';
+import {
+  AbstractControl, NonNullableFormBuilder, ReactiveFormsModule, Validators,
+} from '@angular/forms';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  TnButtonComponent, TnCheckboxComponent, TnDialogShellComponent, TnFormFieldComponent, TnSelectComponent,
+  InputType, TnButtonComponent, TnCheckboxComponent, TnDialogShellComponent,
+  TnFormFieldComponent, TnInputComponent, TnSelectComponent,
 } from '@truenas/ui-components';
-import { of, Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { of, startWith } from 'rxjs';
 import { minimumPbkdf2Iterations } from 'app/constants/dataset.constants';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { EncryptionKeyFormat } from 'app/enums/encryption-key-format.enum';
 import { Role } from 'app/enums/role.enum';
 import { findInTree } from 'app/helpers/find-in-tree.utils';
-import { combineLatestIsAny } from 'app/helpers/operators/combine-latest-is-any.helper';
 import { helptextDatasetForm } from 'app/helptext/storage/volumes/datasets/dataset-form';
 import { DatasetChangeKeyParams } from 'app/interfaces/dataset-change-key.interface';
 import { Dataset } from 'app/interfaces/dataset.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
-import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
-import { IxTextareaComponent } from 'app/modules/forms/ix-forms/components/ix-textarea/ix-textarea.component';
-import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
+import {
+  FormSubmitEvent, IxFormComponent, SubmitResult, ixFormMinSubmitFeedbackMs,
+} from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
 import { matchOthersFgValidator } from 'app/modules/forms/ix-forms/validators/password-validation/password-validation';
 import { exactLength } from 'app/modules/forms/ix-forms/validators/validators';
 import { LoaderService } from 'app/modules/loader/loader.service';
-import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { isPasswordEncrypted, isEncryptionRoot } from 'app/pages/datasets/utils/dataset.utils';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
@@ -40,42 +38,65 @@ enum EncryptionType {
   Passphrase = 'passphrase',
 }
 
+interface EncryptionOptionsFormValue {
+  inherit_encryption: boolean;
+  encryption_type: EncryptionType | null;
+  generate_key: boolean;
+  key: string;
+  passphrase: string;
+  confirm_passphrase: string;
+  pbkdf2iters: number;
+  confirm: boolean;
+}
+
 @Component({
   selector: 'ix-encryption-options-dialog',
   templateUrl: './encryption-options-dialog.component.html',
   styleUrls: ['./encryption-options-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    // The submit-feedback hold exists so a `<tn-side-panel>`'s progress bar is perceptible on a
+    // fast save. A dialog has no such indicator (the job dialog / global loader below covers the
+    // request), so holding here would only delay the close.
+    { provide: ixFormMinSubmitFeedbackMs, useValue: 0 },
+  ],
   imports: [
     TnDialogShellComponent,
     TranslateModule,
     ReactiveFormsModule,
+    IxFormComponent,
     TnCheckboxComponent,
     TnFormFieldComponent,
     TnSelectComponent,
-    IxTextareaComponent,
-    IxInputComponent,
-    AsyncPipe,
+    TnInputComponent,
     FormActionsComponent,
     TnButtonComponent,
     RequiresRolesDirective,
   ],
 })
-export class EncryptionOptionsDialog implements OnInit, OnDestroy {
-  private fb = inject(FormBuilder);
+export class EncryptionOptionsDialog implements OnInit {
+  private fb = inject(NonNullableFormBuilder);
   private api = inject(ApiService);
   private translate = inject(TranslateService);
   private loader = inject(LoaderService);
   private dialog = inject(DialogService);
   protected dialogRef = inject<DialogRef>(DialogRef);
-  private formErrorHandler = inject(FormErrorHandlerService);
   private errorHandler = inject(ErrorHandlerService);
-  private snackbar = inject(SnackbarService);
   data = inject<EncryptionOptionsDialogData>(DIALOG_DATA);
   private destroyRef = inject(DestroyRef);
 
-  form = this.fb.group({
+  /**
+   * The shared form wrapper owns the submit lifecycle (loading, snackbar, validation-error
+   * mapping); the dialog only re-exposes its Save surface to the `tnDialogAction` footer.
+   */
+  private readonly ixForm = viewChild(IxFormComponent);
+
+  protected readonly requiredRoles = [Role.DatasetWrite];
+  protected readonly InputType = InputType;
+
+  protected form = this.fb.group({
     inherit_encryption: [false],
-    encryption_type: new FormControl(null as EncryptionType | null),
+    encryption_type: this.fb.control<EncryptionType | null>(null),
     generate_key: [false],
     key: ['', [Validators.required, exactLength(64)]],
     passphrase: ['', Validators.minLength(8)],
@@ -92,11 +113,12 @@ export class EncryptionOptionsDialog implements OnInit, OnDestroy {
     ],
   });
 
-  subscriptions: Subscription[] = [];
-
-  isInheriting$ = this.form.select((values) => values.inherit_encryption);
-  isKey$ = this.form.select((values) => values.encryption_type === EncryptionType.Key);
-  isSetToGenerateKey$ = this.form.select((values) => values.generate_key);
+  // Mirrors of the three values the template branches on. Kept as signals (rather than read
+  // through getters) so the OnPush template re-evaluates when the form changes; all three are
+  // written from the single `valueChanges` subscription that also owns enabling/disabling.
+  protected readonly isInheriting = signal(false);
+  protected readonly isKeyEncryption = signal(false);
+  protected readonly isGeneratingKey = signal(false);
 
   readonly tooltips = {
     encryption_type: helptextDatasetForm.encryption.typeTooltip,
@@ -105,9 +127,7 @@ export class EncryptionOptionsDialog implements OnInit, OnDestroy {
     pbkdf2iters: helptextDatasetForm.encryption.pbkdf2itersTooltip,
   };
 
-  readonly encryptionTypeOptions$ = of(helptextDatasetForm.encryption.typeOptions);
-
-  protected readonly Role = Role;
+  protected readonly encryptionTypeOptions = helptextDatasetForm.encryption.typeOptions;
 
   get canInherit(): boolean {
     return this.data.parent?.encrypted;
@@ -132,40 +152,35 @@ export class EncryptionOptionsDialog implements OnInit, OnDestroy {
     this.setControlDependencies();
   }
 
-  ngOnDestroy(): void {
-    this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+  protected canSubmit(): boolean {
+    return this.ixForm()?.canSubmit() ?? false;
   }
 
-  onSubmit(): void {
-    if (this.form.value.inherit_encryption) {
-      // Only try to change to inherit if not currently inheriting
+  protected submit(): void {
+    this.ixForm()?.submit();
+  }
+
+  protected handleSubmit = (event: FormSubmitEvent<EncryptionOptionsFormValue>): SubmitResult => {
+    const values = event.allValues;
+
+    if (values.inherit_encryption) {
       if (!isEncryptionRoot(this.data.dataset)) {
-        this.dialogRef.close(false);
-        return;
+        // Already inheriting from the parent — there is nothing to change, so close without a
+        // request and without reporting a save that never happened.
+        return {
+          request$: of(undefined),
+          successMessage: () => null,
+          closeWith: () => false,
+        };
       }
 
-      this.setToInherit();
-    } else {
-      this.saveForm();
+      return {
+        request$: this.api
+          .call('pool.dataset.inherit_parent_encryption_properties', [this.data.dataset.id])
+          .pipe(this.loader.withLoader()),
+        successMessage: this.translate.instant('Encryption Options Saved'),
+      };
     }
-  }
-
-  private setToInherit(): void {
-    this.api.call('pool.dataset.inherit_parent_encryption_properties', [this.data.dataset.id])
-      .pipe(this.loader.withLoader(), takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: () => {
-          this.showSuccessMessage();
-          this.dialogRef.close(true);
-        },
-        error: (error: unknown) => {
-          this.formErrorHandler.handleValidationErrors(error, this.form);
-        },
-      });
-  }
-
-  private saveForm(): void {
-    const values = this.form.getRawValue();
 
     const body = {} as DatasetChangeKeyParams;
     if (values.encryption_type === EncryptionType.Key) {
@@ -178,26 +193,14 @@ export class EncryptionOptionsDialog implements OnInit, OnDestroy {
       body.pbkdf2iters = Number(values.pbkdf2iters);
     }
 
-    this.dialog.jobDialog(
-      this.api.job('pool.dataset.change_key', [this.data.dataset.id, body]),
-      { title: this.translate.instant('Updating key type') },
-    )
-      .afterClosed()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: () => {
-          this.showSuccessMessage();
-          this.dialogRef.close(true);
-        },
-        error: (error: unknown) => {
-          this.formErrorHandler.handleValidationErrors(error, this.form);
-        },
-      });
-  }
-
-  private showSuccessMessage(): void {
-    this.snackbar.success(this.translate.instant('Encryption Options Saved'));
-  }
+    return {
+      request$: this.dialog.jobDialog(
+        this.api.job('pool.dataset.change_key', [this.data.dataset.id, body]),
+        { title: this.translate.instant('Updating key type') },
+      ).afterClosed(),
+      successMessage: this.translate.instant('Encryption Options Saved'),
+    };
+  };
 
   private loadPbkdf2iters(): void {
     this.api.call('pool.dataset.query', [[['id', '=', this.data.dataset.id]]])
@@ -241,19 +244,46 @@ export class EncryptionOptionsDialog implements OnInit, OnDestroy {
       this.form.controls.encryption_type.disable();
     }
 
-    this.subscriptions.push(
-      this.form.controls.key.disabledWhile(combineLatestIsAny([
-        this.isSetToGenerateKey$,
-        this.isKey$.pipe(map((value) => !value)),
-        this.isInheriting$,
-      ])),
-    );
+    this.form.valueChanges.pipe(
+      startWith(null),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(() => this.syncControlStates());
+  }
 
-    const arePassphraseFieldsDisabled$ = combineLatestIsAny([this.isKey$, this.isInheriting$]);
-    this.subscriptions.push(
-      this.form.controls.passphrase.disabledWhile(arePassphraseFieldsDisabled$),
-      this.form.controls.confirm_passphrase.disabledWhile(arePassphraseFieldsDisabled$),
-      this.form.controls.pbkdf2iters.disabledWhile(arePassphraseFieldsDisabled$),
-    );
+  /**
+   * Only the branch of the form the user is actually filling in stays enabled, so the other
+   * branch's validators can't block Save (a half-typed passphrase must not stop a key save).
+   */
+  private syncControlStates(): void {
+    // Raw values: `encryption_type` is disabled outright when the dataset's parent or children
+    // pin the type, and it still decides which branch is in play.
+    const values = this.form.getRawValue();
+    const isInheriting = values.inherit_encryption;
+    const isKey = values.encryption_type === EncryptionType.Key;
+
+    this.isInheriting.set(isInheriting);
+    this.isKeyEncryption.set(isKey);
+    this.isGeneratingKey.set(values.generate_key);
+
+    this.setEnabled(this.form.controls.key, isKey && !values.generate_key && !isInheriting);
+
+    const arePassphraseFieldsEnabled = !isKey && !isInheriting;
+    this.setEnabled(this.form.controls.passphrase, arePassphraseFieldsEnabled);
+    this.setEnabled(this.form.controls.confirm_passphrase, arePassphraseFieldsEnabled);
+    this.setEnabled(this.form.controls.pbkdf2iters, arePassphraseFieldsEnabled);
+  }
+
+  private setEnabled(control: AbstractControl, enabled: boolean): void {
+    if (control.enabled === enabled) {
+      return;
+    }
+
+    // `emitEvent: false` — this runs from the form's own valueChanges, which would otherwise
+    // re-enter.
+    if (enabled) {
+      control.enable({ emitEvent: false });
+    } else {
+      control.disable({ emitEvent: false });
+    }
   }
 }

--- a/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.html
+++ b/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.html
@@ -38,17 +38,11 @@
       [tooltip]="tooltips.type | translate"
       [required]="true"
     >
-      <div class="radio-group" role="radiogroup" [attr.aria-label]="'ACL Type' | translate">
-        @for (option of aclTypes; track option.value) {
-          <tn-radio
-            name="type"
-            formControlName="type"
-            [value]="option.value"
-            [label]="option.label"
-            [testId]="['type', option.label]"
-          ></tn-radio>
-        }
-      </div>
+      <tn-radio-group
+        formControlName="type"
+        [options]="aclTypes"
+        [inline]="true"
+      ></tn-radio-group>
     </tn-form-field>
   </tn-form-section>
 
@@ -59,17 +53,11 @@
         [tooltip]="tooltips.permissionType | translate"
         [required]="true"
       >
-        <div class="radio-group" role="radiogroup" [attr.aria-label]="'Permissions Type' | translate">
-          @for (option of permissionTypes; track option.value) {
-            <tn-radio
-              name="permissionType"
-              formControlName="permissionType"
-              [value]="option.value"
-              [label]="option.label"
-              [testId]="['permissionType', option.label]"
-            ></tn-radio>
-          }
-        </div>
+        <tn-radio-group
+          formControlName="permissionType"
+          [options]="permissionTypes"
+          [inline]="true"
+        ></tn-radio-group>
       </tn-form-field>
       @if (arePermissionsBasic) {
         <tn-form-field
@@ -112,17 +100,11 @@
         [tooltip]="tooltips.flagsType | translate"
         [required]="true"
       >
-        <div class="radio-group" role="radiogroup" [attr.aria-label]="'Flags Type' | translate">
-          @for (option of flagTypes; track option.value) {
-            <tn-radio
-              name="flagsType"
-              formControlName="flagsType"
-              [value]="option.value"
-              [label]="option.label"
-              [testId]="['flagsType', option.label]"
-            ></tn-radio>
-          }
-        </div>
+        <tn-radio-group
+          formControlName="flagsType"
+          [options]="flagTypes"
+          [inline]="true"
+        ></tn-radio-group>
       </tn-form-field>
       @if (areFlagsBasic) {
         <tn-form-field
@@ -130,17 +112,11 @@
           [tooltip]="tooltips.basicFlag | translate"
           [required]="true"
         >
-          <div class="radio-group" role="radiogroup" [attr.aria-label]="'Flags' | translate">
-            @for (option of basicFlags; track option.value) {
-              <tn-radio
-                name="basicFlag"
-                formControlName="basicFlag"
-                [value]="option.value"
-                [label]="option.label"
-                [testId]="['basicFlag', option.label]"
-              ></tn-radio>
-            }
-          </div>
+          <tn-radio-group
+            formControlName="basicFlag"
+            [options]="basicFlags"
+            [inline]="true"
+          ></tn-radio-group>
         </tn-form-field>
       }
       @if (!areFlagsBasic) {

--- a/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.scss
+++ b/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.scss
@@ -20,20 +20,6 @@
   }
 }
 
-.radio-group {
-  align-items: flex-end;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 24px;
-
-  // TEMP: tn-radio ships a default margin-bottom; drop it so the flex gap controls
-  // spacing and the options line up evenly. Remove once @truenas/ui-components
-  // exposes spacing control on tn-radio.
-  ::ng-deep tn-radio {
-    margin-bottom: 0;
-  }
-}
-
 .checkbox-list {
   column-gap: 24px;
   display: flex;

--- a/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.ts
+++ b/src/app/pages/datasets/modules/permissions/components/edit-nfs-ace/edit-nfs-ace.component.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  TnCheckboxComponent, TnFormFieldComponent, TnFormSectionComponent, TnRadioComponent, TnSelectComponent,
+  TnCheckboxComponent, TnFormFieldComponent, TnFormSectionComponent, TnRadioGroupComponent, TnSelectComponent,
 } from '@truenas/ui-components';
 import { fromPairs } from 'lodash-es';
 import {
@@ -69,7 +69,7 @@ function booleanRecordFromLabels<T extends string>(
     TnSelectComponent,
     IxUserComboboxComponent,
     IxGroupComboboxComponent,
-    TnRadioComponent,
+    TnRadioGroupComponent,
     TnCheckboxComponent,
     TranslateModule,
   ],

--- a/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.html
+++ b/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.html
@@ -46,11 +46,11 @@
       </div>
     </tn-form-field>
 
-    <div class="label">{{ 'Flags' | translate }}</div>
-    <tn-checkbox
-      class="default-checkbox"
-      formControlName="default"
-      [label]="'Default' | translate"
-    ></tn-checkbox>
+    <tn-form-field [label]="'Flags' | translate">
+      <tn-checkbox
+        formControlName="default"
+        [label]="'Default' | translate"
+      ></tn-checkbox>
+    </tn-form-field>
   </tn-form-section>
 </form>

--- a/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.scss
+++ b/src/app/pages/datasets/modules/permissions/components/edit-posix-ace/edit-posix-ace.component.scss
@@ -5,14 +5,6 @@
   padding: 16px 24px;
 }
 
-.label {
-  margin-top: 10px;
-}
-
-.default-checkbox {
-  margin-top: 2px;
-}
-
 .checkbox-list {
   column-gap: 24px;
   display: flex;

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.html
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.html
@@ -105,7 +105,18 @@
       </tn-form-section>
     </div>
 
-    <ix-form-actions class="form-actions">
+    <div class="form-actions">
+      <ng-container *ixRequiresRoles="requiredRoles">
+        @if (canSetAcl) {
+          <tn-button
+            class="set-acl-button"
+            testId="set-acl"
+            [label]="'Set ACL' | translate"
+            (onClick)="onSetAclPressed()"
+          ></tn-button>
+        }
+      </ng-container>
+
       <tn-button
         *ixRequiresRoles="requiredRoles"
         class="save-button"
@@ -120,17 +131,6 @@
         [label]="'Cancel' | translate"
         [routerLink]="['/datasets', datasetId]"
       ></tn-button>
-
-      <ng-container *ixRequiresRoles="requiredRoles">
-        @if (canSetAcl) {
-          <tn-button
-            class="set-acl-button"
-            testId="set-acl"
-            [label]="'Set ACL' | translate"
-            (onClick)="onSetAclPressed()"
-          ></tn-button>
-        }
-      </ng-container>
-    </ix-form-actions>
+    </div>
   </ix-form>
 </tn-card>

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.html
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.html
@@ -1,4 +1,4 @@
-<tn-card class="card" [padContent]="false">
+<tn-card class="card" [padContent]="false" [fillHeight]="false">
   <ix-fake-progress-bar [loading]="isLoading()"></ix-fake-progress-bar>
 
   <div class="header">

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.html
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.html
@@ -12,7 +12,13 @@
     </div>
   </div>
 
-  <form class="form" [formGroup]="form" (submit)="onSubmit()">
+  <ix-form
+    class="form"
+    [formGroup]="form"
+    [requiredRoles]="requiredRoles"
+    [submitHandler]="handleSubmit"
+    [externalLoading]="isLoading()"
+  >
     <div class="owner-and-access">
       <tn-form-section class="owner-fields" [heading]="'Owner' | translate">
         <ix-user-combobox
@@ -99,7 +105,7 @@
       </tn-form-section>
     </div>
 
-    <div class="form-actions">
+    <ix-form-actions class="form-actions">
       <tn-button
         *ixRequiresRoles="requiredRoles"
         class="save-button"
@@ -107,7 +113,7 @@
         color="primary"
         testId="save"
         [label]="'Save' | translate"
-        [disabled]="form.invalid || isLoading()"
+        [disabled]="!canSubmit()"
       ></tn-button>
       <tn-button
         testId="cancel"
@@ -125,6 +131,6 @@
           ></tn-button>
         }
       </ng-container>
-    </div>
-  </form>
+    </ix-form-actions>
+  </ix-form>
 </tn-card>

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.scss
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.scss
@@ -95,20 +95,21 @@ ix-form.form {
   }
 }
 
-.set-acl-button {
-  margin-left: auto;
-}
-
 .form-actions {
   display: flex;
   padding: 24px;
 
-  // `ix-form-actions` right-aligns by default; this page's buttons read left-to-right from the
-  // form's left edge, with Set ACL pushed to the far right by its own `margin-left: auto`.
+  // `ix-form-actions` inherits a 10px gutter inside `.ix-form-container`; this footer sets its
+  // own padding instead so the buttons line up with the sections above.
+  column-gap: 10px;
   justify-content: flex-start;
   margin: 0;
 
-  tn-button {
-    margin-right: 10px;
+  // Set ACL leads the row and `margin-right: auto` pushes Save/Cancel to the far right.
+  // Positioned with `order` rather than template order because `ix-form-actions` always renders
+  // the projected `[type=submit]` Save in a wrapper div ahead of its default content slot.
+  .set-acl-button {
+    order: -1;
+    margin-right: auto;
   }
 }

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.scss
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.scss
@@ -95,21 +95,21 @@ ix-form.form {
   }
 }
 
+// A plain row rather than `ix-form-actions`: that component carries a 10px horizontal gutter
+// for legacy forms (which would offset the buttons from the sections above) and always renders
+// the projected `[type=submit]` ahead of its other content, which would put Save first in the
+// DOM. Here the footer owns its own padding and the buttons read in source order, so the visual
+// order matches the tab order. Save still submits natively — it sits inside `<ix-form>`'s form.
 .form-actions {
   display: flex;
+  column-gap: 10px;
+  justify-content: flex-end;
+  // Match the horizontal padding of the sections above so the buttons share their left/right edge.
   padding: 24px;
 
-  // `ix-form-actions` inherits a 10px gutter inside `.ix-form-container`; this footer sets its
-  // own padding instead so the buttons line up with the sections above.
-  column-gap: 10px;
-  justify-content: flex-start;
-  margin: 0;
-
-  // Set ACL leads the row and `margin-right: auto` pushes Save/Cancel to the far right.
-  // Positioned with `order` rather than template order because `ix-form-actions` always renders
-  // the projected `[type=submit]` Save in a wrapper div ahead of its default content slot.
+  // Set ACL leads the row; the auto margin absorbs the free space, pushing Save/Cancel right.
+  // Without the role for it the row is empty on the left and `flex-end` right-aligns the rest.
   .set-acl-button {
-    order: -1;
     margin-right: auto;
   }
 }

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.scss
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.scss
@@ -43,9 +43,9 @@
   }
 }
 
-.form {
-  // Let each section own its horizontal padding so the title, section content and footer
-  // buttons all share one left edge.
+// The `<ix-form>` wrapper renders the form element itself; each section below owns its
+// horizontal padding so the title, section content and footer buttons share one left edge.
+ix-form.form {
   display: block;
 }
 
@@ -102,6 +102,11 @@
 .form-actions {
   display: flex;
   padding: 24px;
+
+  // `ix-form-actions` right-aligns by default; this page's buttons read left-to-right from the
+  // form's left edge, with Set ACL pushed to the far right by its own `margin-left: auto`.
+  justify-content: flex-start;
+  margin: 0;
 
   tn-button {
     margin-right: 10px;

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.scss
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.scss
@@ -15,15 +15,8 @@
 }
 
 .card {
-  height: auto;
   margin: 0 auto;
   max-width: 850px;
-
-  // TEMP: tn-card's inner element is height:100% and stretches to fill the routed
-  // page height, leaving empty space below short content. Size it to content.
-  ::ng-deep .tn-card {
-    height: auto;
-  }
 }
 
 .dataset-path {

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.spec.ts
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.spec.ts
@@ -12,6 +12,7 @@ import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { DatasetAclType } from 'app/enums/dataset.enum';
 import { Dataset } from 'app/interfaces/dataset.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
+import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { StorageService } from 'app/services/storage.service';
@@ -33,6 +34,7 @@ describe('DatasetTrivialPermissionsComponent', () => {
       datasetId: 'pool/trivial',
     },
     providers: [
+      ixFormTestingProviders(),
       mockApi([
         mockCall('pool.dataset.query', [{
           acltype: {

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.ts
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.ts
@@ -18,7 +18,6 @@ import { Role } from 'app/enums/role.enum';
 import { helptextPermissions } from 'app/helptext/storage/volumes/datasets/dataset-permissions';
 import { FilesystemSetPermParams } from 'app/interfaces/filesystem-stat.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
-import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import {
   IxFormComponent, SubmitResult,
 } from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
@@ -59,7 +58,6 @@ interface AccessMode {
     IxGroupComboboxComponent,
     TnCheckboxComponent,
     RequiresRolesDirective,
-    FormActionsComponent,
     TnButtonComponent,
     RouterLink,
     TranslateModule,

--- a/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.ts
+++ b/src/app/pages/datasets/modules/permissions/containers/dataset-trivial-permissions/dataset-trivial-permissions.component.ts
@@ -1,4 +1,6 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, signal, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, signal, viewChild,
+} from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -16,12 +18,14 @@ import { Role } from 'app/enums/role.enum';
 import { helptextPermissions } from 'app/helptext/storage/volumes/datasets/dataset-permissions';
 import { FilesystemSetPermParams } from 'app/interfaces/filesystem-stat.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
+import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
+import {
+  IxFormComponent, SubmitResult,
+} from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
 import { IxGroupComboboxComponent } from 'app/modules/forms/ix-forms/components/ix-group-combobox/ix-group-combobox.component';
 import { IxUserComboboxComponent } from 'app/modules/forms/ix-forms/components/ix-user-combobox/ix-user-combobox.component';
-import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
 import { IxValidatorsService } from 'app/modules/forms/ix-forms/services/ix-validators.service';
 import { FakeProgressBarComponent } from 'app/modules/loader/components/fake-progress-bar/fake-progress-bar.component';
-import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 import { StorageService } from 'app/services/storage.service';
@@ -47,6 +51,7 @@ interface AccessMode {
     TnCardComponent,
     TnTooltipDirective,
     ReactiveFormsModule,
+    IxFormComponent,
     TnFormSectionComponent,
     TnFormFieldComponent,
     TnTestIdDirective,
@@ -54,6 +59,7 @@ interface AccessMode {
     IxGroupComboboxComponent,
     TnCheckboxComponent,
     RequiresRolesDirective,
+    FormActionsComponent,
     TnButtonComponent,
     RouterLink,
     TranslateModule,
@@ -66,13 +72,18 @@ export class DatasetTrivialPermissionsComponent implements OnInit {
   private activatedRoute = inject(ActivatedRoute);
   private api = inject(ApiService);
   private errorHandler = inject(ErrorHandlerService);
-  private formErrorHandler = inject(FormErrorHandlerService);
   private storageService = inject(StorageService);
   private translate = inject(TranslateService);
   private dialog = inject(DialogService);
   private validatorService = inject(IxValidatorsService);
-  private snackbar = inject(SnackbarService);
   private destroyRef = inject(DestroyRef);
+
+  /**
+   * The shared form wrapper owns the submit lifecycle (loading, snackbar, validation-error
+   * mapping). The action row's Save submits natively (`type="submit"` inside the wrapper's own
+   * `<form>`), so only its disabled state is read back from here.
+   */
+  private readonly ixForm = viewChild(IxFormComponent);
 
   protected readonly requiredRoles = [Role.DatasetWrite];
 
@@ -162,25 +173,24 @@ export class DatasetTrivialPermissionsComponent implements OnInit {
     });
   }
 
-  onSubmit(): void {
+  protected canSubmit(): boolean {
+    return this.ixForm()?.canSubmit() ?? false;
+  }
+
+  protected handleSubmit = (): SubmitResult => {
     const payload = this.preparePayload();
 
-    this.dialog.jobDialog(
-      this.api.job('filesystem.setperm', [payload]),
-      { title: this.translate.instant('Saving Permissions') },
-    )
-      .afterClosed()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: () => {
-          this.snackbar.success(this.translate.instant('Permissions saved.'));
-          this.router.navigate(['/datasets', this.datasetId]);
-        },
-        error: (error: unknown) => {
-          this.formErrorHandler.handleValidationErrors(error, this.form);
-        },
-      });
-  }
+    return {
+      request$: this.dialog.jobDialog(
+        this.api.job('filesystem.setperm', [payload]),
+        { title: this.translate.instant('Saving Permissions') },
+      ).afterClosed(),
+      successMessage: this.translate.instant('Permissions saved.'),
+      onSuccess: () => {
+        this.router.navigate(['/datasets', this.datasetId]);
+      },
+    };
+  };
 
   private loadPermissionsInformation(): void {
     this.isLoading.set(true);


### PR DESCRIPTION
### Scope
T9 — datasets quota / unlock / encryption / ACL editors.

The Material → `tn-*` pass for these files had **already landed**: there was zero `mat-*` or
`@angular/material` left in any of the seven when the ticket started. The work here is the other
half of the ask — putting every submittable form in the area on the shared `<ix-form>` wrapper so
they share one submit lifecycle (loading, snackbar, validation-error mapping, close), plus the
layout/spacing fixes that came out of reviewing the result.

### Forms moved onto `<ix-form>`

| Form | Host | Notes |
|---|---|---|
| `dataset-quota-add-form` | side panel | already on the wrapper (NAS-141985) — unchanged |
| `encryption-options-dialog` | `TnDialog` | second consumer of the `<ix-form>`-inside-a-dialog pattern after `replication-restore-dialog` |
| `dataset-unlock` | routed page | **first routed-page host for `<ix-form>`** |
| `dataset-trivial-permissions` | routed page | same |

`<ix-form>`'s template is now just `<form class="ix-form-container" (ngSubmit)>` + `<ng-content>`,
so it fits a routed page as well as a slide-in / panel / dialog. These two pages do **not** extend
`IxFormHostForm` — there is no host to serve; they hold a `viewChild(IxFormComponent)` and expose
`canSubmit()` for the footer button's disabled state. Save stays a native `type="submit"` inside the
wrapper's own `<form>`, so Enter-to-submit is preserved and no `submit()` delegate is needed.

### Not moved, deliberately

- **`edit-nfs-ace` / `edit-posix-ace`** are presentational: they push into `DatasetAclEditorStore` on
  every `valueChanges` and have no submit of their own. Controls-only, no wrapper — same call as the
  nvme-of namespace base form.
- **`dataset-acl-editor`** keeps its Save in `acl-editor-save-controls`, which goes through the store
  with confirmation dialogs rather than a single `request$`. That is the "keep outlier forms bespoke"
  case the `<ix-form>` docblock describes.

### Fixes that came with it

- **`edit-nfs-ace`: four hand-rolled `@for <tn-radio formControlName>` sets → `tn-radio-group`.**
  This is a real bug, not style — several standalone `tn-radio`s bound to one control leave
  `standaloneChecked` stale, so the previously-checked option keeps rendering as checked. Test-id
  parity is free at 0.7.1 (the group falls back to the control name and scopes options by label), so
  the spec's existing `radio-button-permission-type-*` selectors needed no change. Drops the
  `role="radiogroup"` wrapper divs and a `::ng-deep tn-radio { margin-bottom: 0 }` TEMP.
- **`dataset-unlock`**: card constrained to `max-width: 850px` to match the permissions editor, and
  the buttons moved into a proper right-aligned card footer with a top divider. The old page stacked
  three paddings (`tn-card` content padding + the form's own + `ix-list`'s `margin-top: 18px`),
  leaving a large empty band above the first field.
- **`dataset-trivial-permissions`**: footer buttons now align with the sections above, with Set ACL
  leading the row and Save/Cancel trailing right. Uses a plain row rather than `ix-form-actions` —
  that component carries a 10px horizontal gutter for legacy forms and force-projects `[type=submit]`
  ahead of its other content, which would have put Save first in the DOM. Source order now matches
  visual order, so tab order does too.
- **`dataset-form` preset box**: the checkbox/SMB-name fields had no gap at all — the block is a
  single direct child of `tn-form-section`, whose `gap` only spaces *its* children.
- **Retired a TEMP**: `::ng-deep .tn-card { height: auto }` replaced with the library's supported
  `[fillHeight]="false"` input on both cards.