### PR TITLE
NAS-142746 / 27.0.0-BETA.1 / Align master-detail layouts on Apps, Containers, Audit and Users

### DIFF
--- a/src/app/modules/master-detail-view/master-detail-view.component.scss
+++ b/src/app/modules/master-detail-view/master-detail-view.component.scss
@@ -84,3 +84,21 @@
     width: 100%;
   }
 }
+
+// The master list sizes to its content instead of stretching to the details column's
+// height. The details column is given an explicit viewport-based height (ixDetailsHeight),
+// and the row's default `align-items: stretch` made the master card match it — leaving a
+// large empty card below the last row whenever the list is short. Hugging the content
+// keeps the card ending at its last row; a list taller than the viewport still scrolls
+// with the page (same approach as the datasets tree, see dataset-management.component.scss).
+.table-container {
+  align-self: flex-start;
+}
+
+// Collapse the detail-header row when the page projects no title into it (Installed Apps
+// shows one only in mobile view). The empty h3 still reserved ~30px, which pushed the
+// details cards below the top of the master card; hiding it lines both columns up.
+// The mobile back button lives in the same row, so keep the row whenever it is rendered.
+.header-container:not(:has(ix-mobile-back-button)):has(.header:empty) {
+  display: none;
+}

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.html
@@ -161,7 +161,7 @@
       <tn-button
         *ixRequiresRoles="requiredRoles"
         variant="outline"
-        color="warn"
+        color="default"
         [testId]="[app().name, 'delete']"
         [label]="'Delete' | translate"
         (onClick)="deleteButtonPressed()"

--- a/src/app/pages/apps/components/installed-apps/app-state-cell/app-state-cell.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-state-cell/app-state-cell.component.scss
@@ -17,12 +17,16 @@
     }
   }
 
