### PR TITLE
Pin the self-hosted unit-test job to the ARM builder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,10 @@ jobs:
     if: needs.check-ux-team.outputs.is_member == 'true'
     strategy:
       fail-fast: false
-    runs-on: self-hosted
+    # Named labels rather than a bare `self-hosted`, which matches whichever
+    # registered runner happens to be free. More than one is registered, and
+    # they are not interchangeable — this job wants the ARM builder.
+    runs-on: [self-hosted, Linux, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Cherry-pick of #14000 (stable/26) / #13999 (master), which never reached this branch.

The "Run tests (UX Team - Self-hosted)" job here still uses a bare `runs-on: self-hosted`, so it goes to whichever registered runner is free. Runs that land on the `truenas-will` lab runner fail in the Install step: yarn re-packs the git-sourced `@truenas/common-typescript` dependency there and its checksum does not match the lockfile (#14045, #14059). Runs on `eng-s-armbld-01` pass. Naming the labels sends the job to the ARM builder only, as master and stable/26 already do.