### PR TITLE
NAS-142255 / 26.0.0 / Stop long migration stats from overlapping each other (by AlexKarpov98) (by bugclerk)

### DIFF
--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.html
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.html
@@ -46,7 +46,7 @@
       <div class="stat-card">
         <div class="stat-label">{{ 'Data Scanned' | translate }}</div>
         <div class="stat-value">
-          <span class="stat-part">{{ stats.count_bytes | ixFileSize }} /</span>
+          <span class="stat-part">{{ stats.count_bytes | ixFileSize }} /</span>&ngsp;
           <span class="stat-part">{{ stats.total_bytes | ixFileSize }}</span>
         </div>
       </div>
@@ -54,7 +54,7 @@
       <div class="stat-card">
         <div class="stat-label">{{ 'Items Succeeded' | translate }}</div>
         <div class="stat-value">
-          <span class="stat-part">{{ stats.success }} /</span>
+          <span class="stat-part">{{ stats.success }} /</span>&ngsp;
           <span class="stat-part">{{ stats.total_items }}</span>
         </div>
       </div>

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.html
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.html
@@ -46,20 +46,24 @@
       <div class="stat-card">
         <div class="stat-label">{{ 'Data Scanned' | translate }}</div>
         <div class="stat-value">
-          {{ stats.count_bytes | ixFileSize }}
-          /
-          {{ stats.total_bytes | ixFileSize }}
+          <span class="stat-part">{{ stats.count_bytes | ixFileSize }} /</span>
+          <span class="stat-part">{{ stats.total_bytes | ixFileSize }}</span>
         </div>
       </div>
 
       <div class="stat-card">
         <div class="stat-label">{{ 'Items Succeeded' | translate }}</div>
-        <div class="stat-value">{{ stats.success }} / {{ stats.total_items }}</div>
+        <div class="stat-value">
+          <span class="stat-part">{{ stats.success }} /</span>
+          <span class="stat-part">{{ stats.total_items }}</span>
+        </div>
       </div>
 
       <div class="stat-card">
         <div class="stat-label">{{ 'Failures' | translate }}</div>
-        <div class="stat-value">{{ stats.failures }}</div>
+        <div class="stat-value">
+          <span class="stat-part">{{ stats.failures }}</span>
+        </div>
       </div>
     </div>
   } @else if (isRunning()) {

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.scss
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.scss
@@ -64,16 +64,25 @@ mat-progress-bar {
   margin-bottom: 16px;
 }
 
+// Grid, not flex: with `auto-fit` the columns drop to a second row once they
+// cannot hold `$stat-column-min` each, instead of being squeezed narrower than
+// their contents. A byte pair like "1023.99 MiB / 1023.99 GiB" is ~190px wide,
+// which no longer fits three-across as soon as the dialog hits its 90vw cap on
+// a narrow window.
+$stat-column-min: 150px;
+
 .stats-cards {
-  display: flex;
+  display: grid;
   gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax($stat-column-min, 1fr));
 }
 
 // Not a card any more - the stats read as plain columns aligned with the rest
 // of the dialog body, so the box went with the padding.
 .stat-card {
-  flex: 1;
-  min-width: 120px;
+  // Grid items default to min-width: auto, which floors the track at the
+  // content's width and lets a long value push its neighbour off the dialog.
+  min-width: 0;
 
   .stat-label {
     font-size: 12px;
@@ -81,9 +90,20 @@ mat-progress-bar {
     margin-bottom: 4px;
   }
 
+  // No `nowrap` here: it made an over-wide value overflow its column and paint
+  // on top of the next one (NAS-142255). The value wraps between its parts
+  // instead, and `anywhere` is the last resort for a single token - an item
+  // count with no break opportunity in it - that still cannot fit.
   .stat-value {
     font-size: 16px;
     font-weight: 500;
+    overflow-wrap: anywhere;
+  }
+
+  // Each half of an "x / y" pair stays intact, so a wrap can only happen at the
+  // slash and never between a number and its unit.
+  .stat-part {
+    display: inline-block;
     white-space: nowrap;
   }
 }

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.scss
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.scss
@@ -92,16 +92,15 @@ $stat-column-min: 150px;
 
   // No `nowrap` here: it made an over-wide value overflow its column and paint
   // on top of the next one (NAS-142255). The value wraps between its parts
-  // instead, and `anywhere` is the last resort for a single token - an item
-  // count with no break opportunity in it - that still cannot fit.
+  // instead.
   .stat-value {
     font-size: 16px;
     font-weight: 500;
-    overflow-wrap: anywhere;
   }
 
   // Each half of an "x / y" pair stays intact, so a wrap can only happen at the
-  // slash and never between a number and its unit.
+  // `&ngsp;` separator the template keeps between the parts, never between a
+  // number and its unit.
   .stat-part {
     display: inline-block;
     white-space: nowrap;

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.spec.ts
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.spec.ts
@@ -75,6 +75,12 @@ describe('DataMigrationStatusDialogComponent', () => {
       const parts = spectator.queryAll('.stat-value .stat-part').map((part) => part.textContent.trim());
 
       expect(parts).toEqual(['4.77 MiB /', '9.54 MiB', '5 /', '10', '0']);
+
+      // The separator between the parts must survive Angular's whitespace
+      // removal, or the pair renders as "4.77 MiB /9.54 MiB".
+      const values = spectator.queryAll('.stat-value').map((value) => value.textContent.trim());
+
+      expect(values).toEqual(['4.77 MiB / 9.54 MiB', '5 / 10', '0']);
     });
   });
 

