### PR TITLE
NAS-143109 / 27.0.0-BETA.1 / Run the suite nightly and on master, and publish failure traces

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -367,11 +367,14 @@ jobs:
       # release step below. Do not upload these from a pipeline that reuses an
       # appliance or a credential.
       #
-      # Only on failure: Playwright keeps a trace on the first retry and a
-      # screenshot only for failures (playwright.config.ts), so a green run
-      # has nothing here, and `ignore` is the truthful setting for that.
+      # Whenever the suite ran, not only when it failed. Playwright keeps a
+      # trace on the first retry (playwright.config.ts), and a test that fails
+      # once and passes on the retry — the flake R8.4's quarantine policy is
+      # built on triaging — leaves the step green with exactly that trace on
+      # disk. A clean run has nothing here, and `ignore` is the truthful
+      # setting for that.
       - name: Upload failure traces
-        if: always() && steps.suite.outcome == 'failure'
+        if: always() && steps.suite.outcome != 'skipped'
         uses: actions/upload-artifact@v4
         with:
           name: e2e-failure-traces

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,10 +33,29 @@
 name: E2E
 
 on:
-  # Nightly, once this is trusted. Commented out while the pipeline is being
-  # brought up, so the only runs are ones somebody asked for.
-  # schedule:
-  #   - cron: '0 3 * * *'
+  # Nightly, against whatever master is that morning. This and the master
+  # push below are the runs that test merged UI code; the suite drives the
+  # UI built from the checkout, so a run on master is a run on master's code.
+  schedule:
+    - cron: '0 3 * * *'
+  # Every merged change to the UI or the suite. Not every pull request: one
+  # runner, one appliance, ~8 minutes a run, and a concurrency group that
+  # keeps one pending run at most, so under normal PR volume most pushes
+  # would never get a run and nobody could tell which. A PR that wants a run
+  # asks for one with `workflow_dispatch` on its branch.
+  push:
+    branches: [master]
+    paths:
+      - 'src/**'
+      - 'e2e/**'
+      - '!e2e/docs/**'
+      - '!e2e/CLAUDE.md'
+      - '!e2e/README.md'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/e2e.yml'
+  # Pull requests that change the suite or the pipeline itself.
   pull_request:
     paths:
       - 'e2e/**'
@@ -48,6 +67,7 @@ on:
       - '!e2e/README.md'
       - 'playwright.config.ts'
       - '.github/workflows/e2e.yml'
+  # The opt-in for any other branch: `gh workflow run e2e.yml --ref <branch>`.
   workflow_dispatch:
     inputs:
       grep:
@@ -320,16 +340,6 @@ jobs:
       # with only 80 and 443 forwarded, so there is no SSH to collect over. It
       # needs an API route; until then the job log is what there is.
       #
-      # Safe to publish: test names and failure messages, no attachments.
-      #
-      # Traces, videos and screenshots are NOT uploaded yet. Artifacts on a
-      # public repository are downloadable by anyone, and a Playwright trace
-      # records action parameters verbatim — including the appliance password
-      # `signIn` types. The precondition for publishing them now holds: the
-      # password is generated per claim and the appliance is destroyed at
-      # release, so a published trace carries a credential to nothing. Turning
-      # that upload on is a deliberate next step, not a side effect.
-      #
       # Runs whenever the suite ran, pass or fail, and then insists on the
       # file: JUnit is the run history R7.4 and R8.4 are built on, so a run
       # that produced none must not report green. The only honest no-file
@@ -341,6 +351,34 @@ jobs:
           name: e2e-junit
           path: test-results/junit.xml
           if-no-files-found: error
