### PR TITLE
NAS-142517 / 27.0.0-BETA.1 / Fix Storage Dashboard failing when zpool.query returns null properties

### DIFF
--- a/src/app/interfaces/zpool.interface.ts
+++ b/src/app/interfaces/zpool.interface.ts
@@ -18,7 +18,9 @@ export interface Zpool {
   warning: boolean;
   status_code: string;
   status_detail: string | null;
-  properties: Record<string, ZpoolProperty>;
+  // Null for pools ZFS cannot read properties from, e.g. an unavailable or
+  // faulted pool, so every access has to be guarded.
+  properties: Record<string, ZpoolProperty> | null;
   topology: PoolTopology | null;
   scan: PoolScanUpdate | null;
   // `expand` and `features` are present on the wire but not consumed in the

--- a/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.ts
+++ b/src/app/pages/sharing/components/change-tier-dialog/change-tier-dialog.component.ts
@@ -142,10 +142,10 @@ export class ChangeTierDialogComponent implements OnInit {
       takeUntilDestroyed(this.destroyRef),
     ).subscribe({
       next: ([zpools, datasets]) => {
-        const zpool = zpools[0];
-        if (zpool) {
-          const regularAvailable = Number(zpool.properties.class_normal_available?.value ?? 0);
-          const specialAvailable = Number(zpool.properties.class_special_available?.value ?? 0);
+        const properties = zpools[0]?.properties;
+        if (properties) {
+          const regularAvailable = Number(properties.class_normal_available?.value ?? 0);
+          const specialAvailable = Number(properties.class_special_available?.value ?? 0);
           this.regularAvailable.set(buildNormalizedFileSize(regularAvailable, 'B', 2));
           if (specialAvailable > 0) {
             this.performanceAvailable.set(buildNormalizedFileSize(specialAvailable, 'B', 2));

--- a/src/app/pages/storage/stores/pools-dashboard-store.service.spec.ts
+++ b/src/app/pages/storage/stores/pools-dashboard-store.service.spec.ts
@@ -221,4 +221,56 @@ describe('PoolsDashboardStore', () => {
       });
     });
   });
+
+  it('keeps showing pools when zpool.query returns null properties', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const mockedApi = spectator.inject(ApiService);
+      const pools = [
+        {
+          id: 1, name: 'pool1', used: 10, available: 20,
+        },
+      ] as Pool[];
+      const zpools = [
+        { name: 'pool1', properties: null },
+      ];
+
+      jest.spyOn(mockedApi, 'call').mockImplementation((method: string) => {
+        switch (method) {
+          case 'pool.dataset.query':
+            return cold('-a|', { a: [] });
+          case 'zpool.query':
+            return cold('-a|', { a: zpools });
+          case 'pool.scrub.query':
+            return cold('-a|', { a: [] });
+          case 'disk.query':
+            return cold('-a|', { a: [] });
+          case 'disk.temperature_alerts':
+            return cold('-a|', { a: [] });
+          case 'disk.temperature_agg':
+            return cold('-a|', { a: {} });
+          default:
+            throw new Error(`Unexpected method: ${method}`);
+        }
+      });
+      jest.spyOn(mockedApi, 'callAndSubscribe').mockImplementation((method: string) => {
+        if (method === 'pool.query') {
+          return cold('-a|', { a: pools });
+        }
+        throw new Error(`Unexpected method: ${method}`);
+      });
+
+      spectator.service.loadDashboard();
+
+      expectObservable(
+        spectator.service.select((state) => state.pools),
+      ).toBe('ab', {
+        a: [],
+        b: [
+          {
+            id: 1, name: 'pool1', used: 10, available: 20,
+          },
+        ],
+      });
+    });
+  });
 });

--- a/src/app/pages/storage/stores/pools-dashboard-store.service.ts
+++ b/src/app/pages/storage/stores/pools-dashboard-store.service.ts
@@ -110,19 +110,21 @@ export class PoolsDashboardStore extends ComponentStore<PoolsDashboardState> {
       tap(([pools, rootDatasets, zpools]) => {
         const zpoolsByName = keyBy(zpools, (zpool) => zpool.name);
         const poolsWithTierData = pools.map((pool) => {
-          const zpool = zpoolsByName[pool.name];
-          if (!zpool) return pool;
+          // `properties` is null when ZFS can't read them (unavailable pool),
+          // in which case the pool is shown with the numbers pool.query gave us.
+          const properties = zpoolsByName[pool.name]?.properties;
+          if (!properties) return pool;
           const toBytes = (raw: number | string | undefined | null): number => Number(raw ?? 0);
           // The metadata reserve is derived in the Usage card from
           // zfs.tier.config (special_class_metadata_reserve_pct), so the raw
           // ZFS values are passed through here untouched.
-          const rawSpecialUsable = zpool.properties.class_special_usable?.value;
+          const rawSpecialUsable = properties.class_special_usable?.value;
           return {
             ...pool,
-            used: toBytes(zpool.properties.class_normal_used?.value) || pool.used,
-            available: toBytes(zpool.properties.class_normal_available?.value) || pool.available,
-            special_class_used: toBytes(zpool.properties.class_special_used?.value),
-            special_class_available: toBytes(zpool.properties.class_special_available?.value),
+            used: toBytes(properties.class_normal_used?.value) || pool.used,
+            available: toBytes(properties.class_normal_available?.value) || pool.available,
+            special_class_used: toBytes(properties.class_special_used?.value),
+            special_class_available: toBytes(properties.class_special_available?.value),
             // Left undefined (not 0) when ZFS doesn't report it, so the Usage card
             // can tell "absent" from a genuine empty special vdev and fall back.
             special_class_usable: rawSpecialUsable == null ? undefined : Number(rawSpecialUsable),


### PR DESCRIPTION
I used this file to reproduce the bug (on master branch):

[nas-142517-zpool-null-properties.mock.json](https://github.com/user-attachments/files/31690929/nas-142517-zpool-null-properties.mock.json)

One thing you must edit before importing: replace REPLACE_WITH_BROKEN_POOL_NAME and REPLACE_WITH_HEALTHY_POOL_NAME with actual pool names from your system. The store keys the zpool list by name and only overlays a pool when zpoolsByName[pool.name] hits (pools-dashboard-store.service.ts:118) — a non-matching name is silently ignored and nothing reproduces. If you only have one pool, point the null entry at it and leave the second entry as-is.


**Changes:**

The Storage Dashboard threw `can't access property "class_special_usable", T.properties is null` and rendered no pools at all.

`zpool.query` returns `properties: null` for a pool ZFS can't read properties from (unavailable/faulted). `PoolsDashboardStore.loadPoolsAndRootDatasets()` dereferenced it unguarded — the existing `?.` only covered a *missing* property (a pool with no special vdev), not a null `properties` object. The throw happens inside the `tap`, so the `catchError` wrapping the whole `forkJoin` swallows the entire load: one bad pool hides every pool.

- `zpool.interface.ts` — `Zpool.properties` is now `Record<string, ZpoolProperty> | null`, so the compiler forces the guard at every call site.
- `pools-dashboard-store.service.ts` — hoists `properties` and returns the plain `pool.query` pool when it's null. The pool still renders with the used/available numbers `pool.query` supplied; only the tier overlay is skipped.
- `change-tier-dialog.component.ts` — same unguarded deref, guarded the same way. (`dataset-capacity-management-card` already used `?.properties?.` and needed no change.)
- Spec: added *"keeps showing pools when zpool.query returns null properties"*.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | No — no user-facing behavior or wording change.
|Testing         | Yes — worth an E2E/manual case for a dashboard with a faulted or unavailable pool; previously untested path.