### PR TITLE
NAS-143096 / 26.0.0-RC.1 / Don't count disabled tasks in the Backup Tasks widget (by AlexKarpov98)

### DIFF
--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.spec.ts
@@ -332,7 +332,26 @@ describe('WidgetBackupComponent', () => {
         providers: [
           mockProvider(WidgetResourcesService, {
             backups$: of([
-              [],
+              [
+                {
+                  id: 1,
+                  direction: Direction.Push,
+                  enabled: false,
+                  state: {
+                    state: TaskState.Error,
+                    datetime: { $date: currentDatetime.getTime() - 50000 },
+                  },
+                },
+                {
+                  // `enabled` is optional on ReplicationTask, so a task that does not report it stays counted.
+                  id: 2,
+                  direction: Direction.Push,
+                  state: {
+                    state: TaskState.Error,
+                    datetime: { $date: currentDatetime.getTime() - 50000 },
+                  },
+                },
+              ] as ReplicationTask[],
               [
                 {
                   id: 1,
@@ -353,6 +372,72 @@ describe('WidgetBackupComponent', () => {
                   },
                 },
               ] as RsyncTask[],
+              [
+                {
+                  id: 1,
+                  direction: Direction.Push,
+                  enabled: false,
+                  job: {
+                    state: JobState.Failed,
+                    time_finished: { $date: currentDatetime.getTime() - 50000 },
+                  },
+                },
+              ] as CloudSyncTask[],
+              [
+                {
+                  id: 1,
+                  enabled: false,
+                  job: {
+                    state: JobState.Failed,
+                    time_finished: { $date: currentDatetime.getTime() - 50000 },
+                  },
+                },
+              ] as CloudBackup[],
+            ]),
+          }),
+        ],
+      });
+
+      widgetBackup = await TestbedHarnessEnvironment.harnessForFixture(spectator.fixture, WidgetBackupHarness);
+    });
+
+    it('does not count failures of disabled tasks', async () => {
+      const header = await widgetBackup.getHeader();
+      expect(header.icon).toBe('alert');
+      expect(header.message).toBe('1 of 6 tasks failed');
+    });
+
+    it('still lists disabled tasks in the tile totals', async () => {
+      const tiles = await widgetBackup.getTiles();
+
+      expect(tiles['Cloud Sync'].firstColumn).toEqual(['1 send task', '0 receive tasks', 'Total failed: 0']);
+      expect(tiles.Replication.firstColumn).toEqual(['2 send tasks', '0 receive tasks', 'Total failed: 1']);
+      expect(tiles.Rsync.firstColumn).toEqual(['0 send tasks', '2 receive tasks', 'Total failed: 0']);
+      expect(tiles['TrueCloud Backup'].firstColumn).toEqual(['1 send task', '0 receive tasks', 'Total failed: 0']);
+    });
+  });
+
+  describe('when every task is disabled', () => {
+    beforeEach(async () => {
+      spectator = createComponent({
+        props: {
+          size: SlotSize.Full,
+        },
+        providers: [
+          mockProvider(WidgetResourcesService, {
+            backups$: of([
+              [],
+              [
+                {
+                  id: 1,
+                  direction: Direction.Pull,
+                  enabled: false,
+                  job: {
+                    state: JobState.Failed,
+                    time_finished: { $date: currentDatetime.getTime() - 50000 },
+                  },
+                },
+              ] as RsyncTask[],
               [],
               [],
             ]),
@@ -363,13 +448,15 @@ describe('WidgetBackupComponent', () => {
       widgetBackup = await TestbedHarnessEnvironment.harnessForFixture(spectator.fixture, WidgetBackupHarness);
     });
 
-    it('does not count disabled tasks', async () => {
-      const header = await widgetBackup.getHeader();
-      expect(header.icon).toBe('check-circle');
-      expect(header.message).toBeFalsy();
+    it('still shows the task instead of the empty state', async () => {
+      expect(await widgetBackup.getEmptyCardMessage()).toBeNull();
 
       const tiles = await widgetBackup.getTiles();
       expect(tiles.Rsync.firstColumn).toEqual(['0 send tasks', '1 receive task', 'Total failed: 0']);
+
+      const header = await widgetBackup.getHeader();
+      expect(header.icon).toBe('check-circle');
+      expect(header.message).toBeFalsy();
     });
   });
 

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.spec.ts
@@ -323,6 +323,56 @@ describe('WidgetBackupComponent', () => {
     });
   });
 
+  describe('disabled tasks', () => {
+    beforeEach(async () => {
+      spectator = createComponent({
+        props: {
+          size: SlotSize.Full,
+        },
+        providers: [
+          mockProvider(WidgetResourcesService, {
+            backups$: of([
+              [],
+              [
+                {
+                  id: 1,
+                  direction: Direction.Pull,
+                  enabled: true,
+                  job: {
+                    state: JobState.Success,
+                    time_finished: { $date: currentDatetime.getTime() - 50000 },
+                  },
+                },
+                {
+                  id: 2,
+                  direction: Direction.Pull,
+                  enabled: false,
+                  job: {
+                    state: JobState.Failed,
+                    time_finished: { $date: currentDatetime.getTime() - 50000 },
+                  },
+                },
+              ] as RsyncTask[],
+              [],
+              [],
+            ]),
+          }),
+        ],
+      });
+
+      widgetBackup = await TestbedHarnessEnvironment.harnessForFixture(spectator.fixture, WidgetBackupHarness);
+    });
+
+    it('does not count disabled tasks', async () => {
+      const header = await widgetBackup.getHeader();
+      expect(header.icon).toBe('check-circle');
+      expect(header.message).toBeFalsy();
+
+      const tiles = await widgetBackup.getTiles();
+      expect(tiles.Rsync.firstColumn).toEqual(['0 send tasks', '1 receive task', 'Total failed: 0']);
+    });
+  });
+
   describe('fifth mockup variation', () => {
     beforeEach(async () => {
       spectator = createComponent({

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
@@ -40,6 +40,14 @@ interface BackupRow {
   direction: Direction;
 }
 
+/**
+ * Disabled tasks are not going to run, so they are excluded from the widget counts
+ * to avoid reporting a failure that no longer needs attention.
+ */
+function isTaskEnabled(task: { enabled?: boolean }): boolean {
+  return task.enabled !== false;
+}
+
 @Component({
   selector: 'ix-widget-backup',
   templateUrl: './widget-backup.component.html',
@@ -140,25 +148,25 @@ export class WidgetBackupComponent implements OnInit {
       .subscribe(([replicationTasks, rsyncTasks, cloudSyncTasks, cloudBackupTasks]) => {
         this.isLoading = false;
         this.backups = [
-          ...replicationTasks.map((task) => ({
+          ...replicationTasks.filter(isTaskEnabled).map((task) => ({
             type: BackupType.Replication,
             direction: task.direction,
             state: task.state.state,
             timestamp: task.state.datetime,
           })),
-          ...rsyncTasks.map((task) => ({
+          ...rsyncTasks.filter(isTaskEnabled).map((task) => ({
             type: BackupType.Rsync,
             direction: task.direction,
             state: task.job?.state || (task.locked ? TaskState.Locked : TaskState.Pending),
             timestamp: task.job?.time_finished,
           })),
-          ...cloudSyncTasks.map((task) => ({
+          ...cloudSyncTasks.filter(isTaskEnabled).map((task) => ({
             type: BackupType.CloudSync,
             direction: task.direction,
             state: task.job?.state || (task.locked ? TaskState.Locked : TaskState.Pending),
             timestamp: task.job?.time_finished,
           })),
-          ...cloudBackupTasks.map((task) => ({
+          ...cloudBackupTasks.filter(isTaskEnabled).map((task) => ({
             type: BackupType.CloudBackup,
             direction: Direction.Push,
             state: task.job?.state || (task.locked ? TaskState.Locked : TaskState.Pending),

--- a/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
+++ b/src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.ts
@@ -38,12 +38,9 @@ interface BackupRow {
   timestamp: ApiTimestamp;
   state: DisplayableState;
   direction: Direction;
+  enabled: boolean;
 }
 
-/**
- * Disabled tasks are not going to run, so they are excluded from the widget counts
- * to avoid reporting a failure that no longer needs attention.
- */
 function isTaskEnabled(task: { enabled?: boolean }): boolean {
   return task.enabled !== false;
 }
@@ -94,7 +91,7 @@ export class WidgetBackupComponent implements OnInit {
   }
 
   get failedCount(): number {
-    return this.backups.filter((backup) => this.failedStates.includes(backup.state)).length;
+    return this.backups.filter((backup) => this.isFailedTask(backup)).length;
   }
 
   get replicationTasks(): BackupRow[] {
@@ -148,29 +145,33 @@ export class WidgetBackupComponent implements OnInit {
       .subscribe(([replicationTasks, rsyncTasks, cloudSyncTasks, cloudBackupTasks]) => {
         this.isLoading = false;
         this.backups = [
-          ...replicationTasks.filter(isTaskEnabled).map((task) => ({
+          ...replicationTasks.map((task) => ({
             type: BackupType.Replication,
             direction: task.direction,
             state: task.state.state,
             timestamp: task.state.datetime,
+            enabled: isTaskEnabled(task),
           })),
-          ...rsyncTasks.filter(isTaskEnabled).map((task) => ({
+          ...rsyncTasks.map((task) => ({
             type: BackupType.Rsync,
             direction: task.direction,
             state: task.job?.state || (task.locked ? TaskState.Locked : TaskState.Pending),
             timestamp: task.job?.time_finished,
+            enabled: isTaskEnabled(task),
           })),
-          ...cloudSyncTasks.filter(isTaskEnabled).map((task) => ({
+          ...cloudSyncTasks.map((task) => ({
             type: BackupType.CloudSync,
             direction: task.direction,
             state: task.job?.state || (task.locked ? TaskState.Locked : TaskState.Pending),
             timestamp: task.job?.time_finished,
+            enabled: isTaskEnabled(task),
           })),
-          ...cloudBackupTasks.filter(isTaskEnabled).map((task) => ({
+          ...cloudBackupTasks.map((task) => ({
             type: BackupType.CloudBackup,
             direction: Direction.Push,
             state: task.job?.state || (task.locked ? TaskState.Locked : TaskState.Pending),
             timestamp: task.job?.time_finished,
+            enabled: isTaskEnabled(task),
           })),
         ];
         this.cdr.markForCheck();
@@ -214,15 +215,23 @@ export class WidgetBackupComponent implements OnInit {
       totalSend: tasks.filter((backup) => this.isSendTask(backup)).length,
       totalReceive: tasks.filter((backup) => !this.isSendTask(backup)).length,
       failedSend: tasks
-        .filter((backup) => this.failedStates.includes(backup.state) && this.isSendTask(backup)).length,
+        .filter((backup) => this.isFailedTask(backup) && this.isSendTask(backup)).length,
       failedReceive: tasks
-        .filter((backup) => this.failedStates.includes(backup.state) && !this.isSendTask(backup)).length,
+        .filter((backup) => this.isFailedTask(backup) && !this.isSendTask(backup)).length,
       lastWeekSend: successfulTasks
         .filter((backup) => this.isSendTask(backup) && this.isThisWeek(backup.timestamp)).length,
       lastWeekReceive: successfulTasks
         .filter((backup) => !this.isSendTask(backup) && this.isThisWeek(backup.timestamp)).length,
       lastSuccessfulTask,
     };
+  }
+
+  /**
+   * A disabled task is never going to run again, so a failure it recorded before it was
+   * disabled is history rather than something the administrator needs to act on.
+   */
+  private isFailedTask(backup: BackupRow): boolean {
+    return backup.enabled && this.failedStates.includes(backup.state);
   }
 
   private isSendTask(backup: BackupRow): boolean {


### PR DESCRIPTION
### Problem

A backup task that the administrator has **disabled** still counts as failed in the Backup Tasks widget on the Dashboard. A disabled rsync task whose last run failed keeps the widget showing `1 of N tasks failed` and a warning icon forever, even though the task will never run again — implying action is needed when it isn't.

### Change

Disabled tasks are still listed by the widget, they just stop being reported as failures. `BackupRow` carries `enabled`, and a single `isFailedTask()` predicate (`enabled && failedStates.includes(state)`) now drives both the header's `failedCount` and each tile's `failedSend` / `failedReceive`. This applies to all four task types the widget aggregates (Replication, Rsync, Cloud Sync, TrueCloud Backup).

Deliberately unchanged:

- **Disabled tasks stay in `allCount` and the tile totals.** Dropping them from the rows entirely would send a system whose tasks are *all* disabled into the widget's empty state — "Backup to Cloud or another TrueNAS via links below" plus the create-a-task actions — telling an admin who has backup tasks that they have none, and inviting a duplicate. The complaint is about health reporting, not existence.
- **`lastSuccessfulTask` and the "this week" counts** still include disabled tasks. Those are historical facts and remain true.
- Tasks that report no `enabled` field (it is optional on `ReplicationTask`) are still counted as enabled, so nothing is silently hidden.

### Before / After

Reproduced with two pull rsync tasks: one enabled and successful, one **disabled** whose last run failed.

**Before** — the disabled failed task is counted, widget warns `1 of 2 tasks failed`:

![before](https://raw.githubusercontent.com/AlexKarpov98/webui/screenshots/NAS-143096/screenshots/nas-143096-before.png)

**After** — both tasks are still listed, but the disabled one no longer registers as a failure:

![after](https://raw.githubusercontent.com/AlexKarpov98/webui/screenshots/NAS-143096/screenshots/nas-143096-after.png)

### Testing

`yarn test src/app/pages/dashboard/widgets/backup/widget-backup/widget-backup.component.spec.ts` — 10 passed, including three new cases:

- a fixture with a disabled task of **each** of the four types (plus a replication task that reports no `enabled`, pinning the "still counted" behaviour) asserting only the enabled failure reaches the header;
- the same fixture asserting disabled tasks remain in the tile totals;
- an all-disabled system asserting the widget shows the task rather than the empty state.

Also verified manually against a live system with the widget mocked to the state above (screenshots).


Original PR: https://github.com/truenas/webui/pull/14019