--- a/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.spec.ts
+++ b/src/app/pages/sharing/components/data-migration-status-dialog/data-migration-status-dialog.component.spec.ts
@@ -68,6 +68,16 @@ describe('DataMigrationStatusDialogComponent', () => {
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   }
 
+  describe('stats', () => {
+    it('splits each pair into its own unbreakable part, so a long value wraps instead of overlapping', () => {
+      build({ ...baseJob, stats: { ...baseStats } });
+
+      const parts = spectator.queryAll('.stat-value .stat-part').map((part) => part.textContent.trim());
+
+      expect(parts).toEqual(['4.77 MiB /', '9.54 MiB', '5 /', '10', '0']);
+    });
+  });
+
   describe('progress math', () => {
     it('renders progressPercent as 50 when half the items are done', () => {
       build({ ...baseJob, stats: { ...baseStats } });


### PR DESCRIPTION
### Problem

In the **Data Migration** dialog the three stats (`Data Scanned`, `Items Succeeded`, `Failures`) sat in a flex row whose values were `white-space: nowrap`. A value wider than its column could neither wrap nor shrink the column, so it overflowed its box and painted on top of the next column's text — the overlap reported in NAS-142255.

The fixed `width: min(640px, 90vw)` on the dialog hid it at desktop width for typical values (a ~187px column vs ~172px of text), but it still collides with a longer pair such as `1023.99 MiB / 1023.99 GiB` (~192px), and at any window under ~675px where the `90vw` cap shrinks the columns.

### Fix

- `.stats-cards` becomes a grid: `repeat(auto-fit, minmax(150px, 1fr))`. When the columns can no longer hold their contents they reflow onto another row instead of being squeezed under content width. `.stat-card` gets `min-width: 0` so a long value can't floor its track.
- `.stat-value` drops `nowrap` and gains `overflow-wrap: anywhere`. Each half of an `x / y` pair is a `.stat-part` span that stays `nowrap`, so the only break opportunity is at the slash — a value wraps as `222.61 KiB /` / `171.33 GiB`, never between a number and its unit.

Original PR: https://github.com/truenas/webui/pull/14011


Original PR: https://github.com/truenas/webui/pull/14024
