### PR TITLE
NAS-142096 / 27.0.0-BETA.1 / Show network interface description on dashboard network widgets

### DIFF
--- a/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.html
+++ b/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.html
@@ -2,6 +2,11 @@
   <div class="card-content">
     <div class="header">
       <h3>{{ label() | translate }}</h3>
+
+      @let desc = description();
+      @if (desc) {
+        <div class="description">{{ desc }}</div>
+      }
     </div>
 
     <div

--- a/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.scss
+++ b/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.scss
@@ -19,6 +19,16 @@
     .header {
       padding-bottom: 0;
       padding-right: 12px;
+
+      .description {
+        font-size: 12px;
+        line-height: 1.3;
+        opacity: 0.6;
+        overflow: hidden;
+        padding-top: 2px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
 
     .container {

--- a/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.spec.ts
@@ -18,6 +18,7 @@ describe('WidgetDatapointComponent', () => {
     label: string;
     text: string;
     subText?: string;
+    description?: string;
   }): void {
     spectator = createComponent({ props });
   }
@@ -40,6 +41,18 @@ describe('WidgetDatapointComponent', () => {
 
     it(`it has sub text '${subText}'`, () => {
       expect(spectator.query('.container .sub-text')).toHaveText(subText);
+    });
+
+    it('has no description line when no description is provided', () => {
+      expect(spectator.query('.header .description')).not.toExist();
+    });
+
+    it('shows the description under the label when one is provided', () => {
+      setupTest({
+        size: SlotSize.Full, label, text, subText, description: 'Management network',
+      });
+
+      expect(spectator.query('.header .description')).toHaveText('Management network');
     });
   });
 

--- a/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.ts
+++ b/src/app/pages/dashboard/widgets/common/widget-datapoint/widget-datapoint.component.ts
@@ -20,6 +20,10 @@ import { SlotSize } from 'app/pages/dashboard/types/widget.interface';
 export class WidgetDatapointComponent {
   size = input.required<SlotSize>();
   label = input<string>('');
+  /**
+   * Free-form user text shown under the label. Not translated.
+   */
+  description = input<string>('');
   text = input.required<string>();
   subText = input<string>();
 

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.spec.ts
@@ -28,9 +28,11 @@ describe('WidgetInterfaceIpSettingsComponent', () => {
           value: [{
             id: '1',
             name: 'eth0',
+            description: 'Management network',
           }, {
             id: '2',
             name: 'eth1',
+            description: '',
           }, {
             id: '3',
             name: 'eth2',
@@ -49,11 +51,11 @@ describe('WidgetInterfaceIpSettingsComponent', () => {
   it('checks pre-select first option when no settings', async () => {
     const networkInterface = await loader.getHarness(TnSelectHarness);
     const selectedInterface = await networkInterface.getDisplayText();
-    expect(selectedInterface).toBe('eth0');
+    expect(selectedInterface).toBe('eth0 (Management network)');
   });
 
-  it('checks interface options', async () => {
+  it('labels interface options with their description when there is one', async () => {
     const networkInterface = await loader.getHarness(TnSelectHarness);
-    expect(await networkInterface.getOptions()).toEqual(['eth0', 'eth1', 'eth2']);
+    expect(await networkInterface.getOptions()).toEqual(['eth0 (Management network)', 'eth1', 'eth2']);
   });
 });

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip-settings/widget-interface-ip-settings.component.ts
@@ -5,8 +5,9 @@ import { FormBuilder } from '@ngneat/reactive-forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { TnFormFieldComponent, TnSelectComponent } from '@truenas/ui-components';
 import { filter, map, startWith } from 'rxjs';
-import { idNameArrayToOptions } from 'app/helpers/operators/options.operators';
+import { Option } from 'app/interfaces/option.interface';
 import { getAllFormErrors } from 'app/modules/forms/ix-forms/utils/get-form-errors.utils';
+import { ignoreTranslation } from 'app/modules/translate/translate.helper';
 import { WidgetResourcesService } from 'app/pages/dashboard/services/widget-resources.service';
 import { WidgetSettingsComponent } from 'app/pages/dashboard/types/widget-component.interface';
 import { WidgetSettingsRef } from 'app/pages/dashboard/types/widget-settings-ref.interface';
@@ -36,11 +37,15 @@ export class WidgetInterfaceIpSettingsComponent implements WidgetSettingsCompone
     interface: [null as string | null, [Validators.required]],
   });
 
+  // Labelled with the interface description when there is one, so a NIC can be picked by its
+  // role ("Management", "VM traffic") instead of its driver-assigned name.
   protected networkInterfaceOptions$ = this.resources.networkInterfaces$.pipe(
     filter((state) => !!state.value && !state.isLoading),
-    map((state) => state.value),
-    startWith([]),
-    idNameArrayToOptions(),
+    map((state) => state.value.map((nic) => ({
+      label: ignoreTranslation(nic.description ? `${nic.name} (${nic.description})` : nic.name),
+      value: nic.id,
+    }))),
+    startWith([] as Option<string>[]),
   );
 
   protected networkInterfaceOptions = toSignal(this.networkInterfaceOptions$, { initialValue: [] });

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.html
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.html
@@ -4,6 +4,10 @@
       <div class="card-content">
         <div class="header">
           <h3>{{ widgetName() }}</h3>
+
+          @if (description()) {
+            <div class="header-description">{{ description() }}</div>
+          }
         </div>
         <div class="ip-addresses" role="list" [attr.aria-label]="'Network addresses' | translate">
           @for (ipData of ipList; track ipData.address) {
@@ -22,6 +26,7 @@
       *ixWithLoadingState="ips() as ips"
       [size]="size()"
       [label]="widgetName()"
+      [description]="description()"
       [text]="ips"
     ></ix-widget-datapoint>
   }

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.scss
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.scss
@@ -39,6 +39,16 @@ $ip-label-opacity: 0.6;
   padding-right: 12px;
 }
 
+.header-description {
+  font-size: 12px;
+  line-height: 1.3;
+  opacity: 0.6;
+  overflow: hidden;
+  padding-top: 2px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .ip-addresses {
   align-items: center;
   display: flex;

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.spec.ts
@@ -26,6 +26,7 @@ describe('WidgetInterfaceIpComponent', () => {
           value: [
             {
               name: 'eth0',
+              description: 'Management network',
               aliases: [],
               failover_aliases: [],
               failover_virtual_aliases: [],
@@ -82,6 +83,18 @@ describe('WidgetInterfaceIpComponent', () => {
       const widget = spectator.query(WidgetDatapointComponent)!;
       expect(widget).toBeTruthy();
       expect(widget.text()).toBe('192.168.1.1\n192.168.1.2');
+    });
+
+    it('passes the interface description to the datapoint widget', () => {
+      const widget = spectator.query(WidgetDatapointComponent)!;
+      expect(widget.description()).toBe('Management network');
+    });
+
+    it('passes an empty description when the interface has none', () => {
+      spectator.setInput('settings', { interface: 'eth1' });
+
+      const widget = spectator.query(WidgetDatapointComponent)!;
+      expect(widget.description()).toBe('');
     });
 
     it('renders IPv4 addresses for the selected network interface from state', () => {
@@ -155,6 +168,7 @@ describe('WidgetInterfaceIpComponent', () => {
             value: [
               {
                 name: 'eth0',
+                description: 'Management network',
                 aliases: [],
                 failover_aliases: [
                   { type: NetworkInterfaceAliasType.Inet, address: '10.220.16.58' },
@@ -184,6 +198,11 @@ describe('WidgetInterfaceIpComponent', () => {
           size: SlotSize.Quarter,
         },
       });
+    });
+
+    it('renders the interface description under the widget title', () => {
+      haSpectator.detectChanges();
+      expect(haSpectator.query('.header-description')).toHaveText('Management network');
     });
 
     it('renders IP addresses with HA labels', () => {

--- a/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface-ip/widget-interface-ip.component.ts
@@ -66,6 +66,20 @@ export class WidgetInterfaceIpComponent implements WidgetComponent<WidgetInterfa
     return this.translate.instant('{nic} Address', { nic: this.interfaceId() }) || '';
   });
 
+  /**
+   * User-provided interface description, shown under the widget title so the NIC can be
+   * identified without opening its edit form.
+   */
+  protected description = computed(() => {
+    const interfaces = this.interfaces();
+    if (interfaces?.isLoading || !interfaces?.value) {
+      return '';
+    }
+
+    const interfaceId = this.interfaceId();
+    return interfaces.value.find((nic) => nic.name === interfaceId)?.description || '';
+  });
+
   // Memoized translated labels to avoid repeated translate.instant() calls
   private virtualIpLabel = computed(() => this.translate.instant('(Virtual IP)'));
   private thisControllerLabel = computed(() => this.translate.instant('(This Controller)'));

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.html
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.html
@@ -21,6 +21,9 @@
         <div class="nic-info">
           <div class="info-header">
             <h3 class="info-header-title">{{ interface.name }}</h3>
+            @if (interface.description) {
+              <div class="info-header-description" [tnTooltip]="interface.description">{{ interface.description }}</div>
+            }
           </div>
         </div>
         <ix-widget-stale-data-notice></ix-widget-stale-data-notice>
@@ -28,6 +31,9 @@
         <div class="nic-info">
         <div class="info-header">
           <h3 class="info-header-title">{{ interface.name }}</h3>
+          @if (interface.description) {
+            <div class="info-header-description" [tnTooltip]="interface.description">{{ interface.description }}</div>
+          }
         </div>
         <div class="info-body">
           <div class="info-column primary">

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.scss
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.scss
@@ -275,6 +275,16 @@
   white-space: nowrap;
 }
 
+.info-header-description {
+  font-size: 12px;
+  line-height: 1.3;
+  opacity: 0.6;
+  overflow: hidden;
+  padding-top: 2px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .icon-wrapper {
   cursor: default;
   display: inline-flex;

--- a/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/network/widget-interface/widget-interface.component.spec.ts
@@ -38,6 +38,7 @@ describe('WidgetInterfaceComponent', () => {
               id: '1',
               type: NetworkInterfaceType.Physical,
               name: 'ens1',
+              description: 'Management network',
               aliases: [
                 {
                   address: '192.168.238.12',
@@ -111,6 +112,11 @@ describe('WidgetInterfaceComponent', () => {
     it('shows interface name', fakeAsync(() => {
       spectator.tick(1);
       expect(spectator.query('.info-header-title')).toHaveText('ens1');
+    }));
+
+    it('shows interface description', fakeAsync(() => {
+      spectator.tick(1);
+      expect(spectator.query('.info-header-description')).toHaveText('Management network');
     }));
 
     it('shows interface state', fakeAsync(() => {
@@ -268,6 +274,11 @@ describe('WidgetInterfaceComponent', () => {
     it('shows interface name', fakeAsync(() => {
       spectator.tick(1);
       expect(spectator.query('.info-header-title')).toHaveText('ens1');
+    }));
+
+    it('shows interface description', fakeAsync(() => {
+      spectator.tick(1);
+      expect(spectator.query('.info-header-description')).toHaveText('Management network');
     }));
 
     it('shows interface state', fakeAsync(() => {


### PR DESCRIPTION
### Description

ER-79 asks for the network interface **Description** field to be visible on the dashboard, so a NIC can be recognised by its role ("Management", "VM traffic", wire speed, VLAN purpose) instead of its driver-assigned name.

The Description now renders under the title on all three network widgets, and the widget's interface picker is labelled with it too. The Interfaces list on **Network** already showed `name (description)` — unchanged here, included below for completeness.

- **Interface** widget — description under the NIC name, at full/half/quarter size and in the stale-data state. Truncates with an ellipsis and gets a tooltip when space is tight.
- **IPv4 / IPv6 Address** widgets — description under the `<nic> Address` title, in both the HA list layout and the non-HA datapoint layout.
- **`WidgetDatapointComponent`** — new optional `description` input (rendered untranslated, it's user text). Nothing renders when it's empty, so existing call sites are unaffected.
- **Widget settings** — the Interface dropdown now reads `enp2s0 (Management + VM traffic)` instead of bare `enp2s0`. The option `value` is still `nic.id`, so stored widget settings are untouched.

### Screenshots

**Before** — no description anywhere:

![before](https://raw.githubusercontent.com/AlexKarpov98/webui/assets/nas-142096/0-before-no-description.png)

**Interface widget, full size:**

![interface widget full size](https://raw.githubusercontent.com/AlexKarpov98/webui/assets/nas-142096/1-interface-widget-full-size.png)

**Dashboard — IPv4 Address widget + half-size Interface widget:**

![dashboard widgets](https://raw.githubusercontent.com/AlexKarpov98/webui/assets/nas-142096/2-dashboard-ip-and-interface-widgets.png)

**Quarter size** — truncates with an ellipsis, full text on hover:

![quarter size](https://raw.githubusercontent.com/AlexKarpov98/webui/assets/nas-142096/3-interface-widget-quarter-size.png)
![tooltip](https://raw.githubusercontent.com/AlexKarpov98/webui/assets/nas-142096/4-truncated-description-tooltip.png)

**Widget settings** — interface picker labelled with the description:

![widget settings](https://raw.githubusercontent.com/AlexKarpov98/webui/assets/nas-142096/5-widget-settings-interface-picker.png)

**Network → Interfaces** (pre-existing behaviour, for reference):

![interfaces list](https://raw.githubusercontent.com/AlexKarpov98/webui/assets/nas-142096/6-network-interfaces-list.png)

> Screenshots were taken against a live HA appliance. Because interface edits are blocked while HA is enabled, the `description` field alone was injected via the built-in websocket debug panel — every other value (IPs, MAC, link state, traffic, chart) is real.

### Testing

- 57 specs pass across the touched widgets, including new coverage for each surface.
- Full `src/app/pages/dashboard` suite shows no new failures (the 7 failing suites are identical on master).
- ESLint + Stylelint clean; AOT `yarn build` clean.