### PR TITLE
NAS-143345 / 27.0.0-BETA.1 / Make object lock a basic S3 bucket option, expire access keys by default, show versioning in the list

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@smarttools/eslint-plugin-rxjs": "~1.0.22",
     "@stylistic/eslint-plugin": "~2.9.0",
     "@truenas/common-typescript": "github:truenas/tn-common-typescript#master",
-    "@truenas/ui-components": "~0.7.2",
+    "@truenas/ui-components": "~0.7.4",
     "@types/cheerio": "~0.22.35",
     "@types/d3": "~7.4.3",
     "@types/dygraphs": "^2.1.10",

--- a/src/app/helptext/sharing/s3/s3.ts
+++ b/src/app/helptext/sharing/s3/s3.ts
@@ -16,15 +16,21 @@ export const helptextSharingS3 = {
   grantsTooltip: T('Who may access the bucket and how, beyond its owner. A <b>Deny</b> grant refuses every\
  operation for the principal and outranks the owner.'),
   globalGrantsTooltip: T('Grants that apply to every bucket. A <b>Deny</b> here suspends the principal everywhere.'),
-  versioningTooltip: T('Keep previous versions of objects. Object lock requires versioning to be Enabled.'),
+  versioningTooltip: T('Keep previous versions of objects. Object lock keeps versioning enabled.'),
+  versioningLockedHint: T('Kept enabled while object lock is on.'),
   snapshotVersionsTooltip: T('Patterns over the names of the bucket dataset\'s ZFS snapshots, with <i>*</i> and\
  <i>?</i> as the only wildcards. Every matching snapshot serves each object\'s state as a read-only version.'),
   snapshotVersionsMaxTooltip: T('How many of the newest matching snapshots one version listing consults.'),
   multipartEtagTooltip: T('<b>Composite</b> is the standard S3 construction and costs an MD5 pass over every\
  part. <b>Minted</b> skips that pass and gives the object an opaque token. Choose Minted only where nothing\
  writing the bucket reads its ETags, such as a backup target with its own checksums.'),
-  objectLockTooltip: T('Requires versioning to be Enabled and a permissions model other than Multiprotocol.'),
-  objectLockDefaultModeTooltip: T('Retention mode of the default object lock rule. Leave empty for no default rule.'),
+  objectLockTooltip: T('Protect objects from being overwritten or deleted for a retention period, as backup\
+ targets expect. Turns on versioning, which object lock requires.'),
+  objectLockMultiprotocolHint: T('Not available with the Multiprotocol permissions model: another protocol could\
+ rewrite a locked object.'),
+  objectLockDefaultModeTooltip: T('Retention mode applied to new objects. <b>Compliance</b> cannot be shortened or\
+ removed by anyone for the retention period. <b>Governance</b> can be overridden by users with the special\
+ permission. Leave empty for no default rule.'),
   objectLockDefaultDaysTooltip: T('Retention period of the default object lock rule in days.'),
   auditTooltip: T('Which S3 actions on this bucket are recorded in the audit log.'),
   auditOverflowTooltip: T('What an audited request gets when no audit record slot is free.'),

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
@@ -113,15 +113,15 @@ describe('S3AccessKeyFormComponent', () => {
 
       await (await getInput('name')).setValue('backup-key');
       await (await loader.getHarness(IxFormHarness)).fillForm({ User: 'alice' });
-      const expiry = new Date('2030-01-15T00:00:00Z');
-      await (await loader.getHarness(TnDateInputHarness)).setValue(expiry);
+      // The picker stores the chosen day at local midnight, so it is set and asserted in local time.
+      await (await loader.getHarness(TnDateInputHarness)).setValue(new Date(2030, 0, 15));
 
       spectator.component.submit();
 
-      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('s3.accesskey.create', [expect.objectContaining({
-        name: 'backup-key',
-        expires_at: { $date: expect.any(Number) },
-      })]);
+      const api = spectator.inject(ApiService) as unknown as { call: jest.Mock };
+      const [, [payload]] = api.call.mock.calls.find(([method]) => method === 's3.accesskey.create');
+      const expiresAt = new Date((payload as { expires_at: { $date: number } }).expires_at.$date);
+      expect([expiresAt.getFullYear(), expiresAt.getMonth() + 1, expiresAt.getDate()]).toEqual([2030, 1, 15]);
     });
 
     it('asks for an expiry date by default and requires it until Non-expiring is checked', async () => {

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
@@ -2,7 +2,9 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { TnCheckboxHarness, TnDialog, TnInputHarness } from '@truenas/ui-components';
+import {
+  TnCheckboxHarness, TnDateInputHarness, TnDialog, TnInputHarness,
+} from '@truenas/ui-components';
 import { parseISO } from 'date-fns';
 import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
@@ -104,6 +106,24 @@ describe('S3AccessKeyFormComponent', () => {
   });
 
   describe('expiry', () => {
+    it('creates an expiring key with the chosen date by default', async () => {
+      spectator = createComponent();
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+      await spectator.fixture.whenStable();
+
+      await (await getInput('name')).setValue('backup-key');
+      await (await loader.getHarness(IxFormHarness)).fillForm({ User: 'alice' });
+      const expiry = new Date('2030-01-15T00:00:00Z');
+      await (await loader.getHarness(TnDateInputHarness)).setValue(expiry);
+
+      spectator.component.submit();
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('s3.accesskey.create', [expect.objectContaining({
+        name: 'backup-key',
+        expires_at: { $date: expect.any(Number) },
+      })]);
+    });
+
     it('asks for an expiry date by default and requires it until Non-expiring is checked', async () => {
       spectator = createComponent();
       loader = TestbedHarnessEnvironment.loader(spectator.fixture);

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
@@ -85,6 +85,7 @@ describe('S3AccessKeyFormComponent', () => {
       await (await getInput('name')).setValue('backup-key');
       const form = await loader.getHarness(IxFormHarness);
       await form.fillForm({ User: 'alice' });
+      await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Non-expiring' }))).check();
 
       spectator.component.submit();
 
@@ -103,15 +104,18 @@ describe('S3AccessKeyFormComponent', () => {
   });
 
   describe('expiry', () => {
-    it('requires a date once Non-expiring is unchecked', async () => {
+    it('asks for an expiry date by default and requires it until Non-expiring is checked', async () => {
       spectator = createComponent();
       loader = TestbedHarnessEnvironment.loader(spectator.fixture);
       await spectator.fixture.whenStable();
 
-      await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Non-expiring' }))).uncheck();
-
+      const nonExpiring = await loader.getHarness(TnCheckboxHarness.with({ label: 'Non-expiring' }));
+      expect(await nonExpiring.isChecked()).toBe(false);
       expect(spectator.component.form.controls.expires_at.errors).toMatchObject({ required: true });
       expect(spectator.component.canSubmit()).toBe(false);
+
+      await nonExpiring.check();
+      expect(spectator.component.form.controls.expires_at.errors).toBeNull();
     });
   });
 

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.ts
@@ -63,7 +63,8 @@ export class S3AccessKeyFormComponent extends SidePanelForm implements OnInit {
     name: ['', Validators.required],
     username: ['', Validators.required],
     enabled: [true],
-    nonExpiring: [true],
+    // Keys expire unless the admin opts out, so a new key asks for a date up front.
+    nonExpiring: [false],
     expires_at: [null as Date | null],
   });
 

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
@@ -74,22 +74,6 @@
   </tn-form-section>
 
   @if (isAdvancedMode()) {
-    <tn-form-section [heading]="'Access' | translate">
-      <tn-form-field
-        [label]="'Permissions Model' | translate"
-        [tooltip]="helptext.permissionsModelTooltip | translate"
-        [required]="true"
-      >
-        <tn-select formControlName="permissions_model" [options]="permissionsModelOptions()"></tn-select>
-      </tn-form-field>
-
-      <ix-s3-grants-list
-        [formArray]="form.controls.grants"
-        [label]="'Grants' | translate"
-        [tooltip]="helptext.grantsTooltip | translate"
-      ></ix-s3-grants-list>
-    </tn-form-section>
-
     <tn-form-section [heading]="'Versioning' | translate">
       <tn-form-field
         [label]="'Versioning' | translate"
@@ -119,6 +103,22 @@
           ></tn-input>
         </tn-form-field>
       }
+    </tn-form-section>
+
+    <tn-form-section [heading]="'Access' | translate">
+      <tn-form-field
+        [label]="'Permissions Model' | translate"
+        [tooltip]="helptext.permissionsModelTooltip | translate"
+        [required]="true"
+      >
+        <tn-select formControlName="permissions_model" [options]="permissionsModelOptions()"></tn-select>
+      </tn-form-field>
+
+      <ix-s3-grants-list
+        [formArray]="form.controls.grants"
+        [label]="'Grants' | translate"
+        [tooltip]="helptext.grantsTooltip | translate"
+      ></ix-s3-grants-list>
     </tn-form-section>
 
     <tn-form-section [heading]="'Other Options' | translate">

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
@@ -85,11 +85,16 @@
       </tn-form-field>
 
       @if (form.controls.versioning.value !== S3Versioning.Off) {
-        <ix-chips
-          formControlName="snapshot_versions"
+        <tn-form-field
           [label]="'Snapshot Versions' | translate"
           [tooltip]="helptext.snapshotVersionsTooltip | translate"
-        ></ix-chips>
+        >
+          <tn-chip-input
+            testId="snapshot-versions"
+            formControlName="snapshot_versions"
+            [allowCustomValue]="true"
+          ></tn-chip-input>
+        </tn-form-field>
 
         <tn-form-field
           [label]="'Snapshot Versions Listed' | translate"

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
@@ -44,6 +44,35 @@
     </tn-form-field>
   </tn-form-section>
 
+  <tn-form-section [heading]="'Object Lock' | translate">
+    <tn-form-field [tooltip]="helptext.objectLockTooltip | translate" [hint]="objectLockHint()">
+      <tn-checkbox formControlName="object_lock" [label]="'Enable Object Lock' | translate"></tn-checkbox>
+    </tn-form-field>
+
+    @if (form.controls.object_lock.value) {
+      <tn-form-field
+        [label]="'Default Retention Mode' | translate"
+        [tooltip]="helptext.objectLockDefaultModeTooltip | translate"
+      >
+        <tn-select formControlName="object_lock_default_mode" [options]="objectLockModeOptions"></tn-select>
+      </tn-form-field>
+
+      @if (form.controls.object_lock_default_mode.value) {
+        <tn-form-field
+          [label]="'Default Retention Days' | translate"
+          [tooltip]="helptext.objectLockDefaultDaysTooltip | translate"
+          [required]="true"
+        >
+          <tn-input
+            formControlName="object_lock_default_days"
+            [inputType]="InputType.Number"
+            [allowDecimals]="false"
+          ></tn-input>
+        </tn-form-field>
+      }
+    }
+  </tn-form-section>
+
   @if (isAdvancedMode()) {
     <tn-form-section [heading]="'Access' | translate">
       <tn-form-field
@@ -51,7 +80,7 @@
         [tooltip]="helptext.permissionsModelTooltip | translate"
         [required]="true"
       >
-        <tn-select formControlName="permissions_model" [options]="permissionsModelOptions"></tn-select>
+        <tn-select formControlName="permissions_model" [options]="permissionsModelOptions()"></tn-select>
       </tn-form-field>
 
       <ix-s3-grants-list
@@ -65,6 +94,7 @@
       <tn-form-field
         [label]="'Versioning' | translate"
         [tooltip]="helptext.versioningTooltip | translate"
+        [hint]="versioningHint()"
         [required]="true"
       >
         <tn-select formControlName="versioning" [options]="versioningOptions"></tn-select>
@@ -88,35 +118,6 @@
             [allowDecimals]="false"
           ></tn-input>
         </tn-form-field>
-      }
-    </tn-form-section>
-
-    <tn-form-section [heading]="'Object Lock' | translate">
-      <tn-form-field [tooltip]="helptext.objectLockTooltip | translate" [hint]="objectLockHint()">
-        <tn-checkbox formControlName="object_lock" [label]="'Enable Object Lock' | translate"></tn-checkbox>
-      </tn-form-field>
-
-      @if (form.controls.object_lock.value) {
-        <tn-form-field
-          [label]="'Default Retention Mode' | translate"
-          [tooltip]="helptext.objectLockDefaultModeTooltip | translate"
-        >
-          <tn-select formControlName="object_lock_default_mode" [options]="objectLockModeOptions"></tn-select>
-        </tn-form-field>
-
-        @if (form.controls.object_lock_default_mode.value) {
-          <tn-form-field
-            [label]="'Default Retention Days' | translate"
-            [tooltip]="helptext.objectLockDefaultDaysTooltip | translate"
-            [required]="true"
-          >
-            <tn-input
-              formControlName="object_lock_default_days"
-              [inputType]="InputType.Number"
-              [allowDecimals]="false"
-            ></tn-input>
-          </tn-form-field>
-        }
       }
     </tn-form-section>
 

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
@@ -93,6 +93,7 @@
             testId="snapshot-versions"
             formControlName="snapshot_versions"
             [allowCustomValue]="true"
+            [addOnBlur]="true"
           ></tn-chip-input>
         </tn-form-field>
 

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -5,7 +5,8 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { Store } from '@ngrx/store';
 import { provideMockStore } from '@ngrx/store/testing';
 import {
-  TnCheckboxHarness, TnDialog, TnFormFieldHarness, TnFormListHarness, TnInputHarness, TnSelectHarness,
+  TnCheckboxHarness, TnChipInputHarness, TnDialog, TnFormFieldHarness, TnFormListHarness, TnInputHarness,
+  TnSelectHarness,
 } from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
@@ -302,6 +303,10 @@ describe('S3BucketFormComponent', () => {
       expect(await (await getCheckbox('enabled')).isChecked()).toBe(true);
       expect(await (await getSelect('permissions_model')).getDisplayText()).toBe('S3 Only');
       expect(await (await getSelect('versioning')).getDisplayText()).toBe('Enabled');
+      const snapshotVersions = await loader.getHarness(
+        TnChipInputHarness.with({ testId: 'chip-input-snapshot-versions' }),
+      );
+      expect(await snapshotVersions.getChips()).toEqual(['auto-*']);
       expect(await (await getSelect('principal_type')).getDisplayText()).toBe('Group');
       expect(await (await getSelect('access')).getDisplayText()).toBe('Read / Write');
     });

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -118,16 +118,41 @@ describe('S3BucketFormComponent', () => {
       jest.spyOn(store$, 'dispatch');
     });
 
-    it('shows only basic fields until Advanced Options is pressed', async () => {
+    it('shows object lock with the basic fields and the rest only after Advanced Options is pressed', async () => {
+      expect(await loader.hasHarness(TnCheckboxHarness.with({ label: 'Enable Object Lock' }))).toBe(true);
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Permissions Model' }))).toBe(false);
+      expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Versioning' }))).toBe(false);
 
       await clickAdvancedOptions();
 
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Permissions Model' }))).toBe(true);
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Versioning' }))).toBe(true);
-      expect(await loader.hasHarness(TnCheckboxHarness.with({ label: 'Enable Object Lock' }))).toBe(true);
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Multipart ETag' }))).toBe(true);
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Audit' }))).toBe(false);
+    });
+
+    it('turns versioning on and defaults to Compliance retention when object lock is enabled', async () => {
+      await clickAdvancedOptions();
+      expect(await (await getSelect('versioning')).getDisplayText()).toBe('Off');
+
+      await (await getCheckbox('object_lock')).check();
+
+      const versioning = await getSelect('versioning');
+      expect(await versioning.getDisplayText()).toBe('Enabled');
+      expect(await versioning.isDisabled()).toBe(true);
+      expect(await (await getSelect('object_lock_default_mode')).getDisplayText()).toBe('Compliance');
+
+      await (await getCheckbox('object_lock')).uncheck();
+      expect(await (await getSelect('versioning')).isDisabled()).toBe(false);
+    });
+
+    it('does not offer object lock with the Multiprotocol permissions model', async () => {
+      await clickAdvancedOptions();
+      await (await getSelect('permissions_model')).selectOption('Multiprotocol');
+
+      const objectLock = await getCheckbox('object_lock');
+      expect(await objectLock.isDisabled()).toBe(true);
+      expect(await objectLock.isChecked()).toBe(false);
     });
 
     it('rejects the /mnt root as a parent dataset', async () => {
@@ -257,25 +282,18 @@ describe('S3BucketFormComponent', () => {
       expect(spectator.component.canSubmit()).toBe(false);
     });
 
-    it('requires retention days once a default retention mode is chosen', async () => {
-      await clickAdvancedOptions();
-      await (await getSelect('versioning')).selectOption('Enabled');
+    it('requires retention days once object lock is on with a default retention mode', async () => {
       await (await getCheckbox('object_lock')).check();
-      await (await getSelect('object_lock_default_mode')).selectOption('Governance');
 
       expect(spectator.component.form.controls.object_lock_default_days.errors).toMatchObject({ required: true });
       expect(spectator.component.canSubmit()).toBe(false);
     });
 
     it('stops requiring retention days once object lock is turned off again', async () => {
-      await clickAdvancedOptions();
-      await (await getSelect('versioning')).selectOption('Enabled');
       await (await getCheckbox('object_lock')).check();
-      await (await getSelect('object_lock_default_mode')).selectOption('Governance');
       expect(spectator.component.canSubmit()).toBe(false);
 
-      // Turning versioning off clears object lock programmatically; the hidden days field must not block Save.
-      await (await getSelect('versioning')).selectOption('Off');
+      await (await getCheckbox('object_lock')).uncheck();
 
       expect(spectator.component.form.controls.object_lock_default_days.errors).toBeNull();
       expect(spectator.component.canSubmit()).toBe(true);
@@ -317,7 +335,6 @@ describe('S3BucketFormComponent', () => {
     });
 
     it('does not let a hidden out-of-range retention period block Save', async () => {
-      await clickAdvancedOptions();
       await (await getCheckbox('object_lock')).check();
       await (await getSelect('object_lock_default_mode')).selectOption('Governance');
       await (await getInput('object_lock_default_days')).setValue('0');

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -11,7 +11,7 @@ import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import {
-  S3Access, S3MultipartEtag, S3PermissionsModel, S3PrincipalType, S3Versioning,
+  S3Access, S3MultipartEtag, S3ObjectLockMode, S3PermissionsModel, S3PrincipalType, S3Versioning,
 } from 'app/enums/s3.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { Group } from 'app/interfaces/group.interface';
@@ -143,7 +143,45 @@ describe('S3BucketFormComponent', () => {
       expect(await (await getSelect('object_lock_default_mode')).getDisplayText()).toBe('Compliance');
 
       await (await getCheckbox('object_lock')).uncheck();
-      expect(await (await getSelect('versioning')).isDisabled()).toBe(false);
+      const released = await getSelect('versioning');
+      expect(await released.isDisabled()).toBe(false);
+      expect(await released.getDisplayText()).toBe('Off');
+    });
+
+    it('creates a bucket with object lock, versioning and the Compliance default rule', async () => {
+      await (await getInput('name')).setValue('backups');
+      await form.fillForm({
+        'Parent Dataset': 'tank',
+        Owner: 'alice',
+      });
+      await (await getCheckbox('object_lock')).check();
+      await (await getInput('object_lock_default_days')).setValue('30');
+
+      spectator.component.submit();
+
+      expect(api.call).toHaveBeenCalledWith('sharing.s3.create', [expect.objectContaining({
+        versioning: S3Versioning.Enabled,
+        object_lock: true,
+        object_lock_default_mode: S3ObjectLockMode.Compliance,
+        object_lock_default_days: 30,
+      })]);
+    });
+
+    it('does not leave versioning on after object lock is checked and unchecked in basic mode', async () => {
+      await (await getInput('name')).setValue('plain');
+      await form.fillForm({
+        'Parent Dataset': 'tank',
+        Owner: 'alice',
+      });
+      await (await getCheckbox('object_lock')).check();
+      await (await getCheckbox('object_lock')).uncheck();
+
+      spectator.component.submit();
+
+      expect(api.call).toHaveBeenCalledWith('sharing.s3.create', [expect.objectContaining({
+        versioning: S3Versioning.Off,
+        object_lock: false,
+      })]);
     });
 
     it('does not offer object lock with the Multiprotocol permissions model', async () => {
@@ -257,6 +295,18 @@ describe('S3BucketFormComponent', () => {
       expect(await (await getSelect('versioning')).getDisplayText()).toBe('Enabled');
       expect(await (await getSelect('principal_type')).getDisplayText()).toBe('Group');
       expect(await (await getSelect('access')).getDisplayText()).toBe('Read / Write');
+    });
+
+    it('keeps a stored "no default rule" when object lock is unchecked and re-checked', async () => {
+      spectator = createComponent({
+        props: { bucket: { ...existingBucket, object_lock: true, object_lock_default_mode: null } },
+      });
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+
+      await (await getCheckbox('object_lock')).uncheck();
+      await (await getCheckbox('object_lock')).check();
+
+      expect(spectator.component.form.controls.object_lock_default_mode.value).toBeNull();
     });
 
     it('lets an EVERYONE grant be switched to a user grant', async () => {

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -167,6 +167,15 @@ describe('S3BucketFormComponent', () => {
       })]);
     });
 
+    it('keeps a "no default rule" chosen in this session when object lock is re-checked', async () => {
+      await (await getCheckbox('object_lock')).check();
+      await (await getSelect('object_lock_default_mode')).selectOption('No default rule');
+      await (await getCheckbox('object_lock')).uncheck();
+      await (await getCheckbox('object_lock')).check();
+
+      expect(spectator.component.form.controls.object_lock_default_mode.value).toBeNull();
+    });
+
     it('does not leave versioning on after object lock is checked and unchecked in basic mode', async () => {
       await (await getInput('name')).setValue('plain');
       await form.fillForm({

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -8,8 +8,8 @@ import {
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  InputType, TnCheckboxComponent, TnFormFieldComponent, TnFormSectionComponent, TnInputComponent,
-  TnSelectComponent, type TnSelectOption,
+  InputType, TnCheckboxComponent, TnChipInputComponent, TnFormFieldComponent, TnFormSectionComponent,
+  TnInputComponent, TnSelectComponent, type TnSelectOption,
 } from '@truenas/ui-components';
 import {
   map, merge, Observable, startWith,
@@ -35,7 +35,6 @@ import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextSharingS3 } from 'app/helptext/sharing';
 import { S3AuditMask, S3Bucket, S3BucketCreate } from 'app/interfaces/s3.interface';
-import { IxChipsComponent } from 'app/modules/forms/ix-forms/components/ix-chips/ix-chips.component';
 import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
 import { IxFormHostForm } from 'app/modules/forms/ix-forms/components/ix-form/ix-form-host-form.directive';
 import {
@@ -69,10 +68,10 @@ export const s3BucketNamePattern = /^[a-z0-9][a-z0-9.-]*[a-z0-9]$/;
     TnFormFieldComponent,
     TnInputComponent,
     TnCheckboxComponent,
+    TnChipInputComponent,
     TnSelectComponent,
     IxExplorerComponent,
     IxUserPickerComponent,
-    IxChipsComponent,
     S3GrantsListComponent,
     TranslateModule,
   ],

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -110,7 +110,7 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
   readonly treeNodeProvider = this.datasetService.getDatasetNodeProvider();
   protected readonly ownerProvider = createS3UserPickerProvider();
 
-  protected readonly permissionsModelOptions = mapToOptions(s3PermissionsModelLabels, this.translate);
+  private readonly permissionsModelBaseOptions = mapToOptions(s3PermissionsModelLabels, this.translate);
   protected readonly versioningOptions = mapToOptions(s3VersioningLabels, this.translate);
   protected readonly multipartEtagOptions = mapToOptions(s3MultipartEtagLabels, this.translate);
   protected readonly objectLockModeOptions: TnSelectOption<S3ObjectLockMode | null>[] = [
@@ -205,20 +205,37 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
     return this.translate.instant('Bucket dataset: {dataset}', { dataset: `${parent}/${name}` });
   });
 
+  /**
+   * Object lock is a primary option (backup targets), so it drives versioning rather than depending
+   * on it: checking it switches versioning on and keeps it there. The one thing that rules it out is
+   * the Multiprotocol permissions model, under which another protocol could rewrite a locked object.
+   */
   protected readonly canUseObjectLock = computed(() => {
-    const { versioning, permissions_model: permissionsModel } = this.formValue();
-    return versioning === S3Versioning.Enabled && permissionsModel !== S3PermissionsModel.Multiprotocol;
+    return this.formValue().permissions_model !== S3PermissionsModel.Multiprotocol;
   });
 
   protected readonly objectLockHint = computed(() => {
-    return this.canUseObjectLock() ? '' : this.translate.instant(this.helptext.objectLockTooltip);
+    return this.canUseObjectLock() ? '' : this.translate.instant(this.helptext.objectLockMultiprotocolHint);
+  });
+
+  protected readonly isObjectLockOn = computed(() => !!this.formValue().object_lock);
+
+  /** Multiprotocol cannot be picked while object lock is on, for the same reason. */
+  protected readonly permissionsModelOptions = computed<TnSelectOption<S3PermissionsModel>[]>(() => {
+    return this.permissionsModelBaseOptions.map((option) => ({
+      ...option,
+      disabled: this.isObjectLockOn() && option.value === S3PermissionsModel.Multiprotocol,
+    }));
+  });
+
+  protected readonly versioningHint = computed(() => {
+    return this.isObjectLockOn() ? this.translate.instant(this.helptext.versioningLockedHint) : '';
   });
 
   /** Controls that only render in advanced mode. */
   private readonly advancedControls = [
-    'permissions_model', 'grants', 'versioning', 'snapshot_versions', 'snapshot_versions_max', 'object_lock',
-    'object_lock_default_mode', 'object_lock_default_days', 'multipart_etag', 'audit_mode', 'audit_actions',
-    'audit_overflow',
+    'permissions_model', 'grants', 'versioning', 'snapshot_versions', 'snapshot_versions_max', 'multipart_etag',
+    'audit_mode', 'audit_actions', 'audit_overflow',
   ] as const;
 
   private readonly formStatus = toSignal(this.form.statusChanges.pipe(startWith(this.form.status)));
@@ -309,8 +326,17 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
 
   private setupObjectLockDependency(): void {
     this.syncObjectLockAvailability();
+    this.syncVersioningLock(this.form.controls.object_lock.value);
     this.form.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.syncObjectLockAvailability();
+    });
+    // Wired after the edit data is patched, so a stored "no default rule" is kept; only a user
+    // turning object lock on gets the Compliance default.
+    this.form.controls.object_lock.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((objectLock) => {
+      if (objectLock && this.form.controls.object_lock_default_mode.value === null) {
+        this.form.controls.object_lock_default_mode.setValue(S3ObjectLockMode.Compliance);
+      }
+      this.syncVersioningLock(objectLock);
     });
     // The gated validators above read sibling controls, so the switches they depend on re-run them.
     merge(
@@ -324,6 +350,19 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
     });
   }
 
+  /** Object lock requires versioning, so the select is set to Enabled and held there while it is on. */
+  private syncVersioningLock(objectLock: boolean): void {
+    const versioning = this.form.controls.versioning;
+    if (objectLock) {
+      if (versioning.value !== S3Versioning.Enabled) {
+        versioning.setValue(S3Versioning.Enabled);
+      }
+      versioning.disable({ emitEvent: false });
+    } else if (versioning.disabled) {
+      versioning.enable({ emitEvent: false });
+    }
+  }
+
   private syncObjectLockAvailability(): void {
     const control = this.form.controls.object_lock;
     if (this.canUseObjectLock()) {
@@ -333,7 +372,8 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
     } else if (control.enabled) {
       control.setValue(false, { emitEvent: false });
       control.disable({ emitEvent: false });
-      // Cleared silently above, so the days validator has to be re-run by hand for the same reason.
+      // Cleared silently above, so the dependants have to be updated by hand for the same reason.
+      this.syncVersioningLock(false);
       this.form.controls.object_lock_default_days.updateValueAndValidity();
     }
   }

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -330,10 +330,11 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
     this.form.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.syncObjectLockAvailability();
     });
-    // Wired after the edit data is patched, so a stored "no default rule" is kept; only a user
-    // turning object lock on gets the Compliance default.
+    // Compliance is the default for a bucket that gains object lock here. A bucket that already had
+    // object lock with no default rule keeps that choice, even across an uncheck and re-check.
+    const hadObjectLock = !!this.bucket()?.object_lock;
     this.form.controls.object_lock.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((objectLock) => {
-      if (objectLock && this.form.controls.object_lock_default_mode.value === null) {
+      if (objectLock && !hadObjectLock && this.form.controls.object_lock_default_mode.value === null) {
         this.form.controls.object_lock_default_mode.setValue(S3ObjectLockMode.Compliance);
       }
       this.syncVersioningLock(objectLock);
@@ -350,16 +351,28 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
     });
   }
 
-  /** Object lock requires versioning, so the select is set to Enabled and held there while it is on. */
+  /** What versioning was set to before object lock forced it on, restored when object lock is released. */
+  private versioningBeforeLock: S3Versioning | null = null;
+
+  /**
+   * Object lock requires versioning, so the select is set to Enabled and held there while it is on.
+   * Releasing it puts the previous choice back, so a check-then-uncheck in basic mode (where the
+   * select is not even rendered) is a no-op rather than a silent switch to versioning.
+   */
   private syncVersioningLock(objectLock: boolean): void {
     const versioning = this.form.controls.versioning;
     if (objectLock) {
       if (versioning.value !== S3Versioning.Enabled) {
+        this.versioningBeforeLock = versioning.value;
         versioning.setValue(S3Versioning.Enabled);
       }
       versioning.disable({ emitEvent: false });
     } else if (versioning.disabled) {
       versioning.enable({ emitEvent: false });
+      if (this.versioningBeforeLock !== null) {
+        versioning.setValue(this.versioningBeforeLock);
+        this.versioningBeforeLock = null;
+      }
     }
   }
 

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -325,16 +325,19 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
   }
 
   private setupObjectLockDependency(): void {
+    // Read here rather than in a field initializer: inputs are not set yet when fields initialize.
+    this.defaultModeOffered = !!this.bucket()?.object_lock;
     this.syncObjectLockAvailability();
     this.syncVersioningLock(this.form.controls.object_lock.value);
     this.form.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.syncObjectLockAvailability();
     });
-    // Compliance is the default for a bucket that gains object lock here. A bucket that already had
-    // object lock with no default rule keeps that choice, even across an uncheck and re-check.
-    const hadObjectLock = !!this.bucket()?.object_lock;
+    // Compliance is offered once, the first time object lock is turned on for a bucket that did not
+    // have it. After that a "no default rule", whether stored or picked here, survives an uncheck and
+    // re-check: it is the only way to express object lock without a default rule.
     this.form.controls.object_lock.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((objectLock) => {
-      if (objectLock && !hadObjectLock && this.form.controls.object_lock_default_mode.value === null) {
+      if (objectLock && !this.defaultModeOffered && this.form.controls.object_lock_default_mode.value === null) {
+        this.defaultModeOffered = true;
         this.form.controls.object_lock_default_mode.setValue(S3ObjectLockMode.Compliance);
       }
       this.syncVersioningLock(objectLock);
@@ -353,6 +356,9 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
 
   /** What versioning was set to before object lock forced it on, restored when object lock is released. */
   private versioningBeforeLock: S3Versioning | null = null;
+
+  /** Whether the Compliance default has been offered; a bucket stored with object lock starts offered. */
+  private defaultModeOffered = false;
 
   /**
    * Object lock requires versioning, so the select is set to Enabled and held there while it is on.

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.html
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.html
@@ -94,7 +94,7 @@
         </ng-template>
       </ng-container>
 
-      <ng-container [tnColumnDef]="'versioning'">
+      <ng-container [tnColumnDef]="'versioning'" [sortable]="true">
         <ng-template tnHeaderCellDef>{{ 'Versioning' | translate }}</ng-template>
         <ng-template let-row tnCellDef>
           <span
@@ -104,7 +104,7 @@
         </ng-template>
       </ng-container>
 
-      <ng-container [tnColumnDef]="'object_lock'">
+      <ng-container [tnColumnDef]="'object_lock'" [sortable]="true">
         <ng-template tnHeaderCellDef>{{ 'Object Lock' | translate }}</ng-template>
         <ng-template let-row tnCellDef>
           <span

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
@@ -9,7 +9,7 @@ import {
 import { Subject, of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { S3PermissionsModel } from 'app/enums/s3.enum';
+import { S3PermissionsModel, S3Versioning } from 'app/enums/s3.enum';
 import { Pool } from 'app/interfaces/pool.interface';
 import { S3Bucket } from 'app/interfaces/s3.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -34,6 +34,8 @@ describe('S3BucketListComponent', () => {
       dataset: 'tank/buckets/backups',
       owner: 'bob',
       permissions_model: S3PermissionsModel.BucketOwnerEnforced,
+      versioning: S3Versioning.Enabled,
+      object_lock: true,
       enabled: true,
       locked: false,
     },
@@ -83,10 +85,10 @@ describe('S3BucketListComponent', () => {
 
   it('shows table rows', async () => {
     expect(await table.getHeaderTexts()).toEqual([
-      'Name', 'Dataset', 'Owner', 'Permissions Model', 'Enabled', '',
+      'Name', 'Dataset', 'Owner', 'Permissions Model', 'Versioning', 'Object Lock', 'Enabled', '',
     ]);
     expect(await table.getAllRowTexts()).toEqual([
-      ['backups', 'tank/buckets/backups', 'bob', 'Bucket Owner Enforced', '', ''],
+      ['backups', 'tank/buckets/backups', 'bob', 'Bucket Owner Enforced', 'Enabled', 'Yes', '', ''],
     ]);
   });
 

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
@@ -138,6 +138,7 @@ export class S3BucketListComponent implements OnInit {
     column({
       title: this.translate.instant('Permissions Model'),
       propertyName: 'permissions_model',
+      sortBy: (row) => this.permissionsModelLabel(row),
     }),
     column({
       title: this.translate.instant('Versioning'),

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
@@ -142,12 +142,10 @@ export class S3BucketListComponent implements OnInit {
     column({
       title: this.translate.instant('Versioning'),
       propertyName: 'versioning',
-      hidden: true,
     }),
     column({
       title: this.translate.instant('Object Lock'),
       propertyName: 'object_lock',
-      hidden: true,
     }),
     column({
       title: this.translate.instant('Enabled'),

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
@@ -142,6 +142,8 @@ export class S3BucketListComponent implements OnInit {
     column({
       title: this.translate.instant('Versioning'),
       propertyName: 'versioning',
+      // Sort on the label the cell shows, not the raw enum, so the order matches the visible text.
+      sortBy: (row) => this.versioningLabel(row),
     }),
     column({
       title: this.translate.instant('Object Lock'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4551,9 +4551,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@truenas/ui-components@npm:~0.7.2":
-  version: 0.7.2
-  resolution: "@truenas/ui-components@npm:0.7.2"
+"@truenas/ui-components@npm:~0.7.4":
+  version: 0.7.4
+  resolution: "@truenas/ui-components@npm:0.7.4"
   dependencies:
     "@material-design-icons/svg": "npm:~0.14.13"
     "@mdi/svg": "npm:~7.4.47"
@@ -4574,7 +4574,7 @@ __metadata:
     "@mdi/js": ^7.4.47
   bin:
     truenas-icons: scripts/icon-sprite/cli.js
-  checksum: 10/49db52ddec7985ad0d51a25b1a5c15869bf16f0895676019b9c4bd714ac1256d00ce86ff08d57dd019ce3d47851bf56481706488b2f0169a4c5684b48aaa797b
+  checksum: 10/9865855745264b861476fbbbf0a80da459f71288af288d06d18420c560b44f86e6f60387a5168fc235a38ad93b99dd8e7f971bd9171220f21eda82477bed37a5
   languageName: node
   linkType: hard
 
@@ -16102,7 +16102,7 @@ __metadata:
     "@stylistic/eslint-plugin": "npm:~2.9.0"
     "@truenas/api-client": "npm:~3.0.2"
     "@truenas/common-typescript": "github:truenas/tn-common-typescript#master"
-    "@truenas/ui-components": "npm:~0.7.2"
+    "@truenas/ui-components": "npm:~0.7.4"
     "@types/cheerio": "npm:~0.22.35"
     "@types/d3": "npm:~7.4.3"
     "@types/dygraphs": "npm:^2.1.10"


### PR DESCRIPTION
Follow-up to #14047 after review of the first S3 build.

## Changes

- **Object lock is a basic option.** It has its own section next to the bucket fields instead of living under Advanced Options, since backup targets are the primary use case. Checking it switches Versioning to Enabled and holds it there (the select shows a hint while locked); unchecking releases it. The Multiprotocol permissions model is disabled in the picker while object lock is on, and object lock is disabled with a hint when Multiprotocol is already selected.
- **Retention mode defaults to Compliance** when object lock is turned on. A stored "no default rule" on an existing bucket is left alone; only a user enabling object lock gets the default.
- **New access keys expire by default.** Non-expiring is now opt-in, so the form asks for a date up front.
- **Bucket list shows Versioning and Object Lock** columns by default, both sortable.

## Tests

Bucket form: object lock in basic mode, versioning forced and locked, Compliance default, Multiprotocol exclusion, retention days required/released. Access key form: date required by default until Non-expiring is checked. List: new columns in the row text. 25 tests, lint and AOT clean.