+          retention-days: 14
+
+      # Traces, screenshots and video for the tests that failed (R7.1). These
+      # are what make a failure triageable without a local reproduction
+      # (R6.2): the trace holds a DOM snapshot per step, the network, and the
+      # console.
+      #
+      # Artifacts on a public repository are downloadable by anyone, and a
+      # trace records action parameters verbatim — including the appliance
+      # password `signIn` types and the login token in the setup project's
+      # URL. Publishing them is safe because both are worthless by the time
+      # anyone can download this: the password is generated per claim, the
+      # token expires, and the appliance they belonged to is destroyed by the
+      # release step below. Do not upload these from a pipeline that reuses an
+      # appliance or a credential.
+      #
+      # Only on failure: Playwright keeps a trace on the first retry and a
+      # screenshot only for failures (playwright.config.ts), so a green run
+      # has nothing here, and `ignore` is the truthful setting for that.
+      - name: Upload failure traces
+        if: always() && steps.suite.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-failure-traces
+          path: |
+            test-results/**
+            !test-results/junit.xml
+          if-no-files-found: ignore
           retention-days: 14
 
       # A leftover UI container would go on proxying to a destroyed appliance

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -198,10 +198,17 @@ nested VM installed fresh for every run, driving the UI built from the change
 under test rather than the one in the appliance's ISO. `docs/05-ci.md`
 describes the pipeline, what the lab box has to provide, and what each early
 failure taught.
-It runs on same-repo pull requests that touch the suite. A pull request that
-only touches documentation does not trigger it; note that GitHub evaluates the
-path filter against everything the pull request changes, so within a PR that
-touches code, every push runs it.
+It runs nightly, on every push to master that touches the UI or the suite,
+and on same-repo pull requests that touch the suite or the pipeline. Any other
+branch can ask for a run:
+
+```bash
+gh workflow run e2e.yml --ref <your-branch>
+```
+
+A pull request that only touches documentation does not trigger it; note that
+GitHub evaluates the path filter against everything the pull request changes,
+so within a PR that touches code, every push runs it.
 
 ## Troubleshooting
 

--- a/e2e/docs/04-environment-architecture.md
+++ b/e2e/docs/04-environment-architecture.md
@@ -597,13 +597,19 @@ and a third supersedes the pending one, so under load some PR runs never
 happen. That is acceptable for an informational check and not for a gate
 (**D1**).
 
-**Artifacts.** JUnit XML leaves the runner today. Traces, video and screenshots
-(**R7.1**) do not yet, for the reason given in the workflow: a trace records
-the appliance password as typed, and this is a public repository. The
-precondition for publishing them — a credential worthless once published — now
-holds, since the password is per claim and the appliance is destroyed at
-release. Turning the upload on is a deliberate step. **R7.2**'s middleware log
-collection has no path under `hostfwd`; it needs an API route or bridge mode.
+**Artifacts.** JUnit XML leaves the runner on every run, and traces, video and
+screenshots (**R7.1**) for failed tests. Publishing a trace is safe only
+because the credential it records is per claim and the appliance it belonged
+to is destroyed at release; that is the rule, and it holds here. **R7.2**'s
+middleware log collection has no path under `hostfwd`; it needs an API route
+or bridge mode.
+
+**When it runs.** Nightly, and on every push to master that touches the UI or
+the suite — those are the runs that test merged code, since the suite drives
+the UI built from the checkout. Pull requests run it only when they change the
+suite or the pipeline; any other branch opts in with `workflow_dispatch`. Not
+every PR, deliberately: one runner, one appliance, and the concurrency caveat
+above.
 
 ### The public-repository constraint
 

--- a/e2e/docs/05-ci.md
+++ b/e2e/docs/05-ci.md
@@ -63,7 +63,7 @@ ISO instead.
 
 | Trigger | Why |
 |---|---|
-| Nightly, 03:00 UTC | Master's UI against that morning's nightly ISO. |
+| Nightly, 03:00 UTC | Master's UI against the configured ISO, which is one fixed nightly until rotation exists (see *Next*). |
 | Push to master touching `src/`, the suite, `playwright.config.ts`, the lockfile or the workflow | Every merged UI change gets a run. |
 | Pull request touching the suite or the workflow, same-repo only | Changes to the tests and the pipeline prove themselves. |
 | `gh workflow run e2e.yml --ref <branch>` | The opt-in for any other branch. Not every PR: one runner, one appliance, ~8 minutes a run, and a concurrency group that holds one pending run, so under normal PR volume most pushes would never run and nobody could tell which. |

--- a/e2e/docs/05-ci.md
+++ b/e2e/docs/05-ci.md
@@ -47,7 +47,10 @@ One job, on a self-hosted runner that is itself a **TrueNAS box**. Per run:
    one that tolerates a self-signed certificate. Credentials reach the
    container through an `--env-file` on the runner's dataset, never on the
    command line.
-7. **Upload JUnit.** Nothing else leaves the runner yet (see *Next*).
+7. **Upload JUnit**, always, and **traces, screenshots and video** for failed
+   tests. Publishing traces is safe because the credential they contain is
+   per claim and the appliance is destroyed at release; do not copy that
+   upload into a pipeline that reuses either.
 8. **Stop the UI container and release the appliance**, unconditionally:
    `tn_guest.py delete`. A claim that died before the workflow recorded the
    name is still released, because `claim` writes the nickname to a file first
@@ -55,6 +58,15 @@ One job, on a self-hosted runner that is itself a **TrueNAS box**. Per run:
 
 `workflow_dispatch` takes `ui: shipped` to run against the UI baked into the
 ISO instead.
+
+## When it runs
+
+| Trigger | Why |
+|---|---|
+| Nightly, 03:00 UTC | Master's UI against that morning's nightly ISO. |
+| Push to master touching `src/`, the suite, `playwright.config.ts`, the lockfile or the workflow | Every merged UI change gets a run. |
+| Pull request touching the suite or the workflow, same-repo only | Changes to the tests and the pipeline prove themselves. |
+| `gh workflow run e2e.yml --ref <branch>` | The opt-in for any other branch. Not every PR: one runner, one appliance, ~8 minutes a run, and a concurrency group that holds one pending run, so under normal PR volume most pushes would never run and nobody could tell which. |
 
 The appliance sits behind QEMU user-mode NAT (`hostfwd`): its ports 80 and 443
 are forwarded to a per-deployment port pair on the host, so the suite's target
@@ -148,14 +160,11 @@ on a release image, which the design's 210s assumed.
 ## Next
 
 - **Rotate the ISO.** `E2E_TN_GUEST_ISO` names one nightly file, which goes
-  stale. Something on the box should fetch the latest nightly and the variable
-  should point at a stable name.
-- **Publish traces.** The precondition the design set — a credential worthless
-  once published — now holds: the password is per claim and the appliance is
-  destroyed at release. Uploading traces, video and screenshots is a deliberate
-  switch to flip, not a side effect.
-- **Enable the nightly schedule** in `e2e.yml` once a few PR runs have been
-  stable.
+  stale; the nightly run then tests master against an ageing appliance.
+  Deliberately deferred: how the box gets nightlies is still to be decided.
+- **Measure Q0b**, the rollback-and-boot cycle, by hand on the box. It decides
+  whether the snapshot design in `04-environment-architecture.md` is worth
+  building (its *Sequence*, step 2).
 - **Middleware logs.** Behind `hostfwd` there is no SSH; collection needs an
   API route.
 - **Snapshot restore** (`04-environment-architecture.md`, E1/E5) is now ours to

--- a/e2e/docs/status.md
+++ b/e2e/docs/status.md
@@ -71,9 +71,10 @@ a number. See `05-ci.md`.
    stands, the substrate is a TrueNAS host with zvol-backed VMs rather than
    `ixnode` on libvirt, and its next step is measuring the rollback cycle.
 
-   What is next for the pipeline, in order: rotate the nightly ISO
-   automatically, publish traces (the per-claim credential the design required
-   now holds), and enable the nightly schedule.
+   It runs nightly and on every merged UI change, drives the UI built from
+   the checkout, and publishes traces for failed tests. What is next for the
+   pipeline is measuring the rollback cycle (Q0b in the design) and deciding
+   about snapshots on that number.
 3. **Observability.** No WebSocket capture, no middleware log collection (the
    guest is behind `hostfwd`, so it needs an API route rather than SSH), no
    version recording in reports. These are what make a 3am failure diagnosable


### PR DESCRIPTION
Stacked on #14015; base is that branch and this should land after it.

## What changes

- **Nightly schedule** at 03:00 UTC, and a **push-to-master trigger** for changes under `src/`, the suite, `playwright.config.ts`, the lockfile or the workflow. Now that the suite drives the UI built from the checkout, these are the runs that test merged code.
- **Not every pull request.** PRs still trigger only when they change the suite or the pipeline; any other branch opts in with `gh workflow run e2e.yml --ref <branch>`. One runner, one appliance, ~8 minutes a run, and a concurrency group that holds one pending run, so on every PR most pushes would never run and nobody could tell which.
- **Failure traces are published.** Traces, screenshots and video for failed tests upload as `e2e-failure-traces`, only when the suite ran and failed. The workflow comment carries the safety argument: the credential a trace records is per claim and the appliance is destroyed at release, so it is worthless by the time anyone can download it. The same comment says not to copy that upload into a pipeline that reuses either.
- Docs: a "when it runs" table in `e2e/docs/05-ci.md`, the README's CI section with the opt-in command, the status doc and the design's E12.

## Not in this PR

Nightly ISO rotation. `E2E_TN_GUEST_ISO` still names one file. Deferred on purpose; recorded in `05-ci.md` under *Next*.

## Test plan

- Dispatched on this branch: all steps green, 4 passed, and the failure-trace upload correctly skipped on a green run (https://github.com/truenas/webui/actions/runs/33790237874).
- The schedule and master triggers can only be observed after merge.
