### PR TITLE
NAS-143105 / 27.0.0-BETA.1 / Test the UI built from the checkout in the e2e pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -215,6 +215,7 @@ jobs:
             -e "s|^\([[:space:]]*access_log\) .*|\1 off;|" \
             -e "s|^\([[:space:]]*\)listen[[:space:]]*0\.0\.0\.0:80;|\1listen 0.0.0.0:443 ssl; ssl_certificate /etc/nginx/e2e-ui.crt; ssl_certificate_key /etc/nginx/e2e-ui.key;|" \
             -e "/listen[[:space:]]*\[::\]:80;/d" \
+            -e "/error_page[[:space:]]*500 502 503 504/d" \
             docker/nginx.conf > "$conf"
           grep -q "listen 0.0.0.0:443 ssl" "$conf" || { echo "::error::docker/nginx.conf no longer has the listen line this step rewrites"; exit 1; }
           $DOCKER run -d --rm --name "$name" \
@@ -230,16 +231,20 @@ jobs:
           url="https://localhost:${port}/ui/"
           # Fail here, not four steps later inside a test, if the UI or its
           # proxy to the appliance is not answering. The proxy check asks for
-          # the WebSocket endpoint over plain GET: any answer that is not a
-          # 5xx came from the appliance, while 502 is nginx saying it could
-          # not reach it.
+          # the WebSocket endpoint over plain GET. A 5xx is nginx unable to
+          # reach the appliance — the sed above removes the inherited
+          # `error_page` handler, whose 50x page does not exist in this image
+          # and would otherwise turn that 502 into a 404. A 404 is excluded
+          # too, since nginx can produce one on its own; anything else in
+          # 1xx–4xx had to come from the appliance.
           ready=
           for i in $(seq 1 30); do
             ui=$(curl -sk -o /dev/null -w '%{http_code}' "$url" || true)
             proxy=$(curl -sk -o /dev/null -w '%{http_code}' "https://localhost:${port}/api/current" || true)
-            case "$ui/$proxy" in
-              200/[1234]*) ready=1; break ;;
-            esac
+            if [ "$ui" = 200 ] && [[ "$proxy" =~ ^[1-4] ]] && [ "$proxy" != 404 ]; then
+              ready=1
+              break
+            fi
             sleep 2
           done
           if [ -z "$ready" ]; then
@@ -247,9 +252,8 @@ jobs:
             $DOCKER logs "$name" || true
             exit 1
           fi
-          echo "UI_CONTAINER=$name" >> "$GITHUB_ENV"
           echo "TN_UI_BASE_URL=$url" >> "$GITHUB_ENV"
-          echo "Serving the built UI at $url, proxying to the appliance at $TN_HOST_HTTP"
+          echo "Serving the built UI at $url (proxy check answered $proxy), proxying to the appliance at $TN_HOST_HTTP"
 
       - name: Run the suite
         id: suite
@@ -341,10 +345,12 @@ jobs:
 
       # A leftover UI container would go on proxying to a destroyed appliance
       # and sit on the daemon forever. `--rm` covers a clean exit; this covers
-      # the rest.
+      # the rest, including a container that started but never passed the
+      # readiness gate. Stateless on purpose: the name is derived, not read
+      # from something the serve step may have died before writing.
       - name: Stop the UI
-        if: always() && env.UI_CONTAINER != ''
-        run: $DOCKER rm -f "$UI_CONTAINER" > /dev/null || true
+        if: always() && env.DOCKER != ''
+        run: $DOCKER rm -f "e2e-ui-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" > /dev/null 2>&1 || true
 
       # Unconditional: an appliance left claimed is one the next run cannot use.
       # Reads the domain from the file `claim` wrote, so a failure between the

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,13 @@ on:
         description: Optional Playwright --grep filter
         type: string
         default: ''
+      ui:
+        description: >-
+          Which UI to test. `built` builds this checkout and serves it beside
+          the appliance; `shipped` uses the UI baked into the appliance's ISO.
+        type: choice
+        default: built
+        options: [built, shipped]
 
 # Reads code, uploads artifacts. No reason to write to the repository.
 permissions:
@@ -89,6 +96,9 @@ jobs:
       TN_GUEST_HOST_USER: ${{ vars.E2E_TN_GUEST_HOST_USER || 'root' }}
       TN_GUEST_HOST_API_KEY: ${{ secrets.TN_GUEST_HOST_API_KEY }}
       TN_GUEST_HOST_PASSWORD: ${{ secrets.TN_GUEST_HOST_PASSWORD }}
