### PR TITLE
NAS-143098 / 26.0.0-RC.1 / Hide TrueCloud Backup getting started banner on edit (by AlexKarpov98)

### DIFF
--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.html
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.html
@@ -2,18 +2,22 @@
 <mat-card>
   <mat-card-content>
     <form class="ix-form-container" [formGroup]="form" (submit)="onSubmit()">
-      <tn-banner
-        type="info"
-        [heading]="helptext.introHeading | translate"
-        [message]="helptext.introMessage | translate"
-      >
-        <a target="_blank" rel="noopener noreferrer" tnBannerAction [href]="storjAccountUrl">
-          {{ helptext.createStorjAccountLink | translate }}
-        </a>
-        <a target="_blank" rel="noopener noreferrer" tnBannerAction [href]="documentationUrl">
-          {{ helptext.viewDocumentationLink | translate }}
-        </a>
-      </tn-banner>
+      <!-- Onboarding guidance is only relevant while creating a task; on edit the account and
+           credentials already exist, so the banner would just take up permanent space. -->
+      @if (isNew) {
+        <tn-banner
+          type="info"
+          [heading]="helptext.introHeading | translate"
+          [message]="helptext.introMessage | translate"
+        >
+          <a target="_blank" rel="noopener noreferrer" tnBannerAction [href]="storjAccountUrl">
+            {{ helptext.createStorjAccountLink | translate }}
+          </a>
+          <a target="_blank" rel="noopener noreferrer" tnBannerAction [href]="documentationUrl">
+            {{ helptext.viewDocumentationLink | translate }}
+          </a>
+        </tn-banner>
+      }
 
       <div class="fieldsets">
         <ix-fieldset

--- a/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
+++ b/src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.spec.ts
@@ -4,7 +4,7 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnSpriteLoaderService } from '@truenas/ui-components';
+import { TnBannerHarness, TnSpriteLoaderService } from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
@@ -270,6 +270,10 @@ describe('CloudBackupFormComponent', () => {
         ],
       });
       loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+    });
+
+    it('does not show the getting started banner when editing', async () => {
+      expect(await loader.getAllHarnesses(TnBannerHarness)).toHaveLength(0);
     });
 
     it('shows values for an existing cloud backup task when it is open for edit', async () => {


### PR DESCRIPTION
### Problem

The "Getting Started with TrueCloud Backup" info banner rendered unconditionally in the TrueCloud Backup Task form, so it also showed up when **editing** an existing task — where Credentials, Bucket and Folder are already configured.

On edit it is:

- redundant — it tells you to create a Storj account and set up cloud credentials that demonstrably already exist;
- slightly misleading — it implies account setup is still outstanding;
- permanent — the banner has no dismiss control of its own, and the only "X" in the panel closes the whole Edit form.

### Change

The banner is now rendered only in the **Add** (create) flow, gated on the form's existing `isNew` getter. No new state, no per-user dismissal preference to store — onboarding guidance simply stops appearing once there is a task to edit.

`src/app/pages/data-protection/cloud-backup/cloud-backup-form/cloud-backup-form.component.html`:

```html
@if (isNew) {
  <tn-banner type="info" ...>...</tn-banner>
}
```

### Screenshots

**Before — Edit TrueCloud Backup Task** (banner shown, everything already configured):

![Before: banner on edit](https://raw.githubusercontent.com/AlexKarpov98/webui/screenshots/NAS-143098/before-edit-banner.png)

**After — Edit TrueCloud Backup Task** (banner gone, form starts at Local/Remote):

![After: no banner on edit](https://raw.githubusercontent.com/AlexKarpov98/webui/screenshots/NAS-143098/after-edit-no-banner.png)

**After — Add TrueCloud Backup Task** (banner retained, unchanged):

![After: banner kept on add](https://raw.githubusercontent.com/AlexKarpov98/webui/screenshots/NAS-143098/after-add-banner-kept.png)


Original PR: https://github.com/truenas/webui/pull/14020
