### PR TITLE
NAS-142773 / 26.0.0-RC.1 / Let admins add API keys for directory service users (by AlexKarpov98)

### DIFF
--- a/src/app/pages/credentials/privileges/privilege-form/privilege-form.component.html
+++ b/src/app/pages/credentials/privileges/privilege-form/privilege-form.component.html
@@ -29,7 +29,7 @@
 
           @if (showDsAuthButton()) {
             <div class="ds-auth-prompt">
-              <p>{{ 'Directory Service users cannot login to TrueNAS WebUI. Enable DS authentication to allow access.' | translate }}</p>
+              <p>{{ 'Directory Service users have no UI or API access to TrueNAS. Enable Directory Service authentication to allow access.' | translate }}</p>
               <button
                 type="button"
                 mat-button

--- a/src/app/pages/credentials/privileges/privilege-form/privilege-form.component.spec.ts
+++ b/src/app/pages/credentials/privileges/privilege-form/privilege-form.component.spec.ts
@@ -4,7 +4,10 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
-import { lastValueFrom, of, throwError } from 'rxjs';
+import {
+  Subject, lastValueFrom, of, throwError,
+} from 'rxjs';
+import { MockApiService } from 'app/core/testing/classes/mock-api.service';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import { DirectoryServiceStatus } from 'app/enums/directory-services.enum';
@@ -716,6 +719,69 @@ describe('PrivilegeFormComponent', () => {
       spectator.detectChanges();
       const buttonAfter = spectator.query('button[ixTest="enable-ds-auth"]');
       expect(buttonAfter).toBeFalsy();
+    });
+
+    it('should show button when editing a privilege that already has DS groups', async () => {
+      spectator = createComponent({
+        detectChanges: false,
+        providers: [
+          mockProvider(SlideInRef, {
+            ...slideInRef,
+            getData: () => ({
+              ...fakeDataPrivilege,
+              ds_groups: [{ gid: 333, group: 'AD\\Domain Admins' }],
+            } as Privilege),
+          }),
+          provideMockStore({
+            selectors: [
+              {
+                selector: selectEntitlements,
+                value: {},
+              },
+              {
+                selector: selectGeneralConfig,
+                value: {
+                  ds_auth: false,
+                },
+              },
+            ],
+          }),
+          mockProvider(UserService, {
+            groupQueryDsCache: jest.fn(() => of([])),
+            getGroupByName: jest.fn(() => of({ gr_gid: 1000, gr_mem: [], gr_name: 'test' })),
+            getGroupByNameCached: jest.fn((groupName: string) => of({ gr_gid: 1000, gr_mem: [], gr_name: groupName })),
+          }),
+          mockAuth(),
+        ],
+      });
+
+      // `mockCall` answers synchronously, which hides this bug: the status would land
+      // during ngOnInit, before the chips control replays `ds_groups`. A real WebSocket
+      // round-trip resolves *after* the form has settled, so drive the status by hand.
+      const mockApiService = spectator.inject(MockApiService);
+      const status$ = new Subject<DirectoryServicesStatus>();
+      const passThrough = mockApiService.call.getMockImplementation();
+      mockApiService.call.mockImplementation((method: string, params: unknown) => {
+        return method === 'directoryservices.status'
+          ? status$.asObservable()
+          : passThrough?.(method, params);
+      });
+
+      spectator.detectChanges();
+      await spectator.fixture.whenStable();
+
+      // Status arrives late. The edit path patched `ds_groups` back in ngOnInit, so its only
+      // `valueChanges` emission is long gone — visibility has to be re-evaluated here, or the
+      // prompt stays hidden for exactly the privileges that already carry DS groups.
+      status$.next({
+        type: 'ACTIVEDIRECTORY',
+        status: DirectoryServiceStatus.Healthy,
+      } as DirectoryServicesStatus);
+      spectator.detectChanges();
+      await spectator.fixture.whenStable();
+
+      const button = spectator.query('button[ixTest="enable-ds-auth"]');
+      expect(button).toBeTruthy();
     });
   });
 });

