### PR TITLE
NAS-143434 / 27.0.0-BETA.1 / Show CSR fields enabled by a selected profile

### DIFF
--- a/src/app/pages/credentials/certificates-dash/csr-add/csr-add.component.spec.ts
+++ b/src/app/pages/credentials/certificates-dash/csr-add/csr-add.component.spec.ts
@@ -249,6 +249,38 @@ describe('CsrAddComponent', () => {
     ]);
   });
 
+  it('shows the fields of the constraints enabled by a profile selected on an earlier step', async () => {
+    await setInput('name', 'profile');
+    await selectValue('profile', 'HTTPS RSA Certificate');
+
+    await nextButton.click();
+    await updateStepHarnesses();
+
+    await nextButton.click();
+    await updateStepHarnesses();
+
+    await selectValue('country', 'United States');
+    await form.fillForm({
+      'Subject Alternative Name': ['jobs.umbrella.com'],
+    });
+    await setInput('state', 'Pennsylvania');
+    await setInput('city', 'Racoon City');
+    await setInput('organization', 'Umbrella Corp');
+    await setInput('email', 'no-reply@umbrella.com');
+
+    await nextButton.click();
+    await updateStepHarnesses();
+
+    const basicConstraints = await loader.getHarness(TnCheckboxHarness.with({ label: 'Basic Constraints' }));
+    expect(await basicConstraints.isChecked()).toBe(true);
+
+    // The checkbox is checked by the profile, so the fields it controls must be shown right away.
+    const pathLength = await loader.getHarnessOrNull(
+      TnInputHarness.with({ selector: '[formControlName="path_length"]' }),
+    );
+    expect(pathLength).not.toBeNull();
+  });
+
   it('updates form fields and sets constrains when Profile is emitted by CertificateIdentifierAndTypeComponent', async () => {
     // tn-stepper only renders the active step's content, so inactive step
     // components are resolved via the parent's viewChild signals rather than a DOM query.

--- a/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-constraints/csr-constraints.component.ts
+++ b/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-constraints/csr-constraints.component.ts
@@ -86,6 +86,14 @@ export class CsrConstraintsComponent implements OnInit, SummaryProvider {
     { initialValue: this.form.valid },
   );
 
+  // Mirrors the form value so `hasExtension()` is signal-driven. A profile patch comes from the
+  // parent wizard, which doesn't mark this OnPush view dirty: the tn-checkboxes would update
+  // themselves while the `@if` blocks around their fields kept the stale value.
+  private readonly formValue = toSignal(
+    this.form.valueChanges.pipe(map(() => this.form.getRawValue())),
+    { initialValue: this.form.getRawValue() },
+  );
+
   readonly helptext = helptextSystemCertificates;
 
   protected readonly InputType = InputType;
@@ -102,7 +110,7 @@ export class CsrConstraintsComponent implements OnInit, SummaryProvider {
   }
 
   hasExtension(extension: CertificateExtension): boolean {
-    return this.form.getRawValue()[extension].enabled;
+    return this.formValue()[extension].enabled;
   }
 
   getSummary(): SummarySection {

--- a/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-options/csr-options.component.ts
+++ b/src/app/pages/credentials/certificates-dash/csr-add/steps/csr-options/csr-options.component.ts
@@ -65,8 +65,15 @@ export class CsrOptionsComponent implements SummaryProvider {
 
   readonly helptext = helptextSystemCertificates;
 
+  // Mirrors the form value so `isRsa` is signal-driven. A profile patch comes from the parent
+  // wizard, which doesn't mark this OnPush view dirty, leaving the `@if` block stale.
+  private readonly formValue = toSignal(
+    this.form.valueChanges.pipe(map(() => this.form.getRawValue())),
+    { initialValue: this.form.getRawValue() },
+  );
+
   get isRsa(): boolean {
-    return this.form.value.key_type === CertificateKeyType.Rsa;
+    return this.formValue().key_type === CertificateKeyType.Rsa;
   }
 
   readonly keyTypes$ = of(mapToOptions(certificateKeyTypeLabels, this.translate));


### PR DESCRIPTION
### Problem

Picking a **Profile** on step 1 of the Add CSR wizard patches the later steps' forms, but those steps are `OnPush` and a programmatic `patchValue` from the parent wizard does not mark their views dirty. The `tn-*` controls refresh themselves (they are signal-based), while the `@if` blocks around the fields they control keep the stale value — so the checkboxes look enabled with nothing under them, and you have to uncheck one to make the rest appear.

The same latent bug was on **Certificate Options**: `isRsa` gates Key Length vs EC Curve and is patched by the same profile, so an EC profile showed `Key Type: EC` with a `Key Length` field below it.

The old `ix-checkbox` hid this — its `writeValue` called `cdr.markForCheck()`, which dirtied the ancestor view too.

### Fix

Mirror each step's form value in a `toSignal(...)` and read it from `hasExtension()` / `isRsa`, so the template re-renders on any patch, wherever it comes from.

- `csr-constraints.component.ts` — `hasExtension()` reads the signal
- `csr-options.component.ts` — `isRsa` reads the signal
- `csr-add.component.spec.ts` — regression test: select a profile, walk to Extra Constraints, assert the Path Length field is rendered (fails without the fix)

### Proof

Add CSR → name → Profile **HTTPS ECC Certificate** → through the steps.

**Extra Constraints — before / after**

| Before | After |
| --- | --- |
| <img width="480" src="https://raw.githubusercontent.com/AlexKarpov98/webui/3e000f9b1beb30e50f129bfa976785c8000f76eb/screenshots/before-1-constraints.png"> | <img width="480" src="https://raw.githubusercontent.com/AlexKarpov98/webui/3e000f9b1beb30e50f129bfa976785c8000f76eb/screenshots/after-1-constraints.png"> |
| All three boxes checked, no fields | Fields shown, pre-filled from the profile |

**Certificate Options — before / after**

| Before | After |
| --- | --- |
| <img width="480" src="https://raw.githubusercontent.com/AlexKarpov98/webui/3e000f9b1beb30e50f129bfa976785c8000f76eb/screenshots/before-2-options-key-length.png"> | <img width="480" src="https://raw.githubusercontent.com/AlexKarpov98/webui/3e000f9b1beb30e50f129bfa976785c8000f76eb/screenshots/after-2-options-ec-curve.png"> |
| `Key Type: EC` but `Key Length: 2048` | `EC Curve: SECP384R1` |

**Confirm Options** — profile values carried through to the summary:

<img width="480" src="https://raw.githubusercontent.com/AlexKarpov98/webui/3e000f9b1beb30e50f129bfa976785c8000f76eb/screenshots/after-3-summary.png">

### Testing

- `yarn test src/app/pages/credentials/certificates-dash/csr-add` — 30 passed
- Verified manually against a live appliance (screenshots above); the "before" shots are the same build with the two components reverted.