+      # Serves the built UI. Debian-based on purpose: docker/nginx.conf runs
+      # as `www-data`, which the alpine image does not have.
+      NGINX_IMAGE: nginx:1.27
 
     steps:
       - uses: actions/checkout@v4
@@ -139,6 +149,24 @@ jobs:
           $docker pull --quiet "$image"
           echo "PLAYWRIGHT_IMAGE=$image" >> "$GITHUB_ENV"
 
+      # The UI under test is the one in this checkout, not the one baked into
+      # the appliance's ISO. Same production build as main.yml's Build job —
+      # `--base-href /ui/`, so it is served where the appliance's nginx would
+      # serve it. Built before the claim so the lab is not held during the
+      # build, and so the build's memory is back before a 6GB guest starts.
+      #
+      # The web server is a stock nginx image with the repository's own
+      # `docker/nginx.conf`, the file the shipped UI is served through. Pulled
+      # here for the same fail-early reason as the Playwright image.
+      - name: Build the UI
+        if: (inputs.ui || 'built') == 'built'
+        run: |
+          set -euo pipefail
+          yarn build:prod
+          [ -f dist/index.html ] || { echo "::error::yarn build:prod produced no dist/index.html"; exit 1; }
+          $DOCKER pull --quiet "$NGINX_IMAGE"
+          echo "UI_DIST=$GITHUB_WORKSPACE/dist" >> "$GITHUB_ENV"
+
       - name: Claim an appliance
         run: |
           set -euo pipefail
@@ -149,6 +177,64 @@ jobs:
           echo "::add-mask::$(sed -n 's/^TN_PASSWORD=//p' "$RUNNER_TEMP/appliance.env")"
           cat "$RUNNER_TEMP/appliance.env" >> "$GITHUB_ENV"
           rm -f "$RUNNER_TEMP/appliance.env"
+
+      # nginx serves the build at /ui/ and proxies /api, /_upload, /_download
+      # and the WebSocket to the appliance over plain HTTP, exactly as
+      # `docker/nginx.conf` does on the appliance itself and in the Dockerfile.
+      # The two placeholders are filled the way `docker/start.sh` fills them,
+      # plus the syslog targets, which a container has no socket for. The
+      # upstream is the appliance's forwarded port 80, reached from the
+      # container's bridge network through Docker's host gateway. It cannot
+      # share the host network: nginx binds port 80, which is the TrueNAS
+      # host's own UI.
+      #
+      # Published on an ephemeral loopback port so a leftover container from a
+      # crashed run cannot hold the address, and named after the run so the
+      # teardown step can find it without state.
+      - name: Serve the UI
+        if: env.UI_DIST != ''
+        run: |
+          set -euo pipefail
+          name="e2e-ui-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          conf="$RUNNER_TEMP/nginx.conf"
+          sed \
+            -e "s|%%HOSTNAME%%|host.docker.internal:${TN_HOST_HTTP#*:}|g" \
+            -e "s|%%VERTAG%%|$(date +%s)|g" \
+            -e "s|^\(\s*error_log\) .*|\1 /dev/stderr;|" \
+            -e "s|^\(\s*access_log\) .*|\1 off;|" \
+            docker/nginx.conf > "$conf"
+          $DOCKER run -d --rm --name "$name" \
+            --add-host host.docker.internal:host-gateway \
+            -p 127.0.0.1::80 \
+            -v "$UI_DIST:/var/www/webui:ro" \
+            -v "$conf:/etc/nginx/tn-nginx.conf:ro" \
+            "$NGINX_IMAGE" nginx -c /etc/nginx/tn-nginx.conf > /dev/null
+          port=$($DOCKER port "$name" 80/tcp | head -1 | sed 's/.*://')
+          [ -n "$port" ] || { echo "::error::The UI container published no port"; exit 1; }
+          url="http://localhost:${port}/ui/"
+          # Fail here, not four steps later inside a test, if the UI or its
+          # proxy to the appliance is not answering. The proxy check asks for
+          # the WebSocket endpoint over plain GET: any answer that is not a
+          # 5xx came from the appliance, while 502 is nginx saying it could
+          # not reach it.
+          ready=
+          for i in $(seq 1 30); do
+            ui=$(curl -s -o /dev/null -w '%{http_code}' "$url" || true)
+            proxy=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${port}/api/current" || true)
+            case "$ui/$proxy" in
+              200/[1234]*) ready=1; break ;;
+            esac
+            sleep 2
+          done
+          if [ -z "$ready" ]; then
+            echo "::error::UI container is not serving at ${url} (ui=${ui:-none}, proxy=${proxy:-none})"
+            $DOCKER logs "$name" || true
+            exit 1
+          fi
+          echo "UI_CONTAINER=$name" >> "$GITHUB_ENV"
+          echo "TN_UI_BASE_URL=$url" >> "$GITHUB_ENV"
+          echo "TN_PROFILE=branch" >> "$GITHUB_ENV"
+          echo "Serving the built UI at $url, proxying to the appliance at $TN_HOST_HTTP"
 
       - name: Run the suite
         id: suite
