### PR TITLE
NAS-143052 / 26.0.0 / Remove force_remove_ix_volumes from app delete payload (by william-gr)

### DIFF
--- a/src/app/interfaces/app.interface.ts
+++ b/src/app/interfaces/app.interface.ts
@@ -304,7 +304,6 @@ export type AppDeleteParams = [
   {
     remove_images?: boolean;
     remove_ix_volumes?: boolean;
-    force_remove_ix_volumes?: boolean;
   },
 ];
 

--- a/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.html
+++ b/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.html
@@ -12,13 +12,6 @@
       formControlName="removeVolumes"
       [label]="'Remove iXVolumes' | translate"
     ></ix-checkbox>
-
-    @if (data.showRemoveVolumes && form.value.removeVolumes) {
-      <ix-checkbox
-        formControlName="forceRemoveVolumes"
-        [label]="'Force-remove iXVolumes' | translate"
-      ></ix-checkbox>
-    }
   }
 
   <ix-checkbox

--- a/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.spec.ts
+++ b/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.spec.ts
@@ -58,29 +58,6 @@ describe('AppDeleteDialogComponent', () => {
       confirmAppName: 'ix-test-app',
       removeImages: true,
       removeVolumes: true,
-      forceRemoveVolumes: false,
-    });
-  });
-
-  it('shows force remove volumes checkbox when Remove iXVolumes is selected', async () => {
-    expect(await form.getLabels()).not.toContain('Force-remove iXVolumes');
-
-    const confirmInput = await loader.getHarness(IxInputHarness);
-    await confirmInput.setValue('ix-test-app');
-
-    await form.fillForm({
-      'Remove iXVolumes': true,
-      'Force-remove iXVolumes': true,
-    });
-
-    const deleteButton = await loader.getHarness(MatButtonHarness.with({ text: 'Delete' }));
-    await deleteButton.click();
-
-    expect(spectator.inject(MatDialogRef).close).toHaveBeenCalledWith({
-      confirmAppName: 'ix-test-app',
-      removeImages: true,
-      removeVolumes: true,
-      forceRemoveVolumes: true,
     });
   });
 

--- a/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.ts
+++ b/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.component.ts
@@ -41,7 +41,6 @@ export class AppDeleteDialog {
   form = this.formBuilder.nonNullable.group({
     removeVolumes: [false],
     removeImages: [true],
-    forceRemoveVolumes: [false],
     confirmAppName: ['', [Validators.required, this.validators.confirmValidator(
       this.data.name,
       this.translate.instant('Enter application name to continue.'),

--- a/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.interface.ts
+++ b/src/app/pages/apps/components/app-delete-dialog/app-delete-dialog.interface.ts
@@ -6,5 +6,4 @@ export interface AppDeleteDialogInputData {
 export interface AppDeleteDialogOutputData {
   removeVolumes: boolean;
   removeImages: boolean;
-  forceRemoveVolumes: boolean;
 }

--- a/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
+++ b/src/app/pages/apps/components/installed-apps/app-info-card/app-info-card.component.ts
@@ -207,7 +207,6 @@ export class AppInfoCardComponent {
       this.api.job('app.delete', [name, {
         remove_images: options.removeImages,
         remove_ix_volumes: options.removeVolumes,
-        force_remove_ix_volumes: options.forceRemoveVolumes,
       }]),
       { title: this.translate.instant(helptextApps.apps.deleting) },
     )

--- a/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.ts
+++ b/src/app/pages/apps/components/installed-apps/installed-apps-list/installed-apps-list.component.ts
@@ -432,7 +432,6 @@ export class InstalledAppsListComponent implements OnInit {
       {
         remove_images: options.removeImages,
         remove_ix_volumes: options.removeVolumes,
-        force_remove_ix_volumes: options.forceRemoveVolumes,
       },
     ]);
 


### PR DESCRIPTION
## Summary
- `force_remove_ix_volumes` was removed from the `app.delete` API (no backend effect), so stop sending it from the single-app delete and the `core.bulk` delete.
- Drop the "Force-remove iXVolumes" checkbox from the delete dialog, along with the `forceRemoveVolumes` form control and output field.
- Remove the field from the `AppDeleteParams` type.

`remove_ix_volumes` is unchanged and still controls whether ix-volumes are deleted.

## Test plan
- [x] `yarn test:changed` passes (app-delete-dialog, app-info-card, installed-apps-list specs)
- [x] `yarn lint` clean on changed files

Original PR: https://github.com/truenas/webui/pull/14012
