### PR TITLE
NAS-143227 / 26.0.0-RC.1 / Show WebShare on non-Enterprise systems regardless of the WEBSHARE entitlement (by william-gr)

### DIFF
--- a/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.spec.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.spec.ts
@@ -11,8 +11,8 @@ import { S3CardComponent } from 'app/pages/sharing/components/shares-dashboard/s
 import { SharesDashboardComponent } from 'app/pages/sharing/components/shares-dashboard/shares-dashboard.component';
 import { SmbCardComponent } from 'app/pages/sharing/components/shares-dashboard/smb-card/smb-card.component';
 import { WebShareCardComponent } from 'app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component';
-import { EntitlementsService } from 'app/services/entitlements.service';
 import { poolStore } from 'app/services/global-store/stores.constant';
+import { LicenseService } from 'app/services/license.service';
 
 describe('SharesDashboardComponent', () => {
   let spectator: Spectator<SharesDashboardComponent>;
@@ -46,8 +46,8 @@ describe('SharesDashboardComponent', () => {
   function setup(shouldShowWebshare = true): void {
     spectator = createComponent({
       providers: [
-        mockProvider(EntitlementsService, {
-          entitled: () => () => shouldShowWebshare,
+        mockProvider(LicenseService, {
+          shouldShowWebshare$: of(shouldShowWebshare),
         }),
       ],
     });
@@ -64,7 +64,7 @@ describe('SharesDashboardComponent', () => {
     expect(spectator.query(WebShareCardComponent)).toExist();
   });
 
-  it('hides WebShare card on enterprise systems', () => {
+  it('hides WebShare card when WebShare should not be shown', () => {
     setup(false);
 
     expect(spectator.query(WebShareCardComponent)).not.toExist();

--- a/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.ts
+++ b/src/app/pages/sharing/components/shares-dashboard/shares-dashboard.component.ts
@@ -5,7 +5,6 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { map } from 'rxjs';
 import { sharesEmptyConfig } from 'app/constants/empty-configs';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
-import { EntitlementFeature } from 'app/enums/entitlement-feature.enum';
 import { Role } from 'app/enums/role.enum';
 import { EmptyConfig } from 'app/interfaces/empty-config.interface';
 import { EmptyComponent } from 'app/modules/empty/empty.component';
@@ -14,8 +13,8 @@ import { NvmeOfCardComponent } from 'app/pages/sharing/components/shares-dashboa
 import { S3CardComponent } from 'app/pages/sharing/components/shares-dashboard/s3-card/s3-card.component';
 import { sharesDashboardElements } from 'app/pages/sharing/components/shares-dashboard/shares-dashboard.elements';
 import { WebShareCardComponent } from 'app/pages/sharing/components/shares-dashboard/webshare-card/webshare-card.component';
-import { EntitlementsService } from 'app/services/entitlements.service';
 import { poolStore } from 'app/services/global-store/stores.constant';
+import { LicenseService } from 'app/services/license.service';
 import { IscsiCardComponent } from './iscsi-card/iscsi-card.component';
 import { NfsCardComponent } from './nfs-card/nfs-card.component';
 import { SmbCardComponent } from './smb-card/smb-card.component';
@@ -42,7 +41,7 @@ export class SharesDashboardComponent {
   private poolStoreService = inject(poolStore);
   private translate = inject(TranslateService);
   private router = inject(Router);
-  private entitlements = inject(EntitlementsService);
+  private license = inject(LicenseService);
 
   protected readonly searchableElements = sharesDashboardElements;
 
@@ -58,5 +57,5 @@ export class SharesDashboardComponent {
 
   readonly pools = toSignal(this.poolStoreService.call.pipe(map((pools) => pools.length)), { initialValue: null });
 
-  protected readonly shouldShowWebshare = this.entitlements.entitled(EntitlementFeature.Webshare);
+  protected readonly shouldShowWebshare = toSignal(this.license.shouldShowWebshare$, { initialValue: false });
 }

--- a/src/app/pages/sharing/webshare/webshare.guard.spec.ts
+++ b/src/app/pages/sharing/webshare/webshare.guard.spec.ts
@@ -5,15 +5,15 @@ import {
 import { mockProvider } from '@ngneat/spectator/jest';
 import { firstValueFrom, Observable, of } from 'rxjs';
 import { webShareGuard } from 'app/pages/sharing/webshare/webshare.guard';
-import { EntitlementsService } from 'app/services/entitlements.service';
+import { LicenseService } from 'app/services/license.service';
 
 describe('webShareGuard', () => {
   function setup(shouldShowWebshare: boolean): Promise<boolean | UrlTree> {
     TestBed.configureTestingModule({
       providers: [
         provideRouter([]),
-        mockProvider(EntitlementsService, {
-          entitled$: () => of(shouldShowWebshare),
+        mockProvider(LicenseService, {
+          shouldShowWebshare$: of(shouldShowWebshare),
         }),
       ],
     });

--- a/src/app/pages/sharing/webshare/webshare.guard.ts
+++ b/src/app/pages/sharing/webshare/webshare.guard.ts
@@ -1,17 +1,16 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { map, take } from 'rxjs/operators';
-import { EntitlementFeature } from 'app/enums/entitlement-feature.enum';
-import { EntitlementsService } from 'app/services/entitlements.service';
+import { LicenseService } from 'app/services/license.service';
 
-// `entitled$` only emits once entitlements are known, so the guard never redirects on a
-// transient denial while they are still loading.
+// `shouldShowWebshare$` only emits once the product type and entitlements are known, so the
+// guard never redirects on a transient denial while they are still loading.
 export const webShareGuard: CanActivateFn = () => {
-  const entitlements = inject(EntitlementsService);
+  const license = inject(LicenseService);
   const router = inject(Router);
 
-  return entitlements.entitled$(EntitlementFeature.Webshare).pipe(
+  return license.shouldShowWebshare$.pipe(
     take(1),
-    map((isEntitled) => isEntitled || router.createUrlTree(['/sharing'])),
+    map((shouldShow) => shouldShow || router.createUrlTree(['/sharing'])),
   );
 };

--- a/src/app/services/license.service.spec.ts
+++ b/src/app/services/license.service.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { mockProvider } from '@ngneat/spectator/jest';
+import { provideMockStore } from '@ngrx/store/testing';
+import { firstValueFrom, of } from 'rxjs';
+import { EntitlementFeature } from 'app/enums/entitlement-feature.enum';
+import { ProductType } from 'app/enums/product-type.enum';
+import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
+import { EntitlementsService } from 'app/services/entitlements.service';
+import { LicenseService } from 'app/services/license.service';
+import { selectProductType } from 'app/store/system-info/system-info.selectors';
+
+describe('LicenseService', () => {
+  function setup(productType: ProductType | null, isWebshareEntitled: boolean): LicenseService {
+    TestBed.configureTestingModule({
+      providers: [
+        LicenseService,
+        mockProvider(TruenasConnectService, { config$: of(null) }),
+        mockProvider(EntitlementsService, {
+          entitled$: (feature: EntitlementFeature) => of(feature === EntitlementFeature.Webshare && isWebshareEntitled),
+        }),
+        provideMockStore({
+          selectors: [{ selector: selectProductType, value: productType }],
+        }),
+      ],
+    });
+    return TestBed.inject(LicenseService);
+  }
+
+  describe('shouldShowWebshare$', () => {
+    it('emits true on non-enterprise systems even without the WEBSHARE entitlement', async () => {
+      const service = setup(ProductType.CommunityEdition, false);
+
+      await expect(firstValueFrom(service.shouldShowWebshare$)).resolves.toBe(true);
+    });
+
+    it('emits true on enterprise systems with the WEBSHARE entitlement', async () => {
+      const service = setup(ProductType.Enterprise, true);
+
+      await expect(firstValueFrom(service.shouldShowWebshare$)).resolves.toBe(true);
+    });
+
+    it('emits false on enterprise systems without the WEBSHARE entitlement', async () => {
+      const service = setup(ProductType.Enterprise, false);
+
+      await expect(firstValueFrom(service.shouldShowWebshare$)).resolves.toBe(false);
+    });
+
+    it('does not emit until the product type has loaded', () => {
+      const service = setup(null, true);
+
+      let hasEmitted = false;
+      service.shouldShowWebshare$.subscribe(() => {
+        hasEmitted = true;
+      });
+
+      expect(hasEmitted).toBe(false);
+    });
+  });
+});

--- a/src/app/services/license.service.ts
+++ b/src/app/services/license.service.ts
@@ -1,13 +1,18 @@
 import { Injectable, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { shareReplay } from 'rxjs';
+import { combineLatest, shareReplay } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { EntitlementFeature } from 'app/enums/entitlement-feature.enum';
+import { ProductType } from 'app/enums/product-type.enum';
 import { TruenasConnectStatus } from 'app/enums/truenas-connect-status.enum';
+import { selectNotNull } from 'app/helpers/operators/select-not-null.helper';
 import { TruenasConnectService } from 'app/modules/truenas-connect/services/truenas-connect.service';
+import { EntitlementsService } from 'app/services/entitlements.service';
 import { AppState } from 'app/store';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
   selectHasEnclosureSupport,
+  selectProductType,
 } from 'app/store/system-info/system-info.selectors';
 
 @Injectable({
@@ -16,6 +21,7 @@ import {
 export class LicenseService {
   private store$ = inject<Store<AppState>>(Store);
   private truenasConnectService = inject(TruenasConnectService);
+  private entitlements = inject(EntitlementsService);
 
   /** Seeded by `failover.licensed` at sign-in, then kept in step with the `HA` entitlement. */
   hasFailover$ = this.store$.select(selectIsHaLicensed);
@@ -23,6 +29,20 @@ export class LicenseService {
   /** Not an entitlement — iX hardware detection. */
   hasEnclosure$ = this.store$.select(selectHasEnclosureSupport);
 
+  /**
+   * WebShare (a TrueNAS Connect feature) is offered on every non-Enterprise system. On Enterprise
+   * it is available only when the licence carries the `WEBSHARE` entitlement.
+   *
+   * Waits for both the product type and the entitlements to load, so the shares dashboard card
+   * and the webshare route guard never act on a transient answer while either is still unknown.
+   */
+  readonly shouldShowWebshare$ = combineLatest([
+    this.store$.pipe(selectNotNull(selectProductType)),
+    this.entitlements.entitled$(EntitlementFeature.Webshare),
+  ]).pipe(
+    map(([productType, isEntitled]) => isEntitled || productType !== ProductType.Enterprise),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
 
   /**
    * Check if the system is configured with TrueNAS Connect.


### PR DESCRIPTION
WebShare was gated solely on the `WEBSHARE` entitlement, which hid it on Community Edition systems that never carry a licence key.

## Change

- WebShare shows when the system is **not Enterprise**, or when it is Enterprise **and** entitled to `WEBSHARE`.
- `LicenseService.shouldShowWebshare$` combines the product type with the entitlement and waits for both to load, so the shares dashboard card and the WebShare route guard never act on a transient answer.
- Both consumers read that one observable, so they cannot disagree.

## Tests

- New `license.service.spec.ts` covers Community without entitlement, Enterprise with, Enterprise without, and no emission before the product type loads.
- Guard and dashboard specs updated to mock `LicenseService`.

Ticket number is a placeholder.

Original PR: https://github.com/truenas/webui/pull/14044
