### PR TITLE
NAS-143478 / 26.0.0-RC.1 / Follow the S3 object ownership split in the bucket form and list (by william-gr)

### DIFF
--- a/src/app/enums/s3.enum.ts
+++ b/src/app/enums/s3.enum.ts
@@ -26,16 +26,34 @@ export const s3PrincipalTypeLabels = new Map<S3PrincipalType, string>([
   [S3PrincipalType.Everyone, T('Everyone')],
 ]);
 
+/**
+ * How the S3 service treats the filesystem permissions on a bucket's tree.
+ * Which account an operation runs as is `S3ObjectOwnership`'s answer, not this one's.
+ */
 export enum S3PermissionsModel {
   S3 = 'S3',
   Multiprotocol = 'MULTIPROTOCOL',
-  BucketOwnerEnforced = 'S3_BUCKET_OWNER_ENFORCED',
 }
 
 export const s3PermissionsModelLabels = new Map<S3PermissionsModel, string>([
-  [S3PermissionsModel.S3, T('S3 Only')],
+  [S3PermissionsModel.S3, T('S3')],
   [S3PermissionsModel.Multiprotocol, T('Multiprotocol')],
-  [S3PermissionsModel.BucketOwnerEnforced, T('Bucket Owner Enforced')],
+]);
+
+/**
+ * S3 Object Ownership: who owns an uploaded object and whether the bucket supports S3 ACLs.
+ * A Multiprotocol bucket is always `ObjectWriter`; middleware folds it so.
+ */
+export enum S3ObjectOwnership {
+  BucketOwnerEnforced = 'BUCKET_OWNER_ENFORCED',
+  BucketOwnerPreferred = 'BUCKET_OWNER_PREFERRED',
+  ObjectWriter = 'OBJECT_WRITER',
+}
+
+export const s3ObjectOwnershipLabels = new Map<S3ObjectOwnership, string>([
+  [S3ObjectOwnership.BucketOwnerEnforced, T('Bucket Owner Enforced')],
+  [S3ObjectOwnership.BucketOwnerPreferred, T('Bucket Owner Preferred')],
+  [S3ObjectOwnership.ObjectWriter, T('Object Writer')],
 ]);
 
 export enum S3Versioning {

--- a/src/app/helptext/sharing/s3/s3.ts
+++ b/src/app/helptext/sharing/s3/s3.ts
@@ -8,11 +8,18 @@ export const helptextSharingS3 = {
   ownerTooltip: T('Account that owns the bucket. The owner bypasses the grants and owns the <i>s3data</i> \
  directory when the S3 service creates it.'),
   enabledTooltip: T('Whether the bucket is served. Toggling restarts the S3 service.'),
-  permissionsModelTooltip: T('<b>S3 Only</b>: only the S3 service writes the dataset and every object is written \
- under the account that put it.<br>\
- <b>Multiprotocol</b>: other protocols share the tree, so file permissions also apply to reads.<br>\
- <b>Bucket Owner Enforced</b>: every read and write runs as the owner, so the grants are the whole of the \
- bucket\'s access control.'),
+  permissionsModelTooltip: T('<b>S3</b>: the S3 service is the only door to the dataset. Its filesystem \
+ permissions are ignored, and the grants decide access.<br>\
+ <b>Multiprotocol</b>: SMB or NFS share the tree, so its filesystem ACL is enforced for S3 callers as well as the \
+ grants. S3 ACLs are not supported on such a bucket.'),
+  objectOwnershipTooltip: T('Who owns an uploaded object, and whether the bucket supports S3 ACLs.<br>\
+ <b>Bucket Owner Enforced</b>: the owner owns every object and ACLs are disabled, so the grants are the whole of \
+ the bucket\'s access control and a grantee needs no permissions on the dataset.<br>\
+ <b>Bucket Owner Preferred</b>: the owner owns objects uploaded with the bucket-owner-full-control ACL; any other \
+ upload is owned by the account that wrote it.<br>\
+ <b>Object Writer</b>: the account that uploads an object owns it and may grant access to it through ACLs.'),
+  objectOwnershipMultiprotocolHint: T('A Multiprotocol bucket always runs as the object writer, with S3 ACLs off: \
+ the other protocols\' users own the filesystem permissions.'),
   grantsTooltip: T('Who may access the bucket and how, beyond its owner. A <b>Deny</b> grant refuses every \
  operation for the principal and outranks the owner.'),
   globalGrantsTooltip: T('Grants that apply to every bucket. A <b>Deny</b> here suspends the principal everywhere.'),

--- a/src/app/interfaces/s3.interface.ts
+++ b/src/app/interfaces/s3.interface.ts
@@ -5,6 +5,7 @@ import {
   S3LogLevel,
   S3MultipartEtag,
   S3ObjectLockMode,
+  S3ObjectOwnership,
   S3PermissionsModel,
   S3PrincipalType,
   S3Versioning,
@@ -66,6 +67,7 @@ export interface S3Bucket {
   owner_uid: number;
   grants: S3GrantEntry[];
   permissions_model: S3PermissionsModel;
+  object_ownership: S3ObjectOwnership;
   versioning: S3Versioning;
   snapshot_versions: string[];
   snapshot_versions_max: number;

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.html
@@ -113,6 +113,15 @@
             [required]="true"
           ></ix-select>
 
+          <ix-select
+            formControlName="object_ownership"
+            [label]="'Object Ownership' | translate"
+            [tooltip]="helptext.objectOwnershipTooltip | translate"
+            [hint]="objectOwnershipHint()"
+            [options]="objectOwnershipOptions$"
+            [required]="true"
+          ></ix-select>
+
           <ix-s3-grants-list
             [formArray]="form.controls.grants"
             [label]="'Grants' | translate"

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -9,7 +9,7 @@ import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import {
-  S3Access, S3MultipartEtag, S3ObjectLockMode, S3PermissionsModel, S3PrincipalType, S3Versioning,
+  S3Access, S3MultipartEtag, S3ObjectLockMode, S3ObjectOwnership, S3PermissionsModel, S3PrincipalType, S3Versioning,
 } from 'app/enums/s3.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { Group } from 'app/interfaces/group.interface';
@@ -43,6 +43,7 @@ describe('S3BucketFormComponent', () => {
     owner: 'alice',
     enabled: true,
     permissions_model: S3PermissionsModel.S3,
+    object_ownership: S3ObjectOwnership.BucketOwnerPreferred,
     grants: [
       {
         principal_type: S3PrincipalType.Group, xid: 1001, name: 'staff', access: S3Access.ReadWrite,
@@ -129,6 +130,7 @@ describe('S3BucketFormComponent', () => {
 
       const advancedLabels = await form.getLabels();
       expect(advancedLabels).toContain('Permissions Model');
+      expect(advancedLabels).toContain('Object Ownership');
       expect(advancedLabels).toContain('Versioning');
       expect(advancedLabels).toContain('Multipart ETag');
       expect(advancedLabels).not.toContain('Audit');
@@ -203,6 +205,41 @@ describe('S3BucketFormComponent', () => {
       const objectLock = await getCheckbox('Enable Object Lock');
       expect(await objectLock.isDisabled()).toBe(true);
       expect(await objectLock.getValue()).toBe(false);
+    });
+
+    it('holds object ownership at Object Writer while Multiprotocol is selected, then restores the choice', async () => {
+      await clickAdvancedOptions();
+      expect(await (await getSelect('Object Ownership')).getValue()).toBe('Bucket Owner Enforced');
+      await form.fillForm({ 'Object Ownership': 'Bucket Owner Preferred' });
+
+      await form.fillForm({ 'Permissions Model': 'Multiprotocol' });
+
+      const folded = await getSelect('Object Ownership');
+      expect(await folded.getValue()).toBe('Object Writer');
+      expect(await folded.isDisabled()).toBe(true);
+
+      await form.fillForm({ 'Permissions Model': 'S3' });
+
+      const released = await getSelect('Object Ownership');
+      expect(await released.isDisabled()).toBe(false);
+      expect(await released.getValue()).toBe('Bucket Owner Preferred');
+    });
+
+    it('sends Object Writer ownership for a Multiprotocol bucket', async () => {
+      await form.fillForm({
+        Name: 'shared',
+        'Parent Dataset': 'tank',
+        Owner: 'alice',
+      });
+      await clickAdvancedOptions();
+      await form.fillForm({ 'Permissions Model': 'Multiprotocol' });
+
+      await (await getSaveButton()).click();
+
+      expect(api.call).toHaveBeenCalledWith('sharing.s3.create', [expect.objectContaining({
+        permissions_model: S3PermissionsModel.Multiprotocol,
+        object_ownership: S3ObjectOwnership.ObjectWriter,
+      })]);
     });
 
     it('requires retention days once object lock is on with a default retention mode', async () => {
@@ -294,7 +331,8 @@ describe('S3BucketFormComponent', () => {
         dataset: 'tank/buckets/videos',
         owner: 'alice',
         enabled: true,
-        permissions_model: S3PermissionsModel.BucketOwnerEnforced,
+        permissions_model: S3PermissionsModel.S3,
+        object_ownership: S3ObjectOwnership.BucketOwnerEnforced,
         grants: [],
         versioning: S3Versioning.Off,
         snapshot_versions: [],
@@ -357,7 +395,8 @@ describe('S3BucketFormComponent', () => {
         Dataset: 'tank/buckets/photos',
         Owner: 'alice',
         Enabled: true,
-        'Permissions Model': 'S3 Only',
+        'Permissions Model': 'S3',
+        'Object Ownership': 'Bucket Owner Preferred',
         Versioning: 'Enabled',
         'Snapshot Versions': ['auto-*'],
       });
@@ -384,6 +423,7 @@ describe('S3BucketFormComponent', () => {
         owner: 'bob',
         enabled: false,
         permissions_model: S3PermissionsModel.S3,
+        object_ownership: S3ObjectOwnership.BucketOwnerPreferred,
         grants: [{ principal_type: S3PrincipalType.Group, xid: 1001, access: S3Access.ReadWrite }],
         versioning: S3Versioning.Enabled,
         snapshot_versions: ['auto-*'],
@@ -416,6 +456,34 @@ describe('S3BucketFormComponent', () => {
       await form.fillForm({ 'Enable Object Lock': true });
 
       expect(spectator.component.form.controls.object_lock_default_mode.value).toBeNull();
+    });
+  });
+
+  describe('editing a stored Multiprotocol bucket', () => {
+    beforeEach(async () => {
+      spectator = createComponent({
+        providers: [
+          mockProvider(SlideInRef, {
+            ...slideInRef,
+            getData: () => ({
+              ...existingBucket,
+              permissions_model: S3PermissionsModel.Multiprotocol,
+              object_ownership: S3ObjectOwnership.ObjectWriter,
+            }),
+          }),
+        ],
+      });
+      loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+      form = await loader.getHarness(IxFormHarness);
+    });
+
+    it('holds its ownership at Object Writer and keeps object lock unavailable', async () => {
+      await clickAdvancedOptions();
+
+      const ownership = await getSelect('Object Ownership');
+      expect(await ownership.getValue()).toBe('Object Writer');
+      expect(await ownership.isDisabled()).toBe(true);
+      expect(await (await getCheckbox('Enable Object Lock')).isDisabled()).toBe(true);
     });
   });
 });

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -19,6 +19,7 @@ import {
   S3AuditOverflow,
   S3MultipartEtag,
   S3ObjectLockMode,
+  S3ObjectOwnership,
   S3PermissionsModel,
   S3Versioning,
   s3AuditAll,
@@ -26,6 +27,7 @@ import {
   s3AuditOverflowLabels,
   s3MultipartEtagLabels,
   s3ObjectLockModeLabels,
+  s3ObjectOwnershipLabels,
   s3PermissionsModelLabels,
   s3VersioningLabels,
 } from 'app/enums/s3.enum';
@@ -118,6 +120,7 @@ export class S3BucketFormComponent implements OnInit {
   protected readonly ownerProvider = createS3UserPickerProvider();
 
   private readonly permissionsModelBaseOptions = mapToOptions(s3PermissionsModelLabels, this.translate);
+  protected readonly objectOwnershipOptions$ = of(mapToOptions(s3ObjectOwnershipLabels, this.translate));
   protected readonly versioningOptions$ = of(mapToOptions(s3VersioningLabels, this.translate));
   protected readonly multipartEtagOptions$ = of(mapToOptions(s3MultipartEtagLabels, this.translate));
   protected readonly objectLockModeOptions$ = of(mapToOptions(s3ObjectLockModeLabels, this.translate));
@@ -152,9 +155,11 @@ export class S3BucketFormComponent implements OnInit {
     ]],
     owner: ['', Validators.required],
     enabled: [true],
-    // The middleware defaults to S3, but Bucket Owner Enforced is the model that works without any
-    // extra ACL setup for grantees, so it is the better default for a form that hides it in basic mode.
-    permissions_model: [S3PermissionsModel.BucketOwnerEnforced],
+    // The middleware defaults: S3 with Bucket Owner Enforced ownership, the pairing under which
+    // the grants are the whole of the access control and a grantee needs no permissions on the dataset.
+    // The right defaults for a form that hides both in basic mode.
+    permissions_model: [S3PermissionsModel.S3],
+    object_ownership: [S3ObjectOwnership.BucketOwnerEnforced],
     grants: this.fb.array<S3GrantFormGroup>([]),
     versioning: [S3Versioning.Off],
     snapshot_versions: [[] as string[]],
@@ -191,8 +196,14 @@ export class S3BucketFormComponent implements OnInit {
    * on it: checking it switches versioning on and keeps it there. The one thing that rules it out is
    * the Multiprotocol permissions model, under which another protocol could rewrite a locked object.
    */
-  protected readonly canUseObjectLock = computed(() => {
-    return this.formValue().permissions_model !== S3PermissionsModel.Multiprotocol;
+  protected readonly isMultiprotocol = computed(() => {
+    return this.formValue().permissions_model === S3PermissionsModel.Multiprotocol;
+  });
+
+  protected readonly canUseObjectLock = computed(() => !this.isMultiprotocol());
+
+  protected readonly objectOwnershipHint = computed(() => {
+    return this.isMultiprotocol() ? this.translate.instant(this.helptext.objectOwnershipMultiprotocolHint) : '';
   });
 
   protected readonly objectLockHint = computed(() => {
@@ -232,6 +243,7 @@ export class S3BucketFormComponent implements OnInit {
       this.setupExistingDatasetCheck();
     }
     this.setupObjectLockDependency();
+    this.setupObjectOwnershipDependency();
   }
 
   private setupExistingDatasetCheck(): void {
@@ -367,6 +379,40 @@ export class S3BucketFormComponent implements OnInit {
     }
   }
 
+  /**
+   * Middleware folds a Multiprotocol bucket to Object Writer ownership whatever it is given — the
+   * other protocols' users own the filesystem permissions, so only the caller's own account may act,
+   * and such a bucket supports no S3 ACLs under any value. The select shows that rather than offering
+   * a choice middleware would overrule: it is set to Object Writer and held there while Multiprotocol
+   * is selected, and the previous choice comes back when the model changes again.
+   */
+  private setupObjectOwnershipDependency(): void {
+    this.syncObjectOwnership(this.form.controls.permissions_model.value);
+    this.form.controls.permissions_model.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((model) => {
+      this.syncObjectOwnership(model);
+    });
+  }
+
+  /** What ownership was set to before Multiprotocol folded it, restored when the model changes back. */
+  private ownershipBeforeMultiprotocol: S3ObjectOwnership | null = null;
+
+  private syncObjectOwnership(model: S3PermissionsModel): void {
+    const ownership = this.form.controls.object_ownership;
+    if (model === S3PermissionsModel.Multiprotocol) {
+      if (ownership.value !== S3ObjectOwnership.ObjectWriter) {
+        this.ownershipBeforeMultiprotocol = ownership.value;
+        ownership.setValue(S3ObjectOwnership.ObjectWriter);
+      }
+      ownership.disable({ emitEvent: false });
+    } else if (ownership.disabled) {
+      ownership.enable({ emitEvent: false });
+      if (this.ownershipBeforeMultiprotocol !== null) {
+        ownership.setValue(this.ownershipBeforeMultiprotocol);
+        this.ownershipBeforeMultiprotocol = null;
+      }
+    }
+  }
+
   private syncObjectLockAvailability(): void {
     const control = this.form.controls.object_lock;
     if (this.canUseObjectLock()) {
@@ -393,6 +439,7 @@ export class S3BucketFormComponent implements OnInit {
       owner: values.owner,
       enabled: values.enabled,
       permissions_model: values.permissions_model,
+      object_ownership: values.object_ownership,
       grants: toS3Grants(this.form.controls.grants.controls),
       versioning: values.versioning,
       snapshot_versions: values.versioning === S3Versioning.Off ? [] : values.snapshot_versions,

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
@@ -7,7 +7,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
-import { S3PermissionsModel, S3Versioning } from 'app/enums/s3.enum';
+import { S3ObjectOwnership, S3PermissionsModel, S3Versioning } from 'app/enums/s3.enum';
 import { Pool } from 'app/interfaces/pool.interface';
 import { S3Bucket } from 'app/interfaces/s3.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -35,7 +35,8 @@ describe('S3BucketListComponent', () => {
       name: 'backups',
       dataset: 'tank/buckets/backups',
       owner: 'bob',
-      permissions_model: S3PermissionsModel.BucketOwnerEnforced,
+      permissions_model: S3PermissionsModel.S3,
+      object_ownership: S3ObjectOwnership.BucketOwnerEnforced,
       versioning: S3Versioning.Enabled,
       object_lock: true,
       enabled: true,
@@ -81,7 +82,7 @@ describe('S3BucketListComponent', () => {
     const cells = await table.getCellTexts();
     expect(cells).toEqual([
       ['Name', 'Dataset', 'Owner', 'Permissions Model', 'Versioning', 'Object Lock', 'Enabled', ''],
-      ['backups', 'tank/buckets/backups', 'bob', 'Bucket Owner Enforced', 'Enabled', 'Yes', '', ''],
+      ['backups', 'tank/buckets/backups', 'bob', 'S3', 'Enabled', 'Yes', '', ''],
     ]);
   });
 

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
@@ -15,7 +15,7 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { EmptyType } from 'app/enums/empty-type.enum';
 import { Role } from 'app/enums/role.enum';
-import { s3PermissionsModelLabels, s3VersioningLabels } from 'app/enums/s3.enum';
+import { s3ObjectOwnershipLabels, s3PermissionsModelLabels, s3VersioningLabels } from 'app/enums/s3.enum';
 import { helptextSharingS3 } from 'app/helptext/sharing';
 import { S3Bucket } from 'app/interfaces/s3.interface';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -118,6 +118,13 @@ export class S3BucketListComponent implements OnInit {
       sortBy: (row) => this.permissionsModelLabel(row),
     }),
     textColumn({
+      title: this.translate.instant('Object Ownership'),
+      propertyName: 'object_ownership',
+      hidden: true,
+      getValue: (row) => this.objectOwnershipLabel(row),
+      sortBy: (row) => this.objectOwnershipLabel(row),
+    }),
+    textColumn({
       title: this.translate.instant('Versioning'),
       propertyName: 'versioning',
       getValue: (row) => this.versioningLabel(row),
@@ -160,6 +167,10 @@ export class S3BucketListComponent implements OnInit {
 
   private permissionsModelLabel(row: S3Bucket): string {
     return this.translate.instant(s3PermissionsModelLabels.get(row.permissions_model) || row.permissions_model);
+  }
+
+  private objectOwnershipLabel(row: S3Bucket): string {
+    return this.translate.instant(s3ObjectOwnershipLabels.get(row.object_ownership) || row.object_ownership);
   }
 
   private versioningLabel(row: S3Bucket): string {


### PR DESCRIPTION
Counterpart of truenas/middleware#19661, which gives S3 object ownership its own key.

## What changed in middleware

`permissions_model` now only says how the S3 service treats the filesystem permissions on a bucket's tree: `S3` (ignored, the grants decide) or `MULTIPROTOCOL` (the filesystem ACL is enforced too). A new `object_ownership` field says who owns an uploaded object and whether the bucket supports S3 ACLs: `BUCKET_OWNER_ENFORCED` (default), `BUCKET_OWNER_PREFERRED` or `OBJECT_WRITER`. A `MULTIPROTOCOL` bucket is always folded to `OBJECT_WRITER`. `S3_BUCKET_OWNER_ENFORCED` is still accepted, stored as the pair, and kept only until webui stops sending it — which is this PR.

## What changed here

- **Enums and interface**: `S3PermissionsModel` drops `BucketOwnerEnforced`; new `S3ObjectOwnership` with labels; `S3Bucket.object_ownership`.
- **Bucket form**: an Object Ownership select under Permissions Model in the Access section. The form's defaults are now middleware's, S3 Only with Bucket Owner Enforced, which is the same pairing the old default expressed in one value. Choosing Multiprotocol sets ownership to Object Writer and holds it there with a hint, mirroring the fold rather than offering a choice middleware would overrule; the previous choice comes back when the model changes again. The payload sends `object_ownership`.
- **Bucket list**: an Object Ownership column, hidden by default, sorted by label.
- **Helptext**: the permissions model tooltip describes the two remaining models; new tooltips for ownership and the Multiprotocol hint.

## Tests

Bucket form: Object Ownership shown in advanced mode, the Multiprotocol fold and restore, the Object Writer payload for a Multiprotocol bucket, defaults and edit payloads updated. List mock updated. 32 tests across the three affected specs, lint and AOT clean.

Note for the backport: the middleware change also lands in 26.0, so stable/26 needs the same change on the ix-* form; bugclerk's cherry-pick will not apply there, as with #14058.

Original PR: https://github.com/truenas/webui/pull/14080
