### PR TITLE
NAS-143416 / 27.0.0-BETA.1 / "Unlock Datasets" allows submitting with no keys or passphrases entered

### DIFF
--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.spec.ts
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.spec.ts
@@ -81,6 +81,21 @@ describe('DatasetUnlockComponent', () => {
     });
   });
 
+  it('does not allow submitting when no keys or passphrases were entered manually', async () => {
+    await fillControlValues(await indexFormControls(loader), {
+      'Unlock with Key file': 'Provide keys/passphrases manually',
+    });
+
+    const unlockButton = await loader.getHarness(TnButtonHarness.with({ label: 'Unlock' }));
+    expect(await unlockButton.isDisabled()).toBe(true);
+
+    await fillControlValues(await indexFormControls(loader), {
+      'Dataset Passphrase': '12345678',
+    });
+
+    expect(await unlockButton.isDisabled()).toBe(false);
+  });
+
   it('saves when set key manually', async () => {
     await fillControlValues(await indexFormControls(loader), {
       'Unlock with Key file': 'Provide keys/passphrases manually',

--- a/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.ts
+++ b/src/app/pages/datasets/modules/encryption/components/dataset-unlock/dataset-unlock.component.ts
@@ -3,7 +3,8 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
-  FormControl, FormGroup, NonNullableFormBuilder, ReactiveFormsModule, Validators,
+  AbstractControl, FormControl, FormGroup, NonNullableFormBuilder, ReactiveFormsModule, ValidationErrors,
+  ValidatorFn, Validators,
 } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -39,6 +40,25 @@ interface DatasetFormGroup {
   name: FormControl<string>;
   is_passphrase: FormControl<boolean>;
   file?: FormControl<File[]>;
+}
+
+type DatasetFormValue = Partial<{ key: string; passphrase: string; is_passphrase: boolean }>;
+
+/**
+ * `minLength` and `exactLength` both pass on an empty value, so without this the form is valid
+ * (and "Unlock" is clickable) while every passphrase/key is still blank — and only turns invalid
+ * once the user starts typing. Datasets left blank are intentionally skipped when building the
+ * payload, so this only requires that at least one of them is filled in.
+ */
+function requireAtLeastOneKeyOrPassphrase(message: string): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const datasets = (control.value || []) as DatasetFormValue[];
+    const hasAnyValue = datasets.some((dataset) => {
+      return dataset.is_passphrase ? Boolean(dataset.passphrase) : Boolean(dataset.key);
+    });
+
+    return hasAnyValue ? null : { requireAtLeastOneKeyOrPassphrase: { message } };
+  };
 }
 
 @Component({
@@ -93,7 +113,11 @@ export class DatasetUnlockComponent implements OnInit {
     unlock_children: [true],
     file: [null as File[] | null, [Validators.required]],
     key: [''],
-    datasets: this.formBuilder.array<FormGroup<DatasetFormGroup>>([]),
+    datasets: this.formBuilder.array<FormGroup<DatasetFormGroup>>([], [
+      requireAtLeastOneKeyOrPassphrase(
+        this.translate.instant('Enter a key or passphrase for at least one dataset.'),
+      ),
+    ]),
     force: [false],
   });
 
@@ -113,6 +137,8 @@ export class DatasetUnlockComponent implements OnInit {
 
   ngOnInit(): void {
     this.pk = this.aroute.snapshot.params['datasetId'] as string;
+    // Matches the initial `use_file` value, so the manual keys are not validated until they are shown.
+    this.form.controls.datasets.disable();
     this.getEncryptionSummary();
 
     this.form.controls.use_file.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((useFile) => {


### PR DESCRIPTION
**Changes:**

On the **Unlock Datasets** page, the per-dataset controls are validated with
`Validators.minLength(8)` (passphrase) and `exactLength(64)` (key). Both of those
deliberately return `null` for an empty value, so a blank field passed validation:
the form was valid and **Unlock** was clickable while nothing had been entered, and
it only turned invalid once the user started typing. Submitting in that state sent
`datasets: []` — an encryption summary request with nothing to unlock.

Added an array-level validator on `form.controls.datasets` that requires at least one
dataset to have a key or passphrase. It is "at least one" rather than `required` on
every field because `handleSubmit` intentionally skips blank entries and the summary
dialog reports per-dataset failures — unlocking only the datasets you have credentials
for is a supported flow.

Two supporting details:

- `ix-list` already renders `<ix-errors [control]="formArray()">`, so the message
  _"Enter a key or passphrase for at least one dataset."_ shows under the **Datasets**
  label and explains why the button is disabled.
- `datasets` is now disabled at the start of `ngOnInit` to match the initial
  `use_file: true`. Without it, a failed or empty encryption-summary fetch would leave
  the array enabled and empty, and the new validator would block the key-file path too.

**Testing:**

1. Lock an encrypted, passphrase-protected dataset and open **Datasets → Unlock**.
2. Choose **Provide keys/passphrases manually** — **Unlock** is disabled and the list
   shows _"Enter a key or passphrase for at least one dataset."_
3. Type a valid passphrase (8+ chars) — **Unlock** becomes enabled.
4. Clear it again — **Unlock** goes back to disabled.
5. Switch to **From a key file** — behaviour is unchanged; **Unlock** enables once a
   key file is selected.
6. With several locked datasets, filling in only one still submits and the summary
   dialog reports the rest as unable to unlock (partial unlock still works).

Added a spec covering steps 2–3. `yarn lint` and `tsc -p src/tsconfig.app.json` are clean.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   | No — no UI or workflow changes beyond validation
|Testing         | Yes — E2E that submits the unlock form without entering a passphrase would now find the button disabled
