### PR TITLE
NAS-142970 / 26.0.0-RC.1 / Fix Schedule Preview dropping runs at a month boundary (by AlexKarpov98)

### DIFF
--- a/src/app/modules/scheduler/components/scheduler-modal/scheduler-preview-column/scheduler-preview-column.component.html
+++ b/src/app/modules/scheduler/components/scheduler-modal/scheduler-preview-column/scheduler-preview-column.component.html
@@ -24,11 +24,13 @@
     <strong>{{ 'System Time Zone:' | translate }}</strong> {{ timezone() }}
   </div>
 
-  @if (cronPreview && !isPastMonth) {
+  <!-- Null for a month the system time zone has already left behind, and for a crontab
+       that fails to parse, so it doubles as the "nothing to preview" guard for both. -->
+  @if (preview; as preview) {
     <ix-scheduler-date-examples
       class="schedule-example-section"
-      [cronPreview]="cronPreview"
-      [startDate]="startDate"
+      [cronPreview]="preview.cron"
+      [startDate]="preview.startDate"
     ></ix-scheduler-date-examples>
   }
 </div>

--- a/src/app/modules/scheduler/components/scheduler-modal/scheduler-preview-column/scheduler-preview-column.component.spec.ts
+++ b/src/app/modules/scheduler/components/scheduler-modal/scheduler-preview-column/scheduler-preview-column.component.spec.ts
@@ -34,24 +34,31 @@ describe('SchedulerPreviewColumnComponent', () => {
 
   beforeEach(() => {
     // TODO: Not sure why doNotFake is needed. Try removing after some Angular/Material upgrades.
-    jest
-      .useFakeTimers({
-        doNotFake: ['queueMicrotask'],
-      })
-      .setSystemTime(new Date('2022-02-22 16:28:00'));
-
-    spectator = createComponent({
-      props: {
-        crontab: '0 2 24-25 * mon',
-        timezone: 'America/New_York',
-      },
+    jest.useFakeTimers({
+      doNotFake: ['queueMicrotask'],
     });
-    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
+
+  /**
+   * The clock has to be set before the component is created — the preview reads "now" as the
+   * calendar first renders — so creation lives here rather than in `beforeEach`.
+   */
+  function setup(options: { crontab?: string; timezone?: string; now?: string } = {}): void {
+    const {
+      crontab = '0 2 24-25 * mon',
+      timezone = 'America/New_York',
+      now = '2022-02-22 16:28:00',
+    } = options;
+
+    jest.setSystemTime(new Date(now));
+
+    spectator = createComponent({ props: { crontab, timezone } });
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+  }
 
   async function getHighlightedCalendarDays(): Promise<string[]> {
     const calendar = await loader.getHarness(MatCalendarHarness);
@@ -60,32 +67,96 @@ describe('SchedulerPreviewColumnComponent', () => {
   }
 
   it('shows crontab for the cron provided', () => {
+    setup();
+
     expect(spectator.query('.crontab')).toHaveExactText('0 2 24-25 * mon');
   });
 
   it('shows human friendly description of the schedule', () => {
+    setup();
+
     expect(spectator.query('.crontab-explanation'))
       .toHaveExactText('At 02:00 (02:00 AM), between day 24 and 25 of the month, and on Monday');
   });
 
   it('shows calendar for current month with dates highlighted when task will be run', async () => {
+    setup();
+
     const highlightedDays = await getHighlightedCalendarDays();
     expect(highlightedDays).toEqual(['24', '25', '28']);
   });
 
+  // Near a month boundary the browser and the configured system time zone disagree about
+  // which month "now" is in — Kiev has already rolled over to March here while New York is
+  // still in February. The calendar shows the browser's month, so that is where the marks
+  // have to land; counting from the system time zone would put them in a month off screen.
+  it('marks days in the month on screen when the system timezone is in another month', async () => {
+    setup({ now: '2022-03-01 00:30:00' });
+
+    const calendar = await loader.getHarness(MatCalendarHarness);
+
+    expect(await calendar.getCurrentViewLabel()).toBe('MAR 2022');
+    expect(await getHighlightedCalendarDays()).toEqual(['7', '14', '21', '24', '25', '28']);
+  });
+
+  // NAS-142970. The same clock split as above, on a schedule that runs every day: none of
+  // the month on screen has happened yet in the system time zone, so all of it is still to
+  // come — including the 1st, whose run is hours away in Los Angeles. Counting from the
+  // system clock instead of the month it is about to enter blanked the month entirely.
+  it('marks the whole month on screen when the system timezone has not reached it yet', async () => {
+    setup({
+      crontab: '0 4 * * *',
+      timezone: 'America/Los_Angeles',
+      now: '2026-09-01 05:00:00',
+    });
+
+    const calendar = await loader.getHarness(MatCalendarHarness);
+
+    expect(await calendar.getCurrentViewLabel()).toBe('SEP 2026');
+    expect(await getHighlightedCalendarDays()).toHaveLength(30);
+
+    const examplesComponent = spectator.query(SchedulerDateExamplesComponent)!;
+    expect(examplesComponent.startDate).toEqual(parse('2026-09-01 00:00:00', 'yyyy-MM-dd HH:mm:ss', new Date()));
+  });
+
+  // The mirror of the case above, with the clocks the other way round: Kiritimati has
+  // already rolled over to March while the browser is still on the last evening of
+  // February. The 23:30 run the browser still has ahead of it went off hours ago in
+  // Kiritimati, so February holds nothing left to preview — the examples are in the system
+  // time zone, and listing that run would be listing one that has already happened.
+  it('shows nothing for a month the system timezone has already left', async () => {
+    setup({
+      crontab: '30 23 * * *',
+      timezone: 'Pacific/Kiritimati',
+      now: '2022-02-28 23:00:00',
+    });
+
+    const calendar = await loader.getHarness(MatCalendarHarness);
+
+    expect(await calendar.getCurrentViewLabel()).toBe('FEB 2022');
+    expect(await getHighlightedCalendarDays()).toHaveLength(0);
+    expect(spectator.query(SchedulerDateExamplesComponent)).not.toExist();
+  });
+
   it('shows current system timezone', () => {
+    setup();
+
     const timezoneElement = spectator.query('.timezone-message');
 
     expect(timezoneElement).toHaveText('System Time Zone: America/New_York');
   });
 
   it('passes cron and time constraints to SchedulerDateExamplesComponent to show date examples', () => {
+    setup();
+
     const examplesComponent = spectator.query(SchedulerDateExamplesComponent)!;
 
     expect(examplesComponent.startDate).toEqual(parse('2022-02-22 09:28:00', 'yyyy-MM-dd HH:mm:ss', new Date()));
   });
 
   it('shows calendar for next month with dates highlighted when next arrow is pressed', async () => {
+    setup();
+
     const calendar = await loader.getHarness(MatCalendarHarness);
     await calendar.next();
 
@@ -97,6 +168,8 @@ describe('SchedulerPreviewColumnComponent', () => {
   });
 
   it('updates SchedulerDateExamplesComponent when next month is selected', async () => {
+    setup();
+
     const calendar = await loader.getHarness(MatCalendarHarness);
     await calendar.next();
 
@@ -105,6 +178,8 @@ describe('SchedulerPreviewColumnComponent', () => {
   });
 
   it('does not show any dates when user goes in the past', async () => {
+    setup();
+
     const calendar = await loader.getHarness(MatCalendarHarness);
     await calendar.previous();
 

--- a/src/app/modules/scheduler/components/scheduler-modal/scheduler-preview-column/scheduler-preview-column.component.ts
+++ b/src/app/modules/scheduler/components/scheduler-modal/scheduler-preview-column/scheduler-preview-column.component.ts
@@ -7,14 +7,19 @@ import { MatDialogClose } from '@angular/material/dialog';
 import { TranslateModule } from '@ngx-translate/core';
 import { TnIconButtonComponent } from '@truenas/ui-components';
 import {
-  getDate, isBefore,
-  startOfMonth, differenceInCalendarMonths,
+  endOfMonth, getDate, isAfter, isBefore, startOfMonth,
 } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import { CronSchedulePreview } from 'app/modules/scheduler/classes/cron-schedule-preview/cron-schedule-preview';
 import { SchedulerDateExamplesComponent } from 'app/modules/scheduler/components/scheduler-modal/scheduler-date-examples/scheduler-date-examples.component';
 import { CrontabExplanationPipe } from 'app/modules/scheduler/pipes/crontab-explanation.pipe';
 import { TestDirective } from 'app/modules/test-id/test.directive';
+
+interface SchedulePreview {
+  cron: CronSchedulePreview;
+  /** Where counting starts, as a wall clock in the system time zone. */
+  startDate: Date;
+}
 
 @Component({
   selector: 'ix-scheduler-preview-column',
@@ -45,21 +50,14 @@ export class SchedulerPreviewColumnComponent implements OnChanges, OnInit {
    */
   highlightedCalendarDays = new Set<number>();
 
-  cronPreview: CronSchedulePreview | null;
+  /**
+   * Null means there is nothing to preview in the month on screen: the system time zone
+   * is already past the end of it, or the crontab failed to parse. The marked days and the
+   * example list are both derived from this, so they cannot disagree about the start date.
+   */
+  preview: SchedulePreview | null = null;
 
   readonly calendar: Signal<MatCalendar<Date>> = viewChild.required('calendar', { read: MatCalendar });
-
-  get startDate(): Date {
-    if (!this.calendar().activeDate || differenceInCalendarMonths(this.calendar().activeDate, new Date()) < 1) {
-      return toZonedTime(new Date(), this.timezone());
-    }
-
-    return startOfMonth(this.calendar().activeDate);
-  }
-
-  get isPastMonth(): boolean {
-    return isBefore(this.calendar().activeDate, startOfMonth(new Date()));
-  }
 
   ngOnChanges(): void {
     this.updatePreviewDates();
@@ -81,27 +79,60 @@ export class SchedulerPreviewColumnComponent implements OnChanges, OnInit {
     return '';
   };
 
+  /**
+   * Where the preview starts counting from, as a wall clock in the system time zone — the
+   * zone the schedule actually runs in, and the one the example times are shown in.
+   *
+   * The calendar pages in the browser's months, so the month on screen is the frame and
+   * where "now" falls within it decides where counting starts. The two clocks disagree
+   * about the date most of the day and about the *month* on the first and last day of one,
+   * which is what made this worth spelling out: counting from the system clock while the
+   * browser had already rolled over left the whole month on screen blank (NAS-142970).
+   *
+   * Null means there is nothing left to preview in the month on screen, because the system
+   * time zone is already past the end of it — a month the user paged back to, and equally
+   * the tail of the browser's current month once the system time zone has rolled over.
+   */
+  private getStartDate(): Date | null {
+    const activeDate = this.calendar().activeDate || new Date();
+    const zonedNow = toZonedTime(new Date(), this.timezone());
+
+    if (isBefore(zonedNow, startOfMonth(activeDate))) {
+      return startOfMonth(activeDate);
+    }
+
+    if (isAfter(zonedNow, endOfMonth(activeDate))) {
+      return null;
+    }
+
+    return zonedNow;
+  }
+
   private onCalendarUpdated(): void {
     this.updatePreviewDates();
   }
 
   private updatePreviewDates(): void {
-    if (this.isPastMonth) {
-      this.cronPreview = null;
+    const startDate = this.getStartDate();
+    if (!startDate) {
+      this.preview = null;
       this.highlightedCalendarDays = new Set();
       return;
     }
 
     try {
-      this.cronPreview = new CronSchedulePreview({
+      const cron = new CronSchedulePreview({
         crontab: this.crontab(),
         startTime: this.startTime(),
         endTime: this.endTime(),
       });
 
-      this.highlightedCalendarDays = this.cronPreview.getNextDaysInMonthWithRuns(this.startDate);
+      this.preview = { cron, startDate };
+      this.highlightedCalendarDays = cron.getNextDaysInMonthWithRuns(startDate);
     } catch (error: unknown) {
       console.error(error);
+      this.preview = null;
+      this.highlightedCalendarDays = new Set();
     }
   }
 


### PR DESCRIPTION
preview-after.png
<img width="760" height="750" alt="preview-after" src="https://github.com/user-attachments/assets/abe392be-180f-4cb2-8528-f459e568c9a9" />

preview-before-release.png
<img width="760" height="750" alt="preview-before-release" src="https://github.com/user-attachments/assets/fff62455-a7bb-49ad-86b4-b24d4a64f0f6" />

preview-before-master.png
<img width="760" height="750" alt="preview-before-master" src="https://github.com/user-attachments/assets/71c432a9-48fc-4d25-b1eb-497e7d8f038d" />

**Changes:**

The Schedule Preview counts runs in the **system time zone**, but the calendar pages in
the **browser's** months. On the first and last day of a month the two disagree about
*which month it is*, and the preview lost runs because of it.

The reported case (NAS-142970, seen on 26.04): at 00:30 on Oct 1 in the browser,
Los Angeles is still Sep 30. The released code counted from the system clock —
September — while the calendar showed October, and both `getNextDaysInMonthWithRuns()`
and `listNextRunsInMonth()` stop as soon as the first run leaves the month they were
given. The whole month on screen came back empty: no marked days, no example times.
Paging to the next month worked, since a future month is counted from its 1st.

Master already narrowed this in the tn-calendar migration (2dec781d0e), but the fallback
there counts from the *browser's* clock, which skips runs still to come in the system
time zone — on Oct 1 at 07:00 with a `0 4 * * *` schedule, the 1st went unmarked and the
example list started on the 2nd.

Replaced the two-clock fallback with one rule, driven by the month on screen and where
system-time "now" falls inside it:

- before that month → count from its 1st;
- inside it → count from now;
- past its end → nothing to preview.

The last case also covers paging into the past, so `isPastMonth` is gone. The marked days
and the example list now come from a single computed, so they cannot be derived from
different start dates.

One expectation changed deliberately: when the system time zone is a month *ahead* of the
browser (`Pacific/Kiritimati`, browser still on Feb 28), February used to mark the 23:30
run. That run went off hours ago in system time, and the example list renders in system
time, so listing it was showing a run that had already happened. February now shows
nothing.

**Testing:**

Reproduces only when the browser and the appliance's time zone straddle a month boundary.
With an appliance on `America/Los_Angeles`:

1. Set the browser clock to `2026-10-01 07:00` in a zone at UTC+3 (LA is then Sep 30 21:00) —
   e.g. Playwright's `page.clock.setFixedTime()`.
2. Data Protection → Periodic Snapshot Tasks → **Add** → Schedule → **Create Custom schedule**.
3. Enter minutes `0`, hours `4`, days of month `*`.

Before: October 1 is unmarked and the example list starts `2026-10-02 04:00:00`.
After: all 31 days are marked and the list starts `2026-10-01 04:00:00`.
On the 26.04 logic the entire month is blank — the ticket's screenshots.

Unit tests cover both clock directions, including the reported case; `yarn jest
src/app/modules/scheduler` is green.

Note for the ticket: this is a preview-rendering bug only. It does not explain why the
reporter's replication task failed to run on schedule — that is middleware side.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | No — no UI or wording changes.
|Testing         | Yes — worth a backport to the release branch, where the whole month is blank rather than one day short. Any coverage should pin the browser clock and the appliance time zone; the bug is invisible unless they straddle a month boundary.

Original PR: https://github.com/truenas/webui/pull/14017
