### PR TITLE
NAS-141066 / 27.0.0-BETA.1 / Route the last direct MatDialog.open() call site through DialogService

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -15,8 +15,8 @@
     "selector-pseudo-element-no-unknown": [true, {
       "ignorePseudoElements": ["ng-deep"]
     }],
-    "selector-disallowed-list": [["mat-icon", "/\\.tn-list-item__/"], {
-      "message": "Disallowed selector. `mat-icon` is Angular Material — use `ix-icon`/`tn-icon`. `.tn-list-item__*` is internal @truenas/ui-components markup — use (or add) a mixin in src/assets/styles/mixins/tn-list.scss instead, see \"Known Library Gaps\" in TRUENAS_UI_INTEGRATION.md."
+    "selector-disallowed-list": [["mat-icon", "/\\.tn-list-item__/", "/mat-dialog|mdc-dialog/"], {
+      "message": "Disallowed selector. `mat-icon` is Angular Material — use `ix-icon`/`tn-icon`. `.tn-list-item__*` is internal @truenas/ui-components markup — use (or add) a mixin in src/assets/styles/mixins/tn-list.scss instead, see \"Known Library Gaps\" in TRUENAS_UI_INTEGRATION.md. Angular Material dialogs are gone (NAS-141066), so `mat-dialog-*`/`mdc-dialog-*` selectors can never match — style the `tn-dialog` overlay via its `panelClass` and `.tn-dialog-panel` instead."
     }]
   },
   "ignoreFiles": [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,10 @@ const projectOverrides = {
       {
         paths: [
           {
+            name: '@angular/material/dialog',
+            message: "Angular Material dialogs have been fully replaced by `tn-dialog` (NAS-141066). Open dialogs through `DialogService` (app/modules/dialog/dialog.service.ts), or inject `TnDialog` from '@truenas/ui-components' for a dialog DialogService does not wrap.",
+          },
+          {
             name: '@angular/common',
             importNames: ['DatePipe'],
             message: "Do not use Angular's DatePipe directly. It bypasses user datetime format preferences. Use FormatDateTimePipe from 'app/modules/dates/pipes/format-date-time/format-datetime.pipe' or LocaleService methods instead. For fixed formats (like filenames), use date-fns directly.",

--- a/src/app/modules/feedback/components/file-review/file-review.component.scss
+++ b/src/app/modules/feedback/components/file-review/file-review.component.scss
@@ -4,10 +4,3 @@
   margin-top: -16px;
   padding-left: 30px;
 }
-
-:host mat-dialog-content {
-  margin-bottom: 20px;
-  overflow-y: auto !important;
-  padding-bottom: 5px;
-  padding-top: 0;
-}

--- a/src/app/modules/feedback/components/file-ticket-licensed/file-ticket-licensed.component.scss
+++ b/src/app/modules/feedback/components/file-ticket-licensed/file-ticket-licensed.component.scss
@@ -4,13 +4,6 @@
   padding-left: 30px;
 }
 
-:host mat-dialog-content {
-  margin-bottom: 20px;
-  overflow-y: auto !important;
-  padding-bottom: 5px;
-  padding-top: 0;
-}
-
 .columns {
   column-gap: 15px;
   display: flex;

--- a/src/app/modules/feedback/components/file-ticket/file-ticket.component.scss
+++ b/src/app/modules/feedback/components/file-ticket/file-ticket.component.scss
@@ -3,10 +3,3 @@
   margin-top: -16px;
   padding-left: 30px;
 }
-
-:host mat-dialog-content {
-  margin-bottom: 20px;
-  overflow-y: auto !important;
-  padding-bottom: 5px;
-  padding-top: 0;
-}

--- a/src/app/modules/forms/editable/editable.component.ts
+++ b/src/app/modules/forms/editable/editable.component.ts
@@ -153,7 +153,6 @@ export class EditableComponent implements AfterViewInit, OnDestroy {
     try {
       if (
         allowedOverlaySelectors.some((sel) => document.querySelector(sel)?.contains(target))
-        || document.querySelector('.mat-mdc-dialog-container')
         || document.querySelector('.tn-dialog-panel')
       ) {
         return true;

--- a/src/app/modules/forms/ix-forms/components/form-actions/form-actions.component.scss
+++ b/src/app/modules/forms/ix-forms/components/form-actions/form-actions.component.scss
@@ -1,7 +1,6 @@
 @import 'scss-imports/variables';
 
-:host,
-:host-context(mat-dialog-container .ix-form-container) :host {
+:host {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;

--- a/src/app/modules/tn-table-cells/state-cell/task-state-cell.component.spec.ts
+++ b/src/app/modules/tn-table-cells/state-cell/task-state-cell.component.spec.ts
@@ -1,11 +1,9 @@
-import { MatDialog } from '@angular/material/dialog';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { DisplayableState, JobState } from 'app/enums/job-state.enum';
 import { TaskState } from 'app/enums/task-state.enum';
 import { Job } from 'app/interfaces/job.interface';
-import { ShowLogsDialog } from 'app/modules/dialog/components/show-logs-dialog/show-logs-dialog.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import {
   TaskStateCellComponent,
@@ -23,7 +21,6 @@ describe('TaskStateCellComponent', () => {
       mockProvider(DialogService, {
         jobDialog: jest.fn(() => ({ afterClosed: () => of(undefined) })) as unknown as DialogService['jobDialog'],
       }),
-      mockProvider(MatDialog, { open: jest.fn() }),
       mockProvider(ErrorHandlerService),
     ],
   });
@@ -73,7 +70,7 @@ describe('TaskStateCellComponent', () => {
 
     spectator.click('button.state-button');
 
-    expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(ShowLogsDialog, { data: job });
+    expect(spectator.inject(DialogService).showLogs).toHaveBeenCalledWith(job);
   });
 
   it('warns when there are no logs to show', () => {

--- a/src/app/modules/tn-table-cells/state-cell/task-state-cell.component.ts
+++ b/src/app/modules/tn-table-cells/state-cell/task-state-cell.component.ts
@@ -2,7 +2,6 @@ import {
   ChangeDetectionStrategy, Component, computed, DestroyRef, inject, input,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { MatDialog } from '@angular/material/dialog';
 import { Store } from '@ngrx/store';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { TnTestIdDirective, TnTooltipDirective } from '@truenas/ui-components';
@@ -15,7 +14,6 @@ import { observeJob } from 'app/helpers/operators/observe-job.operator';
 import { helptextGlobal } from 'app/helptext/global-helptext';
 import { ApiJobMethod, ApiJobResponse } from 'app/interfaces/api/api-job-directory.interface';
 import { Job } from 'app/interfaces/job.interface';
-import { ShowLogsDialog } from 'app/modules/dialog/components/show-logs-dialog/show-logs-dialog.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { JobSlice, selectJob } from 'app/modules/jobs/store/job.selectors';
 import { formatJobStateValue, JobStateDisplayPipe } from 'app/modules/pipes/job-state-display/job-state-display.pipe';
@@ -43,9 +41,8 @@ export function formatTaskStateValue(
  * Shared across data-protection task lists/cards and the jobs list. The
  * library has no multi-colour status pill (`tn-button` only does filled/outline,
  * `tn-chip` only primary/secondary/accent), so the pill markup is a plain
- * `<button>` styled locally rather than a `tn-*` element. The running-job log
- * viewer is still opened through `MatDialog` (as in the original
- * `ix-cell-state-button` cell), pending the dialog migration (NAS-141022).
+ * `<button>` styled locally rather than a `tn-*` element. Every dialog this cell
+ * opens goes through `DialogService`, which owns the `tn-dialog` overlays.
  * The live job state arrives via the bound `[state]`/`[job]` inputs (the host
  * card updates the row); the cell itself handles the click, opening the
  * running-job dialog or the error / logs modals as `ix-cell-state-button` did.
@@ -63,7 +60,6 @@ export function formatTaskStateValue(
   ],
 })
 export class TaskStateCellComponent {
-  private matDialog = inject(MatDialog);
   private translate = inject(TranslateService);
   private dialogService = inject(DialogService);
   private errorHandler = inject(ErrorHandlerService);
@@ -149,7 +145,7 @@ export class TaskStateCellComponent {
     }
 
     if (job?.logs_excerpt) {
-      this.matDialog.open(ShowLogsDialog, { data: job });
+      this.dialogService.showLogs(job);
       return;
     }
 

--- a/src/app/pages/apps/components/installed-apps/app-update-dialog/app-update-dialog.component.scss
+++ b/src/app/pages/apps/components/installed-apps/app-update-dialog/app-update-dialog.component.scss
@@ -2,18 +2,6 @@
   font-size: 14px;
 }
 
-:host ::ng-deep .mat-mdc-dialog-content {
-  max-width: unset;
-  overflow: auto;
-
-  .mat-mdc-form-field {
-    flex: 1;
-    margin: 0 0 0 10px;
-    min-width: 0;
-    width: unset !important;
-  }
-}
-
 .logo-container {
   align-items: center;
   display: flex;

--- a/src/app/pages/credentials/users/password-change-required-dialog/password-change-required-dialog.component.scss
+++ b/src/app/pages/credentials/users/password-change-required-dialog/password-change-required-dialog.component.scss
@@ -14,8 +14,7 @@
     z-index: 99999;
   }
 
-  .cdk-overlay-pane.full-screen-modal,
-  .mat-mdc-dialog-container {
+  .cdk-overlay-pane.full-screen-modal {
     max-width: none !important;
   }
 }

--- a/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.scss
+++ b/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.scss
@@ -14,8 +14,7 @@
     z-index: 99999;
   }
 
-  .cdk-overlay-pane.full-screen-modal,
-  .mat-mdc-dialog-container {
+  .cdk-overlay-pane.full-screen-modal {
     max-width: none !important;
   }
 }

--- a/src/assets/styles/other/_material-overrides.scss
+++ b/src/assets/styles/other/_material-overrides.scss
@@ -14,19 +14,8 @@ html .ix-dark {
 
   --mat-card-title-text-tracking: normal;
 
-  --mdc-dialog-subhead-color: var(--fg1);
-  --mdc-dialog-supporting-text-color: var(--fg2);
   --mdc-dialog-supporting-text-font: var(--font-family-body);
-  --mdc-dialog-supporting-text-size: 0.875rem;
-  --mdc-dialog-subhead-size: 1.42rem;
   --mdc-dialog-subhead-font: var(--font-family-body);
-  --mdc-dialog-supporting-text-weight: 400;
-  --mdc-dialog-subhead-weight: 600;
-  --mdc-dialog-supporting-text-line-height: 1.65;
-  --mdc-dialog-subhead-line-height: 1.65;
-  --mdc-dialog-supporting-text-tracking: 0;
-  --mdc-dialog-container-shape: 0;
-  --mdc-dialog-subhead-tracking: 0;
   --mdc-shape-medium: 4px;
   --mdc-theme-primary: var(--primary);
   --mat-slide-toggle-selected-track-color: var(--primary);
@@ -155,11 +144,6 @@ html .ix-dark {
   --mat-sidenav-content-text-color: var(--fg1);
   --mat-list-list-item-label-text-color: var(--fg2);
   --mat-list-list-item-hover-label-text-color: var(--fg1);
-  --mat-dialog-subhead-color: var(--fg2);
-  --mat-dialog-subhead-weight: var(--mdc-dialog-subhead-weight, var(--mat-sys-headline-small-weight, 400));
-  --mat-dialog-supporting-text-color: var(--fg2);
-  --mat-dialog-supporting-text-line-height: var(--mdc-dialog-supporting-text-line-height, var(--mat-sys-body-medium-line-height, 1.5rem));
-  --mat-dialog-subhead-tracking: 0;
   --mat-button-toggle-selected-state-text-color: var(--fg1);
   --mat-slide-toggle-label-text-color: var(--fg1);
   --mat-checkbox-selected-checkmark-color: var(--primary-txt);

--- a/src/assets/styles/other/_material-reduction.scss
+++ b/src/assets/styles/other/_material-reduction.scss
@@ -915,13 +915,6 @@ body .mat-calendar-next-button::after {
   }
 }
 
-.cdk-overlay-pane.mat-mdc-dialog-panel {
-  @media(max-width: $breakpoint-xs) {
-    max-width: 95% !important;
-    width: inherit;
-  }
-}
-
 body .mat-vertical-content {
   @media(max-width: $breakpoint-sm) {
     padding: 0 8px 8px;
@@ -961,13 +954,6 @@ mat-list-item {
     max-width: fill-available;
     white-space: pre-wrap;
     overflow-wrap: break-word;
-  }
-}
-
-@media(max-width: $breakpoint-sm) {
-  .mdc-dialog__container,
-  mat-dialog-container {
-    max-width: 100% !important;
   }
 }
 

--- a/src/assets/styles/other/_tn-styles.scss
+++ b/src/assets/styles/other/_tn-styles.scss
@@ -128,8 +128,6 @@ $primary-dark: color.adjust(map.get($md-primary, 500), $lightness: -8%);
   .mat-mdc-select-panel,
   .mat-mdc-select-panel-done-animating,
   .mat-expansion-panel,
-  .mat-mdc-dialog-container,
-  .mat-mdc-dialog-container .mat-mdc-dialog-surface,
   .mat-stepper-horizontal,
   .mat-stepper-vertical {
     @include variable(background, --bg2, $bg2);
@@ -348,56 +346,6 @@ $primary-dark: color.adjust(map.get($md-primary, 500), $lightness: -8%);
 
   /////////////////// END SpecSelectors
 
-  .mat-dialog-container {
-    max-width: 80vw;
-  }
-
-  .mat-mdc-dialog-container {
-    border-radius: var(--mdc-dialog-container-shape);
-    max-width: 800px;
-
-    :not(.mat-mdc-dialog-content) {
-      > form {
-        padding: 0 24px 24px;
-
-        .mat-mdc-dialog-content,
-        .mat-mdc-dialog-actions {
-          padding: 0 0 5px;
-        }
-      }
-    }
-
-    .mat-mdc-dialog-actions {
-      justify-content: end;
-    }
-  }
-
-  .mat-mdc-dialog-title {
-    display: flex;
-    margin: 0 0 15px;
-    padding: 24px 24px 0;
-  }
-
-  .mdc-dialog__actions {
-    min-height: inherit;
-    padding: 0 24px 20px;
-  }
-
-  .mat-mdc-dialog-content {
-    max-height: 50vh;
-    overflow-y: auto;
-
-    .more-info {
-      align-items: center;
-      cursor: pointer;
-      display: flex;
-      gap: 8px;
-      margin-top: 5px;
-      min-height: 40px;
-    }
-
-  }
-
   .mat-spinner circle {
     @include variable(stroke, --primary, $primary, !important);
   }
@@ -597,12 +545,6 @@ $primary-dark: color.adjust(map.get($md-primary, 500), $lightness: -8%);
   // for multi-selection only
   .mat-mdc-option-pseudo-checkbox.mat-pseudo-checkbox {
     display: none;
-  }
-
-  // Bring tooltips to the front in dialogs
-  // Only container needs visible overflow - content should scroll
-  .mat-mdc-dialog-container {
-    overflow: visible !important;
   }
 
   // Fix for overscrolling problem with sidenav
@@ -812,21 +754,6 @@ $primary-dark: color.adjust(map.get($md-primary, 500), $lightness: -8%);
     }
   }
 
-  .topbar-panel {
-    .mat-mdc-dialog-container {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
-    }
-
-    .mat-mdc-dialog-content {
-      overflow: auto !important;
-    }
-
-    .mat-mdc-dialog-actions {
-      padding-bottom: 24px;
-    }
-  }
-
   // Disabled form fields
   .form-element .mat-mdc-text-field-wrapper[disabled],
   .form-element input[type=email][disabled],
@@ -912,18 +839,6 @@ mat-form-field {
 .mdc-line-ripple::before,
 .mdc-line-ripple::after {
   border: 0 !important;
-}
-
-.manual-selection-dialog,
-.inspect-vdevs-dialog {
-  .mat-mdc-dialog-container {
-    max-width: inherit;
-  }
-}
-
-.multi-error-dialog.mat-mdc-dialog-container,
-.multi-error-dialog.mat-mdc-dialog-content {
-  overflow: auto !important;
 }
 
 // `tn-side-panel` renders its overlay inline (position: fixed; z-index: 1000) rather than

--- a/src/setup-jest.ts
+++ b/src/setup-jest.ts
@@ -13,7 +13,6 @@ import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
-import { MatDialogModule } from '@angular/material/dialog';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatListModule } from '@angular/material/list';
 import { MatMenuModule } from '@angular/material/menu';
@@ -164,7 +163,6 @@ defineGlobalsInjections({
     MatDatepickerModule,
     MatNativeDateModule,
     MatSelectModule,
-    MatDialogModule,
     MatSortModule,
     MatTooltipModule,
     MatCardModule,


### PR DESCRIPTION
### Changes

Finisher for the dialog migration epic. The ~120 direct `MatDialog.open()` call sites this ticket was scoped around had already been redirected by the `DialogService` migration (NAS-141022) and the feature-area tickets — ~100 components now inject `TnDialog` directly, and the rest go through `DialogService`. **One** direct `MatDialog.open()` was left behind, plus a trail of dead Material-dialog scaffolding.

**Redirecting the last call site**

- **`task-state-cell.component.ts`** — the running-job log viewer was still opened with `this.matDialog.open(ShowLogsDialog, { data: job })`, with a comment marking it as pending NAS-141022. It now calls `this.dialogService.showLogs(job)`, the `tn-dialog`-backed wrapper that already exists and does exactly this. Every other branch in `onButtonClick` was already going through `DialogService`.
- **`setup-jest.ts`** — dropped `MatDialogModule` from `defineGlobalsInjections`; it only existed to supply `MatDialog` to specs, and nothing injects it any more.

**Removing what that left dead** (second commit, −157 lines)

With no `MatDialog` and no `touchUi` datepicker anywhere, nothing in the app can render a `mat-dialog-container` / `.mat-mdc-dialog-*` element — so every remaining selector for one is provably inert, not merely unused:

- `_tn-styles.scss` — the dialog chrome block (container/title/actions/content sizing), the tooltip `overflow: visible` override, and the `.topbar-panel`, `.manual-selection-dialog`, `.inspect-vdevs-dialog`, `.multi-error-dialog` panel rules, which all reached for `.mat-mdc-dialog-container` inside.
- `_material-reduction.scss` — the `.cdk-overlay-pane.mat-mdc-dialog-panel` and `mat-dialog-container` mobile width rules. `TnDialog` labels its pane `tn-dialog-panel`.
- `_material-overrides.scss` — the `--mat-dialog-*` theme tokens, plus the 11 `--mdc-dialog-*` tokens left with no consumer. `--mdc-dialog-subhead-font` and `--mdc-dialog-supporting-text-font` are **kept**: unrelated rules still read them as general font tokens.
- Seven component stylesheets with dead `mat-dialog-content` / `.mat-mdc-dialog-content` / `mat-dialog-container` rules. In the two full-screen dialogs only the Material half of the selector list is dropped — `.cdk-overlay-pane.full-screen-modal` is still a live `panelClass`.
- **`editable.component.ts`** — `isElementWithin` tested `document.querySelector('.mat-mdc-dialog-container')` to decide whether a dialog is open. That branch can never be true; the `.tn-dialog-panel` check on the next line is the live equivalent.

**Guards, so it can't regress**

- `eslint.config.mjs` — `@angular/material/dialog` added to `no-restricted-imports`, pointing at `DialogService` first and `TnDialog` second.
- `.stylelintrc.json` — `mat-dialog|mdc-dialog` added to `selector-disallowed-list`, alongside the existing `mat-icon` entry.

### Worth a look from a designer

Three `panelClass` styling intents were silently lost when dialogs moved to `tn-dialog` — the rules stopped matching then, not in this PR, and I've deleted them rather than ported them:

- `topbar-panel` — squared-off top corners and `overflow: auto` on content. Still passed by five call sites (jobs indicator, HA status, global search, TNC, `DialogService.update`).
- `manual-selection-dialog` / `inspect-vdevs-dialog` — `max-width: inherit`, i.e. the pool-manager dialogs were meant to opt out of the 800px cap.
- `multi-error-dialog` — `overflow: auto`. This one is doubly dead: the class is no longer passed as a `panelClass` at all.

If those dialogs look right today, nothing to do. If the pool-manager ones feel cramped, that's the missing `max-width` and it wants a `tn-dialog` port in a follow-up.

### Testing

- `yarn test src/app/modules/dialog src/app/modules/loader` — 13 suites / 121 tests.
- `yarn test` across editable, feedback, app-update-dialog, the two full-screen dialogs and form-actions — 11 suites / 97 tests.
- Sweep for the global `setup-jest` change: `yarn test src/app/pages/credentials/users src/app/modules/feedback src/app/pages/apps/components/installed-apps` — 51 suites / 406 tests.
- `npx tsc -p src/tsconfig.app.json --noEmit` — clean.
- `yarn lint` on changed files and `npx stylelint "src/**/*.scss"` — both clean, the latter with the new rule active.

The `task-state-cell` spec now asserts `DialogService.showLogs` was called with the job, instead of asserting on the `MatDialog` mock.

https://claude.ai/code/session_01YWb7ZvZPxunLPDKRaBnce9
