### PR TITLE
NAS-143345 / 26.0.0-RC.1 / Make object lock a basic S3 bucket option, expire access keys by default, show versioning in the list (by william-gr)

### DIFF
--- a/src/app/helptext/sharing/s3/s3.ts
+++ b/src/app/helptext/sharing/s3/s3.ts
@@ -16,15 +16,21 @@ export const helptextSharingS3 = {
   grantsTooltip: T('Who may access the bucket and how, beyond its owner. A <b>Deny</b> grant refuses every \
  operation for the principal and outranks the owner.'),
   globalGrantsTooltip: T('Grants that apply to every bucket. A <b>Deny</b> here suspends the principal everywhere.'),
-  versioningTooltip: T('Keep previous versions of objects. Object lock requires versioning to be Enabled.'),
+  versioningTooltip: T('Keep previous versions of objects. Object lock keeps versioning enabled.'),
+  versioningLockedHint: T('Kept enabled while object lock is on.'),
   snapshotVersionsTooltip: T('Patterns over the names of the bucket dataset\'s ZFS snapshots, with <i>*</i> and \
  <i>?</i> as the only wildcards. Every matching snapshot serves each object\'s state as a read-only version.'),
   snapshotVersionsMaxTooltip: T('How many of the newest matching snapshots one version listing consults.'),
   multipartEtagTooltip: T('<b>Composite</b> is the standard S3 construction and costs an MD5 pass over every \
  part. <b>Minted</b> skips that pass and gives the object an opaque token. Choose Minted only where nothing \
  writing the bucket reads its ETags, such as a backup target with its own checksums.'),
-  objectLockTooltip: T('Requires versioning to be Enabled and a permissions model other than Multiprotocol.'),
-  objectLockDefaultModeTooltip: T('Retention mode of the default object lock rule. Leave empty for no default rule.'),
+  objectLockTooltip: T('Protect objects from being overwritten or deleted for a retention period, as backup \
+ targets expect. Turns on versioning, which object lock requires.'),
+  objectLockMultiprotocolHint: T('Not available with the Multiprotocol permissions model: another protocol could \
+ rewrite a locked object.'),
+  objectLockDefaultModeTooltip: T('Retention mode applied to new objects. <b>Compliance</b> cannot be shortened or \
+ removed by anyone for the retention period. <b>Governance</b> can be overridden by users with the special \
+ permission. Leave empty for no default rule.'),
   objectLockDefaultDaysTooltip: T('Retention period of the default object lock rule in days.'),
   auditTooltip: T('Which S3 actions on this bucket are recorded in the audit log.'),
   auditOverflowTooltip: T('What an audited request gets when no audit record slot is free.'),

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.html
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.html
@@ -47,6 +47,7 @@
             formControlName="expires_at"
             [label]="'Expires On' | translate"
             [min]="minDateToday"
+            [required]="true"
           ></ix-datepicker>
         }
       </ix-fieldset>

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
@@ -84,6 +84,7 @@ describe('S3AccessKeyFormComponent', () => {
       await form.fillForm({
         Name: 'backup-key',
         User: 'alice',
+        'Non-expiring': true,
       });
 
       const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
@@ -100,6 +101,46 @@ describe('S3AccessKeyFormComponent', () => {
         S3AccessKeyCredentialsDialogComponent,
         { data: createdKey },
       );
+    });
+  });
+
+  describe('expiry', () => {
+    beforeEach(async () => {
+      spectator = createComponent();
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+      form = await loader.getHarness(IxFormHarness);
+    });
+
+    it('creates an expiring key with the chosen date by default', async () => {
+      await form.fillForm({
+        Name: 'backup-key',
+        User: 'alice',
+        'Expires On': '2030-01-15',
+      });
+
+      const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await saveButton.click();
+
+      expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('s3.accesskey.create', [{
+        name: 'backup-key',
+        username: 'alice',
+        enabled: true,
+        expires_at: { $date: Date.UTC(2030, 0, 15) },
+      }]);
+    });
+
+    it('asks for an expiry date by default and requires it until Non-expiring is checked', async () => {
+      expect(await form.getValues()).toMatchObject({ 'Non-expiring': false });
+      expect(await form.getLabels()).toContain('Expires On');
+      expect(spectator.component.form.controls.expires_at.errors).toMatchObject({ required: true });
+      const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await form.fillForm({ Name: 'backup-key', User: 'alice' });
+      expect(await saveButton.isDisabled()).toBe(true);
+
+      await form.fillForm({ 'Non-expiring': true });
+
+      expect(await form.getLabels()).not.toContain('Expires On');
+      expect(await saveButton.isDisabled()).toBe(false);
     });
   });
 

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.ts
@@ -73,8 +73,9 @@ export class S3AccessKeyFormComponent implements OnInit {
     name: ['', Validators.required],
     username: ['', Validators.required],
     enabled: [true],
-    nonExpiring: [true],
-    expires_at: [null as Date | null],
+    // Keys expire unless the admin opts out, so a new key asks for a date up front.
+    nonExpiring: [false],
+    expires_at: [null as Date | null, Validators.required],
   });
 
   get title(): string {
@@ -91,6 +92,25 @@ export class S3AccessKeyFormComponent implements OnInit {
     if (this.existingKey) {
       this.setKeyForEdit(this.existingKey);
     }
+    this.setupExpiryDependency();
+  }
+
+  /**
+   * The date is only shown, and only required, while the key expires. The control is disabled rather
+   * than left with a cleared validator: the picker's `[required]` attaches Angular's own validator
+   * while it is rendered, and a disabled control is excluded from validity regardless.
+   */
+  private setupExpiryDependency(): void {
+    const expiresAt = this.form.controls.expires_at;
+    const sync = (nonExpiring: boolean): void => {
+      if (nonExpiring) {
+        expiresAt.disable();
+      } else {
+        expiresAt.enable();
+      }
+    };
+    sync(this.form.controls.nonExpiring.value);
+    this.form.controls.nonExpiring.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(sync);
   }
 
   protected onSubmit(): void {

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
@@ -47,28 +47,42 @@
         ></ix-checkbox>
       </ix-fieldset>
 
-      @if (isAdvancedMode()) {
-        <ix-fieldset [title]="'Access' | translate">
+      <ix-fieldset [title]="'Object Lock' | translate">
+        <ix-checkbox
+          formControlName="object_lock"
+          [label]="'Enable Object Lock' | translate"
+          [tooltip]="helptext.objectLockTooltip | translate"
+          [hint]="objectLockHint()"
+        ></ix-checkbox>
+
+        @if (form.controls.object_lock.value) {
           <ix-select
-            formControlName="permissions_model"
-            [label]="'Permissions Model' | translate"
-            [tooltip]="helptext.permissionsModelTooltip | translate"
-            [options]="permissionsModelOptions$"
-            [required]="true"
+            formControlName="object_lock_default_mode"
+            [label]="'Default Retention Mode' | translate"
+            [tooltip]="helptext.objectLockDefaultModeTooltip | translate"
+            [options]="objectLockModeOptions$"
+            [emptyLabel]="'No default rule' | translate"
           ></ix-select>
 
-          <ix-s3-grants-list
-            [formArray]="form.controls.grants"
-            [label]="'Grants' | translate"
-            [tooltip]="helptext.grantsTooltip | translate"
-          ></ix-s3-grants-list>
-        </ix-fieldset>
+          @if (form.controls.object_lock_default_mode.value) {
+            <ix-input
+              formControlName="object_lock_default_days"
+              type="number"
+              [label]="'Default Retention Days' | translate"
+              [tooltip]="helptext.objectLockDefaultDaysTooltip | translate"
+              [required]="true"
+            ></ix-input>
+          }
+        }
+      </ix-fieldset>
 
+      @if (isAdvancedMode()) {
         <ix-fieldset [title]="'Versioning' | translate">
           <ix-select
             formControlName="versioning"
             [label]="'Versioning' | translate"
             [tooltip]="helptext.versioningTooltip | translate"
+            [hint]="versioningHint()"
             [options]="versioningOptions$"
             [required]="true"
           ></ix-select>
@@ -90,33 +104,20 @@
           }
         </ix-fieldset>
 
-        <ix-fieldset [title]="'Object Lock' | translate">
-          <ix-checkbox
-            formControlName="object_lock"
-            [label]="'Enable Object Lock' | translate"
-            [tooltip]="helptext.objectLockTooltip | translate"
-            [hint]="objectLockHint()"
-          ></ix-checkbox>
+        <ix-fieldset [title]="'Access' | translate">
+          <ix-select
+            formControlName="permissions_model"
+            [label]="'Permissions Model' | translate"
+            [tooltip]="helptext.permissionsModelTooltip | translate"
+            [options]="permissionsModelOptions$"
+            [required]="true"
+          ></ix-select>
 
-          @if (form.controls.object_lock.value) {
-            <ix-select
-              formControlName="object_lock_default_mode"
-              [label]="'Default Retention Mode' | translate"
-              [tooltip]="helptext.objectLockDefaultModeTooltip | translate"
-              [options]="objectLockModeOptions$"
-              [emptyLabel]="'No default rule' | translate"
-            ></ix-select>
-
-            @if (form.controls.object_lock_default_mode.value) {
-              <ix-input
-                formControlName="object_lock_default_days"
-                type="number"
-                [label]="'Default Retention Days' | translate"
-                [tooltip]="helptext.objectLockDefaultDaysTooltip | translate"
-                [required]="true"
-              ></ix-input>
-            }
-          }
+          <ix-s3-grants-list
+            [formArray]="form.controls.grants"
+            [label]="'Grants' | translate"
+            [tooltip]="helptext.grantsTooltip | translate"
+          ></ix-s3-grants-list>
         </ix-fieldset>
 
         <ix-fieldset [title]="'Other Options' | translate">

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -9,13 +9,15 @@ import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import {
-  S3Access, S3MultipartEtag, S3PermissionsModel, S3PrincipalType, S3Versioning,
+  S3Access, S3MultipartEtag, S3ObjectLockMode, S3PermissionsModel, S3PrincipalType, S3Versioning,
 } from 'app/enums/s3.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { Group } from 'app/interfaces/group.interface';
 import { S3Bucket } from 'app/interfaces/s3.interface';
 import { User } from 'app/interfaces/user.interface';
+import { IxCheckboxHarness } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.harness';
 import { IxListHarness } from 'app/modules/forms/ix-forms/components/ix-list/ix-list.harness';
+import { IxSelectHarness } from 'app/modules/forms/ix-forms/components/ix-select/ix-select.harness';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
@@ -94,6 +96,21 @@ describe('S3BucketFormComponent', () => {
     ],
   });
 
+  const clickAdvancedOptions = async (): Promise<void> => {
+    const advancedButton = await loader.getHarness(MatButtonHarness.with({ text: 'Advanced Options' }));
+    await advancedButton.click();
+  };
+
+  const getSaveButton = (): Promise<MatButtonHarness> => loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+
+  const getSelect = async (label: string): Promise<IxSelectHarness> => {
+    return await form.getControl(label) as IxSelectHarness;
+  };
+
+  const getCheckbox = async (label: string): Promise<IxCheckboxHarness> => {
+    return await form.getControl(label) as IxCheckboxHarness;
+  };
+
   describe('creating a bucket', () => {
     beforeEach(async () => {
       spectator = createComponent();
@@ -104,19 +121,131 @@ describe('S3BucketFormComponent', () => {
       jest.spyOn(store$, 'dispatch');
     });
 
-    it('shows only basic fields until Advanced Options is pressed', async () => {
+    it('shows object lock with the basic fields and the rest only after Advanced Options is pressed', async () => {
       const labels = await form.getLabels();
-      expect(labels).toEqual(['Name', 'Parent Dataset', 'Owner', 'Enabled']);
+      expect(labels).toEqual(['Name', 'Parent Dataset', 'Owner', 'Enabled', 'Enable Object Lock']);
 
-      const advancedButton = await loader.getHarness(MatButtonHarness.with({ text: 'Advanced Options' }));
-      await advancedButton.click();
+      await clickAdvancedOptions();
 
       const advancedLabels = await form.getLabels();
       expect(advancedLabels).toContain('Permissions Model');
       expect(advancedLabels).toContain('Versioning');
-      expect(advancedLabels).toContain('Enable Object Lock');
       expect(advancedLabels).toContain('Multipart ETag');
       expect(advancedLabels).not.toContain('Audit');
+    });
+
+    it('turns versioning on and defaults to Compliance retention when object lock is enabled', async () => {
+      await clickAdvancedOptions();
+      expect(await (await getSelect('Versioning')).getValue()).toBe('Off');
+
+      await form.fillForm({ 'Enable Object Lock': true });
+
+      const versioning = await getSelect('Versioning');
+      expect(await versioning.getValue()).toBe('Enabled');
+      expect(await versioning.isDisabled()).toBe(true);
+      expect(await (await getSelect('Default Retention Mode')).getValue()).toBe('Compliance');
+
+      await form.fillForm({ 'Enable Object Lock': false });
+      const released = await getSelect('Versioning');
+      expect(await released.isDisabled()).toBe(false);
+      expect(await released.getValue()).toBe('Off');
+    });
+
+    it('creates a bucket with object lock, versioning and the Compliance default rule', async () => {
+      await form.fillForm({
+        Name: 'backups',
+        'Parent Dataset': 'tank',
+        Owner: 'alice',
+        'Enable Object Lock': true,
+      });
+      await form.fillForm({ 'Default Retention Days': 30 });
+
+      await (await getSaveButton()).click();
+
+      expect(api.call).toHaveBeenCalledWith('sharing.s3.create', [expect.objectContaining({
+        versioning: S3Versioning.Enabled,
+        object_lock: true,
+        object_lock_default_mode: S3ObjectLockMode.Compliance,
+        object_lock_default_days: 30,
+      })]);
+    });
+
+    it('keeps a "no default rule" chosen in this session when object lock is re-checked', async () => {
+      await form.fillForm({ 'Enable Object Lock': true });
+      await form.fillForm({ 'Default Retention Mode': 'No default rule' });
+      await form.fillForm({ 'Enable Object Lock': false });
+      await form.fillForm({ 'Enable Object Lock': true });
+
+      expect(spectator.component.form.controls.object_lock_default_mode.value).toBeNull();
+    });
+
+    it('does not leave versioning on after object lock is checked and unchecked in basic mode', async () => {
+      await form.fillForm({
+        Name: 'plain',
+        'Parent Dataset': 'tank',
+        Owner: 'alice',
+      });
+      await form.fillForm({ 'Enable Object Lock': true });
+      await form.fillForm({ 'Enable Object Lock': false });
+
+      await (await getSaveButton()).click();
+
+      expect(api.call).toHaveBeenCalledWith('sharing.s3.create', [expect.objectContaining({
+        versioning: S3Versioning.Off,
+        object_lock: false,
+      })]);
+    });
+
+    it('does not offer object lock with the Multiprotocol permissions model', async () => {
+      await clickAdvancedOptions();
+      await form.fillForm({ 'Permissions Model': 'Multiprotocol' });
+
+      const objectLock = await getCheckbox('Enable Object Lock');
+      expect(await objectLock.isDisabled()).toBe(true);
+      expect(await objectLock.getValue()).toBe(false);
+    });
+
+    it('requires retention days once object lock is on with a default retention mode', async () => {
+      await form.fillForm({
+        Name: 'backups',
+        'Parent Dataset': 'tank',
+        Owner: 'alice',
+        'Enable Object Lock': true,
+      });
+
+      expect(spectator.component.form.controls.object_lock_default_days.errors).toMatchObject({ required: true });
+      expect(await (await getSaveButton()).isDisabled()).toBe(true);
+    });
+
+    it('stops requiring retention days once object lock is turned off again', async () => {
+      await form.fillForm({
+        Name: 'backups',
+        'Parent Dataset': 'tank',
+        Owner: 'alice',
+        'Enable Object Lock': true,
+      });
+      expect(await (await getSaveButton()).isDisabled()).toBe(true);
+
+      await form.fillForm({ 'Enable Object Lock': false });
+
+      expect(spectator.component.form.controls.object_lock_default_days.disabled).toBe(true);
+      expect(await (await getSaveButton()).isDisabled()).toBe(false);
+    });
+
+    it('does not let a hidden out-of-range retention period block Save', async () => {
+      await form.fillForm({
+        Name: 'backups',
+        'Parent Dataset': 'tank',
+        Owner: 'alice',
+        'Enable Object Lock': true,
+      });
+      await form.fillForm({ 'Default Retention Mode': 'Governance' });
+      await form.fillForm({ 'Default Retention Days': 0 });
+      expect(await (await getSaveButton()).isDisabled()).toBe(true);
+
+      await form.fillForm({ 'Default Retention Mode': 'No default rule' });
+
+      expect(await (await getSaveButton()).isDisabled()).toBe(false);
     });
 
     it('rejects the /mnt root as a parent dataset', async () => {
@@ -265,6 +394,28 @@ describe('S3BucketFormComponent', () => {
         object_lock_default_days: null,
       }]);
       expect(spectator.inject(SlideInRef).close).toHaveBeenCalledWith({ response: true });
+    });
+  });
+
+  describe('editing a bucket stored with object lock and no default rule', () => {
+    beforeEach(async () => {
+      spectator = createComponent({
+        providers: [
+          mockProvider(SlideInRef, {
+            ...slideInRef,
+            getData: () => ({ ...existingBucket, object_lock: true, object_lock_default_mode: null }),
+          }),
+        ],
+      });
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+      form = await loader.getHarness(IxFormHarness);
+    });
+
+    it('keeps the stored "no default rule" when object lock is unchecked and re-checked', async () => {
+      await form.fillForm({ 'Enable Object Lock': false });
+      await form.fillForm({ 'Enable Object Lock': true });
+
+      expect(spectator.component.form.controls.object_lock_default_mode.value).toBeNull();
     });
   });
 });

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -1,7 +1,7 @@
 import {
   ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, signal,
 } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import {
   FormControl, NonNullableFormBuilder, ReactiveFormsModule, Validators,
 } from '@angular/forms';
@@ -9,7 +9,9 @@ import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent } from '@angular/material/card';
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { map, Observable, of } from 'rxjs';
+import {
+  map, merge, Observable, of,
+} from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
 import {
@@ -31,6 +33,7 @@ import { ServiceName } from 'app/enums/service-name.enum';
 import { choicesToOptions } from 'app/helpers/operators/options.operators';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextSharingS3 } from 'app/helptext/sharing';
+import { SelectOption } from 'app/interfaces/option.interface';
 import { S3AuditMask, S3Bucket, S3BucketCreate } from 'app/interfaces/s3.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
@@ -114,7 +117,7 @@ export class S3BucketFormComponent implements OnInit {
   readonly treeNodeProvider = this.datasetService.getDatasetNodeProvider();
   protected readonly ownerProvider = createS3UserPickerProvider();
 
-  protected readonly permissionsModelOptions$ = of(mapToOptions(s3PermissionsModelLabels, this.translate));
+  private readonly permissionsModelBaseOptions = mapToOptions(s3PermissionsModelLabels, this.translate);
   protected readonly versioningOptions$ = of(mapToOptions(s3VersioningLabels, this.translate));
   protected readonly multipartEtagOptions$ = of(mapToOptions(s3MultipartEtagLabels, this.translate));
   protected readonly objectLockModeOptions$ = of(mapToOptions(s3ObjectLockModeLabels, this.translate));
@@ -183,13 +186,33 @@ export class S3BucketFormComponent implements OnInit {
     return this.translate.instant('Bucket dataset: {dataset}', { dataset: `${parent}/${name}` });
   });
 
+  /**
+   * Object lock is a primary option (backup targets), so it drives versioning rather than depending
+   * on it: checking it switches versioning on and keeps it there. The one thing that rules it out is
+   * the Multiprotocol permissions model, under which another protocol could rewrite a locked object.
+   */
   protected readonly canUseObjectLock = computed(() => {
-    const { versioning, permissions_model: permissionsModel } = this.formValue();
-    return versioning === S3Versioning.Enabled && permissionsModel !== S3PermissionsModel.Multiprotocol;
+    return this.formValue().permissions_model !== S3PermissionsModel.Multiprotocol;
   });
 
   protected readonly objectLockHint = computed(() => {
-    return this.canUseObjectLock() ? '' : this.translate.instant(this.helptext.objectLockTooltip);
+    return this.canUseObjectLock() ? '' : this.translate.instant(this.helptext.objectLockMultiprotocolHint);
+  });
+
+  protected readonly isObjectLockOn = computed(() => !!this.formValue().object_lock);
+
+  /** Multiprotocol cannot be picked while object lock is on, for the same reason. */
+  protected readonly permissionsModelOptions$: Observable<SelectOption<S3PermissionsModel>[]> = toObservable(
+    this.isObjectLockOn,
+  ).pipe(
+    map((isObjectLockOn) => this.permissionsModelBaseOptions.map((option) => ({
+      ...option,
+      disabled: isObjectLockOn && option.value === S3PermissionsModel.Multiprotocol,
+    }))),
+  );
+
+  protected readonly versioningHint = computed(() => {
+    return this.isObjectLockOn() ? this.translate.instant(this.helptext.versioningLockedHint) : '';
   });
 
   get title(): string {
@@ -270,10 +293,78 @@ export class S3BucketFormComponent implements OnInit {
   }
 
   private setupObjectLockDependency(): void {
+    this.defaultModeOffered = !!this.existingBucket?.object_lock;
     this.syncObjectLockAvailability();
+    this.syncVersioningLock(this.form.controls.object_lock.value);
+    this.syncHiddenControls();
     this.form.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.syncObjectLockAvailability();
     });
+    // Compliance is offered once, the first time object lock is turned on for a bucket that did not
+    // have it. After that a "no default rule", whether stored or picked here, survives an uncheck and
+    // re-check: it is the only way to express object lock without a default rule.
+    this.form.controls.object_lock.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((objectLock) => {
+      if (objectLock && !this.defaultModeOffered && this.form.controls.object_lock_default_mode.value === null) {
+        this.defaultModeOffered = true;
+        this.form.controls.object_lock_default_mode.setValue(S3ObjectLockMode.Compliance);
+      }
+      this.syncVersioningLock(objectLock);
+    });
+    merge(
+      this.form.controls.object_lock.valueChanges,
+      this.form.controls.object_lock_default_mode.valueChanges,
+      this.form.controls.versioning.valueChanges,
+    ).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.syncHiddenControls();
+    });
+  }
+
+  /** What versioning was set to before object lock forced it on, restored when object lock is released. */
+  private versioningBeforeLock: S3Versioning | null = null;
+
+  /** Whether the Compliance default has been offered; a bucket stored with object lock starts offered. */
+  private defaultModeOffered = false;
+
+  /**
+   * Object lock requires versioning, so the select is set to Enabled and held there while it is on.
+   * Releasing it puts the previous choice back, so a check-then-uncheck in basic mode (where the
+   * select is not even rendered) is a no-op rather than a silent switch to versioning.
+   */
+  private syncVersioningLock(objectLock: boolean): void {
+    const versioning = this.form.controls.versioning;
+    if (objectLock) {
+      if (versioning.value !== S3Versioning.Enabled) {
+        this.versioningBeforeLock = versioning.value;
+        versioning.setValue(S3Versioning.Enabled);
+      }
+      versioning.disable({ emitEvent: false });
+    } else if (versioning.disabled) {
+      versioning.enable({ emitEvent: false });
+      if (this.versioningBeforeLock !== null) {
+        versioning.setValue(this.versioningBeforeLock);
+        this.versioningBeforeLock = null;
+      }
+    }
+  }
+
+  /**
+   * The retention period and the snapshot listing limit only render in some states. A hidden control
+   * is disabled rather than left to its validators: `[required]` on the rendered input attaches
+   * Angular's own validator, whose stale error would otherwise keep Save disabled with nothing on
+   * screen to fix. A disabled control is excluded from validity regardless.
+   */
+  private syncHiddenControls(): void {
+    const { versioning, object_lock: objectLock, object_lock_default_mode: defaultMode } = this.form.controls;
+    this.setEnabled(this.form.controls.snapshot_versions_max, versioning.value !== S3Versioning.Off);
+    this.setEnabled(this.form.controls.object_lock_default_days, !!objectLock.value && !!defaultMode.value);
+  }
+
+  private setEnabled(control: FormControl<unknown>, enabled: boolean): void {
+    if (enabled && control.disabled) {
+      control.enable();
+    } else if (!enabled && control.enabled) {
+      control.disable();
+    }
   }
 
   private syncObjectLockAvailability(): void {
@@ -285,6 +376,9 @@ export class S3BucketFormComponent implements OnInit {
     } else if (control.enabled) {
       control.setValue(false, { emitEvent: false });
       control.disable({ emitEvent: false });
+      // Cleared silently above, so the dependants have to be updated by hand for the same reason.
+      this.syncVersioningLock(false);
+      this.syncHiddenControls();
     }
   }
 