@@ -193,6 +279,7 @@ jobs:
             "CI=$CI" \
             "TN_GREP=${TN_GREP:-}" \
             "TN_PROFILE=$TN_PROFILE" \
+            "TN_UI_BASE_URL=${TN_UI_BASE_URL:-}" \
             "TN_HOST=$TN_HOST" \
             "TN_USERNAME=$TN_USERNAME" \
             "TN_PASSWORD=$TN_PASSWORD" \
@@ -236,6 +323,13 @@ jobs:
           path: test-results/junit.xml
           if-no-files-found: error
           retention-days: 14
+
+      # A leftover UI container would go on proxying to a destroyed appliance
+      # and sit on the daemon forever. `--rm` covers a clean exit; this covers
+      # the rest.
+      - name: Stop the UI
+        if: always() && env.UI_CONTAINER != ''
+        run: $DOCKER rm -f "$UI_CONTAINER" > /dev/null || true
 
       # Unconditional: an appliance left claimed is one the next run cannot use.
       # Reads the domain from the file `claim` wrote, so a failure between the

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -185,8 +185,17 @@ jobs:
       # plus the syslog targets, which a container has no socket for. The
       # upstream is the appliance's forwarded port 80, reached from the
       # container's bridge network through Docker's host gateway. It cannot
-      # share the host network: nginx binds port 80, which is the TrueNAS
-      # host's own UI.
+      # share the host network: nginx binds the ports the TrueNAS host's own
+      # UI is on.
+      #
+      # Served over TLS with a throwaway self-signed certificate, and it has
+      # to be: a production build ignores the login token on a plain-HTTP
+      # origin (`AuthService.setQueryToken`), so over http the suite's setup
+      # project would wait on a sign-in page that never moves. The suite then
+      # runs as the `shipped` profile with `TN_UI_BASE_URL` overriding the
+      # address, which is what makes it tolerate a self-signed certificate —
+      # and is accurate: this is the production build at /ui/ over https,
+      # served the way the appliance serves it, just from a different box.
       #
       # Published on an ephemeral loopback port so a leftover container from a
       # crashed run cannot hold the address, and named after the run so the
@@ -197,21 +206,28 @@ jobs:
           set -euo pipefail
           name="e2e-ui-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           conf="$RUNNER_TEMP/nginx.conf"
+          openssl req -x509 -newkey rsa:2048 -nodes -days 2 -subj /CN=localhost \
+            -keyout "$RUNNER_TEMP/e2e-ui.key" -out "$RUNNER_TEMP/e2e-ui.crt" > /dev/null 2>&1
           sed \
             -e "s|%%HOSTNAME%%|host.docker.internal:${TN_HOST_HTTP#*:}|g" \
             -e "s|%%VERTAG%%|$(date +%s)|g" \
-            -e "s|^\(\s*error_log\) .*|\1 /dev/stderr;|" \
-            -e "s|^\(\s*access_log\) .*|\1 off;|" \
+            -e "s|^\([[:space:]]*error_log\) .*|\1 /dev/stderr;|" \
+            -e "s|^\([[:space:]]*access_log\) .*|\1 off;|" \
+            -e "s|^\([[:space:]]*\)listen[[:space:]]*0\.0\.0\.0:80;|\1listen 0.0.0.0:443 ssl; ssl_certificate /etc/nginx/e2e-ui.crt; ssl_certificate_key /etc/nginx/e2e-ui.key;|" \
+            -e "/listen[[:space:]]*\[::\]:80;/d" \
             docker/nginx.conf > "$conf"