+  // Sized to its label, not to the table cell, and never wrapped: a stretched, two-line
+  // chip was the result inside the narrow Status column.
   &.has-cell {
     border: 1px solid transparent;
     border-radius: 20px;
+    display: inline-flex;
     font-weight: bold;
     gap: 6px;
-    padding: 3px 8px;
+    padding: 3px 6px;
+    white-space: nowrap;
   }
 
   &.running {

--- a/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-workloads-card/app-workloads-card.component.scss
@@ -58,14 +58,21 @@
 .container {
   align-items: center;
   display: flex;
+  // The card is narrow, so a long service name leaves the state with only a few pixels.
+  // Let the row break onto a second line instead of squeezing its parts.
+  flex-wrap: wrap;
   gap: 8px;
 
   .service-name {
     font-weight: 500;
   }
 
+  // The details-cards mixin sets `word-break: break-word` on the whole panel, which chopped
+  // the state into "Runnin" / "g". A state label is one word — it moves to the next line
+  // whole or not at all.
   .container-state {
     flex: 1;
+    word-break: keep-all;
   }
 
   .container-action {

--- a/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.html
+++ b/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.html
@@ -1,7 +1,5 @@
-<div class="table-header">
-  <h2>{{ 'Applications' | translate }}</h2>
-
-  @if (hasCheckedApps) {
+@if (hasCheckedApps) {
+  <div class="table-header">
     <ix-installed-apps-list-bulk-actions
       [checkedApps]="checkedApps()"
       (bulkStart)="onBulkStart()"
@@ -9,8 +7,8 @@
       (bulkUpdate)="onBulkUpdate()"
       (bulkDelete)="onBulkDelete()"
     ></ix-installed-apps-list-bulk-actions>
-  }
-</div>
+  </div>
+}
 
 <div class="item-search">
   <ix-fake-progress-bar
@@ -50,14 +48,14 @@
     (rowClick)="viewDetails($event)"
     (selectionChange)="onSelectionChange($event)"
   >
-    <ng-container [tnColumnDef]="sortableField.Application" [sortable]="true" [width]="'20%'">
+    <ng-container [tnColumnDef]="sortableField.Application" [sortable]="true" [width]="'18%'">
       <ng-template tnHeaderCellDef>{{ 'Application' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
         <div class="name-cell">
           <div class="app-logo">
             <img [src]="row.metadata.icon" [src-fallback]="imagePlaceholder" />
           </div>
-          <div class="app-name">{{ row.name }}</div>
+          <div class="app-name" [tnTooltip]="row.name">{{ row.name }}</div>
           <ix-app-action-required-badge
             [app]="row"
             (actionRequiredClicked)="showActionRequired(row)"
@@ -66,7 +64,7 @@
       </ng-template>
     </ng-container>
 
-    <ng-container [tnColumnDef]="sortableField.State" [sortable]="true" [width]="'12%'">
+    <ng-container [tnColumnDef]="sortableField.State" [sortable]="true" [width]="'13%'">
       <ng-template tnHeaderCellDef>{{ 'Status' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
         <ix-app-state-cell
@@ -91,13 +89,16 @@
       </ng-template>
     </ng-container>
 
-    <ng-container [tnColumnDef]="'ram'" [width]="'8%'">
+    <ng-container [tnColumnDef]="'ram'" [width]="'12%'">
       <ng-template tnHeaderCellDef>{{ 'RAM' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
         @let ramStats = getAppStats(row.name) | async;
-        <span [tnTooltip]="'Memory usage of app' | translate">
+        <span [tnTooltip]="hasStats(row, ramStats)
+          ? (ramStats.memory | ixFileSize)
+          : ('Memory usage of app' | translate)"
+        >
           @if (hasStats(row, ramStats)) {
-            {{ ramStats.memory | ixFileSize }}
+            <span class="stat-part">{{ ramStats.memory | ixFileSize }}</span>
           } @else {
             {{ 'N/A' | translate }}
           }
@@ -105,13 +106,19 @@
       </ng-template>
     </ng-container>
 
-    <ng-container [tnColumnDef]="'io'" [width]="'11%'">
+    <ng-container [tnColumnDef]="'io'" [width]="'12%'">
       <ng-template tnHeaderCellDef>{{ 'Block I/O' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
         @let ioStats = getAppStats(row.name) | async;
-        <span [tnTooltip]="'Block I/O read and writes' | translate">
+        <span [tnTooltip]="hasStats(row, ioStats)
+          ? (ioStats.blkio.read | ixFileSize) + ' - ' + (ioStats.blkio.write | ixFileSize)
+          : ('Block I/O read and writes' | translate)"
+        >
           @if (hasStats(row, ioStats)) {
-            {{ ioStats.blkio.read | ixFileSize }} - {{ ioStats.blkio.write | ixFileSize }}
+            <span class="stat-pair">
+              <span class="stat-part">{{ ioStats.blkio.read | ixFileSize }}</span>
+              <span class="stat-part">- {{ ioStats.blkio.write | ixFileSize }}</span>
+            </span>
           } @else {
             {{ 'N/A' | translate }}
           }
@@ -119,13 +126,19 @@
       </ng-template>
     </ng-container>
 
-    <ng-container [tnColumnDef]="'network'" [width]="'11%'">
+    <ng-container [tnColumnDef]="'network'" [width]="'15%'">
       <ng-template tnHeaderCellDef>{{ 'Network' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
         @let networkStats = getAppStats(row.name) | async;
-        <span [tnTooltip]="'Incoming / Outgoing network traffic' | translate">
+        <span [tnTooltip]="hasStats(row, networkStats) && networkStats.networks?.length
+          ? (incomingTrafficBits(networkStats) | ixNetworkSpeed) + ' - ' + (outgoingTrafficBits(networkStats) | ixNetworkSpeed)
+          : ('Incoming / Outgoing network traffic' | translate)"
+        >
           @if (hasStats(row, networkStats) && networkStats.networks?.length) {
-            {{ incomingTrafficBits(networkStats) | ixNetworkSpeed }} - {{ outgoingTrafficBits(networkStats) | ixNetworkSpeed }}
+            <span class="stat-pair">
+              <span class="stat-part">{{ incomingTrafficBits(networkStats) | ixNetworkSpeed }}</span>
+              <span class="stat-part">- {{ outgoingTrafficBits(networkStats) | ixNetworkSpeed }}</span>
+            </span>
           } @else {
             {{ 'N/A' | translate }}
           }
@@ -133,7 +146,7 @@
       </ng-template>
     </ng-container>
 
-    <ng-container [tnColumnDef]="sortableField.Updates" [sortable]="hasUpdates" [width]="'14%'">
+    <ng-container [tnColumnDef]="sortableField.Updates" [sortable]="hasUpdates" [width]="'15%'">
       <ng-template tnHeaderCellDef>
         <span class="updates-header">
           {{ 'Updates' | translate }}
@@ -153,7 +166,7 @@
       </ng-template>
     </ng-container>
 
-    <ng-container [tnColumnDef]="'controls'" [width]="'12%'">
+    <ng-container [tnColumnDef]="'controls'" [width]="'10%'">
       <ng-template tnHeaderCellDef>{{ 'Controls' | translate }}</ng-template>
       <ng-template let-row tnCellDef>
         <div class="controls-cell">

--- a/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.scss
+++ b/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.scss
@@ -1,27 +1,26 @@
 @import 'mixins/text';
 
+// Only rendered while rows are checked (bulk actions). Padded to line up with the
+// search field below it, which the shared master-detail layout pads by 16px.
 .table-header {
   align-items: flex-end;
   color: var(--fg1);
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 12px;
-  min-height: 56px;
-
-  h2 {
-    align-items: center;
-    display: flex;
-    margin-top: 20px;
-    min-height: 36px;
-  }
-}
-
-.item-search {
-  margin-bottom: 8px;
+  justify-content: flex-end;
+  padding: 16px 16px 0;
 }
 
 .apps-table {
-  font-size: 12px;
+  // The table fits the master pane (no horizontal scroll), so a long value wraps rather
+  // than being cut short — but only at a space, never mid-word: tn-table's
+  // `.tn-table__cell-content` sets `overflow-wrap: anywhere`, which is what broke
+  // "779.57 kb/s - 779.57 kb/s" into "779.57 kb" / "/s - 779." fragments. Reset it and the
+  // value falls onto a second line at its separator instead. The column widths below are
+  // sized so that second line is the most any cell needs.
+  ::ng-deep .tn-table__cell-content {
+    overflow-wrap: normal;
+    word-break: normal;
+  }
 
   // TEMP: tn-table has no cell-density/font-size input, so the compact spacing the
   // apps table needs is applied by reaching into the private `.tn-table__cell` /
@@ -30,8 +29,14 @@
   ::ng-deep .tn-table__cell,
   ::ng-deep .tn-table__header-cell {
     font-size: 13px;
-    padding-left: 3px;
-    padding-right: 3px;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+
+  // Column labels are never worth wrapping — "Block I/O" on two lines would deepen the
+  // header row for every table width.
+  ::ng-deep .tn-table__header-cell {
+    white-space: nowrap;
   }
 
   // TEMP: tn-table has no selection-column width/padding input, so the checkbox
@@ -41,9 +46,24 @@
   // (NAS-141021 library follow-up).
   ::ng-deep .tn-table__select-cell {
     padding-left: 14px;
-    padding-right: 0;
-    width: 30px;
+    padding-right: 6px;
+    width: 38px;
   }
+}
+
+// A stat is made of parts that must stay whole — "226.92 MiB", or the incoming and outgoing
+// halves of a Block I/O / Network pair.
+.stat-part {
+  white-space: nowrap;
+}
+
+// The two halves of a pair sit on their own lines, always. Left to the line breaker the cell
+// was 1, 2 or 3 lines depending on the reading (the separator is its own break opportunity,
+// so "549.48 kb/s" / "-" / "536.45 kb/s" was reachable), and the row height flickered with
+// the numbers. Two fixed lines: each half whole, and the row keeps still.
+.stat-pair {
+  display: flex;
+  flex-direction: column;
 }
 
 .name-cell {
@@ -67,6 +87,8 @@
     }
   }
 
+  // Wraps onto a second line like the other cells (usually at a hyphen), rather than being
+  // trimmed. The clamp caps it at two lines — beyond that the cell's tooltip has the rest.
   .app-name {
     @include line-clamp(2);
     font-weight: bold;

--- a/src/app/pages/audit/components/log-details-panel/log-details-panel.component.scss
+++ b/src/app/pages/audit/components/log-details-panel/log-details-panel.component.scss
@@ -48,4 +48,20 @@
 
 .cards {
   @include details-cards();
+
+  // The shared mixin lays the cards out with CSS multi-column. With only two cards the
+  // browser kept both in the first column and grew the panel instead of balancing them,
+  // so half the details panel sat empty. A grid places them side by side as soon as
+  // there is room for a second column, and collapses to one column when there isn't.
+  .scroll-window {
+    align-items: start;
+    columns: unset;
+    display: grid;
+    gap: $gap;
+    grid-template-columns: repeat(auto-fill, minmax($card-width-slim, 1fr));
+
+    > *:not(:last-child) {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/src/app/pages/containers/components/all-containers/container-list/container-list.component.html
+++ b/src/app/pages/containers/components/all-containers/container-list/container-list.component.html
@@ -1,11 +1,11 @@
-<div class="table-header">
-  @if (hasCheckedContainers) {
+@if (hasCheckedContainers) {
+  <div class="table-header">
     <ix-container-list-bulk-actions
       [checkedContainers]="checkedContainers()"
       (resetBulkSelection)="resetSelection()"
     ></ix-container-list-bulk-actions>
-  }
-</div>
+  </div>
+}
 
 <div class="item-search">
   <ix-fake-progress-bar

--- a/src/app/pages/containers/components/all-containers/container-list/container-list.component.scss
+++ b/src/app/pages/containers/components/all-containers/container-list/container-list.component.scss
@@ -17,12 +17,14 @@
     z-index: 3;
   }
 
+  // Only rendered while rows are checked (bulk actions). Padded to line up with the
+  // search field below it, which the shared master-detail layout pads by 16px.
   .table-header {
     align-items: flex-end;
     color: var(--fg1);
     display: flex;
     justify-content: flex-end;
-    padding: 13px 0;
+    padding: 16px 16px 0;
   }
 
   .controls-cell {

--- a/src/app/pages/credentials/users/all-users/all-users.component.scss
+++ b/src/app/pages/credentials/users/all-users/all-users.component.scss
@@ -13,12 +13,6 @@
       margin: 0;
     }
   }
-
-  .table-container {
-    flex: 2;
-    margin-right: 0;
-    max-width: 100%;
-  }
 }
 
 .item-search {

--- a/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.ts
+++ b/src/app/pages/datasets/components/dataset-form/sections/name-and-options-section/name-and-options-section.component.ts
@@ -162,7 +162,7 @@ export class NameAndOptionsSectionComponent implements OnInit, OnChanges {
     }) || []).filter((name): name is string => name !== undefined);
 
     this.form.controls.name.addValidators([
-      datasetNameTooLong(parent.name),
+      datasetNameTooLong(parent.name, this.translate),
       forbiddenValues(namesInUse, isNameCaseInsensitive),
     ]);
   }

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
@@ -4,7 +4,9 @@ import { maxDatasetPath } from 'app/constants/dataset.constants';
 import { datasetNameTooLong } from 'app/pages/datasets/components/dataset-form/utils/name-length-validation';
 
 describe('datasetNameTooLong', () => {
-  const translate = { instant: (key: string) => key } as TranslateService;
+  const translate = {
+    instant: (key: string, params?: Record<string, unknown>) => key.replace('{max}', String(params?.max)),
+  } as TranslateService;
   const parentPath = '/mnt/tank';
   // The parent path and the '/' are spent already, and the whole path stays under the max.
   const longestAllowedName = maxDatasetPath - parentPath.length - 2;
@@ -46,7 +48,7 @@ describe('datasetNameTooLong', () => {
     expect(validator(new FormControl('d'))).toEqual({
       maxlength: {
         requiredLength: 0,
-        message: 'The parent path is already at the maximum length, so no name will fit.',
+        message: 'The parent path already fills the 200 character limit for a dataset path, so nothing can be created under it.',
       },
     });
   });

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
@@ -1,14 +1,16 @@
 import { FormControl } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
 import { maxDatasetPath } from 'app/constants/dataset.constants';
 import { datasetNameTooLong } from 'app/pages/datasets/components/dataset-form/utils/name-length-validation';
 
 describe('datasetNameTooLong', () => {
+  const translate = { instant: (key: string) => key } as TranslateService;
   const parentPath = '/mnt/tank';
   // The parent path and the '/' are spent already, and the whole path stays under the max.
   const longestAllowedName = maxDatasetPath - parentPath.length - 2;
 
   it('allows a name that keeps the whole path within the maximum', () => {
-    const validator = datasetNameTooLong(parentPath);
+    const validator = datasetNameTooLong(parentPath, translate);
 
     expect(validator(new FormControl(''))).toBeNull();
     expect(validator(new FormControl('a'))).toBeNull();
@@ -16,7 +18,7 @@ describe('datasetNameTooLong', () => {
   });
 
   it('rejects a name that pushes the path over the maximum', () => {
-    const validator = datasetNameTooLong(parentPath);
+    const validator = datasetNameTooLong(parentPath, translate);
 
     expect(validator(new FormControl('a'.repeat(longestAllowedName + 1)))).toEqual({
       maxlength: {
@@ -28,7 +30,7 @@ describe('datasetNameTooLong', () => {
   it('reports the length it actually enforces, so a name of that length passes', () => {
     // A parent path long enough that the name gets a single character.
     const nearlyFullPath = 'a'.repeat(maxDatasetPath - 3);
-    const validator = datasetNameTooLong(nearlyFullPath);
+    const validator = datasetNameTooLong(nearlyFullPath, translate);
 
     expect(validator(new FormControl('d'))).toBeNull();
     expect(validator(new FormControl('dd'))).toEqual({
@@ -38,18 +40,19 @@ describe('datasetNameTooLong', () => {
     });
   });
 
-  it('reports no room at all when the parent path leaves none', () => {
-    const validator = datasetNameTooLong('a'.repeat(maxDatasetPath - 2));
+  it('says the parent path has no room left, rather than "no more than 0"', () => {
+    const validator = datasetNameTooLong('a'.repeat(maxDatasetPath - 2), translate);
 
     expect(validator(new FormControl('d'))).toEqual({
       maxlength: {
         requiredLength: 0,
+        message: 'The parent path is already at the maximum length, so no name will fit.',
       },
     });
   });
 
   it('ignores an empty name or a missing parent path', () => {
-    expect(datasetNameTooLong(parentPath)(new FormControl(''))).toBeNull();
-    expect(datasetNameTooLong('')(new FormControl('name'))).toBeNull();
+    expect(datasetNameTooLong(parentPath, translate)(new FormControl(''))).toBeNull();
+    expect(datasetNameTooLong('', translate)(new FormControl('name'))).toBeNull();
   });
 });

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
@@ -48,9 +48,19 @@ describe('datasetNameTooLong', () => {
     expect(validator(new FormControl('d'))).toEqual({
       maxlength: {
         requiredLength: 0,
-        message: 'The parent path already fills the 200 character limit for a dataset path, so nothing can be created under it.',
+        // 199, not 200: the check rejects at `>=`, so that is the longest path it accepts.
+        message: 'The parent path is too long to fit a dataset name under it: a dataset path can be at most 199 characters.',
       },
     });
+  });
+
+  it('quotes a limit that the longest accepted path actually reaches', () => {
+    const parent = '/mnt/tank';
+    const validator = datasetNameTooLong(parent, translate);
+    const longestName = 'a'.repeat(maxDatasetPath - parent.length - 2);
+
+    expect(validator(new FormControl(longestName))).toBeNull();
+    expect(`${parent}/${longestName}`).toHaveLength(maxDatasetPath - 1);
   });
 
   it('ignores an empty name or a missing parent path', () => {

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.spec.ts
@@ -3,16 +3,53 @@ import { maxDatasetPath } from 'app/constants/dataset.constants';
 import { datasetNameTooLong } from 'app/pages/datasets/components/dataset-form/utils/name-length-validation';
 
 describe('datasetNameTooLong', () => {
-  it('takes path and returns a validator that makes sure that dataset path is less than maximum', () => {
-    const parentPath = '/mnt/tank';
+  const parentPath = '/mnt/tank';
+  // The parent path and the '/' are spent already, and the whole path stays under the max.
+  const longestAllowedName = maxDatasetPath - parentPath.length - 2;
+
+  it('allows a name that keeps the whole path within the maximum', () => {
     const validator = datasetNameTooLong(parentPath);
 
     expect(validator(new FormControl(''))).toBeNull();
     expect(validator(new FormControl('a'))).toBeNull();
-    expect(validator(new FormControl('a'.repeat(maxDatasetPath - parentPath.length - 1)))).toEqual({
+    expect(validator(new FormControl('a'.repeat(longestAllowedName)))).toBeNull();
+  });
+
+  it('rejects a name that pushes the path over the maximum', () => {
+    const validator = datasetNameTooLong(parentPath);
+
+    expect(validator(new FormControl('a'.repeat(longestAllowedName + 1)))).toEqual({
       maxlength: {
-        requiredLength: 191,
+        requiredLength: longestAllowedName,
       },
     });
+  });
+
+  it('reports the length it actually enforces, so a name of that length passes', () => {
+    // A parent path long enough that the name gets a single character.
+    const nearlyFullPath = 'a'.repeat(maxDatasetPath - 3);
+    const validator = datasetNameTooLong(nearlyFullPath);
+
+    expect(validator(new FormControl('d'))).toBeNull();
+    expect(validator(new FormControl('dd'))).toEqual({
+      maxlength: {
+        requiredLength: 1,
+      },
+    });
+  });
+
+  it('reports no room at all when the parent path leaves none', () => {
+    const validator = datasetNameTooLong('a'.repeat(maxDatasetPath - 2));
+
+    expect(validator(new FormControl('d'))).toEqual({
+      maxlength: {
+        requiredLength: 0,
+      },
+    });
+  });
+
+  it('ignores an empty name or a missing parent path', () => {
+    expect(datasetNameTooLong(parentPath)(new FormControl(''))).toBeNull();
+    expect(datasetNameTooLong('')(new FormControl('name'))).toBeNull();
   });
 });

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
@@ -28,12 +28,17 @@ export function datasetNameTooLong(parentPath: string, translate: TranslateServi
       // "no more than 0" is not a length anyone can aim for: the parent path has spent the
       // whole budget, and nothing will fit under it. Say that instead — a custom `message`
       // takes precedence over the generic maxlength wording in both error renderers.
+      //
+      // The limit quoted here is the longest path that passes, which is one less than
+      // `maxDatasetPath`: the check rejects at `>=`, so `<parent>/<name>` may reach 199
+      // characters, not 200. Don't claim the parent "fills" that limit either — this
+      // branch fires from 198 characters up, before the parent has reached it.
       return {
         [DefaultValidationError.MaxLength]: {
           requiredLength: 0,
           message: translate.instant(
-            T('The parent path already fills the {max} character limit for a dataset path, so nothing can be created under it.'),
-            { max: maxDatasetPath },
+            T('The parent path is too long to fit a dataset name under it: a dataset path can be at most {max} characters.'),
+            { max: maxDatasetPath - 1 },
           ),
         },
       };

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
@@ -26,13 +26,14 @@ export function datasetNameTooLong(parentPath: string, translate: TranslateServi
 
     if (maxNameLength === 0) {
       // "no more than 0" is not a length anyone can aim for: the parent path has spent the
-      // whole budget, and no name will fit under it. Say that instead — a custom `message`
+      // whole budget, and nothing will fit under it. Say that instead — a custom `message`
       // takes precedence over the generic maxlength wording in both error renderers.
       return {
         [DefaultValidationError.MaxLength]: {
           requiredLength: 0,
           message: translate.instant(
-            T('The parent path is already at the maximum length, so no name will fit.'),
+            T('The parent path already fills the {max} character limit for a dataset path, so nothing can be created under it.'),
+            { max: maxDatasetPath },
           ),
         },
       };

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
@@ -3,16 +3,24 @@ import { maxDatasetPath } from 'app/constants/dataset.constants';
 import { DefaultValidationError } from 'app/enums/default-validation-error.enum';
 
 export function datasetNameTooLong(parentPath: string): ValidatorFn {
-  const maxLengthAllowed = maxDatasetPath;
-
   return function datasetNameTooLongValidate(control: FormControl<string>) {
     if (!control.value || !parentPath) {
       return null;
     }
 
-    if (parentPath.length + 1 + control.value.length >= maxLengthAllowed) {
+    // What the name may still spend of the `<parent>/<name>` budget: the parent path and
+    // the separator are already gone, and the whole thing has to stay under maxDatasetPath
+    // (the same `>=` boundary the two other path-length checks use).
+    //
+    // This number is quoted back to the user in the maxlength message, so it has to be the
+    // limit that is actually enforced. Reporting `maxDatasetPath - parentPath.length`
+    // promised two characters more than the check allowed: with a 198-character parent the
+    // field said "no more than 2" and then rejected a one-character name.
+    const maxNameLength = Math.max(0, maxDatasetPath - parentPath.length - 2);
+
+    if (control.value.length > maxNameLength) {
       return {
-        [DefaultValidationError.MaxLength]: { requiredLength: maxLengthAllowed - parentPath.length },
+        [DefaultValidationError.MaxLength]: { requiredLength: maxNameLength },
       };
     }
 

--- a/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
+++ b/src/app/pages/datasets/components/dataset-form/utils/name-length-validation.ts
@@ -1,8 +1,10 @@
 import { FormControl, ValidatorFn } from '@angular/forms';
+import { marker as T } from '@biesbjerg/ngx-translate-extract-marker';
+import { TranslateService } from '@ngx-translate/core';
 import { maxDatasetPath } from 'app/constants/dataset.constants';
 import { DefaultValidationError } from 'app/enums/default-validation-error.enum';
 
-export function datasetNameTooLong(parentPath: string): ValidatorFn {
+export function datasetNameTooLong(parentPath: string, translate: TranslateService): ValidatorFn {
   return function datasetNameTooLongValidate(control: FormControl<string>) {
     if (!control.value || !parentPath) {
       return null;
@@ -18,12 +20,26 @@ export function datasetNameTooLong(parentPath: string): ValidatorFn {
     // field said "no more than 2" and then rejected a one-character name.
     const maxNameLength = Math.max(0, maxDatasetPath - parentPath.length - 2);
 
-    if (control.value.length > maxNameLength) {
+    if (control.value.length <= maxNameLength) {
+      return null;
+    }
+
+    if (maxNameLength === 0) {
+      // "no more than 0" is not a length anyone can aim for: the parent path has spent the
+      // whole budget, and no name will fit under it. Say that instead — a custom `message`
+      // takes precedence over the generic maxlength wording in both error renderers.
       return {
-        [DefaultValidationError.MaxLength]: { requiredLength: maxNameLength },
+        [DefaultValidationError.MaxLength]: {
+          requiredLength: 0,
+          message: translate.instant(
+            T('The parent path is already at the maximum length, so no name will fit.'),
+          ),
+        },
       };
     }
 
-    return null;
+    return {
+      [DefaultValidationError.MaxLength]: { requiredLength: maxNameLength },
+    };
   };
 }

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
@@ -64,10 +64,10 @@ ix-dataset-details-panel {
   // Its width is synced (in TS) to the tree's full content width so it still scrolls in
   // step with the rows when the content genuinely can't fit. Below $breakpoint-hidden a
   // trailing column reserves space for the row's mobile chevron.
-  grid-template-columns: auto 100px 100px 100px 100px;
+  grid-template-columns: minmax($tree-name-min-width, 1fr) 100px 100px 100px 100px;
 
   @media (max-width: $breakpoint-hidden) {
-    grid-template-columns: auto 100px 100px 100px 100px 40px;
+    grid-template-columns: minmax($tree-name-min-width, 1fr) 100px 100px 100px 100px 40px;
   }
 
   @media (max-width: $breakpoint-tablet) {

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
@@ -64,10 +64,10 @@ ix-dataset-details-panel {
   // Its width is synced (in TS) to the tree's full content width so it still scrolls in
   // step with the rows when the content genuinely can't fit. Below $breakpoint-hidden a
   // trailing column reserves space for the row's mobile chevron.
-  grid-template-columns: minmax($tree-name-min-width, 1fr) 100px 100px 100px 100px;
+  grid-template-columns: minmax(0, 1fr) 100px 100px 100px 100px;
 
   @media (max-width: $breakpoint-hidden) {
-    grid-template-columns: minmax($tree-name-min-width, 1fr) 100px 100px 100px 100px 40px;
+    grid-template-columns: minmax(0, 1fr) 100px 100px 100px 100px 40px;
   }
 
   @media (max-width: $breakpoint-tablet) {

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
@@ -74,15 +74,6 @@ ix-dataset-details-panel {
     grid-template-columns: auto 0 0 0 0 0;
   }
 
-  // The rows pin their name cell to the left edge while the value columns scroll under it;
-  // the header's own name cell is counter-translated (in TS) to stay over them, so it needs
-  // to be opaque and above the labels sliding past.
-  > div:first-child {
-    background: var(--bg1);
-    position: relative;
-    z-index: 1;
-  }
-
   .available-header {
     display: flex;
     flex-direction: column;
@@ -169,10 +160,7 @@ ix-dataset-details-panel {
   .tn-tree-node__text {
     display: flex;
     align-items: center;
-    // `clip`, not `hidden`: both clip the row identically, but `hidden` makes this box a
-    // scroll container, and that leaves `position: sticky` on the row's name cell inert —
-    // the names scrolled away with the rest of the row instead of pinning to the left edge.
-    overflow: clip;
+    overflow: hidden;
   }
 
   .dataset-node-click {

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.scss
@@ -74,6 +74,15 @@ ix-dataset-details-panel {
     grid-template-columns: auto 0 0 0 0 0;
   }
 
+  // The rows pin their name cell to the left edge while the value columns scroll under it;
+  // the header's own name cell is counter-translated (in TS) to stay over them, so it needs
+  // to be opaque and above the labels sliding past.
+  > div:first-child {
+    background: var(--bg1);
+    position: relative;
+    z-index: 1;
+  }
+
   .available-header {
     display: flex;
     flex-direction: column;
@@ -160,7 +169,10 @@ ix-dataset-details-panel {
   .tn-tree-node__text {
     display: flex;
     align-items: center;
-    overflow: hidden;
+    // `clip`, not `hidden`: both clip the row identically, but `hidden` makes this box a
+    // scroll container, and that leaves `position: sticky` on the row's name cell inert —
+    // the names scrolled away with the rest of the row instead of pinning to the left edge.
+    overflow: clip;
   }
 
   .dataset-node-click {

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -269,14 +269,6 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit {
       // mixin's `overflow: visible` so it isn't collapsed, and translateX tracks the
       // wrapper's horizontal scroll to keep the column labels above their rows.
       treeHeader.style.transform = `translateX(${-tree.scrollLeft}px)`;
-      // The rows pin their name cell to the left edge (`position: sticky`), so the header's
-      // name cell has to stay put too: undo the shift above for that one cell. It can't use
-      // `position: sticky` itself — the header sits outside the scrolling wrapper, so it has
-      // no scrollport to stick to.
-      const nameHeader = treeHeader.firstElementChild as HTMLElement | null;
-      if (nameHeader) {
-        nameHeader.style.transform = `translateX(${tree.scrollLeft}px)`;
-      }
     }
   }
 

--- a/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
+++ b/src/app/pages/datasets/components/dataset-management/dataset-management.component.ts
@@ -269,6 +269,14 @@ export class DatasetsManagementComponent implements OnInit, AfterViewInit {
       // mixin's `overflow: visible` so it isn't collapsed, and translateX tracks the
       // wrapper's horizontal scroll to keep the column labels above their rows.
       treeHeader.style.transform = `translateX(${-tree.scrollLeft}px)`;
+      // The rows pin their name cell to the left edge (`position: sticky`), so the header's
+      // name cell has to stay put too: undo the shift above for that one cell. It can't use
+      // `position: sticky` itself — the header sits outside the scrolling wrapper, so it has
+      // no scrollport to stick to.
+      const nameHeader = treeHeader.firstElementChild as HTMLElement | null;
+      if (nameHeader) {
+        nameHeader.style.transform = `translateX(${tree.scrollLeft}px)`;
+      }
     }
   }
 

--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
@@ -59,6 +59,13 @@
     // margin: 0 0 0 -10px;
     // padding: 0 0 0 10px;
     z-index: 1;
+
+    // The name cell is pinned (`position: sticky` above), so the value columns scroll
+    // underneath it — it has to paint over them, not tie with them on z-index and lose on
+    // source order. Its gradient is what hides them.
+    &:first-child {
+      z-index: 2;
+    }
   }
 
   // The shared tree styles give `.name` `text-overflow: ellipsis`, but they also make it an

--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
@@ -20,11 +20,11 @@
   // icons) never need more than ~80px — so the row fits the tree column without forcing
   // a horizontal scrollbar when the details panel is open.
   //
-  // The name column is `minmax($tree-name-min-width, 1fr)`: `1fr` hands it every spare
-  // pixel of the row, so a name that fits is shown in full and only a longer one
-  // ellipsizes, while the floor keeps it readable on a narrow row — there the grid
-  // outgrows the tree and scrolls horizontally, as it did before.
-  grid-template-columns: minmax($tree-name-min-width, 1fr) 100px 100px 100px 100px;
+  // The name column is `minmax(0, 1fr)`: `1fr` hands it every spare pixel of the row, so
+  // a name that fits is shown in full and only a longer one ellipsizes. The `0` floor is
+  // what keeps that free — a floor in px would exceed the whole row on a laptop, where the
+  // fixed columns already claim 440px of it, and put a horizontal scrollbar under the tree.
+  grid-template-columns: minmax(0, 1fr) 100px 100px 100px 100px;
   min-width: fit-content;
   width: 100%;
 

--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
@@ -59,13 +59,6 @@
     // margin: 0 0 0 -10px;
     // padding: 0 0 0 10px;
     z-index: 1;
-
-    // The name cell is pinned (`position: sticky` above), so the value columns scroll
-    // underneath it — it has to paint over them, not tie with them on z-index and lose on
-    // source order. Its gradient is what hides them.
-    &:first-child {
-      z-index: 2;
-    }
   }
 
   // The shared tree styles give `.name` `text-overflow: ellipsis`, but they also make it an

--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
@@ -18,10 +18,13 @@
   // Fixed value columns (must match .tree-header exactly so the header labels stay
   // aligned over the columns). Kept narrow — the values (sizes, "Unencrypted", usage
   // icons) never need more than ~80px — so the row fits the tree column without forcing
-  // a horizontal scrollbar when the details panel is open. The name column (auto) still
-  // grows and the tree scrolls only when the content genuinely can't fit (very long
-  // names / deep nesting).
-  grid-template-columns: auto 100px 100px 100px 100px;
+  // a horizontal scrollbar when the details panel is open.
+  //
+  // The name column is `minmax($tree-name-min-width, 1fr)`: `1fr` hands it every spare
+  // pixel of the row, so a name that fits is shown in full and only a longer one
+  // ellipsizes, while the floor keeps it readable on a narrow row — there the grid
+  // outgrows the tree and scrolls horizontally, as it did before.
+  grid-template-columns: minmax($tree-name-min-width, 1fr) 100px 100px 100px 100px;
   min-width: fit-content;
   width: 100%;
 

--- a/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
+++ b/src/app/pages/datasets/components/dataset-node/dataset-node.component.scss
@@ -58,6 +58,15 @@
     z-index: 1;
   }
 
+  // The shared tree styles give `.name` `text-overflow: ellipsis`, but they also make it an
+  // inline-flex box, and ellipsis only applies to a block container's own inline content —
+  // so a truncated dataset name was clipped mid-glyph. A dataset name is plain text, so it
+  // can be a block; `align-self` keeps it centred in the stretched cell.
+  .cell-name .name {
+    align-self: center;
+    display: block;
+  }
+
   .cell-used span,
   .cell-available span {
     white-space: nowrap;

--- a/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
+++ b/src/app/pages/datasets/components/zvol-form/zvol-form.component.ts
@@ -552,7 +552,7 @@ export class ZvolFormComponent extends IxFormHostForm<Dataset> implements OnInit
     }) || []).filter((name): name is string => name !== undefined);
 
     this.form.controls.name.addValidators([
-      datasetNameTooLong(parent.name),
+      datasetNameTooLong(parent.name, this.translate),
       forbiddenValues(namesInUse, isCaseInsensitive),
     ]);
   }

--- a/src/app/pages/storage/modules/vdevs/components/topology-item-node/topology-item-node.component.scss
+++ b/src/app/pages/storage/modules/vdevs/components/topology-item-node/topology-item-node.component.scss
@@ -53,6 +53,16 @@
       display: inline-flex;
       gap: 6px;
       padding-right: 15px;
+
+      // The shared tree styles cap and clip `.name`, but ellipsis needs a block container
+      // and this one is a flex box (it also holds the descendant-warning icon), so put the
+      // truncation on the text itself. Without this a capped name is cut mid-glyph.
+      > span {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
 
     .descendant-warning-icon {

--- a/src/app/pages/storage/modules/vdevs/components/topology-item-node/topology-item-node.component.scss
+++ b/src/app/pages/storage/modules/vdevs/components/topology-item-node/topology-item-node.component.scss
@@ -13,7 +13,7 @@
   align-items: center;
   display: grid;
   grid-gap: 8px;
-  grid-template-columns: auto 125px 125px 125px;
+  grid-template-columns: minmax($tree-name-min-width, 1fr) 125px 125px 125px;
   min-width: fit-content;
   width: 100%;
 

--- a/src/app/pages/storage/modules/vdevs/components/topology-item-node/topology-item-node.component.scss
+++ b/src/app/pages/storage/modules/vdevs/components/topology-item-node/topology-item-node.component.scss
@@ -13,7 +13,7 @@
   align-items: center;
   display: grid;
   grid-gap: 8px;
-  grid-template-columns: minmax($tree-name-min-width, 1fr) 125px 125px 125px;
+  grid-template-columns: minmax(0, 1fr) 125px 125px 125px;
   min-width: fit-content;
   width: 100%;
 
@@ -54,9 +54,9 @@
       gap: 6px;
       padding-right: 15px;
 
-      // The shared tree styles cap and clip `.name`, but ellipsis needs a block container
+      // The name cell is clipped by its grid track, but ellipsis needs a block container
       // and this one is a flex box (it also holds the descendant-warning icon), so put the
-      // truncation on the text itself. Without this a capped name is cut mid-glyph.
+      // truncation on the text itself. Without this a clipped name is cut mid-glyph.
       > span {
         min-width: 0;
         overflow: hidden;

--- a/src/app/pages/storage/modules/vdevs/components/vdevs-list/vdevs-list.component.scss
+++ b/src/app/pages/storage/modules/vdevs/components/vdevs-list/vdevs-list.component.scss
@@ -126,7 +126,7 @@
 // The .sticky-header ancestor out-specifies the parent component's host-scoped
 // copies of the mixin rules.
 .sticky-header .tree-header {
-  grid-template-columns: minmax($tree-name-min-width, 1fr) 125px 125px 125px;
+  grid-template-columns: minmax(0, 1fr) 125px 125px 125px;
   padding-left: 41px;
   padding-right: 9px;
 

--- a/src/app/pages/storage/modules/vdevs/components/vdevs-list/vdevs-list.component.scss
+++ b/src/app/pages/storage/modules/vdevs/components/vdevs-list/vdevs-list.component.scss
@@ -126,7 +126,7 @@
 // The .sticky-header ancestor out-specifies the parent component's host-scoped
 // copies of the mixin rules.
 .sticky-header .tree-header {
-  grid-template-columns: auto 125px 125px 125px;
+  grid-template-columns: minmax($tree-name-min-width, 1fr) 125px 125px 125px;
   padding-left: 41px;
   padding-right: 9px;
 

--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -15,8 +15,13 @@
   }
 
   .scroll-window {
-    columns: calc(50vw / 2.7);
-    gap: 8px;
+    // A fixed column width, not a slice of the viewport: the old `calc(50vw / 2.7)` grew the
+    // cards with the screen (711px columns at 2560px), so a card holding "Type: Built-In" was
+    // mostly empty space. The width is the ideal, and the browser stretches the columns to
+    // fill the panel, so the card size is really capped by the details panel's own max-width
+    // (see tree-node-with-details-container in mixins/layout.scss).
+    columns: $card-width-slim;
+    gap: $gap;
 
     @media (max-width: $breakpoint-tablet) {
       columns: 1;
@@ -24,7 +29,6 @@
     }
 
     @media (min-width: $breakpoint-tablet) and (max-width: $breakpoint-md) {
-      columns: calc(50vw / 1.5);
       padding: 0 16px;
     }
 

--- a/src/assets/styles/mixins/cards.scss
+++ b/src/assets/styles/mixins/cards.scss
@@ -28,6 +28,11 @@
       padding: 0 16px;
     }
 
+    // The mobile overlay, where the panel is the full window. No column width of its own
+    // any more: `$card-width-slim` applies here too, so the overlay lays out the same cards
+    // as the docked panel does. Near the top of this band that is the narrower column — the
+    // old `calc(50vw / 1.5)` was 426px at 1279px — so just under $breakpoint-md the overlay
+    // now fits three columns where it used to fit two. At 768px both give two.
     @media (min-width: $breakpoint-tablet) and (max-width: $breakpoint-md) {
       padding: 0 16px;
     }

--- a/src/assets/styles/mixins/layout.scss
+++ b/src/assets/styles/mixins/layout.scss
@@ -63,14 +63,11 @@ $scrollbar-offset: 20px;
       max-width: $singlecolumn-max-width;
     }
 
-    // Two Cards Columns
-    @media (min-width: $breakpoint-dualcolumn-slim) and (max-width: calc($breakpoint-dualcolumn - 1px)) {
+    // Two Cards Columns. This is as wide as the details panel ever gets: the cards hold
+    // short label/value rows, so past two slim columns they only get emptier. Every extra
+    // pixel goes to the master table instead.
+    @media (min-width: $breakpoint-dualcolumn-slim) {
       max-width: ($dualcolumn-slim-max-width + $scrollbar-offset);
-    }
-
-    // Two Cards Columns
-    @media (min-width: $breakpoint-dualcolumn) {
-      max-width: 70%;
     }
   }
 
@@ -267,26 +264,11 @@ $scrollbar-offset: 20px;
       min-width: calc($table-min-width + 0px);
     }
 
-    // Two Cards Slim Columns
-    @media (min-width: $breakpoint-dualcolumn-slim) and (max-width: calc($breakpoint-dualcolumn - 1px)) {
+    // Two Cards Slim Columns. The details panel stops growing here, so the table takes
+    // the whole remainder no matter how wide the screen gets.
+    @media (min-width: $breakpoint-dualcolumn-slim) {
       max-width: calc(100% - $dualcolumn-slim-max-width - 16px - $scrollbar-offset);
       min-width: calc($table-min-width + 0px);
-    }
-
-    // Two Cards Columns
-    @media (min-width: $breakpoint-dualcolumn) and (max-width: calc($breakpoint-flex - 1px)) {
-      min-width: calc(98% - 2 * ($card-width + $gap));
-    }
-
-    // Three Cards Columns
-    @media (min-width: $breakpoint-triplecolumn) and (max-width: calc($breakpoint-flex - 1px)) {
-      min-width: calc(98% - 3 * ($card-width + $gap));
-    }
-
-    // Cards spill to the right
-    @media (min-width: $breakpoint-flex) {
-      max-width: 1200px;
-      width: 50%;
     }
   }
 }

--- a/src/assets/styles/mixins/layout.scss
+++ b/src/assets/styles/mixins/layout.scss
@@ -220,7 +220,11 @@ $scrollbar-offset: 20px;
         .name {
           align-items: center;
           display: inline-flex;
-          max-width: calc(100vw - 80vw);
+          // A fixed cap, not the old `calc(100vw - 80vw)` (= 20vw): that grew the name with
+          // the screen, so one long name took 512px of the row at 2560px. Past the cap the
+          // name ellipsizes and the tree scrolls horizontally; the full name is in the row
+          // tooltip.
+          max-width: $tree-name-max-width;
           overflow: hidden;
           padding-right: 15px;
           text-overflow: ellipsis;

--- a/src/assets/styles/mixins/layout.scss
+++ b/src/assets/styles/mixins/layout.scss
@@ -139,7 +139,7 @@ $scrollbar-offset: 20px;
     color: var(--fg2);
     display: grid;
     grid-gap: 8px;
-    grid-template-columns: minmax($tree-name-min-width, 1fr) 125px 125px 125px 40px;
+    grid-template-columns: minmax(0, 1fr) 125px 125px 125px 40px;
     min-height: 40px;
     min-width: fit-content;
     min-width: 100%;
@@ -152,7 +152,7 @@ $scrollbar-offset: 20px;
     }
 
     @media (min-width: $breakpoint-singlecolumn) {
-      grid-template-columns: minmax($tree-name-min-width, 1fr) 125px 125px 125px;
+      grid-template-columns: minmax(0, 1fr) 125px 125px 125px;
     }
 
     > div {
@@ -210,8 +210,8 @@ $scrollbar-offset: 20px;
         align-items: stretch;
         font-weight: bold;
         margin: 0;
-        // Both let the name shrink to its grid track instead of pushing past it; the track
-        // (see $tree-name-min-width) is what decides how wide a name may get.
+        // Both let the name shrink to its grid track instead of pushing past it; the
+        // `minmax(0, 1fr)` track is what decides how wide a name may get.
         min-width: 0;
         padding: 0;
 

--- a/src/assets/styles/mixins/layout.scss
+++ b/src/assets/styles/mixins/layout.scss
@@ -139,7 +139,7 @@ $scrollbar-offset: 20px;
     color: var(--fg2);
     display: grid;
     grid-gap: 8px;
-    grid-template-columns: auto 125px 125px 125px 40px;
+    grid-template-columns: minmax($tree-name-min-width, 1fr) 125px 125px 125px 40px;
     min-height: 40px;
     min-width: fit-content;
     min-width: 100%;
@@ -152,7 +152,7 @@ $scrollbar-offset: 20px;
     }
 
     @media (min-width: $breakpoint-singlecolumn) {
-      grid-template-columns: auto 125px 125px 125px;
+      grid-template-columns: minmax($tree-name-min-width, 1fr) 125px 125px 125px;
     }
 
     > div {
@@ -210,6 +210,9 @@ $scrollbar-offset: 20px;
         align-items: stretch;
         font-weight: bold;
         margin: 0;
+        // Both let the name shrink to its grid track instead of pushing past it; the track
+        // (see $tree-name-min-width) is what decides how wide a name may get.
+        min-width: 0;
         padding: 0;
 
         .icon-container {
@@ -220,11 +223,7 @@ $scrollbar-offset: 20px;
         .name {
           align-items: center;
           display: inline-flex;
-          // A fixed cap, not the old `calc(100vw - 80vw)` (= 20vw): that grew the name with
-          // the screen, so one long name took 512px of the row at 2560px. Past the cap the
-          // name ellipsizes and the tree scrolls horizontally; the full name is in the row
-          // tooltip.
-          max-width: $tree-name-max-width;
+          min-width: 0;
           overflow: hidden;
           padding-right: 15px;
           text-overflow: ellipsis;

--- a/src/assets/styles/scss-imports/variables.scss
+++ b/src/assets/styles/scss-imports/variables.scss
@@ -4,6 +4,10 @@
 $table-min-width: 620px;
 $table-width: 700px;
 $card-width-slim: 356px;
+// How wide a tree row's name (dataset, vdev) may get before it ellipsizes. Past this the
+// row keeps its full width and the tree scrolls horizontally, rather than the name being
+// squeezed to whatever is left over.
+$tree-name-max-width: 360px;
 $gap: 8px;
 $breakpoint-min-mobile: 320px;
 

--- a/src/assets/styles/scss-imports/variables.scss
+++ b/src/assets/styles/scss-imports/variables.scss
@@ -3,7 +3,6 @@
 // TreeTable - Cards split view breakpoints & other variables
 $table-min-width: 620px;
 $table-width: 700px;
-$card-width: 455px;
 $card-width-slim: 356px;
 $gap: 8px;
 $breakpoint-min-mobile: 320px;
@@ -15,7 +14,6 @@ $breakpoint-tablet: 767px;
 $breakpoint-singlecolumn: $breakpoint-md;
 $breakpoint-dualcolumn-slim: 1680px;
 $breakpoint-dualcolumn: $breakpoint-lg;
-$breakpoint-triplecolumn: 2500px;
 $breakpoint-flex: 3132px;
 $breakpoint-hidden: calc($breakpoint-singlecolumn - 1px);
 

--- a/src/assets/styles/scss-imports/variables.scss
+++ b/src/assets/styles/scss-imports/variables.scss
@@ -4,10 +4,11 @@
 $table-min-width: 620px;
 $table-width: 700px;
 $card-width-slim: 356px;
-// How wide a tree row's name (dataset, vdev) may get before it ellipsizes. Past this the
-// row keeps its full width and the tree scrolls horizontally, rather than the name being
-// squeezed to whatever is left over.
-$tree-name-max-width: 360px;
+// Floor for a tree row's name column (dataset, vdev). The column takes whatever width the
+// row has spare, so a name that fits is shown in full; it only ellipsizes once it is longer
+// than that. When the row can't even give it this much, the column keeps the floor and the
+// tree scrolls horizontally instead of squeezing the name away.
+$tree-name-min-width: 360px;
 $gap: 8px;
 $breakpoint-min-mobile: 320px;
 

--- a/src/assets/styles/scss-imports/variables.scss
+++ b/src/assets/styles/scss-imports/variables.scss
@@ -4,11 +4,6 @@
 $table-min-width: 620px;
 $table-width: 700px;
 $card-width-slim: 356px;
-// Floor for a tree row's name column (dataset, vdev). The column takes whatever width the
-// row has spare, so a name that fits is shown in full; it only ellipsizes once it is longer
-// than that. When the row can't even give it this much, the column keeps the floor and the
-// tree scrolls horizontally instead of squeezing the name away.
-$tree-name-min-width: 360px;
 $gap: 8px;
 $breakpoint-min-mobile: 320px;
 


### PR DESCRIPTION
Layout polish across the pages that use the shared master-detail view, so they read the same way the Datasets page does.

https://github.com/user-attachments/assets/94cbff90-4747-40ba-8485-080f54409d95

### Shared master-detail view
- The master card sizes to its content instead of stretching to the details column's height. The details column gets an explicit viewport height from `ixDetailsHeight`, and the row's default `align-items: stretch` matched the card to it, leaving a large empty card below the last row whenever the list was short.
- The detail-header row collapses when a page projects no title into it (Installed Apps shows one only in mobile view), so both columns start on the same line.

### Apps — Installed
- Dropped the "Applications" heading; the card starts with the search field. The bulk-actions header now renders only while rows are checked, padded to line up with the search field.
- Table fits the master pane at every width — no horizontal scroll — and row height no longer changes as the stats tick. Each half of a Block I/O / Network pair is an unbreakable `.stat-part` inside a `.stat-pair` flex column, so the cell is exactly two lines for any value; previously the separator was its own break opportunity and the cell flipped between one, two and three lines.
- Names wrap at the hyphen rather than being cut, with the full name on the cell's tooltip; RAM, Block I/O and Network tooltips now carry the value.
- Selection column widened to 38px — the 18px checkbox was being clipped by the library's `overflow: hidden`.
- Detail panel's Delete button is outlined/default instead of red, matching Containers and the rest of the app.
- Workloads "Containers" rows wrap onto a second line instead of chopping a state into `Runnin` / `g` (the details-cards mixin sets `word-break: break-word` panel-wide).

### Containers
- Same header treatment: the bulk-actions row only exists when rows are checked, which removes the extra padding above the search field.

### Audit
- Details cards lay out in two columns. The shared mixin uses CSS multi-column, which kept both cards in the first column and grew the container instead of balancing them, leaving half the panel empty; the panel now uses a grid that collapses back to one column when narrow.

### Users
- Removed the `:host ::ng-deep .table-container` width override. It had the same specificity as the shared layout mixin's rule, so which one won depended on stylesheet insertion order: the page rendered at 1458px after a client-side navigation and 704px after a reload. The mixin's width now holds in both cases.