### PR TITLE
NAS-143038 / 27.0.0-BETA.1 / Pin the self-hosted unit-test job to the ARM builder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,10 @@ jobs:
     if: needs.check-ux-team.outputs.is_member == 'true'
     strategy:
       fail-fast: false
-    runs-on: self-hosted
+    # Named labels rather than a bare `self-hosted`, which matches whichever
+    # registered runner happens to be free. More than one is registered, and
+    # they are not interchangeable — this job wants the ARM builder.
+    runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
`runs-on: self-hosted` matches any registered self-hosted runner, and the organisation now has more than one. The label therefore picks whichever is free rather than the machine this job is meant for, so a unit-test run can end up on a runner reserved for something else entirely.

Naming the ARM builder's labels — `self-hosted`, `Linux`, `ARM64` — makes the choice explicit and independent of what else is registered.

Nothing else changes. The job id and its `name:` are untouched, because branch protection matches the reported check name and this file says so. The `ubuntu-latest` path stays as well: it is what non-members and fork pull requests run on, which is what keeps untrusted code off a self-hosted runner in a public repository.