### PR TITLE
NAS-143219 / 26.0.0 / Rename "Save And Go To Review" button to "Go to Review" (by AlexKarpov98)

### DIFF
--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/3-data-wizard-step/data-wizard-step.component.html
@@ -50,6 +50,6 @@
     ixTest="save-and-go-to-review-data"
     (click)="goToReviewStep()"
   >
-    {{ 'Save And Go To Review' | translate }}
+    {{ 'Go to Review' | translate }}
   </button>
 </ix-form-actions>

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/4-log-wizard-step/log-wizard-step.component.html
@@ -50,7 +50,7 @@
     ixTest="save-and-go-to-review-log"
     (click)="goToReviewStep()"
   >
-    {{ 'Save And Go To Review' | translate }}
+    {{ 'Go to Review' | translate }}
   </button>
 </ix-form-actions>
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.html
@@ -50,7 +50,7 @@
     ixTest="save-and-go-to-review-spare"
     (click)="goToReviewStep()"
   >
-    {{ 'Save And Go To Review' | translate }}
+    {{ 'Go to Review' | translate }}
   </button>
 </ix-form-actions>
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.spec.ts
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/5-spare-wizard-step/spare-wizard-step.component.spec.ts
@@ -69,9 +69,9 @@ describe('SpareWizardStepComponent', () => {
     expect(spectator.inject(PoolManagerStore).resetStep).toHaveBeenCalledWith(VDevType.Spare);
   });
 
-  it('emits goToLastStep when Save And Go To Review button is clicked', async () => {
+  it('emits goToLastStep when Go to Review button is clicked', async () => {
     jest.spyOn(spectator.component.goToLastStep, 'emit');
-    const reviewButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save And Go To Review' }));
+    const reviewButton = await loader.getHarness(MatButtonHarness.with({ text: 'Go to Review' }));
     await reviewButton.click();
     expect(spectator.component.goToLastStep.emit).toHaveBeenCalled();
   });

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/6-cache-wizard-step/cache-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/6-cache-wizard-step/cache-wizard-step.component.html
@@ -51,7 +51,7 @@
     ixTest="save-and-go-to-review-cache"
     (click)="goToReviewStep()"
   >
-    {{ 'Save And Go To Review' | translate }}
+    {{ 'Go to Review' | translate }}
   </button>
 </ix-form-actions>
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/7-metadata-wizard-step/metadata-wizard-step.component.html
@@ -51,7 +51,7 @@
     ixTest="save-and-go-to-review-metadata"
     (click)="goToReviewStep()"
   >
-    {{ 'Save And Go To Review' | translate }}
+    {{ 'Go to Review' | translate }}
   </button>
 </ix-form-actions>
 

--- a/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
+++ b/src/app/pages/storage/modules/pool-manager/components/pool-manager-wizard/steps/8-dedup-wizard-step/dedup-wizard-step.component.html
@@ -51,7 +51,7 @@
     ixTest="save-and-go-to-review-dedup"
     (click)="goToReviewStep()"
   >
-    {{ 'Save And Go To Review' | translate }}
+    {{ 'Go to Review' | translate }}
   </button>
 </ix-form-actions>
 


### PR DESCRIPTION
The button in the pool manager wizard steps (data, log, spare, cache, metadata, dedup) was labelled **Save And Go To Review**, which is misleading: it saves nothing, it just jumps the wizard to the final review step.

Renamed to **Go to Review**, using sentence case instead of capitalising every word.

Test IDs (`save-and-go-to-review-*`) are left untouched so the existing E2E locator keeps working.


Original PR: https://github.com/truenas/webui/pull/14051
