### PR TITLE
NAS-143012 / 26.0.0 / Restore enterprise gate on EULA dialog (by aervin)

### DIFF
--- a/src/app/store/eula/eula.effects.spec.ts
+++ b/src/app/store/eula/eula.effects.spec.ts
@@ -1,5 +1,6 @@
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { provideMockActions } from '@ngrx/effects/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { of, ReplaySubject } from 'rxjs';
 import { MockApiService } from 'app/core/testing/classes/mock-api.service';
@@ -11,6 +12,7 @@ import { DialogService } from 'app/modules/dialog/dialog.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { adminUiInitialized } from 'app/store/admin-panel/admin.actions';
 import { EulaEffects } from 'app/store/eula/eula.effects';
+import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors';
 
 describe('EulaEffects', () => {
   let spectator: SpectatorService<EulaEffects>;
@@ -30,11 +32,17 @@ describe('EulaEffects', () => {
       mockProvider(TranslateService, {
         get: jest.fn((key: string) => of(key)),
       }),
+      provideMockStore({
+        selectors: [{
+          selector: selectIsEnterprise,
+          value: true,
+        }],
+      }),
       mockAuth(),
     ],
   });
 
-  describe('with FullAdmin role', () => {
+  describe('on enterprise systems with FullAdmin role', () => {
     beforeEach(() => {
       actions$ = new ReplaySubject<unknown>(1);
       spectator = createService({
@@ -46,13 +54,13 @@ describe('EulaEffects', () => {
       spectator.service.checkEula$.subscribe();
     });
 
-    it('shows the EULA dialog whenever middleware reports it pending, with no product-type check', () => {
+    it('shows the EULA dialog when middleware reports it pending', () => {
       expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith(expect.objectContaining({
         message: 'Please do not sue us.',
       }));
     });
 
-    it('should call truenas.accept_eula when EULA dialog is accepted', () => {
+    it('calls truenas.accept_eula when the EULA dialog is accepted', () => {
       expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('truenas.accept_eula');
     });
   });
@@ -74,9 +82,29 @@ describe('EulaEffects', () => {
     });
   });
 
+  describe('on community systems', () => {
+    it('does not check or show the EULA even when middleware reports it pending', () => {
+      actions$ = new ReplaySubject<unknown>(1);
+      spectator = createService({
+        providers: [
+          provideMockActions(() => actions$),
+        ],
+      });
+      const store$ = spectator.inject(MockStore);
+      store$.overrideSelector(selectIsEnterprise, false);
+      store$.refreshState();
+      jest.clearAllMocks();
+
+      actions$.next(adminUiInitialized());
+      spectator.service.checkEula$.subscribe();
+
+      expect(spectator.inject(ApiService).call).not.toHaveBeenCalledWith('truenas.is_eula_accepted');
+      expect(spectator.inject(DialogService).confirm).not.toHaveBeenCalled();
+    });
+  });
+
   describe('without FullAdmin role', () => {
     it('does not check for EULA if user does not have FullAdmin role', () => {
-      // Create a fresh instance with ReadonlyAdmin role
       actions$ = new ReplaySubject<unknown>(1);
 
       const authServiceMock = {

--- a/src/app/store/eula/eula.effects.ts
+++ b/src/app/store/eula/eula.effects.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { forkJoin, Observable } from 'rxjs';
 import {
@@ -12,7 +13,9 @@ import { DialogService } from 'app/modules/dialog/dialog.service';
 import { ignoreTranslation } from 'app/modules/translate/translate.helper';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+import { AppState } from 'app/store';
 import { adminUiInitialized } from 'app/store/admin-panel/admin.actions';
+import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors';
 
 @Injectable()
 export class EulaEffects {
@@ -21,11 +24,16 @@ export class EulaEffects {
   private dialogService = inject(DialogService);
   private translate = inject(TranslateService);
   private errorHandler = inject(ErrorHandlerService);
+  private store$ = inject<Store<AppState>>(Store);
   private authService = inject(AuthService);
 
-  /** Middleware arms the EULA on enterprise license upload; `is_eula_accepted` is the only gate needed. */
+  /**
+   * `truenas.is_eula_accepted` only reports whether the pending marker exists; it does not check
+   * the license, so the UI must gate on product type or community systems would see the dialog.
+   */
   checkEula$ = createEffect(() => this.actions$.pipe(
     ofType(adminUiInitialized),
+    filterAsync(() => this.store$.select(selectIsEnterprise).pipe(filter(Boolean))),
     filterAsync(() => this.authService.hasRole([Role.FullAdmin])),
     mergeMap(() => {
       return this.api.call('truenas.is_eula_accepted').pipe(


### PR DESCRIPTION
**Changes:**

Regression from #14032: that PR removed the `selectIsEnterprise` gate from `EulaEffects.checkEula$` on the assumption that middleware only arms the EULA on enterprise license upload. Middleware's `truenas.is_eula_accepted` is just `not os.path.exists('/data/truenas-eula-pending')` with no license or product-type check, so unlicensed community systems that carry the pending marker were shown the EULA dialog.

- Restore the `selectIsEnterprise` filter ahead of the FullAdmin check and the `is_eula_accepted` call.
- Replace the misleading doc comment with one describing what middleware actually checks.
- Spec: mock the store with `selectIsEnterprise`; add a community-system case asserting `is_eula_accepted` is never called and no dialog opens even when middleware reports the EULA pending.

Same regression exists on `stable/26` via #14034 and this commit cherry-picks cleanly there.

**Testing:**

- `yarn test src/app/store/eula/eula.effects.spec.ts` (5 passed)
- Community system with `/data/truenas-eula-pending` present: no EULA dialog after login.
- Enterprise system with the marker present: EULA dialog still shown to Full Admin; accepting calls `truenas.accept_eula`.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |No
|Testing         |Yes, verify EULA dialog gating on community vs enterprise systems


Original PR: https://github.com/truenas/webui/pull/14083
