### PR TITLE
NAS-143125 / 26.0.0-RC.1 / Show the full list of licensed features on the General page (by AlexKarpov98)

### DIFF
--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.html
@@ -75,9 +75,9 @@
         <span class="value">{{ license.serials.join(' / ') }}</span>
       </mat-list-item>
     }
-    <mat-list-item>
+    <mat-list-item class="features-row">
       <span class="label">{{ 'Features' | translate }}:</span>
-      <span class="value">
+      <span class="value features-value">
         @if (license.featureNames.length) {
           {{ license.featureNames.join(', ') }}
         } @else {

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.scss
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.scss
@@ -25,3 +25,29 @@
     gap: 4px;
   }
 }
+
+// The licensed features list can be long. Let this one row grow to as many
+// lines as it needs, undoing the fixed height of a single-line list item and
+// the ellipsis the shared card styles put on .value.
+// .mdc-list-item is part of the selector to outweigh Material's own
+// .mdc-list-item.mdc-list-item--with-one-line height.
+.features-row.mdc-list-item {
+  height: auto;
+  min-height: 48px;
+  overflow: visible;
+  padding-bottom: 8px;
+  padding-top: 8px;
+
+  ::ng-deep .mdc-list-item__content {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
+  .features-value {
+    overflow: visible;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+    white-space: normal;
+  }
+}

--- a/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
+++ b/src/app/pages/system/general-settings/support/sys-info/sys-info.component.spec.ts
@@ -97,6 +97,23 @@ describe('SysInfoComponent', () => {
     });
   });
 
+  it('lets the Features row wrap so a long license feature list stays fully visible', () => {
+    spectator.setInput({
+      licenseInfo: {
+        ...licenseInfo,
+        featureNames: Array.from({ length: 20 }, (_, index) => `FEATURE_${index}`),
+      },
+      hasLicense: true,
+    });
+
+    const featuresRow = spectator.query('mat-list-item.features-row');
+
+    expect(featuresRow?.querySelector('.features-value')).toExist();
+    expect(getInfoRows()['Features:']).toBe(
+      Array.from({ length: 20 }, (_, index) => `FEATURE_${index}`).join(', '),
+    );
+  });
+
   describe('Proactive support status', () => {
     beforeEach(() => {
       spectator.setInput({


### PR DESCRIPTION

<img width="688" height="72" alt="Screenshot 2026-09-08 at 13 10 03" src="https://github.com/user-attachments/assets/47eafb8d-204e-4b30-81bf-aabe4aa4ce5b" />

### Problem

On System → General, the Support card's **Features** row was clipped to a single
line with an ellipsis, so on systems with many licensed features the list was
unreadable. There was also no tooltip, so hovering gave no way to see the rest.

Two layers of clipping were responsible:

1. `tn-list-item`'s internal `.tn-list-item__primary-text` is
   `white-space: nowrap; overflow: hidden; text-overflow: ellipsis`.
2. The shared `common-settings-card.scss` applies the same single-line ellipsis
   to `.value`.

### Fix

- The Features row opts into `tn-list-item`'s own **`[wrap]="true"`** input
  (shipped in `@truenas/ui-components` 0.7.4) rather than reaching into the
  library's internals with `::ng-deep`. This disables the ellipsis on the
  primary-text block.
- A scoped `.features-row .features-value` rule undoes the card-level
  nowrap/ellipsis on `.value`, with `overflow-wrap: anywhere` so a single very
  long feature name can't stretch the card.

The feature list now wraps onto as many lines as it needs and is fully visible —
no hover or secondary dialog required.

Original PR: https://github.com/truenas/webui/pull/14065
