### PR TITLE
NAS-142385 / 27.0.0-BETA.1 / Migrate directory-service, dashboard and jobs forms to tn-*

### DIFF
--- a/src/app/modules/forms/ix-forms/validators/file-validator/file-validator.service.ts
+++ b/src/app/modules/forms/ix-forms/validators/file-validator/file-validator.service.ts
@@ -60,10 +60,15 @@ export class FileValidatorService {
     };
   }
 
+  /**
+   * Accepts either shape a file control can hold: `ix-file-input` always stored a `File[]`, while
+   * `tn-file-input` in single mode stores one `File`.
+   */
   maxSize(maxSizeInBytes: number) {
-    return (control: FormControl<File[] | null>): ValidationErrors | null => {
-      const files = control.value;
-      if (!files?.length) {
+    return (control: FormControl<File | File[] | null>): ValidationErrors | null => {
+      const value = control.value;
+      const files = value ? [value].flat() : [];
+      if (!files.length) {
         return null;
       }
 

--- a/src/app/pages/dashboard/components/widget-group-form/widget-group-form.component.html
+++ b/src/app/pages/dashboard/components/widget-group-form/widget-group-form.component.html
@@ -1,5 +1,5 @@
 <form class="ix-form-container" (submit)="$event.preventDefault(); submit()">
-  <ix-fieldset>
+  <tn-form-section>
     <div class="form-row">
       <div class="layout-control">
         <span id="widget-group-layout-label" class="layout-label">{{ 'Layout' | translate }}</span>
@@ -19,7 +19,7 @@
         </tn-button-toggle-group>
       </div>
     </div>
-  </ix-fieldset>
+  </tn-form-section>
 
   <div class="editor-container">
     <ix-widget-editor-group

--- a/src/app/pages/dashboard/components/widget-group-form/widget-group-form.component.ts
+++ b/src/app/pages/dashboard/components/widget-group-form/widget-group-form.component.ts
@@ -8,10 +8,9 @@ import {
 } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import {
-  TnButtonToggleComponent, TnButtonToggleGroupComponent, TnIconComponent,
+  TnButtonToggleComponent, TnButtonToggleGroupComponent, TnFormSectionComponent, TnIconComponent,
 } from '@truenas/ui-components';
 import { startWith, tap } from 'rxjs';
-import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { SidePanelForm } from 'app/modules/slide-ins/side-panel-form.directive';
 import { SlotPosition } from 'app/pages/dashboard/types/slot-position.enum';
 import { WidgetGroupSlot } from 'app/pages/dashboard/types/widget-group-slot.interface';
@@ -33,7 +32,7 @@ import { WidgetGroupSlotFormComponent } from './widget-group-slot-form/widget-gr
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ReactiveFormsModule,
-    IxFieldsetComponent,
+    TnFormSectionComponent,
     TnButtonToggleGroupComponent,
     TnButtonToggleComponent,
     TnIconComponent,

--- a/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.html
+++ b/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="form">
   <div class="widget-options-container">
-    <ix-fieldset
-      [title]="'Card {slot} Settings' | translate: { slot: slot().slotPosition + 1 }"
+    <tn-form-section
+      [heading]="'Card {slot} Settings' | translate: { slot: slot().slotPosition + 1 }"
     >
       <tn-form-field class="half-width" [label]="'Card Category' | translate" [required]="true">
         <tn-select
@@ -22,6 +22,6 @@
         </tn-form-field>
       }
       <ng-container #settingsContainer></ng-container>
-    </ix-fieldset>
+    </tn-form-section>
   </div>
 </form>

--- a/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.scss
+++ b/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.scss
@@ -1,24 +1,11 @@
 @import 'scss-imports/cssvars';
 
-.category-type-wrapper {
-  display: flex;
-  gap: 10px;
-  width: 100%;
-}
-
+// `tn-form-section` lays its body out as a flex column with its own gap, so the fields need no
+// margin of their own — `ix-fieldset` had no such gap and the margin here supplied the spacing.
 .half-width {
   width: 50%;
 
   @media (max-width: $breakpoint-xs) {
     width: 100%;
-  }
-}
-
-tn-form-field {
-  display: block;
-  margin-bottom: 1rem;
-
-  &:last-child {
-    margin-bottom: 0;
   }
 }

--- a/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.spec.ts
+++ b/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.spec.ts
@@ -3,7 +3,9 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
-import { TnFormFieldComponent, TnSelectComponent, TnSelectHarness } from '@truenas/ui-components';
+import {
+  TnFormFieldComponent, TnFormSectionHarness, TnSelectComponent, TnSelectHarness,
+} from '@truenas/ui-components';
 import { MockComponent, ngMocks } from 'ng-mocks';
 import { WidgetGroupSlotFormComponent } from 'app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component';
 import { SlotPosition } from 'app/pages/dashboard/types/slot-position.enum';
@@ -57,6 +59,11 @@ describe('WidgetGroupSlotComponent', () => {
       },
     });
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+  });
+
+  it('names the section after the slot it edits', async () => {
+    const section = await loader.getHarness(TnFormSectionHarness);
+    expect(await section.getHeadingText()).toBe('Card 1 Settings');
   });
 
   it('shows entered values on the form fields', async () => {

--- a/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.ts
+++ b/src/app/pages/dashboard/components/widget-group-form/widget-group-slot-form/widget-group-slot-form.component.ts
@@ -25,12 +25,11 @@ import {
   FormBuilder, ValidationErrors, Validators, ReactiveFormsModule,
 } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
-import { TnFormFieldComponent, TnSelectComponent } from '@truenas/ui-components';
+import { TnFormFieldComponent, TnFormSectionComponent, TnSelectComponent } from '@truenas/ui-components';
 import {
   Observable, Subscription, combineLatest, map, of, switchMap,
 } from 'rxjs';
 import { Option, SelectOption } from 'app/interfaces/option.interface';
-import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { SimpleWidget } from 'app/pages/dashboard/types/simple-widget.interface';
 import { SlotPosition } from 'app/pages/dashboard/types/slot-position.enum';
 import { WidgetCategory, widgetCategoryLabels } from 'app/pages/dashboard/types/widget-category.enum';
@@ -47,7 +46,7 @@ import { widgetRegistry } from 'app/pages/dashboard/widgets/all-widgets.constant
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ReactiveFormsModule,
-    IxFieldsetComponent,
+    TnFormSectionComponent,
     TnFormFieldComponent,
     TnSelectComponent,
     TranslateModule,

--- a/src/app/pages/directory-service/components/directory-services-form/active-directory-config/trusted-domains-config/trusted-domains-config.component.html
+++ b/src/app/pages/directory-service/components/directory-services-form/active-directory-config/trusted-domains-config/trusted-domains-config.component.html
@@ -8,158 +8,187 @@
       ></tn-checkbox>
     </tn-form-field>
     @if (form.controls.enable_trusted_domains.value) {
-      <ix-list
+      <tn-form-list
         formArrayName="trustedDomains"
-        [empty]="trustedDomainsArray.length === 0"
+        [control]="trustedDomainsArray"
         [label]="'Trusted Domains' | translate"
-        [formArray]="trustedDomainsArray"
+        [addLabel]="'Add' | translate"
+        [emptyMessage]="'No items have been added yet.' | translate"
         (add)="addTrustedDomain()"
       >
       @for (domain of trustedDomainsArray.controls; track domain; let i = $index) {
-        <ix-list-item
+        <tn-form-list-item
+          testId="remove-from-list"
           [label]="'Trusted Domain' | translate"
+          [removeAriaLabel]="'Remove {label} item' | translate: { label: 'Trusted Domain' | translate }"
           [formGroupName]="i"
           (delete)="removeTrustedDomain(i)"
         >
-          <div class="trusted-domain-config">
-            <div class="columns">
-              <ix-fieldset [title]="'Basic Configuration' | translate">
-                <ix-select
-                  formControlName="idmap_backend"
-                  [required]="true"
-                  [label]="'IDMAP Backend' | translate"
-                  [options]="trustedDomainIdmapOptions$"
-                  [tooltip]="helptext.idmapBackendTooltip | translate"
-                ></ix-select>
+          <tn-form-section [heading]="'Basic Configuration' | translate">
+            <tn-form-field
+              [label]="'IDMAP Backend' | translate"
+              [tooltip]="helptext.idmapBackendTooltip | translate"
+              [required]="true"
+            >
+              <tn-select
+                formControlName="idmap_backend"
+                [options]="trustedDomainIdmapOptions"
+                [optionTestIdKey]="idmapBackendOptionTestId"
+              ></tn-select>
+            </tn-form-field>
 
-                @let idmapBackend = getIdmapTypeForItem(i);
-                @if(idmapBackend) {
-                  <ix-input
-                    formControlName="name"
-                    [label]="'Name' | translate"
+            @let idmapBackend = getIdmapTypeForItem(i);
+            @if (idmapBackend) {
+              <tn-form-field
+                [label]="'Name' | translate"
+                [tooltip]="helptext.name.tooltip | translate"
+                [required]="true"
+              >
+                <tn-input formControlName="name" [required]="true"></tn-input>
+              </tn-form-field>
+              <tn-form-field
+                [label]="'Range Low' | translate"
+                [tooltip]="helptext.rangeLowTooltip | translate"
+                [required]="true"
+              >
+                <tn-input
+                  formControlName="range_low"
+                  [inputType]="InputType.Number"
+                  [required]="true"
+                ></tn-input>
+              </tn-form-field>
+              <tn-form-field
+                [label]="'Range High' | translate"
+                [tooltip]="helptext.rangeHighTooltip | translate"
+                [required]="true"
+              >
+                <tn-input
+                  formControlName="range_high"
+                  [inputType]="InputType.Number"
+                  [required]="true"
+                ></tn-input>
+              </tn-form-field>
+              @if (idmapBackend === IdmapBackend.Ad) {
+                <tn-form-field
+                  [label]="'Schema Mode' | translate"
+                  [tooltip]="helptext.schemaModeTooltip | translate"
+                  [required]="true"
+                >
+                  <tn-select
+                    formControlName="schema_mode"
+                    [options]="schemaModeOptions"
+                    [optionTestIdKey]="schemaModeOptionTestId"
+                  ></tn-select>
+                </tn-form-field>
+                <tn-form-field [tooltip]="helptext.unixPrimaryGroupTooltip | translate">
+                  <tn-checkbox
+                    formControlName="unix_primary_group"
+                    [label]="'Unix Primary Group' | translate"
+                  ></tn-checkbox>
+                </tn-form-field>
+                <tn-form-field [tooltip]="helptext.unixNssTooltip | translate">
+                  <tn-checkbox
+                    formControlName="unix_nss_info"
+                    [label]="'Unix NSS Info' | translate"
+                  ></tn-checkbox>
+                </tn-form-field>
+              }
+              @if (idmapBackend === IdmapBackend.Rfc2307 || idmapBackend === IdmapBackend.Ldap) {
+                @if (idmapBackend === IdmapBackend.Rfc2307) {
+                  <tn-form-field
+                    [label]="'LDAP Url' | translate"
+                    [tooltip]="helptext.ldapUrlTooltip | translate"
                     [required]="true"
-                    [tooltip]="helptext.name.tooltip | translate"
-                  ></ix-input>
-                  <ix-input
-                    formControlName="range_low"
-                    [label]="'Range Low' | translate"
-                    [required]="true"
-                    [type]="'number'"
-                    [tooltip]="helptext.rangeLowTooltip | translate"
-                  ></ix-input>
-                  <ix-input
-                    formControlName="range_high"
-                    [label]="'Range High' | translate"
-                    [required]="true"
-                    [type]="'number'"
-                    [tooltip]="helptext.rangeHighTooltip | translate"
-                  ></ix-input>
-                  @if (idmapBackend === IdmapBackend.Ad) {
-                    <ix-select
-                      formControlName="schema_mode"
-                      [label]="'Schema Mode' | translate"
-                      [required]="true"
-                      [options]="schemaModeOptions$"
-                      [tooltip]="helptext.schemaModeTooltip | translate"
-                    ></ix-select>
-                    <ix-checkbox
-                      formControlName="unix_primary_group"
-                      [label]="'Unix Primary Group' | translate"
-                      [tooltip]="helptext.unixPrimaryGroupTooltip | translate"
-                    ></ix-checkbox>
-                    <ix-checkbox
-                      formControlName="unix_nss_info"
-                      [label]="'Unix NSS Info' | translate"
-                      [tooltip]="helptext.unixNssTooltip | translate"
-                    ></ix-checkbox>
-                  }
-                  @if (idmapBackend === IdmapBackend.Rfc2307 || idmapBackend === IdmapBackend.Ldap) {
-                    @if (idmapBackend === IdmapBackend.Rfc2307) {
-                      <ix-input
-                        formControlName="ldap_url"
-                        [required]="true"
-                        [label]="'LDAP Url' | translate"
-                        [tooltip]="helptext.ldapUrlTooltip | translate"
-                      ></ix-input>
-                    }
-                    @if (idmapBackend === IdmapBackend.Ldap) {
-                      <ix-input
-                        formControlName="ldap_base_dn"
-                        [label]="'LDAP Base DN' | translate"
-                        [required]="true"
-                        [tooltip]="helptext.ldapBasednTooltip | translate"
-                      ></ix-input>
-                    }
-                    <ix-input
-                      formControlName="ldap_user_dn"
-                      [required]="true"
-                      [label]="'LDAP User DN' | translate"
-                      [tooltip]="helptext.ldapUserdnTooltip | translate"
-                    ></ix-input>
-                    <ix-input
-                      formControlName="ldap_user_dn_password"
-                      [required]="true"
-                      [label]="'LDAP User DN Password' | translate"
-                      [tooltip]="helptext.ldapUserDnPasswordTooltip | translate"
-                    ></ix-input>
-                    @if (idmapBackend === IdmapBackend.Ldap) {
-                      <ix-input
-                        formControlName="ldap_url"
-                        [required]="true"
-                        [label]="'LDAP Url' | translate"
-                        [tooltip]="helptext.ldapUrlTooltip | translate"
-                      ></ix-input>
-                      <ix-checkbox
-                        formControlName="readonly"
-                        [label]="'Readonly' | translate"
-                        [tooltip]="helptext.readonlyTooltip | translate"
-                      ></ix-checkbox>
-                    }
-                    @if (idmapBackend === IdmapBackend.Rfc2307) {
-                      <ix-input
-                        formControlName="bind_path_user"
-                        [label]="'Bind Path User' | translate"
-                        [required]="true"
-                        [tooltip]="helptext.bindPathUserTooltip | translate"
-                      ></ix-input>
-                      <ix-input
-                        formControlName="bind_path_group"
-                        [label]="'Bind Path Group' | translate"
-                        [required]="true"
-                        [tooltip]="helptext.bindPathGroupTooltip | translate"
-                      ></ix-input>
-                      <ix-checkbox
-                        formControlName="user_cn"
-                        [label]="'User CN' | translate"
-                        [tooltip]="helptext.userCnTooltip | translate"
-                      ></ix-checkbox>
-                      <ix-checkbox
-                        formControlName="ldap_realm"
-                        [label]="'LDAP Realm' | translate"
-                        [tooltip]="helptext.ldapRealmTooltip | translate"
-                      ></ix-checkbox>
-                    }
-                    <ix-checkbox
-                      formControlName="validate_certificates"
-                      [label]="'Validate Certificates' | translate"
-                      [tooltip]="helptextLdap.validateCertificatesTooltip | translate"
-                    ></ix-checkbox>
-                  }
-                  @if (idmapBackend === IdmapBackend.Rid) {
-                    <ix-checkbox
-                      formControlName="sssd_compat"
-                      [label]="'SSSD Compat' | translate"
-                      [tooltip]="helptext.sssdCompatTooltip | translate"
-                    ></ix-checkbox>
-                  }
+                  >
+                    <tn-input formControlName="ldap_url" [required]="true"></tn-input>
+                  </tn-form-field>
                 }
-                
-              </ix-fieldset>
-            </div>
-          </div>
-        </ix-list-item>
+                @if (idmapBackend === IdmapBackend.Ldap) {
+                  <tn-form-field
+                    [label]="'LDAP Base DN' | translate"
+                    [tooltip]="helptext.ldapBasednTooltip | translate"
+                    [required]="true"
+                  >
+                    <tn-input formControlName="ldap_base_dn" [required]="true"></tn-input>
+                  </tn-form-field>
+                }
+                <tn-form-field
+                  [label]="'LDAP User DN' | translate"
+                  [tooltip]="helptext.ldapUserdnTooltip | translate"
+                  [required]="true"
+                >
+                  <tn-input formControlName="ldap_user_dn" [required]="true"></tn-input>
+                </tn-form-field>
+                <tn-form-field
+                  [label]="'LDAP User DN Password' | translate"
+                  [tooltip]="helptext.ldapUserDnPasswordTooltip | translate"
+                  [required]="true"
+                >
+                  <tn-input formControlName="ldap_user_dn_password" [required]="true"></tn-input>
+                </tn-form-field>
+                @if (idmapBackend === IdmapBackend.Ldap) {
+                  <tn-form-field
+                    [label]="'LDAP Url' | translate"
+                    [tooltip]="helptext.ldapUrlTooltip | translate"
+                    [required]="true"
+                  >
+                    <tn-input formControlName="ldap_url" [required]="true"></tn-input>
+                  </tn-form-field>
+                  <tn-form-field [tooltip]="helptext.readonlyTooltip | translate">
+                    <tn-checkbox
+                      formControlName="readonly"
+                      [label]="'Readonly' | translate"
+                    ></tn-checkbox>
+                  </tn-form-field>
+                }
+                @if (idmapBackend === IdmapBackend.Rfc2307) {
+                  <tn-form-field
+                    [label]="'Bind Path User' | translate"
+                    [tooltip]="helptext.bindPathUserTooltip | translate"
+                    [required]="true"
+                  >
+                    <tn-input formControlName="bind_path_user" [required]="true"></tn-input>
+                  </tn-form-field>
+                  <tn-form-field
+                    [label]="'Bind Path Group' | translate"
+                    [tooltip]="helptext.bindPathGroupTooltip | translate"
+                    [required]="true"
+                  >
+                    <tn-input formControlName="bind_path_group" [required]="true"></tn-input>
+                  </tn-form-field>
+                  <tn-form-field [tooltip]="helptext.userCnTooltip | translate">
+                    <tn-checkbox
+                      formControlName="user_cn"
+                      [label]="'User CN' | translate"
+                    ></tn-checkbox>
+                  </tn-form-field>
+                  <tn-form-field [tooltip]="helptext.ldapRealmTooltip | translate">
+                    <tn-checkbox
+                      formControlName="ldap_realm"
+                      [label]="'LDAP Realm' | translate"
+                    ></tn-checkbox>
+                  </tn-form-field>
+                }
+                <tn-form-field [tooltip]="helptextLdap.validateCertificatesTooltip | translate">
+                  <tn-checkbox
+                    formControlName="validate_certificates"
+                    [label]="'Validate Certificates' | translate"
+                  ></tn-checkbox>
+                </tn-form-field>
+              }
+              @if (idmapBackend === IdmapBackend.Rid) {
+                <tn-form-field [tooltip]="helptext.sssdCompatTooltip | translate">
+                  <tn-checkbox
+                    formControlName="sssd_compat"
+                    [label]="'SSSD Compat' | translate"
+                  ></tn-checkbox>
+                </tn-form-field>
+              }
+            }
+          </tn-form-section>
+        </tn-form-list-item>
       }
-      </ix-list>
+      </tn-form-list>
     }
 
   </tn-form-section>

--- a/src/app/pages/directory-service/components/directory-services-form/active-directory-config/trusted-domains-config/trusted-domains-config.component.spec.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/active-directory-config/trusted-domains-config/trusted-domains-config.component.spec.ts
@@ -2,10 +2,11 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
-import { TnCheckboxHarness } from '@truenas/ui-components';
+import {
+  TnCheckboxHarness, TnFormListHarness, TnInputHarness, TnSelectHarness,
+} from '@truenas/ui-components';
 import { ActiveDirectorySchemaMode, IdmapBackend } from 'app/enums/directory-services.enum';
 import { DomainIdmap } from 'app/interfaces/active-directory-config.interface';
-import { IxListHarness } from 'app/modules/forms/ix-forms/components/ix-list/ix-list.harness';
 import { TrustedDomainsConfigComponent } from 'app/pages/directory-service/components/directory-services-form/active-directory-config/trusted-domains-config/trusted-domains-config.component';
 
 describe('TrustedDomainsConfigComponent', () => {
@@ -14,6 +15,30 @@ describe('TrustedDomainsConfigComponent', () => {
 
   const getEnableCheckbox = (): Promise<TnCheckboxHarness> => {
     return loader.getHarness(TnCheckboxHarness.with({ label: 'Enable Trusted Domains' }));
+  };
+
+  const getList = (): Promise<TnFormListHarness> => {
+    return loader.getHarness(TnFormListHarness.with({ label: 'Trusted Domains' }));
+  };
+
+  /**
+   * `tn-form-field` cannot reach the control it projects, and the tn-* control harnesses have no
+   * label filter — so entries are addressed positionally, by the `formControlName` attribute the
+   * reactive-forms directive leaves on each control.
+   */
+  const getInput = (controlName: string, index = 0): Promise<TnInputHarness> => {
+    return loader.getAllHarnesses(TnInputHarness.with({ selector: `[formControlName="${controlName}"]` }))
+      .then((harnesses) => harnesses[index]);
+  };
+
+  const getSelect = (controlName: string, index = 0): Promise<TnSelectHarness> => {
+    return loader.getAllHarnesses(TnSelectHarness.with({ selector: `[formControlName="${controlName}"]` }))
+      .then((harnesses) => harnesses[index]);
+  };
+
+  const getCheckbox = (label: string, index = 0): Promise<TnCheckboxHarness> => {
+    return loader.getAllHarnesses(TnCheckboxHarness.with({ label }))
+      .then((harnesses) => harnesses[index]);
   };
 
   const mockTrustedDomains: DomainIdmap[] = [
@@ -72,26 +97,23 @@ describe('TrustedDomainsConfigComponent', () => {
     await (await getEnableCheckbox()).check();
 
     spectator.detectChanges();
-    const trustedDomainsList = await loader.getHarness(IxListHarness.with({ label: 'Trusted Domains' }));
-    const trustedDomains = await trustedDomainsList.getFormValues();
-    expect(trustedDomains).toEqual([
-      {
-        Name: 'trusted-domain-1',
-        'Range Low': '100000001',
-        'Range High': '200000000',
-        'IDMAP Backend': 'AD (RFC2307/SFU attributes from Active Directory)',
-        'Schema Mode': ActiveDirectorySchemaMode.Rfc2307,
-        'Unix Primary Group': true,
-        'Unix NSS Info': false,
-      },
-      {
-        Name: 'trusted-domain-2',
-        'Range Low': '200000001',
-        'Range High': '300000000',
-        'IDMAP Backend': 'RID (Default - algorithmic mapping based on RID values)',
-        'SSSD Compat': true,
-      },
-    ]);
+    expect(await (await getList()).getItemCount()).toBe(2);
+
+    expect(await (await getSelect('idmap_backend', 0)).getDisplayText())
+      .toBe('AD (RFC2307/SFU attributes from Active Directory)');
+    expect(await (await getInput('name', 0)).getValue()).toBe('trusted-domain-1');
+    expect(await (await getInput('range_low', 0)).getValue()).toBe('100000001');
+    expect(await (await getInput('range_high', 0)).getValue()).toBe('200000000');
+    expect(await (await getSelect('schema_mode')).getDisplayText()).toBe(ActiveDirectorySchemaMode.Rfc2307);
+    expect(await (await getCheckbox('Unix Primary Group')).isChecked()).toBe(true);
+    expect(await (await getCheckbox('Unix NSS Info')).isChecked()).toBe(false);
+
+    expect(await (await getSelect('idmap_backend', 1)).getDisplayText())
+      .toBe('RID (Default - algorithmic mapping based on RID values)');
+    expect(await (await getInput('name', 1)).getValue()).toBe('trusted-domain-2');
+    expect(await (await getInput('range_low', 1)).getValue()).toBe('200000001');
+    expect(await (await getInput('range_high', 1)).getValue()).toBe('300000000');
+    expect(await (await getCheckbox('SSSD Compat')).isChecked()).toBe(true);
   });
 
   it('should emit trustedDomainsChanged when form values change', async () => {
@@ -116,6 +138,21 @@ describe('TrustedDomainsConfigComponent', () => {
     await (await getEnableCheckbox()).check();
 
     expect(emittedValid).toBe(true);
+  });
+
+  it('removes a trusted domain', async () => {
+    spectator.setInput('trustedDomains', mockTrustedDomains);
+    spectator.component.ngOnInit();
+    spectator.detectChanges();
+    await (await getEnableCheckbox()).check();
+    spectator.detectChanges();
+
+    const items = await (await getList()).getItems();
+    await items[0].remove();
+    spectator.detectChanges();
+
+    expect(await (await getList()).getItemCount()).toBe(1);
+    expect(await (await getInput('name', 0)).getValue()).toBe('trusted-domain-2');
   });
 
   describe('edge cases', () => {
@@ -143,26 +180,28 @@ describe('TrustedDomainsConfigComponent', () => {
   });
 
   describe('dynamic validation based on backend', () => {
+    const addDomain = async (backendLabel: string): Promise<void> => {
+      await (await getEnableCheckbox()).check();
+      spectator.detectChanges();
+
+      await (await getList()).add();
+      spectator.detectChanges();
+
+      await (await getSelect('idmap_backend')).selectOption(backendLabel);
+      spectator.detectChanges();
+
+      await (await getInput('name')).setValue('test-domain');
+      await (await getInput('range_low')).setValue('100000');
+      await (await getInput('range_high')).setValue('200000');
+    };
+
     it('should be valid with RID backend when only base fields are filled', async () => {
       let emittedValid: boolean | undefined;
       spectator.component.isValid.subscribe((valid) => {
         emittedValid = valid;
       });
 
-      await (await getEnableCheckbox()).check();
-      spectator.detectChanges();
-
-      const trustedDomainsList = await loader.getHarness(IxListHarness.with({ label: 'Trusted Domains' }));
-      await trustedDomainsList.pressAddButton();
-      spectator.detectChanges();
-
-      const listItem = await trustedDomainsList.getLastListItem();
-      await listItem.fillForm({
-        'IDMAP Backend': 'RID (Default - algorithmic mapping based on RID values)',
-        Name: 'test-domain',
-        'Range Low': '100000',
-        'Range High': '200000',
-      });
+      await addDomain('RID (Default - algorithmic mapping based on RID values)');
 
       expect(emittedValid).toBe(true);
     });
@@ -173,21 +212,8 @@ describe('TrustedDomainsConfigComponent', () => {
         emittedValid = valid;
       });
 
-      await (await getEnableCheckbox()).check();
-      spectator.detectChanges();
-
-      const trustedDomainsList = await loader.getHarness(IxListHarness.with({ label: 'Trusted Domains' }));
-      await trustedDomainsList.pressAddButton();
-      spectator.detectChanges();
-
-      const listItem = await trustedDomainsList.getLastListItem();
-      await listItem.fillForm({
-        'IDMAP Backend': 'AD (RFC2307/SFU attributes from Active Directory)',
-        Name: 'test-domain',
-        'Range Low': '100000',
-        'Range High': '200000',
-        'Schema Mode': ActiveDirectorySchemaMode.Rfc2307,
-      });
+      await addDomain('AD (RFC2307/SFU attributes from Active Directory)');
+      await (await getSelect('schema_mode')).selectOption(ActiveDirectorySchemaMode.Rfc2307);
 
       expect(emittedValid).toBe(true);
     });
@@ -198,20 +224,7 @@ describe('TrustedDomainsConfigComponent', () => {
         emittedValid = valid;
       });
 
-      await (await getEnableCheckbox()).check();
-      spectator.detectChanges();
-
-      const trustedDomainsList = await loader.getHarness(IxListHarness.with({ label: 'Trusted Domains' }));
-      await trustedDomainsList.pressAddButton();
-      spectator.detectChanges();
-
-      const listItem = await trustedDomainsList.getLastListItem();
-      await listItem.fillForm({
-        'IDMAP Backend': 'AD (RFC2307/SFU attributes from Active Directory)',
-        Name: 'test-domain',
-        'Range Low': '100000',
-        'Range High': '200000',
-      });
+      await addDomain('AD (RFC2307/SFU attributes from Active Directory)');
 
       expect(emittedValid).toBe(false);
     });
@@ -222,29 +235,13 @@ describe('TrustedDomainsConfigComponent', () => {
         emittedValid = valid;
       });
 
-      await (await getEnableCheckbox()).check();
-      spectator.detectChanges();
-
-      const trustedDomainsList = await loader.getHarness(IxListHarness.with({ label: 'Trusted Domains' }));
-      await trustedDomainsList.pressAddButton();
-      spectator.detectChanges();
-
-      const listItem = await trustedDomainsList.getLastListItem();
-
       // First select AD backend without schema_mode - should be invalid
-      await listItem.fillForm({
-        'IDMAP Backend': 'AD (RFC2307/SFU attributes from Active Directory)',
-        Name: 'test-domain',
-        'Range Low': '100000',
-        'Range High': '200000',
-      });
+      await addDomain('AD (RFC2307/SFU attributes from Active Directory)');
 
       expect(emittedValid).toBe(false);
 
       // Now switch to RID backend - should become valid since schema_mode is no longer required
-      await listItem.fillForm({
-        'IDMAP Backend': 'RID (Default - algorithmic mapping based on RID values)',
-      });
+      await (await getSelect('idmap_backend')).selectOption('RID (Default - algorithmic mapping based on RID values)');
 
       expect(emittedValid).toBe(true);
     });

--- a/src/app/pages/directory-service/components/directory-services-form/active-directory-config/trusted-domains-config/trusted-domains-config.component.ts
+++ b/src/app/pages/directory-service/components/directory-services-form/active-directory-config/trusted-domains-config/trusted-domains-config.component.ts
@@ -7,11 +7,12 @@ import {
   Validators,
 } from '@angular/forms';
 import { FormBuilder, FormControl, FormGroup } from '@ngneat/reactive-forms';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  TnCheckboxComponent, TnFormFieldComponent, TnFormSectionComponent,
+  InputType,
+  TnCheckboxComponent, TnFormFieldComponent, TnFormListComponent, TnFormListItemComponent,
+  TnFormSectionComponent, TnInputComponent, TnSelectComponent, TnSelectOption,
 } from '@truenas/ui-components';
-import { Observable, of } from 'rxjs';
 import { ActiveDirectorySchemaMode, IdmapBackend } from 'app/enums/directory-services.enum';
 import { helptextActiveDirectory } from 'app/helptext/directory-service/active-directory';
 import { helptextIdmap } from 'app/helptext/directory-service/idmap';
@@ -19,13 +20,8 @@ import { helptextLdap } from 'app/helptext/directory-service/ldap';
 import {
   ActiveDirectoryIdmap, DomainIdmap, domainIdmapTypeOptions, LdapIdmap, Rfc2307Idmap, RidIdmap,
 } from 'app/interfaces/active-directory-config.interface';
-import { Option } from 'app/interfaces/option.interface';
-import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
-import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
-import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
-import { IxListItemComponent } from 'app/modules/forms/ix-forms/components/ix-list/ix-list-item/ix-list-item.component';
-import { IxListComponent } from 'app/modules/forms/ix-forms/components/ix-list/ix-list.component';
-import { IxSelectComponent } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.component';
+import { normalizeTestIdString } from 'app/modules/test-id/normalize-test-id.utils';
+import { translateOptions } from 'app/modules/translate/translate.helper';
 
 type Controls<T> = {
   [K in keyof T]: FormControl<T[K]>;
@@ -61,21 +57,20 @@ interface AllTrustedDomainsIdmapFieldsInterface {
   standalone: true,
   imports: [
     ReactiveFormsModule,
-    IxFieldsetComponent,
-    IxInputComponent,
-    IxSelectComponent,
-    IxCheckboxComponent,
-    IxListComponent,
-    IxListItemComponent,
     TranslateModule,
     TnFormSectionComponent,
     TnFormFieldComponent,
     TnCheckboxComponent,
+    TnInputComponent,
+    TnSelectComponent,
+    TnFormListComponent,
+    TnFormListItemComponent,
   ],
 })
 export class TrustedDomainsConfigComponent implements OnInit {
   private fb = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
+  private translate = inject(TranslateService);
 
   protected readonly helptextAd = helptextActiveDirectory;
   protected readonly helptext = helptextIdmap.idmap;
@@ -87,19 +82,41 @@ export class TrustedDomainsConfigComponent implements OnInit {
   readonly trustedDomains = input.required<DomainIdmap[]>();
 
   protected readonly IdmapBackend = IdmapBackend;
+  protected readonly InputType = InputType;
 
-  protected readonly schemaModeOptions$ = of([
+  // Labels are the enum values themselves, so there is nothing to translate.
+  protected readonly schemaModeOptions: TnSelectOption<ActiveDirectorySchemaMode>[] = [
     { label: ActiveDirectorySchemaMode.Rfc2307, value: ActiveDirectorySchemaMode.Rfc2307 },
     { label: ActiveDirectorySchemaMode.Sfu, value: ActiveDirectorySchemaMode.Sfu },
     { label: ActiveDirectorySchemaMode.Sfu20, value: ActiveDirectorySchemaMode.Sfu20 },
-  ]);
+  ];
 
   protected readonly form = this.fb.group({
     enable_trusted_domains: [false],
     trustedDomains: this.fb.array<AllTrustedDomainsIdmapFieldsInterface>([]),
   });
 
-  protected readonly trustedDomainIdmapOptions$: Observable<Option[]> = of(domainIdmapTypeOptions);
+  protected readonly trustedDomainIdmapOptions = translateOptions(this.translate, domainIdmapTypeOptions);
+
+  private readonly rawIdmapBackendLabels = new Map(
+    domainIdmapTypeOptions.map((option) => [option.value, option.label]),
+  );
+
+  /**
+   * `ix-select` keyed an option's `data-test` off the RAW (untranslated) label, while the template
+   * rendered a translated one. `tn-select` derives the id from the label it is given, so keying it
+   * off the pre-translated list would make every option id follow the UI language. Map back to the
+   * raw marker — through lodash kebab, which the library's own normalizer does not reproduce at a
+   * letter/digit boundary (`RFC2307` → `rfc-2307`) — to keep the ids byte-identical.
+   */
+  protected readonly idmapBackendOptionTestId = (option: TnSelectOption<IdmapBackend>): string => {
+    return normalizeTestIdString(this.rawIdmapBackendLabels.get(option.value) ?? option.label);
+  };
+
+  /** Same letter/digit kebab gap as {@link idmapBackendOptionTestId}: `SFU20` → `sfu-20`. */
+  protected readonly schemaModeOptionTestId = (option: TnSelectOption<ActiveDirectorySchemaMode>): string => {
+    return normalizeTestIdString(option.label);
+  };
 
   protected get trustedDomainsArray(): FormArray {
     return this.form.controls.trustedDomains;

--- a/src/app/pages/directory-service/components/kerberos-keytabs/kerberos-keytabs-form/kerberos-keytabs-form.component.html
+++ b/src/app/pages/directory-service/components/kerberos-keytabs/kerberos-keytabs-form/kerberos-keytabs-form.component.html
@@ -1,4 +1,12 @@
-<form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
+<ix-form
+  [formGroup]="form"
+  [isEditMode]="isEditMode()"
+  [addTitle]="'Add Kerberos Keytab' | translate"
+  [editTitle]="'Edit Kerberos Keytab' | translate"
+  [requiredRoles]="requiredRoles"
+  [submitHandler]="handleSubmit"
+  (closed)="closed.emit($event)"
+>
   <tn-form-section>
     <tn-form-field [label]="helptext.name | translate" [required]="true">
       <tn-input
@@ -10,13 +18,25 @@
       ></tn-input>
     </tn-form-field>
 
-    <ix-file-input
-      formControlName="file"
+    <tn-form-field
       [label]="helptext.keytab | translate"
       [tooltip]="helptext.keytabTooltip | translate"
-      [multiple]="false"
       [required]="true"
-      [acceptedFiles]="'binary'"
-    ></ix-file-input>
+    >
+      <!--
+        `tnTestIdType`/`[tnTestId]` on the host rather than `[testId]`: the container declares the
+        `file-input` prefix, and pinning the id here keeps `ix-file-input`'s `input-file` intact.
+      -->
+      <tn-file-input
+        formControlName="file"
+        accept="binary"
+        tnTestIdType="input"
+        [tnTestId]="'file'"
+        [showFileName]="true"
+        [buttonLabel]="'Choose File' | translate"
+        [noFileText]="'No file chosen' | translate"
+        [ariaLabel]="helptext.keytab | translate"
+      ></tn-file-input>
+    </tn-form-field>
   </tn-form-section>
-</form>
+</ix-form>

--- a/src/app/pages/directory-service/components/kerberos-keytabs/kerberos-keytabs-form/kerberos-keytabs-form.component.spec.ts
+++ b/src/app/pages/directory-service/components/kerberos-keytabs/kerberos-keytabs-form/kerberos-keytabs-form.component.spec.ts
@@ -2,11 +2,13 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnInputHarness } from '@truenas/ui-components';
+import { TnFileInputHarness, TnInputHarness } from '@truenas/ui-components';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { KerberosKeytab } from 'app/interfaces/kerberos-config.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
+import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
+import { ApiService } from 'app/modules/websocket/api.service';
 import { KerberosKeytabsFormComponent } from 'app/pages/directory-service/components/kerberos-keytabs/kerberos-keytabs-form/kerberos-keytabs-form.component';
 import { StorageService } from 'app/services/storage.service';
 
@@ -33,8 +35,30 @@ describe('KerberosKeytabsFormComponent', () => {
         mockCall('kerberos.keytab.update'),
       ]),
       mockAuth(),
+      ...ixFormTestingProviders(),
     ],
   });
+
+  /**
+   * `TnFileInputHarness` exposes no `setValue`, so the selection is made the way the component
+   * receives it in the browser: a native `change` carrying a `FileList`-shaped `target`.
+   */
+  const selectFile = (file: File): void => {
+    const input = spectator.query('input[type="file"]');
+    const event = new Event('change');
+    Object.defineProperty(event, 'target', { value: { files: [file] } });
+    input.dispatchEvent(event);
+    spectator.detectChanges();
+  };
+
+  /** Submits and resolves once `<ix-form>` reports the save, which the file read makes async. */
+  const submitAndWait = (): Promise<unknown> => {
+    const closed = new Promise((resolve) => {
+      spectator.component.closed.subscribe(resolve);
+    });
+    spectator.component.submit();
+    return closed;
+  };
 
   describe('Create Kerberos Keytab', () => {
     beforeEach(() => {
@@ -46,6 +70,22 @@ describe('KerberosKeytabsFormComponent', () => {
     it('shows empty values when form is opened for add', async () => {
       const nameInput = await loader.getHarness(TnInputHarness.with({ name: 'name' }));
       expect(await nameInput.getValue()).toBe('');
+
+      const fileInput = await loader.getHarness(TnFileInputHarness);
+      expect(await fileInput.hasFile()).toBe(false);
+    });
+
+    it('creates a keytab when the form is submitted', async () => {
+      const nameInput = await loader.getHarness(TnInputHarness.with({ name: 'name' }));
+      await nameInput.setValue('new_keytab');
+      selectFile(new File(['abc'], 'krb5.keytab'));
+
+      await submitAndWait();
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('kerberos.keytab.create', [{
+        name: 'new_keytab',
+        file: btoa('abc'),
+      }]);
     });
   });
 
@@ -59,6 +99,17 @@ describe('KerberosKeytabsFormComponent', () => {
     it('shows values for an existing kerberos keytabs when form is opened for edit', async () => {
       const nameInput = await loader.getHarness(TnInputHarness.with({ name: 'name' }));
       expect(await nameInput.getValue()).toBe('test_name');
+    });
+
+    it('updates the existing keytab when the form is submitted', async () => {
+      selectFile(new File(['abc'], 'krb5.keytab'));
+
+      await submitAndWait();
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('kerberos.keytab.update', [
+        123,
+        { name: 'test_name', file: btoa('abc') },
+      ]);
     });
   });
 });

--- a/src/app/pages/directory-service/components/kerberos-keytabs/kerberos-keytabs-form/kerberos-keytabs-form.component.ts
+++ b/src/app/pages/directory-service/components/kerberos-keytabs/kerberos-keytabs-form/kerberos-keytabs-form.component.ts
@@ -1,20 +1,37 @@
 import {
-  ChangeDetectionStrategy, Component, DestroyRef, input, OnInit, signal, inject,
+  ChangeDetectionStrategy, Component, OnInit, computed, inject, input,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
-import { TranslateModule } from '@ngx-translate/core';
-import { TnFormFieldComponent, TnFormSectionComponent, TnInputComponent } from '@truenas/ui-components';
-import { Observable } from 'rxjs';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import {
+  TnFileInputComponent, TnFormFieldComponent, TnFormSectionComponent, TnInputComponent, TnTestIdDirective,
+} from '@truenas/ui-components';
+import { Observable, map, switchMap } from 'rxjs';
 import { KiB } from 'app/constants/bytes.constant';
 import { Role } from 'app/enums/role.enum';
 import { helptextKerberosKeytabs } from 'app/helptext/directory-service/kerberos-keytabs-form-list';
 import { KerberosKeytab } from 'app/interfaces/kerberos-config.interface';
-import { IxFileInputComponent } from 'app/modules/forms/ix-forms/components/ix-file-input/ix-file-input.component';
-import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
+import { IxFormHostForm } from 'app/modules/forms/ix-forms/components/ix-form/ix-form-host-form.directive';
+import { IxFormComponent, SubmitResult } from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
 import { FileValidatorService } from 'app/modules/forms/ix-forms/validators/file-validator/file-validator.service';
-import { SidePanelForm } from 'app/modules/slide-ins/side-panel-form.directive';
 import { ApiService } from 'app/modules/websocket/api.service';
+
+/**
+ * `FileReader` rather than `File.arrayBuffer()`: the latter is absent from jsdom, and the read has
+ * to be an observable anyway so `<ix-form>` can run it as the submit request.
+ */
+function readFileAsArrayBuffer(file: File): Observable<ArrayBuffer> {
+  return new Observable<ArrayBuffer>((subscriber) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      subscriber.next(reader.result as ArrayBuffer);
+      subscriber.complete();
+    };
+    reader.onerror = () => subscriber.error(reader.error);
+    reader.readAsArrayBuffer(file);
+    return () => reader.abort();
+  });
+}
 
 @Component({
   selector: 'ix-kereberos-keytabs-form',
@@ -22,88 +39,67 @@ import { ApiService } from 'app/modules/websocket/api.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ReactiveFormsModule,
+    IxFormComponent,
     TnFormSectionComponent,
     TnFormFieldComponent,
     TnInputComponent,
-    IxFileInputComponent,
+    TnFileInputComponent,
+    TnTestIdDirective,
     TranslateModule,
   ],
 })
-export class KerberosKeytabsFormComponent extends SidePanelForm implements OnInit {
+export class KerberosKeytabsFormComponent extends IxFormHostForm implements OnInit {
   private formBuilder = inject(FormBuilder);
-  private errorHandler = inject(FormErrorHandlerService);
   private api = inject(ApiService);
   private fileValidator = inject(FileValidatorService);
-  private destroyRef = inject(DestroyRef);
+  private translate = inject(TranslateService);
 
   readonly editingRow = input<KerberosKeytab | undefined>(undefined);
 
   readonly requiredRoles = [Role.DirectoryServiceWrite];
-  protected editingKerberosKeytab: KerberosKeytab | undefined;
+
+  protected readonly isEditMode = computed(() => Boolean(this.editingRow()));
 
   protected readonly form = this.formBuilder.nonNullable.group({
     name: ['', Validators.required],
-    file: [null as File[] | null, Validators.compose([
+    // `tn-file-input` in single mode holds one `File`, where `ix-file-input` always held a `File[]`.
+    file: [null as File | null, Validators.compose([
       Validators.required,
       this.fileValidator.maxSize(40 * KiB),
     ])],
   });
 
-  protected readonly isFormLoading = signal(false);
-
-  readonly canSubmit = this.trackCanSubmit(this.isFormLoading);
-
-  readonly helptext = helptextKerberosKeytabs;
+  protected readonly helptext = helptextKerberosKeytabs;
 
   ngOnInit(): void {
     const row = this.editingRow();
-    this.editingKerberosKeytab = row;
-
     if (row) {
-      this.form.patchValue({
-        name: row.name,
-      });
+      this.form.patchValue({ name: row.name });
     }
   }
 
-  protected onSubmit(): void {
+  protected handleSubmit = (): SubmitResult => {
     const values = this.form.getRawValue();
+    const editingKeytab = this.editingRow();
 
-    const fReader: FileReader = new FileReader();
-    if (values.file?.length) {
-      fReader.readAsArrayBuffer(values.file[0]);
-    }
+    const request$ = readFileAsArrayBuffer(values.file).pipe(
+      map((arrayBuffer) => {
+        const bytes = new Uint8Array(arrayBuffer);
+        const binaryString = Array.from(bytes).map((byte) => String.fromCharCode(byte)).join('');
+        return { name: values.name, file: btoa(binaryString) };
+      }),
+      switchMap((payload) => {
+        return editingKeytab
+          ? this.api.call('kerberos.keytab.update', [editingKeytab.id, payload])
+          : this.api.call('kerberos.keytab.create', [payload]);
+      }),
+    );
 
-    fReader.onloadend = () => {
-      const arrayBuffer = fReader.result as ArrayBuffer;
-      const bytes = new Uint8Array(arrayBuffer);
-      const binaryString = Array.from(bytes).map((byte) => String.fromCharCode(byte)).join('');
-      const file = btoa(binaryString);
-      const payload = {
-        name: values.name,
-        file,
-      };
-      this.isFormLoading.set(true);
-      let request$: Observable<unknown>;
-      if (this.editingKerberosKeytab) {
-        request$ = this.api.call('kerberos.keytab.update', [
-          this.editingKerberosKeytab.id,
-          payload,
-        ]);
-      } else {
-        request$ = this.api.call('kerberos.keytab.create', [payload]);
-      }
-
-      request$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-        next: () => {
-          this.isFormLoading.set(false);
-          this.close(true);
-        },
-        error: (error: unknown) => {
-          this.isFormLoading.set(false);
-          this.errorHandler.handleValidationErrors(error, this.form);
-        },
-      });
+    return {
+      request$,
+      successMessage: editingKeytab
+        ? this.translate.instant('Kerberos keytab updated')
+        : this.translate.instant('Kerberos keytab added'),
     };
-  }
+  };
 }


### PR DESCRIPTION
**Changes:**

Bundled T15 of the tn-* migration epic — the last `ix-*` form controls in the directory-service,
dashboard and jobs sections. Bundled per the migration plan to avoid three near-empty tickets.

| Area | Change |
|---|---|
| `trusted-domains-config` | `ix-fieldset` → `tn-form-section`; `ix-list`/`ix-list-item` → `tn-form-list`/`tn-form-list-item`; `ix-select`/`ix-input`/`ix-checkbox` → `tn-form-field` + `tn-select`/`tn-input`/`tn-checkbox`. Options are now synchronous arrays (`translateOptions`) instead of `Observable<Option[]>`. |
| `kerberos-keytabs-form` | Now extends `IxFormHostForm` and renders `<ix-form>`, so it picks up the shared submit lifecycle, loading state, dirty guard and success snackbar. `ix-file-input` → `tn-file-input`. The `FileReader` read is wrapped as an observable and becomes the submit `request$`. |
| `widget-group-form`, `widget-group-slot-form` | `ix-fieldset` → `tn-form-section`. Slot-form SCSS de-duplicated: the section body owns the field gap now, so the per-field `margin-bottom` is gone (it was stacking with the new gap). |
| `job-logs-row` | **No change — deliberate hold.** Its only `ix-*` is `ix-code-editor` (a read-only CodeMirror view of the job arguments) and `@truenas/ui-components@0.7.1` ships no code editor. The section is already Material-free. Replacing it with `<pre><code>` would lose JSON highlighting and line numbers, which is a product decision rather than a migration. |
| `file-validator.service` | `maxSize` widened to `FormControl<File \| File[] \| null>` — `tn-file-input` in single mode holds one `File` where `ix-file-input` always held a `File[]`. Backwards compatible; it was the only caller. |

Two things a reviewer should look at deliberately:

- **New snackbar on keytab save.** The form had none before; `<ix-form>` requires a `successMessage`
  or an explicit opt-out, and the snackbar is the wrapper's standard behaviour. Adds two
  translatable strings (`Kerberos keytab added` / `updated`).
- **Two `optionTestIdKey` callbacks in `trusted-domains-config`.** `tn-select` derives an option's
  `data-test` from the label it is handed, so keying off the pre-translated list would make the ids
  follow the UI language, and the library's kebab does not split letter→digit the way lodash does
  (`RFC2307` → `rfc2307`, not `rfc-2307`). The callbacks map each option's value back to the raw
  marker label through `normalizeTestIdString`, which restores both properties in one place.

**Testing:**

- `yarn test:changed` green (34 tests), plus the 11 neighbouring suites these components touch
  (85 tests). `yarn lint` clean on all touched files; `tsc -p src/tsconfig.app.json` clean.
- Specs rewritten onto tn-* harnesses — `TnFormListHarness`, `TnInputHarness`, `TnSelectHarness`,
  `TnCheckboxHarness`, `TnFileInputHarness`, `TnFormSectionHarness`. The keytab spec gained
  create/update submit coverage it did not have before.
- **`data-test` parity was verified empirically**, by dumping every `[data-test]` in the rendered
  DOM before and after rather than by reading the templates. Every control and option id is
  byte-identical, including the four `option-idmap-backend-*` and three `option-schema-mode-*`
  values, and `input-file` (pinned onto the `<tn-file-input>` host with
  `tnTestIdType="input"`, since the container declares the `file-input` prefix).
- Manually exercised on a dev VM in **both light (Paper) and dark themes**: the keytab side panel,
  the trusted-domains list with the AD branch and the 10-field RFC2307 branch, and the widget Card
  Editor. The `tn-form-list-item` border themes correctly from the library's own `themes.css` — no
  local `--tn-lines` bridge needed. The `tn-side-panel` unsaved-changes guard still fires after the
  `IxFormHostForm` conversion.

**Reviewer setup:** a WebSocket Debug Panel mock set covering both features (keytab CRUD + sync job,
an AD config carrying one trusted domain per idmap backend, the update job, and toggleable
validation-error scenarios) is attached to the ticket — import it via Ctrl+Shift+X → Mock
Configurations → Import.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | No — no user-facing copy changes beyond the new save-confirmation snackbar on the Kerberos keytab form.
|Testing         | Every control-level `data-test` is preserved and was diffed against the pre-migration DOM. The label/tooltip chrome ids that `ix-label`/`ix-tooltip` emitted (`text-<control>`, `icon-tooltip-<control>`, `text-tooltip-title`, `text-tooltip-message`, `icon-tooltip-close`) are gone — `tn-form-field` renders its label and tooltip with no ids, and there is nowhere to re-home them. `grep` over `e2e/` finds no references to any of them.