@@ -302,7 +396,11 @@ export class S3BucketFormComponent implements OnInit {
       grants: toS3Grants(this.form.controls.grants.controls),
       versioning: values.versioning,
       snapshot_versions: values.versioning === S3Versioning.Off ? [] : values.snapshot_versions,
-      snapshot_versions_max: values.snapshot_versions_max,
+      // The listing limit only applies with versioning; without it the field is hidden and disabled, so
+      // send the value the bucket already has rather than whatever was left behind.
+      snapshot_versions_max: values.versioning === S3Versioning.Off
+        ? (this.existingBucket?.snapshot_versions_max ?? 64)
+        : values.snapshot_versions_max,
       multipart_etag: values.multipart_etag,
       object_lock: objectLock,
       object_lock_default_mode: hasDefaultRule ? values.object_lock_default_mode : null,

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
@@ -7,7 +7,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { S3PermissionsModel } from 'app/enums/s3.enum';
+import { S3PermissionsModel, S3Versioning } from 'app/enums/s3.enum';
 import { Pool } from 'app/interfaces/pool.interface';
 import { S3Bucket } from 'app/interfaces/s3.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -36,6 +36,8 @@ describe('S3BucketListComponent', () => {
       dataset: 'tank/buckets/backups',
       owner: 'bob',
       permissions_model: S3PermissionsModel.BucketOwnerEnforced,
+      versioning: S3Versioning.Enabled,
+      object_lock: true,
       enabled: true,
       locked: false,
     },
