### PR TITLE
NAS-143052 / 27.0.0-BETA.1 / Remove force_remove_ix_volumes from app delete payload

### DIFF
--- a/src/app/interfaces/app.interface.ts
+++ b/src/app/interfaces/app.interface.ts
@@ -300,7 +300,6 @@ export type AppDeleteParams = [
   {
     remove_images?: boolean;
     remove_ix_volumes?: boolean;
-    force_remove_ix_volumes?: boolean;
   },
 ];
 

--- a/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.html
+++ b/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.html
@@ -19,16 +19,6 @@
         [label]="'Remove iXVolumes' | translate"
       ></tn-checkbox>
     </tn-form-field>
-
-    @if (data.showRemoveVolumes && form.value.removeVolumes) {
-      <tn-form-field>
-        <tn-checkbox
-          testId="force-remove-volumes"
-          formControlName="forceRemoveVolumes"
-          [label]="'Force-remove iXVolumes' | translate"
-        ></tn-checkbox>
-      </tn-form-field>
-    }
   }
 
   <tn-form-field>

--- a/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.spec.ts
+++ b/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.spec.ts
@@ -57,31 +57,6 @@ describe('AppDeleteDialogComponent', () => {
       confirmAppName: 'ix-test-app',
       removeImages: true,
       removeVolumes: true,
-      forceRemoveVolumes: false,
-    });
-  });
-
-  it('shows force remove volumes checkbox when Remove iXVolumes is selected', async () => {
-    expect(await loader.getAllHarnesses(TnCheckboxHarness.with({ label: 'Force-remove iXVolumes' }))).toHaveLength(0);
-
-    const confirmInput = await loader.getHarness(TnInputHarness);
-    await confirmInput.setValue('ix-test-app');
-
-    const removeVolumesCheckbox = await loader.getHarness(TnCheckboxHarness.with({ label: 'Remove iXVolumes' }));
-    await removeVolumesCheckbox.check();
-    const forceRemoveVolumesCheckbox = await loader.getHarness(
-      TnCheckboxHarness.with({ label: 'Force-remove iXVolumes' }),
-    );
-    await forceRemoveVolumesCheckbox.check();
-
-    const deleteButton = await loader.getHarness(TnButtonHarness.with({ label: 'Delete' }));
-    await deleteButton.click();
-
-    expect(spectator.inject(DialogRef).close).toHaveBeenCalledWith({
-      confirmAppName: 'ix-test-app',
-      removeImages: true,
-      removeVolumes: true,
-      forceRemoveVolumes: true,
     });
   });
 

--- a/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.ts
+++ b/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.ts
@@ -37,7 +37,6 @@ export class AppDeleteDialog {
   form = this.formBuilder.nonNullable.group({
     removeVolumes: [false],
     removeImages: [true],
-    forceRemoveVolumes: [false],
     confirmAppName: ['', [Validators.required, this.validators.confirmValidator(
       this.data.name,
       this.translate.instant('Enter application name to continue.'),

--- a/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.interface.ts
+++ b/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.interface.ts
@@ -6,5 +6,4 @@ export interface AppDeleteDialogInputData {
 export interface AppDeleteDialogOutputData {
   removeVolumes: boolean;
   removeImages: boolean;
-  forceRemoveVolumes: boolean;
 }

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -204,7 +204,6 @@ export class AppInfoCardComponent {
       this.api.job('app.delete', [name, {
         remove_images: options.removeImages,
         remove_ix_volumes: options.removeVolumes,
-        force_remove_ix_volumes: options.forceRemoveVolumes,
       }]),
       { title: this.translate.instant(helptextApps.apps.deleting) },
     )

--- a/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.ts
@@ -537,7 +537,6 @@ export class InstalledAppsListComponent implements OnInit {
       {
         remove_images: options.removeImages,
         remove_ix_volumes: options.removeVolumes,
-        force_remove_ix_volumes: options.forceRemoveVolumes,
       },
     ]);
 


### PR DESCRIPTION
## Summary
- `force_remove_ix_volumes` was removed from the `app.delete` API (no backend effect), so stop sending it from the single-app delete and the `core.bulk` delete.
- Drop the "Force-remove iXVolumes" checkbox from the delete dialog, along with the `forceRemoveVolumes` form control and output field.
- Remove the field from the `AppDeleteParams` type.

`remove_ix_volumes` is unchanged and still controls whether ix-volumes are deleted.

## Test plan
- [x] `yarn test:changed` passes (app-delete-dialog, app-info-card, installed-apps-list specs)
- [x] `yarn lint` clean on changed files