### PR TITLE
NAS-143125 / 26.0.0 / Show the full list of licensed features on the General page (by AlexKarpov98)

### DIFF
--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -75,9 +75,9 @@
         <span class="value">{{ license.serials.join(' / ') }}</span>
       </mat-list-item>
     }
-    <mat-list-item>
+    <mat-list-item class="features-row">
       <span class="label">{{ 'Features' | translate }}:</span>
-      <span class="value">
+      <span class="value features-value">
         @if (license.featureNames.length) {
           {{ license.featureNames.join(', ') }}
         } @else {

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.scss
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.scss
@@ -25,3 +25,31 @@
     gap: 4px;
   }
 }
+
+// The licensed features list can be long. Let this row grow past the fixed
+// single-line list item height and undo the ellipsis Material and the shared
+// card styles put on it, so the whole list stays readable.
+.features-row {
+  --mat-list-list-item-one-line-container-height: auto;
+
+  min-height: 48px;
+  padding-bottom: 8px;
+  padding-top: 8px;
+
+  .features-value {
+    display: block;
+    overflow: visible;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+    white-space: normal;
+  }
+}
+
+:host ::ng-deep .features-row {
+  .mdc-list-item__content,
+  .mdc-list-item__primary-text {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+}

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -97,6 +97,24 @@ describe('SysInfoComponent', () => {
     });
   });
 
+  it('lets the Features row wrap so a long license feature list stays fully visible', () => {
+    spectator.setInput({
+      licenseInfo: {
+        ...licenseInfo,
+        featureNames: Array.from({ length: 20 }, (_, index) => `FEATURE_${index}`),
+      },
+      hasLicense: true,
+    });
+
+    const featuresRow = spectator.query('mat-list-item.features-row');
+
+    expect(featuresRow).toExist();
+    expect(featuresRow?.querySelector('.value')).toHaveClass('features-value');
+    expect(getInfoRows()['Features:']).toBe(
+      Array.from({ length: 20 }, (_, index) => `FEATURE_${index}`).join(', '),
+    );
+  });
+
   describe('Proactive support status', () => {
     beforeEach(() => {
       spectator.setInput({


### PR DESCRIPTION

<img width="688" height="72" alt="Screenshot 2026-09-08 at 13 10 03" src="https://github.com/user-attachments/assets/47eafb8d-204e-4b30-81bf-aabe4aa4ce5b" />

### Problem

On System → General, the Support card's **Features** row was clipped to a single
line with an ellipsis, so on systems with many licensed features the list was
unreadable. There was also no tooltip, so hovering gave no way to see the rest.

Two layers of clipping were responsible:

1. `tn-list-item`'s internal `.tn-list-item__primary-text` is
   `white-space: nowrap; overflow: hidden; text-overflow: ellipsis`.
2. The shared `common-settings-card.scss` applies the same single-line ellipsis
   to `.value`.

### Fix

- The Features row opts into `tn-list-item`'s own **`[wrap]="true"`** input
  (shipped in `@truenas/ui-components` 0.7.4) rather than reaching into the
  library's internals with `::ng-deep`. This disables the ellipsis on the
  primary-text block.
- A scoped `.features-row .features-value` rule undoes the card-level
  nowrap/ellipsis on `.value`, with `overflow-wrap: anywhere` so a single very
  long feature name can't stretch the card.

The feature list now wraps onto as many lines as it needs and is fully visible —
no hover or secondary dialog required.

Original PR: https://github.com/truenas/webui/pull/14065
