### PR TITLE
NAS-142236 / 26.0.0 / Stop tooltips swallowing clicks on the controls they cover

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   provideNativeDateAdapter,
 } from '@angular/material/core';
 import { MAT_SNACK_BAR_DEFAULT_OPTIONS, MatSnackBarConfig } from '@angular/material/snack-bar';
+import { MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltipDefaultOptions } from '@angular/material/tooltip';
 import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
 import {
   withPreloading,
@@ -112,6 +113,31 @@ bootstrapApplication(AppComponent, {
         verticalPosition: 'top',
         duration: 3000,
       } as MatSnackBarConfig,
+    },
+    {
+      /**
+       * A tooltip is placed clear of its own trigger, so the area it covers belongs to whatever
+       * sits next to that trigger - on the dataset Details card, the path row's "Copy to Clipboard"
+       * tooltip lands squarely on the Storage Tier badge and its "Change" button one row up.
+       *
+       * Material's tooltips are interactive by default: the trigger's `mouseleave` deliberately
+       * skips `hide()` when the pointer moves onto the tooltip itself, so a panel you walk into on
+       * the way to the control underneath stays up - and, being `pointer-events: auto`, swallows
+       * the click. The only way out is to retreat and re-approach along a path that misses the
+       * panel, which is exactly the "different angles" workaround NAS-142236 reports.
+       *
+       * That interactivity only buys the ability to select tooltip text, which nothing here needs.
+       * Turning it off adds `mat-mdc-tooltip-panel-non-interactive` (`pointer-events: none`), so a
+       * hover tooltip stops being a hit target and `mouseleave` fires normally against whatever is
+       * really underneath.
+       */
+      provide: MAT_TOOLTIP_DEFAULT_OPTIONS,
+      useValue: {
+        showDelay: 0,
+        hideDelay: 0,
+        touchendHideDelay: 1500,
+        disableTooltipInteractivity: true,
+      } as MatTooltipDefaultOptions,
     },
     {
       provide: ErrorHandler,


### PR DESCRIPTION
A tooltip is placed clear of its own trigger, so the area it covers belongs to whatever sits next to that trigger. On the dataset Details card that is the Storage Tier row: the path row's "Copy to Clipboard" tooltip lands squarely on the tier badge and its "Change" button one row up.

Material's tooltips are interactive by default, so the trigger's mouseleave deliberately skips hide() when the pointer moves onto the tooltip itself:

  if (!newTarget || !this._overlayRef?.overlayElement.contains(newTarget)) {
    this.hide();
  }

A panel you walk into on the way to the control underneath therefore stays up, and since the pane is pointer-events: auto it swallows the click. The only way through is to retreat and re-approach along a path that misses the panel - which is the "approach from different angles" workaround the ticket reports, and why it varies with window size and zoom.

That interactivity only buys selecting tooltip text; a Material tooltip renders its message as plain text interpolation, so it can never hold a link or a control. Turning it off adds mat-mdc-tooltip-panel-non-interactive (pointer-events: none), which fixes both halves: the pane stops being a hit target, and mouseleave then fires against whatever is really underneath, so the tooltip also gets out of the way.

The other three values match Material's own defaults factory exactly, since providing MAT_TOOLTIP_DEFAULT_OPTIONS replaces them wholesale.

Verified: before, clicking the badge or Change through the tooltip landed on TOOLTIP PANE and nothing happened; after, both land on their control and open their dialog.
