### PR TITLE
NAS-142927 / 26.0.0-RC.1 / Show a reachable address in the VM display dialog (by AlexKarpov98)

### DIFF
--- a/src/app/services/vm.service.spec.ts
+++ b/src/app/services/vm.service.spec.ts
@@ -6,10 +6,11 @@ import { firstValueFrom, of, throwError } from 'rxjs';
 import { fakeSuccessfulJob } from 'app/core/testing/utils/fake-job.utils';
 import { mockCall, mockJob, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { ApiErrorName, JsonRpcErrorCode } from 'app/enums/api.enum';
-import { VmState } from 'app/enums/vm.enum';
+import { VmDisplayType, VmState } from 'app/enums/vm.enum';
 import { WINDOW } from 'app/helpers/window.helper';
 import { ApiErrorDetails } from 'app/interfaces/api-error.interface';
 import { VirtualMachine } from 'app/interfaces/virtual-machine.interface';
+import { VmDisplayDevice } from 'app/interfaces/vm-device.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { LoaderService } from 'app/modules/loader/loader.service';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -41,6 +42,7 @@ describe('VmService', () => {
         mockCall('vm.get_available_memory', 4096),
         mockJob('vm.stop', fakeSuccessfulJob()),
         mockJob('vm.restart', fakeSuccessfulJob()),
+        mockCall('vm.get_display_devices', []),
       ]),
       mockProvider(DialogService),
       mockProvider(MatDialog, {
@@ -52,7 +54,9 @@ describe('VmService', () => {
         withLoader: () => <T>(source$: T) => source$,
       }),
       mockProvider(TranslateService, {
-        instant: jest.fn((key: string) => key),
+        instant: jest.fn((key: string, params?: Record<string, unknown>) => {
+          return params ? key.replace(/{(\w+)}/g, (_, name: string) => String(params[name])) : key;
+        }),
       }),
       mockProvider(ErrorHandlerService, {
         showErrorModal: jest.fn(),
@@ -67,6 +71,7 @@ describe('VmService', () => {
           open: jest.fn(),
           location: {
             href: '',
+            hostname: 'truenas.local',
           },
         },
       },
@@ -177,5 +182,67 @@ describe('VmService', () => {
     await firstValueFrom(spectator.service.doStartResume(vm));
     expect(apiService.call).toHaveBeenLastCalledWith('vm.start', [1, { overcommit: true }]);
     expect(dialogService.confirm).toHaveBeenCalled();
+  });
+
+  describe('openDisplay', () => {
+    function mockDisplayDevices(devices: VmDisplayDevice[]): void {
+      const apiService = spectator.inject(ApiService);
+      const callSpy = jest.spyOn(apiService, 'call');
+      const mockImpl = callSpy.getMockImplementation();
+
+      callSpy.mockImplementation((method, params) => {
+        if (method === 'vm.get_display_devices') {
+          return of(devices);
+        }
+
+        return mockImpl(method, params);
+      });
+    }
+
+    it('shows the address of the UI host when a VNC device is bound to a wildcard address', () => {
+      mockDisplayDevices([
+        { attributes: { type: VmDisplayType.Vnc, bind: '0.0.0.0', port: 5902 } } as VmDisplayDevice,
+      ]);
+
+      spectator.service.openDisplay(mockVm(VmState.Running));
+
+      expect(spectator.inject(DialogService).info).toHaveBeenCalledWith(
+        'VNC Display Available',
+        'Connect using a VNC client to: truenas.local:5902',
+        true,
+      );
+    });
+
+    it('keeps the address of a VNC device that is bound to a specific address', () => {
+      mockDisplayDevices([
+        { attributes: { type: VmDisplayType.Vnc, bind: '10.10.16.82', port: 5902 } } as VmDisplayDevice,
+      ]);
+
+      spectator.service.openDisplay(mockVm(VmState.Running));
+
+      expect(spectator.inject(DialogService).info).toHaveBeenCalledWith(
+        'VNC Display Available',
+        'Connect using a VNC client to: 10.10.16.82:5902',
+        true,
+      );
+    });
+
+    it('shows the address of the UI host when a SPICE device without web access is bound to a wildcard address', () => {
+      mockDisplayDevices([
+        {
+          attributes: {
+            type: VmDisplayType.Spice, bind: '::', port: 5900, web: false,
+          },
+        } as VmDisplayDevice,
+      ]);
+
+      spectator.service.openDisplay(mockVm(VmState.Running));
+
+      expect(spectator.inject(DialogService).info).toHaveBeenCalledWith(
+        'SPICE Display Available',
+        'Web access is disabled. Connect using a SPICE client to: truenas.local:5900',
+        true,
+      );
+    });
   });
 });

--- a/src/app/services/vm.service.ts
+++ b/src/app/services/vm.service.ts
@@ -2,6 +2,7 @@ import { DestroyRef, Injectable, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
+import ipRegex from 'ip-regex';
 import {
   BehaviorSubject, catchError, filter, Observable, of, repeat, Subject, switchMap, take,
 } from 'rxjs';
@@ -25,6 +26,8 @@ import { ApiService } from 'app/modules/websocket/api.service';
 import { StopVmDialogComponent, StopVmDialogData } from 'app/pages/vm/vm-list/stop-vm-dialog/stop-vm-dialog.component';
 import { DownloadService } from 'app/services/download.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+
+const wildcardBindAddresses = ['0.0.0.0', '::'];
 
 @Injectable({ providedIn: 'root' })
 export class VmService {
@@ -151,7 +154,9 @@ export class VmService {
           if (spiceDevice?.attributes.web) {
             this.openDisplayWebUri(vm.id);
           } else if (vncDevices.length > 0) {
-            const vncConnections = vncDevices.map((device) => `${device.attributes.bind}:${device.attributes.port}`).join(', ');
+            const vncConnections = vncDevices
+              .map((device) => `${this.getReachableAddress(device.attributes.bind)}:${device.attributes.port}`)
+              .join(', ');
             this.dialogService.info(
               this.translate.instant('VNC Display Available'),
               this.translate.instant('Connect using a VNC client to: {connections}', { connections: vncConnections }),
@@ -162,7 +167,9 @@ export class VmService {
               this.translate.instant('SPICE Display Available'),
               this.translate.instant(
                 'Web access is disabled. Connect using a SPICE client to: {connection}',
-                { connection: `${spiceDevice.attributes.bind}:${spiceDevice.attributes.port}` },
+                {
+                  connection: `${this.getReachableAddress(spiceDevice.attributes.bind)}:${spiceDevice.attributes.port}`,
+                },
               ),
               true,
             );
@@ -214,6 +221,19 @@ export class VmService {
           this.errorHandler.showErrorModal(error);
         },
       });
+  }
+
+  /**
+   * Display devices are normally bound to a wildcard address, which is useless to show to a user:
+   * they cannot point a VNC or SPICE client at 0.0.0.0. Fall back to the host the UI is being
+   * served from, which is reachable by definition.
+   */
+  private getReachableAddress(bind: string): string {
+    const hostname = this.window.location.hostname?.replace(/^\[|\]$/g, '');
+    const isWildcard = !bind || wildcardBindAddresses.includes(bind);
+    const address = isWildcard && hostname ? hostname : bind;
+
+    return ipRegex.v6({ exact: true }).test(address) ? `[${address}]` : address;
   }
 
   private openDisplayWebUri(vmId: number): void {


### PR DESCRIPTION
before:
<img width="1500" height="950" alt="before" src="https://github.com/user-attachments/assets/4b5cd6d6-3e10-453d-9c62-31f3558966b9" />

after:
<img width="1500" height="950" alt="after" src="https://github.com/user-attachments/assets/beabc4a0-5c6e-493d-9a99-eb5970fc9dc3" />


Original PR: https://github.com/truenas/webui/pull/13997