+          grep -q "listen 0.0.0.0:443 ssl" "$conf" || { echo "::error::docker/nginx.conf no longer has the listen line this step rewrites"; exit 1; }
           $DOCKER run -d --rm --name "$name" \
             --add-host host.docker.internal:host-gateway \
-            -p 127.0.0.1::80 \
+            -p 127.0.0.1::443 \
             -v "$UI_DIST:/var/www/webui:ro" \
             -v "$conf:/etc/nginx/tn-nginx.conf:ro" \
+            -v "$RUNNER_TEMP/e2e-ui.crt:/etc/nginx/e2e-ui.crt:ro" \
+            -v "$RUNNER_TEMP/e2e-ui.key:/etc/nginx/e2e-ui.key:ro" \
             "$NGINX_IMAGE" nginx -c /etc/nginx/tn-nginx.conf > /dev/null
-          port=$($DOCKER port "$name" 80/tcp | head -1 | sed 's/.*://')
+          port=$($DOCKER port "$name" 443/tcp | head -1 | sed 's/.*://')
           [ -n "$port" ] || { echo "::error::The UI container published no port"; exit 1; }
-          url="http://localhost:${port}/ui/"
+          url="https://localhost:${port}/ui/"
           # Fail here, not four steps later inside a test, if the UI or its
           # proxy to the appliance is not answering. The proxy check asks for
           # the WebSocket endpoint over plain GET: any answer that is not a
@@ -219,8 +235,8 @@ jobs:
           # not reach it.
           ready=
           for i in $(seq 1 30); do
-            ui=$(curl -s -o /dev/null -w '%{http_code}' "$url" || true)
-            proxy=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${port}/api/current" || true)
+            ui=$(curl -sk -o /dev/null -w '%{http_code}' "$url" || true)
+            proxy=$(curl -sk -o /dev/null -w '%{http_code}' "https://localhost:${port}/api/current" || true)
             case "$ui/$proxy" in
               200/[1234]*) ready=1; break ;;
             esac
@@ -233,7 +249,6 @@ jobs:
           fi
           echo "UI_CONTAINER=$name" >> "$GITHUB_ENV"
           echo "TN_UI_BASE_URL=$url" >> "$GITHUB_ENV"
-          echo "TN_PROFILE=branch" >> "$GITHUB_ENV"
           echo "Serving the built UI at $url, proxying to the appliance at $TN_HOST_HTTP"
 
       - name: Run the suite

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -194,8 +194,10 @@ silently miss.
 ## CI
 
 The suite runs in GitHub Actions on a self-hosted TrueNAS runner, against a
-nested VM installed fresh for every run. `docs/05-ci.md` describes the
-pipeline, what the lab box has to provide, and what each early failure taught.
+nested VM installed fresh for every run, driving the UI built from the change
+under test rather than the one in the appliance's ISO. `docs/05-ci.md`
+describes the pipeline, what the lab box has to provide, and what each early
+failure taught.
 It runs on same-repo pull requests that touch the suite. A pull request that
 only touches documentation does not trigger it; note that GitHub evaluates the
 path filter against everything the pull request changes, so within a PR that

--- a/e2e/ci/appliance.sh
+++ b/e2e/ci/appliance.sh
@@ -166,21 +166,27 @@ claim() {
     --network hostfwd) \
     || die "tn_guest.py create failed for '$nickname'"
 
-  local name adminUser apiHost httpsPort
+  local name adminUser apiHost httpPort httpsPort
   name=$(jq -re '.name' <<<"$json")                      || die "create output has no .name"
   adminUser=$(jq -re '.admin_user' <<<"$json")           || die "create output has no .admin_user"
   apiHost=$(jq -re '.nodes[0].api_host' <<<"$json")      || die "create output has no .nodes[0].api_host"
+  httpPort=$(jq -re '.nodes[0].api_port_http' <<<"$json")   || die "create output has no .nodes[0].api_port_http"
   httpsPort=$(jq -re '.nodes[0].api_port_https' <<<"$json") || die "create output has no .nodes[0].api_port_https"
 
   # TN_* are the suite's existing contract — see .env.example and
