### PR TITLE
NAS-143219 / 27.0.0-BETA.1 / Rename "Save And Go To Review" button to "Go to Review"

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.html
@@ -37,7 +37,7 @@
   <tn-button
     color="secondary"
     [testId]="'save-and-go-to-review-data'"
-    [label]="'Save And Go To Review' | translate"
+    [label]="'Go to Review' | translate"
     (onClick)="goToReviewStep()"
   ></tn-button>
 </ix-form-actions>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.html
@@ -37,7 +37,7 @@
   <tn-button
     color="secondary"
     [testId]="'save-and-go-to-review-log'"
-    [label]="'Save And Go To Review' | translate"
+    [label]="'Go to Review' | translate"
     (onClick)="goToReviewStep()"
   ></tn-button>
 </ix-form-actions>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.html
@@ -37,7 +37,7 @@
   <tn-button
     color="secondary"
     [testId]="'save-and-go-to-review-spare'"
-    [label]="'Save And Go To Review' | translate"
+    [label]="'Go to Review' | translate"
     (onClick)="goToReviewStep()"
   ></tn-button>
 </ix-form-actions>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.spec.ts
@@ -68,9 +68,9 @@ describe('SpareWizardStepComponent', () => {
     expect(spectator.inject(PoolManagerStore).resetStep).toHaveBeenCalledWith(VDevType.Spare);
   });
 
-  it('emits goToLastStep when Save And Go To Review button is clicked', async () => {
+  it('emits goToLastStep when Go to Review button is clicked', async () => {
     jest.spyOn(spectator.component.goToLastStep, 'emit');
-    const reviewButton = await loader.getHarness(TnButtonHarness.with({ label: 'Save And Go To Review' }));
+    const reviewButton = await loader.getHarness(TnButtonHarness.with({ label: 'Go to Review' }));
     await reviewButton.click();
     expect(spectator.component.goToLastStep.emit).toHaveBeenCalled();
   });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/6-cache-wizard-step/cache-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/6-cache-wizard-step/cache-wizard-step.component.html
@@ -38,7 +38,7 @@
   <tn-button
     color="secondary"
     [testId]="'save-and-go-to-review-cache'"
-    [label]="'Save And Go To Review' | translate"
+    [label]="'Go to Review' | translate"
     (onClick)="goToReviewStep()"
   ></tn-button>
 </ix-form-actions>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
@@ -38,7 +38,7 @@
   <tn-button
     color="secondary"
     [testId]="'save-and-go-to-review-metadata'"
-    [label]="'Save And Go To Review' | translate"
+    [label]="'Go to Review' | translate"
     (onClick)="goToReviewStep()"
   ></tn-button>
 </ix-form-actions>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
@@ -38,7 +38,7 @@
   <tn-button
     color="secondary"
     [testId]="'save-and-go-to-review-dedup'"
-    [label]="'Save And Go To Review' | translate"
+    [label]="'Go to Review' | translate"
     (onClick)="goToReviewStep()"
   ></tn-button>
 </ix-form-actions>


### PR DESCRIPTION
The button in the pool manager wizard steps (data, log, spare, cache, metadata, dedup) was labelled **Save And Go To Review**, which is misleading: it saves nothing, it just jumps the wizard to the final review step.

Renamed to **Go to Review**, using sentence case instead of capitalising every word.

Test IDs (`save-and-go-to-review-*`) are left untouched so the existing E2E locator keeps working.
