### PR TITLE
NAS-142383 / 27.0.0-BETA.1 / Migrate apps wizard, settings and custom app forms to theshared ix-form wrapper

### DIFF
--- a/src/app/pages/apps/components/app-wizard/app-wizard.component.html
+++ b/src/app/pages/apps/components/app-wizard/app-wizard.component.html
@@ -15,7 +15,14 @@
           [autocompleteOptions]="searchOptions"
         ></ix-input>
       </div>
-      <form [formGroup]="form" (submit)="onSubmit()">
+      <ix-form
+        [formGroup]="form"
+        [isEditMode]="!isNew"
+        [requiredRoles]="requiredRoles"
+        [submitHandler]="handleSubmit"
+        [extraDisabled]="isLoading"
+        [suppressSuccessSnackbar]="true"
+      >
         <ix-dynamic-wizard
           [dynamicSection]="dynamicSection"
           [dynamicForm]="form"
@@ -33,10 +40,10 @@
             color="primary"
             testId="save"
             [label]="isNew ? ('Install' | translate) : ('Update' | translate)"
-            [disabled]="form.invalid || isLoading"
+            [disabled]="!canSubmit()"
           ></tn-button>
         </div>
-      </form>
+      </ix-form>
     </div>
 
     @if (appsLoaded) {

--- a/src/app/pages/apps/components/app-wizard/app-wizard.component.scss
+++ b/src/app/pages/apps/components/app-wizard/app-wizard.component.scss
@@ -4,6 +4,12 @@
   display: flex;
 }
 