@@ -78,8 +80,8 @@ describe('S3BucketListComponent', () => {
   it('shows table rows', async () => {
     const cells = await table.getCellTexts();
     expect(cells).toEqual([
-      ['Name', 'Dataset', 'Owner', 'Permissions Model', 'Enabled', ''],
-      ['backups', 'tank/buckets/backups', 'bob', 'Bucket Owner Enforced', '', ''],
+      ['Name', 'Dataset', 'Owner', 'Permissions Model', 'Versioning', 'Object Lock', 'Enabled', ''],
+      ['backups', 'tank/buckets/backups', 'bob', 'Bucket Owner Enforced', 'Enabled', 'Yes', '', ''],
     ]);
   });
 

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
@@ -114,20 +114,19 @@ export class S3BucketListComponent implements OnInit {
     textColumn({
       title: this.translate.instant('Permissions Model'),
       propertyName: 'permissions_model',
-      getValue: (row) => this.translate.instant(
-        s3PermissionsModelLabels.get(row.permissions_model) || row.permissions_model,
-      ),
+      getValue: (row) => this.permissionsModelLabel(row),
+      sortBy: (row) => this.permissionsModelLabel(row),
     }),
     textColumn({
       title: this.translate.instant('Versioning'),
       propertyName: 'versioning',
-      hidden: true,
-      getValue: (row) => this.translate.instant(s3VersioningLabels.get(row.versioning) || row.versioning),
+      getValue: (row) => this.versioningLabel(row),
+      // Sort on the label the cell shows, not the raw enum, so the order matches the visible text.
+      sortBy: (row) => this.versioningLabel(row),
     }),
     yesNoColumn({
       title: this.translate.instant('Object Lock'),
       propertyName: 'object_lock',
-      hidden: true,
     }),
     toggleColumn({
       title: this.translate.instant('Enabled'),
@@ -158,6 +157,14 @@ export class S3BucketListComponent implements OnInit {
     uniqueRowTag: (row) => 's3-bucket-' + row.name,
     ariaLabels: (row) => [row.name, this.translate.instant('S3 Bucket')],
   });
+
+  private permissionsModelLabel(row: S3Bucket): string {
+    return this.translate.instant(s3PermissionsModelLabels.get(row.permissions_model) || row.permissions_model);
+  }
+
+  private versioningLabel(row: S3Bucket): string {
+    return this.translate.instant(s3VersioningLabels.get(row.versioning) || row.versioning);
+  }
 
   ngOnInit(): void {
     const buckets$ = this.api.call('sharing.s3.query').pipe(


### PR DESCRIPTION
Follow-up to #14047 after review of the first S3 build.

## Changes

- **Object lock is a basic option.** It has its own section next to the bucket fields instead of living under Advanced Options, since backup targets are the primary use case. Checking it switches Versioning to Enabled and holds it there (the select shows a hint while locked); unchecking releases it. The Multiprotocol permissions model is disabled in the picker while object lock is on, and object lock is disabled with a hint when Multiprotocol is already selected.
- **Retention mode defaults to Compliance** when object lock is turned on. A stored "no default rule" on an existing bucket is left alone; only a user enabling object lock gets the default.
- **New access keys expire by default.** Non-expiring is now opt-in, so the form asks for a date up front.
- **Bucket list shows Versioning and Object Lock** columns by default, both sortable.

## Tests

Bucket form: object lock in basic mode, versioning forced and locked, Compliance default, Multiprotocol exclusion, retention days required/released. Access key form: date required by default until Non-expiring is checked. List: new columns in the row text. 25 tests, lint and AOT clean.

Original PR: https://github.com/truenas/webui/pull/14055