--- a/src/app/pages/credentials/privileges/privilege-form/privilege-form.component.ts
+++ b/src/app/pages/credentials/privileges/privilege-form/privilege-form.component.ts
@@ -184,6 +184,7 @@ export class PrivilegeFormComponent implements OnInit {
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((generalConfig) => {
       this.dsAuthEnabled.set(generalConfig.ds_auth);
+      this.refreshDsAuthButtonVisibility();
     });
 
     // Load directory services status once on init (cache it)
@@ -191,6 +192,7 @@ export class PrivilegeFormComponent implements OnInit {
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((status) => {
       this.dsStatus.set(status);
+      this.refreshDsAuthButtonVisibility();
     });
 
     // Watch for DS groups being added and show inline button if needed
@@ -209,6 +211,17 @@ export class PrivilegeFormComponent implements OnInit {
       ),
       ds_groups: existingPrivilege.ds_groups.map((group) => group.group),
     });
+  }
+
+  /**
+   * Re-evaluates the prompt against the groups already in the form. Editing an existing privilege
+   * patches `ds_groups` during `ngOnInit`, long before `directoryservices.status` and the general
+   * config resolve, so the only `valueChanges` emission runs while both are still unknown. Without
+   * this, the prompt stays hidden for every privilege that already has directory service groups —
+   * exactly the case where it is needed.
+   */
+  private refreshDsAuthButtonVisibility(): void {
+    this.updateDsAuthButtonVisibility(this.form.controls.ds_groups.value);
   }
 
   /**

--- a/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.spec.ts
+++ b/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.spec.ts
@@ -267,6 +267,27 @@ describe('UserAccessCardComponent', () => {
       });
     });
 
+    it('offers Add API Key for directory service users, whose roles are never reported', () => {
+      spectator.setInput('user', {
+        ...mockUser,
+        api_keys: [],
+        local: false,
+        roles: [],
+      });
+
+      expect(spectator.query(byText('Add API Key'))).toExist();
+    });
+
+    it('does not offer Add API Key for a local user without roles', () => {
+      spectator.setInput('user', {
+        ...mockUser,
+        api_keys: [],
+        roles: [],
+      });
+
+      expect(spectator.query(byText('Add API Key'))).not.toExist();
+    });
+
     it('downloads public ssh key when Download Public Key link is clicked', () => {
       const downloadLink = spectator.query(byText('Download Public Key'));
       spectator.click(downloadLink);

--- a/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.ts
+++ b/src/app/pages/credentials/users/all-users/user-details/user-access-card/user-access-card.component.ts
@@ -108,8 +108,11 @@ export class UserAccessCardComponent {
   });
 
   protected canAddApiKeys = computed(() => {
-    // TODO: Matches condition in api-key-form, but may not be correct.
-    return this.user().roles.length && this.user().local;
+    // Matches the user picker in api-key-form. `roles` is always empty for directory service users
+    // (group membership is not available from nss_winbind during getpwall/getgrall), so it cannot be
+    // used to decide whether they may hold an API key — their privileges come from their groups.
+    const user = this.user();
+    return !user.local || user.roles.length > 0;
   });
 
   protected shouldShowLockButton = computed(() => {

--- a/src/app/pages/credentials/users/user-api-keys/components/api-key-form/api-key-form.component.html
+++ b/src/app/pages/credentials/users/user-api-keys/components/api-key-form/api-key-form.component.html
@@ -20,7 +20,7 @@
             [label]="'Username' | translate"
             [required]="true"
             [provider]="userPickerProvider"
-            [hint]="'Only users with the required privileges are shown.' | translate"
+            [hint]="'Shows local users with the required privileges, plus directory service users, whose privileges come from their groups.' | translate"
           ></ix-user-picker>
         }
 

--- a/src/app/pages/credentials/users/user-api-keys/components/api-key-form/api-key-form.component.spec.ts
+++ b/src/app/pages/credentials/users/user-api-keys/components/api-key-form/api-key-form.component.spec.ts
@@ -12,6 +12,7 @@ import { ApiKey } from 'app/interfaces/api-key.interface';
 import {
   DialogService,
 } from 'app/modules/dialog/dialog.service';
+import { UserPickerProvider } from 'app/modules/forms/ix-forms/components/ix-user-picker/ix-user-picker-provider';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { LocaleService } from 'app/modules/language/locale.service';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
@@ -179,6 +180,42 @@ describe('ApiKeyFormComponent', () => {
     expect(spectator.inject(SlideInRef).close).toHaveBeenCalledWith({ response: true });
     expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(KeyCreatedDialog, {
       data: 'generated-key',
+    });
+  });
+
+  describe('user picker query', () => {
+    it('offers directory service users alongside privileged local users, one constrained page at a time', async () => {
+      await setupTest();
+      const provider = (spectator.component as unknown as { userPickerProvider: UserPickerProvider })
+        .userPickerProvider;
+
+      provider.fetch('').subscribe();
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('user.query', [
+        [['OR', [['roles', '!=', []], ['local', '=', false]]]],
+        {
+          select: ['username', 'id', 'uid', 'local'],
+          order_by: ['username'],
+          offset: 0,
+          limit: 50,
+        },
+      ]);
+    });
+
+    it('narrows the query by the typed username instead of listing everyone', async () => {
+      await setupTest();
+      const provider = (spectator.component as unknown as { userPickerProvider: UserPickerProvider })
+        .userPickerProvider;
+
+      provider.fetch('AD01\\jsmith').subscribe();
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('user.query', [
+        [
+          ['username', '~', '(?i).*AD01\\\\jsmith'],
+          ['OR', [['roles', '!=', []], ['local', '=', false]]],
+        ],
+        expect.objectContaining({ offset: 0, limit: 50 }),
+      ]);
     });
   });
 

--- a/src/app/pages/credentials/users/user-api-keys/components/api-key-form/api-key-form.component.ts
+++ b/src/app/pages/credentials/users/user-api-keys/components/api-key-form/api-key-form.component.ts
@@ -104,9 +104,19 @@ export class ApiKeyFormComponent implements OnInit {
     reset: [false],
   });
 
+  /**
+   * Local users are narrowed to those that actually have a role, but directory service users are
+   * matched on `local` instead: group membership is not available from nss_winbind during
+   * getpwall/getgrall, so `roles` in `user.query` output is always empty for them and cannot be
+   * treated as authoritative. Their roles come from the privileges of their directory service groups.
+   *
+   * The picker pages this query (50 per page, filtered by the typed username), so a directory
+   * service with thousands of users is never enumerated in one go.
+   */
   protected readonly userQueryParams = new ParamsBuilder<User>()
     .filter('roles', '!=', [])