+// The `<ix-form>` wrapper renders the form element itself, and its host is inline by default —
+// give it a block box so the wizard column keeps its width.
+ix-form {
+  display: block;
+}
+
 .wizard-container {
   width: 80%;
 

--- a/src/app/pages/apps/components/app-wizard/app-wizard.component.spec.ts
+++ b/src/app/pages/apps/components/app-wizard/app-wizard.component.spec.ts
@@ -16,6 +16,7 @@ import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { ChartFormValue, App, ChartSchemaNodeConf } from 'app/interfaces/app.interface';
 import { CatalogApp, CatalogAppVersion } from 'app/interfaces/catalog.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
+import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { PageHeaderComponent } from 'app/modules/page-header/page-title-header/page-header.component';
 import { UnsavedChangesService } from 'app/modules/unsaved-changes/unsaved-changes.service';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -288,6 +289,7 @@ describe('AppWizardComponent', () => {
       mockProvider(TnDialog),
     ],
     providers: [
+      ...ixFormTestingProviders(),
       provideTnFormFieldErrors(),
       mockProvider(DialogService, {
         jobDialog: jest.fn(() => ({
@@ -361,12 +363,13 @@ describe('AppWizardComponent', () => {
       });
     });
 
-    it('editing when form is submitted', () => {
+    it('editing when form is submitted', async () => {
       spectator.component.form.patchValue({
         timezone: 'Europe/Paris',
       });
 
-      spectator.component.onSubmit();
+      const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Update' }));
+      await saveButton.click();
 
       expect(spectator.inject(DialogService).jobDialog).toHaveBeenCalled();
       expect(spectator.inject(ApiService).job).toHaveBeenCalledWith(
@@ -512,7 +515,8 @@ describe('AppWizardComponent', () => {
       const version = await loader.getHarness(TnSelectHarness.with({ displayText: /Version:/ }));
       await version.selectOption('Version: 0.9.0 / Revision: 1.2.0');
 
-      spectator.component.onSubmit();
+      const saveButton = await loader.getHarness(TnButtonHarness.with({ label: 'Install' }));
+      await saveButton.click();
 
       expect(spectator.inject(DialogService).jobDialog).toHaveBeenCalled();
       expect(spectator.inject(ApiService).job).toHaveBeenCalledWith(

--- a/src/app/pages/apps/components/app-wizard/app-wizard.component.ts
+++ b/src/app/pages/apps/components/app-wizard/app-wizard.component.ts
@@ -1,6 +1,6 @@
 import { AsyncPipe } from '@angular/common';
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnDestroy, OnInit,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnDestroy, OnInit, viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
@@ -49,6 +49,7 @@ import { CustomUntypedFormField } from 'app/modules/forms/ix-dynamic-form/compon
 import {
   IxDynamicWizardComponent,
 } from 'app/modules/forms/ix-dynamic-form/components/ix-dynamic-wizard/ix-dynamic-wizard.component';
+import { IxFormComponent, SubmitResult } from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
 import { ReadOnlyComponent } from 'app/modules/forms/ix-forms/components/readonly-badge/readonly-badge.component';
 import { IxValidatorsService } from 'app/modules/forms/ix-forms/services/ix-validators.service';
@@ -73,6 +74,7 @@ import { AppSchemaService } from 'app/services/schema/app-schema.service';
   imports: [
     PageHeaderComponent,
     ReadOnlyComponent,
+    IxFormComponent,
     IxInputComponent,
     AppMetadataCardComponent,
     TnButtonComponent,
@@ -102,6 +104,8 @@ export class AppWizardComponent implements OnInit, OnDestroy {
   private tnDialog = inject(TnDialog);
   private unsavedChangesService = inject(UnsavedChangesService);
   private destroyRef = inject(DestroyRef);
+
+  private readonly ixForm = viewChild(IxFormComponent);
 
   appId: string;
   train: string;
@@ -248,23 +252,18 @@ export class AppWizardComponent implements OnInit, OnDestroy {
     }
   }
 
-  onSubmit(): void {
-    const data = this.appSchemaService.serializeFormValue(this.form.getRawValue(), this.chartSchema) as ChartFormValues;
-
-    const deleteField$ = new Subject<string>();
-    deleteField$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: (fieldToBeDeleted) => {
-        const keys = fieldToBeDeleted.split('.');
-        unset(data, keys);
-      },
-      complete: () => this.saveData(data),
-    });
-
-    this.getFieldsHiddenOnForm(data, deleteField$);
-    deleteField$.complete();
+  /** Whether the wrapping `<ix-form>` will accept a submit right now; drives the Install/Update button. */
+  protected canSubmit(): boolean {
+    return this.ixForm()?.canSubmit() ?? false;
   }
 
-  private saveData(data: ChartFormValues): void {
+  /**
+   * Installing/updating runs behind the job dialog, which reports progress and the outcome itself
+   * and is followed by a navigation to the installed app — hence `suppressSuccessSnackbar` and a
+   * null success message.
+   */
+  protected handleSubmit = (): SubmitResult => {
+    const data = this.buildPayload();
     let job$: Observable<Job<App>>;
 
     if (this.isNew) {
@@ -287,20 +286,40 @@ export class AppWizardComponent implements OnInit, OnDestroy {
       ]);
     }
 
-    this.dialogService.jobDialog(job$, {
-      title: this.isNew
-        ? this.translate.instant(helptextApps.installing)
-        : this.translate.instant(helptextApps.updating),
-    })
-      .afterClosed()
-      .pipe(
-        this.errorHandler.withErrorHandler(),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe(() => this.onSuccess());
+    return {
+      request$: this.dialogService.jobDialog(job$, {
+        title: this.isNew
+          ? this.translate.instant(helptextApps.installing)
+          : this.translate.instant(helptextApps.updating),
+      })
+        .afterClosed()
+        .pipe(this.errorHandler.withErrorHandler()),
+      successMessage: null,
+      onSuccess: () => this.onSuccess(),
+    };
+  };
+
+  /**
+   * Serializes the form and drops the fields the schema currently hides. `hidden$` answers
+   * synchronously, so the subject is drained and torn down before the payload is returned.
+   */
+  private buildPayload(): ChartFormValues {
+    const data = this.appSchemaService.serializeFormValue(this.form.getRawValue(), this.chartSchema) as ChartFormValues;
+
+    const deleteField$ = new Subject<string>();
+    const subscription = deleteField$.subscribe((fieldToBeDeleted) => {
+      const keys = fieldToBeDeleted.split('.');
+      unset(data, keys);
+    });
+
+    this.getFieldsHiddenOnForm(data, deleteField$);
+    deleteField$.complete();
+    subscription.unsubscribe();
+
+    return data;
   }
 
-  onSuccess(): void {
+  private onSuccess(): void {
     this.form.markAsPristine();
     this.dialogService.closeAllDialogs();
     this.router.navigate(['/apps/installed', this.train, this.appId]);

--- a/src/app/pages/apps/components/catalog-settings/apps-settings.component.html
+++ b/src/app/pages/apps/components/catalog-settings/apps-settings.component.html
@@ -1,4 +1,9 @@
-<form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
+<ix-form
+  [formGroup]="form"
+  [requiredRoles]="requiredRoles"
+  [submitHandler]="handleSubmit"
+  (closed)="closed.emit($event)"
+>
   <tn-form-section>
     <ix-checkbox-list
       class="trains"
@@ -94,4 +99,4 @@
       ></tn-checkbox>
     </tn-form-field>
   </tn-form-section>
-</form>
+</ix-form>

--- a/src/app/pages/apps/components/catalog-settings/apps-settings.component.spec.ts
+++ b/src/app/pages/apps/components/catalog-settings/apps-settings.component.spec.ts
@@ -17,6 +17,7 @@ import {
 } from 'app/modules/forms/ix-forms/components/ix-ip-input-with-netmask/ix-ip-input-with-netmask.component';
 import { IxListHarness } from 'app/modules/forms/ix-forms/components/ix-list/ix-list.harness';
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
+import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { AppsSettingsComponent } from 'app/pages/apps/components/catalog-settings/apps-settings.component';
@@ -27,6 +28,7 @@ function getNvidiaProviders(
   nvidiaPresent: boolean,
 ): unknown[] {
   return [
+    ...ixFormTestingProviders(),
     mockApi([
       mockCall('catalog.update'),
       mockCall('catalog.trains', ['stable', 'community', 'test']),
@@ -74,6 +76,7 @@ describe('AppsSettingsComponent', () => {
       IxIpInputWithNetmaskComponent,
     ],
     providers: [
+      ...ixFormTestingProviders(),
       mockApi([
         mockCall('catalog.update'),
         mockCall('catalog.trains', ['stable', 'community', 'test']),

--- a/src/app/pages/apps/components/catalog-settings/apps-settings.component.ts
+++ b/src/app/pages/apps/components/catalog-settings/apps-settings.component.ts
@@ -1,7 +1,6 @@
 import {
-  ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit, signal,
+  ChangeDetectionStrategy, Component, inject, OnInit, signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   FormArray, FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators,
 } from '@angular/forms';
@@ -13,7 +12,6 @@ import {
 import {
   combineLatest,
   filter,
-  finalize,
   forkJoin,
   take,
 } from 'rxjs';
@@ -22,19 +20,41 @@ import { singleArrayToOptions } from 'app/helpers/operators/options.operators';
 import { helptextApps } from 'app/helptext/apps/apps';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
 import { IxCheckboxListComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox-list/ix-checkbox-list.component';
+import { IxFormHostForm } from 'app/modules/forms/ix-forms/components/ix-form/ix-form-host-form.directive';
+import {
+  FormSubmitEvent, IxFormComponent, SubmitResult,
+} from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
 import { IxIpInputWithNetmaskComponent } from 'app/modules/forms/ix-forms/components/ix-ip-input-with-netmask/ix-ip-input-with-netmask.component';
 import { IxListItemComponent } from 'app/modules/forms/ix-forms/components/ix-list/ix-list-item/ix-list-item.component';
 import { IxListComponent } from 'app/modules/forms/ix-forms/components/ix-list/ix-list.component';
-import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
 import { ipv4or6cidrValidator } from 'app/modules/forms/ix-forms/validators/ip-validation';
 import { UrlValidationService } from 'app/modules/forms/ix-forms/validators/url-validation.service';
-import { SidePanelForm } from 'app/modules/slide-ins/side-panel-form.directive';
-import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { DockerStore } from 'app/pages/apps/store/docker.store';
 import { AppState } from 'app/store';
 import { advancedConfigUpdated } from 'app/store/system-config/system-config.actions';
+
+// Built here rather than inline in the component, and left with an inferred return type — see
+// the `V` type parameter on IxFormHostForm for why.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function createAppsSettingsForm(formBuilder: FormBuilder) {
+  return formBuilder.nonNullable.group({
+    preferred_trains: [[] as string[], Validators.required],
+    nvidia: [false],
+    enable_image_updates: [true],
+    address_pools: new FormArray<FormGroup<{
+      base: FormControl<string>;
+      size: FormControl<number | null>;
+    }>>([]),
+    registry_mirrors: new FormArray<FormGroup<{
+      url: FormControl<string>;
+      insecure: FormControl<boolean>;
+    }>>([]),
+  });
+}
+
+type AppsSettingsFormValue = ReturnType<ReturnType<typeof createAppsSettingsForm>['getRawValue']>;
 
 @Component({
   selector: 'ix-apps-settings',
@@ -42,6 +62,7 @@ import { advancedConfigUpdated } from 'app/store/system-config/system-config.act
   styleUrls: ['./apps-settings.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    IxFormComponent,
     ReactiveFormsModule,
     TnFormSectionComponent,
     IxCheckboxListComponent,
@@ -58,37 +79,18 @@ import { advancedConfigUpdated } from 'app/store/system-config/system-config.act
     DockerStore,
   ],
 })
-export class AppsSettingsComponent extends SidePanelForm implements OnInit {
+export class AppsSettingsComponent extends IxFormHostForm<boolean, AppsSettingsFormValue> implements OnInit {
   private dockerStore = inject(DockerStore);
   private api = inject(ApiService);
   private store$ = inject<Store<AppState>>(Store);
-  private errorHandler = inject(FormErrorHandlerService);
   private fb = inject(FormBuilder);
-  private snackbar = inject(SnackbarService);
   private translate = inject(TranslateService);
   private urlValidationService = inject(UrlValidationService);
-  private destroyRef = inject(DestroyRef);
 
-  readonly isFormLoading = signal(false);
   protected showNvidiaCheckbox = signal(false);
   readonly requiredRoles = [Role.AppsWrite, Role.CatalogWrite];
 
-  protected readonly form = this.fb.nonNullable.group({
-    preferred_trains: [[] as string[], Validators.required],
-    nvidia: [false],
-    enable_image_updates: [true],
-    address_pools: new FormArray<FormGroup<{
-      base: FormControl<string>;
-      size: FormControl<number | null>;
-    }>>([]),
-    registry_mirrors: new FormArray<FormGroup<{
-      url: FormControl<string>;
-      insecure: FormControl<boolean>;
-    }>>([]),
-  });
-
-  /** Public signal hosts can read to disable a Save action while invalid or loading. */
-  readonly canSubmit = this.trackCanSubmit(this.isFormLoading);
+  protected readonly form = createAppsSettingsForm(this.fb);
 
   protected allTrains$ = this.api.call('catalog.trains').pipe(
     singleArrayToOptions(),
@@ -100,30 +102,30 @@ export class AppsSettingsComponent extends SidePanelForm implements OnInit {
     registry_mirrors: helptextApps.settingsForm.registryMirrors.generalTooltip,
   };
 
-  get mirrorsCount(): number {
-    return this.form.controls.registry_mirrors.length;
-  }
-
   constructor() {
     super();
     this.dockerStore.initialize();
   }
 
   ngOnInit(): void {
-    this.setupForm();
+    this.loadConfig();
   }
 
-  setupForm(): void {
-    this.isFormLoading.set(true);
-    combineLatest([
-      this.api.call('catalog.config'),
-      this.dockerStore.dockerConfig$.pipe(filter(Boolean), take(1)),
-      this.api.call('system.advanced.nvidia_present'),
-      this.api.call('system.advanced.config'),
-    ])
-      .pipe(finalize(() => this.isFormLoading.set(false)), takeUntilDestroyed(this.destroyRef))
-      .subscribe(([catalogConfig, dockerConfig, hasNvidiaCard, advancedConfig]) => {
+  private loadConfig(): void {
+    this.loadFormConfig(
+      combineLatest([
+        this.api.call('catalog.config'),
+        this.dockerStore.dockerConfig$.pipe(filter(Boolean), take(1)),
+        this.api.call('system.advanced.nvidia_present'),
+        this.api.call('system.advanced.config'),
+      ]),
+      ([catalogConfig, dockerConfig, hasNvidiaCard, advancedConfig]) => {
         this.showNvidiaCheckbox.set(hasNvidiaCard || advancedConfig.nvidia);
+
+        // `patch` replays on retry, so rebuild the rows instead of appending to the ones a
+        // previous attempt already pushed.
+        this.form.controls.address_pools.clear();
+        this.form.controls.registry_mirrors.clear();
 
         dockerConfig.address_pools.forEach(() => {
           this.addAddressPool();
@@ -143,7 +145,8 @@ export class AppsSettingsComponent extends SidePanelForm implements OnInit {
           address_pools: dockerConfig.address_pools,
           registry_mirrors: dockerConfig.registry_mirrors || [],
         });
-      });
+      },
+    );
   }
 
   protected addAddressPool(): void {
@@ -175,41 +178,25 @@ export class AppsSettingsComponent extends SidePanelForm implements OnInit {
     this.form.controls.registry_mirrors.removeAt(index);
   }
 
-  protected onSubmit(): void {
-    if (!this.canSubmit()) {
-      return;
-    }
-
-    const values = this.form.getRawValue();
-
-    this.isFormLoading.set(true);
-    forkJoin([
-      this.api.call('catalog.update', [{ preferred_trains: values.preferred_trains }]),
+  protected handleSubmit = ({ allValues }: FormSubmitEvent<AppsSettingsFormValue>): SubmitResult => ({
+    request$: forkJoin([
+      this.api.call('catalog.update', [{ preferred_trains: allValues.preferred_trains }]),
       this.api.job('docker.update', [{
-        enable_image_updates: values.enable_image_updates,
-        address_pools: values.address_pools,
-        registry_mirrors: values.registry_mirrors,
+        enable_image_updates: allValues.enable_image_updates,
+        address_pools: allValues.address_pools,
+        registry_mirrors: allValues.registry_mirrors,
       }]),
       ...(this.showNvidiaCheckbox()
-        ? [this.api.call('system.advanced.update', [{ nvidia: values.nvidia }])]
+        ? [this.api.call('system.advanced.update', [{ nvidia: allValues.nvidia }])]
         : []),
-    ])
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: () => {
-          this.isFormLoading.set(false);
-          if (this.showNvidiaCheckbox()) {
-            this.store$.dispatch(advancedConfigUpdated());
-          }
-          this.snackbar.success(this.translate.instant('Settings saved'));
-          this.close(true);
-        },
-        error: (error: unknown) => {
-          this.isFormLoading.set(false);
-          this.errorHandler.handleValidationErrors(error, this.form);
-        },
-      });
-  }
+    ]),
+    successMessage: this.translate.instant('Settings saved'),
+    onSuccess: () => {
+      if (this.showNvidiaCheckbox()) {
+        this.store$.dispatch(advancedConfigUpdated());
+      }
+    },
+  });
 
   protected readonly helptext = helptextApps;
 }

--- a/src/app/pages/apps/components/custom-app-form/custom-app-form.component.html
+++ b/src/app/pages/apps/components/custom-app-form/custom-app-form.component.html
@@ -1,7 +1,10 @@
-<form
-  class="ix-form-container"
+<ix-form
   [formGroup]="form"
-  (submit)="onSubmit()"
+  [isEditMode]="!isNew"
+  [requiredRoles]="requiredRoles"
+  [submitHandler]="handleSubmit"
+  [suppressSuccessSnackbar]="true"
+  (closed)="closed.emit($event)"
 >
   <tn-form-section>
     <tn-form-field [label]="'Name' | translate" [required]="true">
@@ -21,4 +24,4 @@
       [required]="true"
     ></ix-code-editor>
   </tn-form-section>
-</form>
+</ix-form>

--- a/src/app/pages/apps/components/custom-app-form/custom-app-form.component.spec.ts
+++ b/src/app/pages/apps/components/custom-app-form/custom-app-form.component.spec.ts
@@ -14,6 +14,7 @@ import { App, ChartFormValue } from 'app/interfaces/app.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxCodeEditorComponent } from 'app/modules/forms/ix-forms/components/ix-code-editor/ix-code-editor.component';
 import { IxCodeEditorHarness } from 'app/modules/forms/ix-forms/components/ix-code-editor/ix-code-editor.harness';
+import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { PageHeaderComponent } from 'app/modules/page-header/page-title-header/page-header.component';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { CustomAppFormComponent } from 'app/pages/apps/components/custom-app-form/custom-app-form.component';
@@ -61,6 +62,7 @@ describe('CustomAppFormComponent', () => {
       ReactiveFormsModule,
     ],
     providers: [
+      ...ixFormTestingProviders(),
       mockAuth(),
       mockProvider(ApplicationsService, {
         getAllApps: jest.fn(() => {

--- a/src/app/pages/apps/components/custom-app-form/custom-app-form.component.ts
+++ b/src/app/pages/apps/components/custom-app-form/custom-app-form.component.ts
@@ -1,7 +1,6 @@
 import {
-  ChangeDetectionStrategy, Component, DestroyRef, inject, input, OnInit, signal,
+  ChangeDetectionStrategy, Component, inject, input, OnInit,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { FormBuilder } from '@ngneat/reactive-forms';
@@ -16,11 +15,25 @@ import { jsonToYaml } from 'app/helpers/json-to-yaml.helper';
 import { App, AppCreate } from 'app/interfaces/app.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxCodeEditorComponent } from 'app/modules/forms/ix-forms/components/ix-code-editor/ix-code-editor.component';
+import { IxFormHostForm } from 'app/modules/forms/ix-forms/components/ix-form/ix-form-host-form.directive';
+import {
+  FormSubmitEvent, IxFormComponent, SubmitResult,
+} from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
 import { forbiddenAsyncValues } from 'app/modules/forms/ix-forms/validators/forbidden-values-validation/forbidden-values-validation';
-import { SidePanelForm } from 'app/modules/slide-ins/side-panel-form.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ApplicationsService } from 'app/pages/apps/services/applications.service';
-import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+
+// Built here rather than inline in the component, and left with an inferred return type — see
+// the `V` type parameter on IxFormHostForm for why.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function createCustomAppForm(formBuilder: FormBuilder) {
+  return formBuilder.group({
+    release_name: ['', Validators.required],
+    custom_compose_config_string: ['\n\n', Validators.required],
+  });
+}
+
+type CustomAppFormValue = ReturnType<ReturnType<typeof createCustomAppForm>['getRawValue']>;
 
 @Component({
   selector: 'ix-custom-app-form',
@@ -28,6 +41,7 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
   styleUrls: ['./custom-app-form.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    IxFormComponent,
     ReactiveFormsModule,
     TranslateModule,
     TnFormFieldComponent,
@@ -36,25 +50,20 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
     IxCodeEditorComponent,
   ],
 })
-export class CustomAppFormComponent extends SidePanelForm implements OnInit {
+export class CustomAppFormComponent extends IxFormHostForm<boolean, CustomAppFormValue> implements OnInit {
   private fb = inject(FormBuilder);
   private translate = inject(TranslateService);
   private api = inject(ApiService);
-  private errorHandler = inject(ErrorHandlerService);
   private dialogService = inject(DialogService);
   private appService = inject(ApplicationsService);
   private router = inject(Router);
-  private destroyRef = inject(DestroyRef);
 
   /** Provided by the `<tn-side-panel>` host in edit mode. */
   readonly app = input<App | undefined>(undefined);
 
   readonly requiredRoles = [Role.AppsWrite];
   protected readonly CodeEditorLanguage = CodeEditorLanguage;
-  protected readonly form = this.fb.group({
-    release_name: ['', Validators.required],
-    custom_compose_config_string: ['\n\n', Validators.required],
-  });
+  protected readonly form = createCustomAppForm(this.fb);
 
   protected get isNew(): boolean {
     return !this.existingApp;
@@ -62,34 +71,37 @@ export class CustomAppFormComponent extends SidePanelForm implements OnInit {
 
   protected existingApp: App | undefined;
 
-  readonly isLoading = signal(false);
-
-  /** Public signal hosts can read to disable a Save action while invalid or loading. */
-  readonly canSubmit = this.trackCanSubmit(this.isLoading);
-
   protected forbiddenAppNames$ = this.appService.getAllApps().pipe(map((apps) => apps.map((app) => app.name)));
 
   ngOnInit(): void {
     this.existingApp = this.app();
 
     if (this.existingApp?.id) {
-      this.handleExistingApp(this.existingApp);
+      this.loadExistingApp(this.existingApp.id);
     }
 
     if (!this.existingApp) {
-      this.setNewApp();
+      this.addForbiddenAppNamesValidator();
     }
   }
 
-  private setNewApp(): void {
-    this.addForbiddenAppNamesValidator();
-  }
-
-  private setAppForEdit(app: App): void {
-    this.form.patchValue({
-      release_name: app.id,
-      custom_compose_config_string: jsonToYaml(app.config),
-    });
+  /**
+   * The custom app's YAML config isn't on the app record the opener passes in, so edit mode
+   * re-reads the app before patching. Routed through `loadFormConfig` so the panel shows its
+   * loader, Save stays disabled until the real config is on screen, and a failed read offers a
+   * retry instead of silently saving the empty defaults.
+   */
+  private loadExistingApp(appId: string): void {
+    this.loadFormConfig(
+      this.appService.getApp(appId).pipe(filter((apps) => apps.length > 0)),
+      ([app]) => {
+        this.existingApp = app;
+        this.form.patchValue({
+          release_name: app.id,
+          custom_compose_config_string: jsonToYaml(app.config),
+        });
+      },
+    );
   }
 
   private addForbiddenAppNamesValidator(): void {
@@ -97,75 +109,43 @@ export class CustomAppFormComponent extends SidePanelForm implements OnInit {
     this.form.controls.release_name.updateValueAndValidity();
   }
 
-  protected onSubmit(): void {
-    if (!this.canSubmit()) {
-      return;
-    }
+  /**
+   * Both paths run behind the job dialog, which reports progress and the outcome itself and is
+   * followed by a navigation to the app — hence `suppressSuccessSnackbar` and a null message.
+   */
+  protected handleSubmit = ({ allValues }: FormSubmitEvent<CustomAppFormValue>): SubmitResult => {
+    const job$ = this.isNew
+      ? this.api.job(
+          'app.create',
+          [{
+            custom_app: true,
+            app_name: allValues.release_name,
+            custom_compose_config_string: allValues.custom_compose_config_string,
+          } as AppCreate],
+        )
+      : this.api.job('app.update', [
+          allValues.release_name,
+          { custom_compose_config_string: allValues.custom_compose_config_string },
+        ]);
 
-    this.isLoading.set(true);
-    const data = this.form.value;
-
-    const appCreate$ = this.api.job(
-      'app.create',
-      [{
-        custom_app: true,
-        app_name: data.release_name,
-        custom_compose_config_string: data.custom_compose_config_string,
-      } as AppCreate],
-    );
-
-    const appUpdate$ = this.api.job('app.update', [
-      data.release_name,
-      { custom_compose_config_string: data.custom_compose_config_string },
-    ]);
-
-    const job$ = this.isNew ? appCreate$ : appUpdate$;
-
-    this.dialogService.jobDialog(
-      job$,
-      {
+    return {
+      request$: this.dialogService.jobDialog(job$, {
         title: this.translate.instant('Custom App'),
         canMinimize: false,
         description: this.isNew
           ? this.translate.instant('Creating custom app')
           : this.translate.instant('Updating custom app'),
-      },
-    ).afterClosed().pipe(
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe({
-      next: () => {
-        this.close(true);
-        if (this.existingApp) {
-          this.router.navigate(['/apps', 'installed', this.existingApp.metadata.train, this.existingApp.name]);
-        } else {
-          this.router.navigate(['/apps', 'installed']);
-        }
-      },
-      error: (error: unknown) => {
-        this.isLoading.set(false);
-        this.errorHandler.showErrorModal(error);
-      },
-    });
-  }
+      }).afterClosed(),
+      successMessage: null,
+      onSuccess: () => this.navigateToApp(),
+    };
+  };
 
-  private handleExistingApp(existingApp: App): void {
-    this.isLoading.set(true);
-
-    this.appService.getApp(existingApp.id).pipe(
-      filter((apps) => apps.length > 0),
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe({
-      next: ([app]) => {
-        this.existingApp = app;
-        this.setAppForEdit(app);
-      },
-      error: (error: unknown) => {
-        this.errorHandler.showErrorModal(error);
-        this.close(false);
-      },
-      complete: () => {
-        this.isLoading.set(false);
-      },
-    });
+  private navigateToApp(): void {
+    if (this.existingApp) {
+      this.router.navigate(['/apps', 'installed', this.existingApp.metadata.train, this.existingApp.name]);
+    } else {
+      this.router.navigate(['/apps', 'installed']);
+    }
   }
 }


### PR DESCRIPTION
**Changes:**

Continues the form-migration epic by moving the three remaining `pages/apps` forms onto the shared `<ix-form>` wrapper, so loading state, Save gating, success feedback, error handling and unsaved-changes tracking come from one place instead of being hand-rolled per form.

**`AppsSettingsComponent`** (Apps → Settings, side panel)

- `SidePanelForm` → `IxFormHostForm<boolean, AppsSettingsFormValue>`; template `<form class="ix-form-container">` → `<ix-form>` with `[requiredRoles]`, `[submitHandler]` and `(closed)`.
- Config load moved to `loadFormConfig()`, so the panel shows its own loader and a failed read offers a retry instead of leaving the form on empty defaults.
- The `address_pools` / `registry_mirrors` `FormArray`s are now `clear()`ed before being rebuilt — `loadFormConfig`'s patch callback replays on retry, and without the clear a retry appended a second set of rows.
- `onSubmit()` → declarative `handleSubmit` returning `{ request$, successMessage, onSuccess }`; the `advancedConfigUpdated` dispatch moved into `onSuccess`. Dropped the local `isFormLoading` signal, `FormErrorHandlerService`, `SnackbarService` and the manual `takeUntilDestroyed` plumbing.

**`CustomAppFormComponent`** (Add/Edit custom app, side panel)

- Same host swap; `[isEditMode]="!isNew"` and `[suppressSuccessSnackbar]="true"` (the job dialog already reports the outcome and is followed by a navigation).
- Edit mode's `app.query` re-read (needed because the YAML config isn't on the record the opener passes in) now runs through `loadFormConfig`, so Save stays disabled until the real config is on screen and a failed read is retryable rather than silently saving the defaults.
- `onSubmit()` → `handleSubmit`, with the create/update job selection kept inline and navigation moved into `onSuccess`.

**`AppWizardComponent`** (routed install/update wizard)

- Not a side panel, so it stays a plain component and uses `<ix-form>` as a routed host: `[submitHandler]`, `[extraDisabled]="isLoading"`, `[suppressSuccessSnackbar]="true"`.
- The wizard's own Install/Update button now reads `canSubmit()`, proxied from the `viewChild(IxFormComponent)`, instead of duplicating `form.invalid || isLoading`.
- `saveData()` folded into `handleSubmit`; payload construction extracted to `buildPayload()`. The hidden-field pruning subject is drained and unsubscribed synchronously there (it already answered synchronously — the old `complete`-callback indirection only obscured that).
- `ix-form { display: block }` added, since the wrapper's host is inline by default and the wizard column would otherwise lose its width.

**Specs:** added `ixFormTestingProviders()` to all three; the wizard's two submit tests now click the real Install/Update button via `TnButtonHarness` instead of calling `onSubmit()` directly.

**Testing:**

- `yarn test src/app/pages/apps/components/app-wizard/app-wizard.component.spec.ts src/app/pages/apps/components/catalog-settings/apps-settings.component.spec.ts src/app/pages/apps/components/custom-app-form/custom-app-form.component.spec.ts`
- Manually: Apps → Settings — save, and confirm a failed load offers retry and that retrying doesn't duplicate address-pool / registry-mirror rows; Apps → Discover → Custom App — create and edit, confirming the job dialog and the redirect to the installed app; Apps → install/update a catalog app through the wizard, confirming Install/Update stays disabled while invalid or loading.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | No — no user-visible behavior or wording changes.
|Testing         | Yes — the wizard's Save button is now driven by `<ix-form>`; E2E flows that install/update an app or save Apps Settings should be re-run.