-  # e2e/support/config.ts. The host is `host:port` because both the UI (https)
-  # and the middleware socket (wss) go through the forwarded 443.
+  # e2e/support/config.ts. The host is `host:port` because both the shipped
+  # UI (https) and the middleware socket (wss) go through the forwarded 443.
+  #
+  # TN_HOST_HTTP is the same appliance over the forwarded 80, for a UI served
+  # from a container whose nginx proxies to the appliance over plain HTTP —
+  # the pipeline's `branch` profile. Not part of the suite's contract.
   #
   # TN_DOMAIN is the deployment name, kept under the name the design uses for
   # the thing to release. TN_BASELINE is which baseline it is running against.
   cat <<EOF
 TN_PROFILE=shipped
 TN_HOST=${apiHost}:${httpsPort}
+TN_HOST_HTTP=${apiHost}:${httpPort}
 TN_USERNAME=$adminUser
 TN_PASSWORD=$password
 TN_DOMAIN=$name

--- a/e2e/ci/appliance.sh
+++ b/e2e/ci/appliance.sh
@@ -177,9 +177,9 @@ claim() {
   # e2e/support/config.ts. The host is `host:port` because both the shipped
   # UI (https) and the middleware socket (wss) go through the forwarded 443.
   #
-  # TN_HOST_HTTP is the same appliance over the forwarded 80, for a UI served
-  # from a container whose nginx proxies to the appliance over plain HTTP —
-  # the pipeline's `branch` profile. Not part of the suite's contract.
+  # TN_HOST_HTTP is the same appliance over the forwarded 80, for the UI the
+  # pipeline builds and serves from a container whose nginx proxies to the
+  # appliance over plain HTTP. Not part of the suite's contract.
   #
   # TN_DOMAIN is the deployment name, kept under the name the design uses for
   # the thing to release. TN_BASELINE is which baseline it is running against.

--- a/e2e/docs/05-ci.md
+++ b/e2e/docs/05-ci.md
@@ -21,18 +21,35 @@ One job, on a self-hosted runner that is itself a **TrueNAS box**. Per run:
    the version read from the installed `@playwright/test` so the two cannot
    drift. Docker is reached directly or through `sudo -n docker`, whichever
    works; a runner with neither fails here, before anything is provisioned.
-3. **Claim an appliance.** `appliance.sh claim fresh-install` drives
+3. **Build the UI.** `yarn build:prod`, the same production build as
+   `main.yml`, with `--base-href /ui/`. The UI under test is this checkout's,
+   not the one baked into the ISO. Built before the claim so the lab is not
+   held during the build and the build's memory is back before the guest
+   starts.
+4. **Claim an appliance.** `appliance.sh claim fresh-install` drives
    `tn_guest.py` (iXsystems/api-ci-testbed) against the box's own middleware
    API: create a nested VM, install TrueNAS from an ISO on the box, set a
    per-run admin password, wait for the API. It prints the suite's `TN_*`
    variables, which the workflow masks and loads into the job environment.
-4. **Run the suite** inside the Playwright container with `--network host`,
-   reusing the host's `node_modules`. Credentials reach the container through
-   an `--env-file` on the runner's dataset, never on the command line.
-5. **Upload JUnit.** Nothing else leaves the runner yet (see *Next*).
-6. **Release**, unconditionally: `tn_guest.py delete`. A claim that died before
-   the workflow recorded the name is still released, because `claim` writes the
-   nickname to a file first and `release` falls back to it.
+5. **Serve the UI.** A stock `nginx` container with `dist/` mounted and the
+   repository's own `docker/nginx.conf`, the file the appliance serves the UI
+   through: `/ui/` from disk, the API paths proxied to the appliance's
+   forwarded port 80 through Docker's host gateway. Published on an ephemeral
+   loopback port. Host networking is not an option: nginx binds 80, which is
+   the TrueNAS host's own UI. The step checks both the UI and the proxy answer
+   before handing over.
+6. **Run the suite** inside the Playwright container with `--network host`,
+   in the `branch` profile against the served UI, reusing the host's
+   `node_modules`. Credentials reach the container through an `--env-file` on
+   the runner's dataset, never on the command line.
+7. **Upload JUnit.** Nothing else leaves the runner yet (see *Next*).
+8. **Stop the UI container and release the appliance**, unconditionally:
+   `tn_guest.py delete`. A claim that died before the workflow recorded the
+   name is still released, because `claim` writes the nickname to a file first
+   and `release` falls back to it.
+
+`workflow_dispatch` takes `ui: shipped` to run against the UI baked into the
+ISO instead.
 
 The appliance sits behind QEMU user-mode NAT (`hostfwd`): its ports 80 and 443
 are forwarded to a per-deployment port pair on the host, so the suite's target

--- a/e2e/docs/05-ci.md
+++ b/e2e/docs/05-ci.md
@@ -34,14 +34,19 @@ One job, on a self-hosted runner that is itself a **TrueNAS box**. Per run:
 5. **Serve the UI.** A stock `nginx` container with `dist/` mounted and the
    repository's own `docker/nginx.conf`, the file the appliance serves the UI
    through: `/ui/` from disk, the API paths proxied to the appliance's
-   forwarded port 80 through Docker's host gateway. Published on an ephemeral
-   loopback port. Host networking is not an option: nginx binds 80, which is
-   the TrueNAS host's own UI. The step checks both the UI and the proxy answer
-   before handing over.
+   forwarded port 80 through Docker's host gateway. Over TLS with a throwaway
+   self-signed certificate, because a production build ignores the login
+   token on a plain-HTTP origin. Published on an ephemeral loopback port.
+   Host networking is not an option: nginx binds the ports the TrueNAS host's
+   own UI is on. The step checks both the UI and the proxy answer before
+   handing over.
 6. **Run the suite** inside the Playwright container with `--network host`,
-   in the `branch` profile against the served UI, reusing the host's
-   `node_modules`. Credentials reach the container through an `--env-file` on
-   the runner's dataset, never on the command line.
+   reusing the host's `node_modules`. The profile is `shipped` with
+   `TN_UI_BASE_URL` pointing at the served UI: it *is* the production build
+   at `/ui/` over https, just not from the appliance, and that profile is the
+   one that tolerates a self-signed certificate. Credentials reach the
+   container through an `--env-file` on the runner's dataset, never on the
+   command line.
 7. **Upload JUnit.** Nothing else leaves the runner yet (see *Next*).
 8. **Stop the UI container and release the appliance**, unconditionally:
    `tn_guest.py delete`. A claim that died before the workflow recorded the


### PR DESCRIPTION
Follow-up to #13960. The e2e pipeline now tests the UI built from the checkout instead of the one baked into the appliance's ISO.

## What changes

- **Build the UI in the job** with `yarn build:prod`, the same production build as `main.yml`. About 50 s on the lab runner. Done before the appliance is claimed so the lab is not held during the build.
- **Serve it beside the appliance** from a stock `nginx:1.27` container using the repository's own `docker/nginx.conf`, the file the appliance serves the UI through. The proxy points through Docker's host gateway at the guest's forwarded port 80. Published on an ephemeral loopback port; host networking is not possible because nginx would bind the TrueNAS host's own UI ports.
- **Over TLS with a throwaway self-signed certificate.** This is required, not cosmetic: a production build ignores the login token on a plain-HTTP origin (`AuthService.setQueryToken`), so over http the setup project waits forever on the sign-in page. The suite runs as the `shipped` profile with `TN_UI_BASE_URL` overriding the address, which is the profile that tolerates a self-signed certificate and is accurate for a production build at `/ui/` over https.
- `workflow_dispatch` gains a `ui` choice: `built` (default) or `shipped` to run against the ISO's UI as before.
- `appliance.sh claim` additionally emits `TN_HOST_HTTP`, the guest over its forwarded port 80, for the proxy.

No image of ours is pulled or pushed. The only images used are stock nginx and Playwright's.

## Not in this PR

The `pull_request` trigger paths are unchanged, so a `src/` change still does not run the suite. Triggering on push to master, a nightly, and an opt-in label for PRs is the next decision, and needs a second appliance slot before every `src/` push can be considered.

## Test plan

- Dispatched on this branch with `ui=built`: build, claim, serve, suite, teardown all green, 4 passed, ~8 minutes end to end (https://github.com/truenas/webui/actions/runs/33774370692).
- The plain-HTTP attempt before the TLS change reproduced the token-login failure exactly as `setQueryToken` predicts, with the two unauthenticated tests passing (https://github.com/truenas/webui/actions/runs/33771432104).
- The PR's own `e2e` check runs this workflow file on a pull request.
