### PR TITLE
NAS-143421 / 27.0.0-BETA.1 / Align Browse Catalog button with the Image input in the container form

### DIFF
--- a/src/app/pages/containers/components/container-form/container-form.component.html
+++ b/src/app/pages/containers/components/container-form/container-form.component.html
@@ -28,21 +28,20 @@
     </tn-form-field>
 
     @if (!isEditMode()) {
-      <div class="image-field">
-        <tn-form-field
-          class="input"
-          [label]="'Image' | translate"
-          [required]="true"
-        >
+      <tn-form-field
+        [label]="'Image' | translate"
+        [required]="true"
+      >
+        <div class="image-field">
           <tn-input formControlName="image" [readonly]="true"></tn-input>
-        </tn-form-field>
 
-        <tn-button
-          testId="browse-images"
-          [label]="'Browse Catalog' | translate"
-          (onClick)="onBrowseCatalogImages()"
-        ></tn-button>
-      </div>
+          <tn-button
+            testId="browse-images"
+            [label]="'Browse Catalog' | translate"
+            (onClick)="onBrowseCatalogImages()"
+          ></tn-button>
+        </div>
+      </tn-form-field>
     }
 
     @if (!isEditMode() && !hasPreferredPool()) {

--- a/src/app/pages/containers/components/container-form/container-form.component.scss
+++ b/src/app/pages/containers/components/container-form/container-form.component.scss
@@ -9,18 +9,19 @@
   padding-bottom: 10px;
 }
 
+// The Browse Catalog button belongs to the Image field's control row, so it is
+// projected into the `<tn-form-field>` alongside the input rather than sitting
+// beside the whole field: the field's label row stays above the pair and its
+// error subscript below, and the button no longer has to guess at their heights.
 .image-field {
-  align-items: end;
+  align-items: center;
   display: flex;
   gap: 1rem;
   width: 100%;
 
-  .input {
+  tn-input {
     flex: 1;
-  }
-
-  button {
-    margin-bottom: 1.34375em;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
After:

<img width="815" height="160" alt="Screenshot 2026-09-08 at 13 52 08" src="https://github.com/user-attachments/assets/5dff0713-72e1-4dbf-a18e-159eb108688d" />

Before:
<img width="807" height="151" alt="Screenshot 2026-09-08 at 13 55 05" src="https://github.com/user-attachments/assets/f65328ce-f066-43a4-84c5-ec2384aa1b8f" />