-    .setOptions({ select: ['username', 'id', 'uid'], order_by: ['username'] })
+    .orFilter('local', '=', false)
+    .setOptions({ select: ['username', 'id', 'uid', 'local'], order_by: ['username'] })
     .getParams();
 
   protected readonly userPickerProvider = new UserPickerProvider({

--- a/src/app/pages/system/advanced/access/access-card/access-card.component.html
+++ b/src/app/pages/system/advanced/access/access-card/access-card.component.html
@@ -28,7 +28,7 @@
     <mat-list>
       @if (hasDirectoryServices()) {
         <mat-list-item>
-          <span class="label">{{ 'Allow Directory Service users to access WebUI' | translate }}:</span>
+          <span class="label">{{ 'Allow Directory Service users UI / API access' | translate }}:</span>
           <span *ixWithLoadingState="generalConfig$ as generalConfig" class="value">
             {{ generalConfig | yesNo }}
           </span>

--- a/src/app/pages/system/advanced/access/access-card/access-card.component.spec.ts
+++ b/src/app/pages/system/advanced/access/access-card/access-card.component.spec.ts
@@ -112,7 +112,7 @@ describe('AccessCardComponent', () => {
 
   it('shows whether DS users are allowed access to WebUI', async () => {
     const allowed = (await loader.getAllHarnesses(MatListItemHarness))[0];
-    expect(await allowed.getFullText()).toBe('Allow Directory Service users to access WebUI: Yes');
+    expect(await allowed.getFullText()).toBe('Allow Directory Service users UI / API access: Yes');
   });
 
   it('shows current login banner', async () => {

--- a/src/app/pages/system/advanced/access/access-form/access-form.component.html
+++ b/src/app/pages/system/advanced/access/access-form/access-form.component.html
@@ -10,7 +10,8 @@
         @if (hasDirectoryServices()) {
           <ix-checkbox
             formControlName="ds_auth"
-            [label]="'Allow Directory Service users to access WebUI' | translate"
+            [label]="'Allow Directory Service users UI / API access' | translate"
+            [tooltip]="'When enabled, users provided by the configured directory service can sign in to the web interface and authenticate against the API, including with API keys. Access is still granted through the privileges assigned to their directory service groups.' | translate"
           ></ix-checkbox>
         }
         <ix-textarea

--- a/src/app/pages/system/advanced/access/access-form/access-form.component.spec.ts
+++ b/src/app/pages/system/advanced/access/access-form/access-form.component.spec.ts
@@ -86,7 +86,7 @@ describe('AccessFormComponent', () => {
 
     expect(values).toEqual({
       'Login Banner': 'test',
-      'Allow Directory Service users to access WebUI': true,
+      'Allow Directory Service users UI / API access': true,
     });
   });
 
@@ -97,7 +97,7 @@ describe('AccessFormComponent', () => {
     const form = await loader.getHarness(IxFormHarness);
     await form.fillForm({
       'Login Banner': '',
-      'Allow Directory Service users to access WebUI': false,
+      'Allow Directory Service users UI / API access': false,
     });
 
     const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));

--- a/src/assets/ui-searchable-elements.json
+++ b/src/assets/ui-searchable-elements.json
@@ -1286,7 +1286,9 @@
     ],
     "synonyms": [],
     "requiredRoles": [],
-    "visibleTokens": [],
+    "visibleTokens": [
+      "SED"
+    ],
     "anchorRouterLink": [
       "/system",
       "advanced"
@@ -1309,7 +1311,9 @@
     "requiredRoles": [
       "SYSTEM_ADVANCED_WRITE"
     ],
-    "visibleTokens": [],
+    "visibleTokens": [
+      "SED"
+    ],
     "anchorRouterLink": [
       "/system",
       "advanced"
@@ -1328,7 +1332,9 @@
     ],
     "synonyms": [],
     "requiredRoles": [],
-    "visibleTokens": [],
+    "visibleTokens": [
+      "SED"
+    ],
     "anchorRouterLink": [
       "/system",
       "advanced"


### PR DESCRIPTION
**Changes:**

Preview:
1a-access-card-label - 
<img width="614" height="300" alt="1a-access-card-label" src="https://github.com/user-attachments/assets/927634ec-87a3-475d-b9aa-5015f37d96d5" />

1b-access-form-tooltip.png
<img width="1500" height="950" alt="1b-access-form-tooltip" src="https://github.com/user-attachments/assets/3ba942f5-6580-46d1-a425-bd029f5660ce" />

2-ds-user-access-card.png
<img width="1500" height="950" alt="2-ds-user-access-card" src="https://github.com/user-attachments/assets/fea2a7e8-4211-4a8a-88ec-9801770a6c41" />

3-api-key-form-hint.png

<img width="1500" height="950" alt="3-api-key-form-hint" src="https://github.com/user-attachments/assets/58b11e0e-62de-4d40-ad8d-3e16c1a4a809" />

4-picker-constrained-search.png
<img width="1500" height="950" alt="4-picker-constrained-search" src="https://github.com/user-attachments/assets/14983c20-ac19-480d-b539-13c7fa5bbaf9" />

5-privilege-ds-auth-prompt.png
<img width="1500" height="950" alt="5-privilege-ds-auth-prompt" src="https://github.com/user-attachments/assets/068146ad-f41e-4bec-b48b-bfeeb86f7faf" />


Addresses all three points from the ticket. Per @william-gr's note, this targets 26+
only — no 25 backport.

**1. `roles` is not authoritative for directory service users (points 2)**

`user.query` reports an empty `roles` list for every non-local user, because group
membership is not available from nss_winbind during `getpwall`/`getgrall`. Two places
treated that emptiness as "has no privileges":

- `api-key-form.component.ts` filtered its user picker on `roles != []`, so directory
  service users were never offered at all. Now `(roles != []) OR (local = false)` —
  local users still need a role, DS users are matched on `local` instead. `local` was
  added to `select` and the reasoning recorded in a comment so it doesn't get
  "simplified" back.
- `user-access-card.component.ts` hid the **Add API Key** link behind
  `roles.length && local`, which excluded DS users for the same reason (it carried a
  `// TODO: ... may not be correct` — this was it). Now `!local || roles.length > 0`.

**2. Constrained queries (point 3)**

No change needed — verified rather than modified. `UserPickerProvider` already pages
`user.query` at `limit: 50` with `offset`, and prepends a
`["username", "~", "(?i).*<term>"]` filter as you type; `UserService` caps group
queries at 50. Nothing enumerates the directory. Two new specs pin the page params and
the search filter down so this can't regress silently.

**3. "UI / API access" wording (point 1)**

The switch governs API authentication as well as web sign-in, which the old copy didn't
say:

- Access settings checkbox: `Allow Directory Service users to access WebUI` →
  **`Allow Directory Service users UI / API access`**, plus a tooltip spelling out that
  it covers API keys and that privileges still come from DS groups.
- The read-only row on the Access card matches.
- Privilege form prompt: "Directory Service users cannot login to TrueNAS WebUI" →
  "Directory Service users have no UI or API access to TrueNAS".

Manual, on a DS-joined system, as a Full Admin (the Username field is hidden otherwise):

1. **Credentials → Users → API Keys → Add**, click into **Username** — domain users now
   appear in the dropdown, and creating a key against one succeeds.
2. With the debug panel open (`Ctrl+Shift+X` → WebSocket tab), the picker's `user.query`
   should read
   `[[["OR", [["roles","!=",[]], ["local","=",false]]]], {"select":[...],"order_by":["username"],"offset":0,"limit":50}]`,
   and typing should issue a *new* query with a `username ~` filter rather than filtering
   a full list client-side.
3. **Credentials → Users**, expand a directory service user — **Add API Key** is now
   offered where nothing was before.
4. **System → Advanced → Access** (Enterprise only) — new label and tooltip on both the
   card row and the Configure form.

Without a DS system, points 1–3 can be exercised by mocking `user.query` in the debug
panel (message pattern `"roles","!="` scopes the mock to the picker), and point 4 by
mocking `system.product_type` → `"ENTERPRISE"`. That path can't cover `api_key.create`
accepting a domain username, which is backend behaviour and worth confirming on a real
appliance.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | The Access setting is renamed to "Allow Directory Service users UI / API access" and gains a tooltip — docs referencing the old "…to access WebUI" label (and screenshots of that card/form) need updating. The privilege form's DS prompt text also changed.
|Testing         | No E2E specs reference the changed strings (grepped `e2e/`). New coverage is unit-level.

Original PR: https://github.com/truenas/webui/pull/14010
