### PR TITLE
NAS-143534 / 27.0.0-BETA.1 / Resolve the newest v27 nightly ISO weekly instead of pinning one

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,6 +81,13 @@ on:
         type: choice
         default: built
         options: [built, shipped]
+      refresh_iso:
+        description: >-
+          Install from the newest v27 nightly now, instead of the one chosen
+          this week or pinned by E2E_TN_GUEST_ISO. For a change merged to
+          middleware this morning.
+        type: boolean
+        default: false
 
 # Reads code, uploads artifacts. No reason to write to the repository.
 permissions:
@@ -109,10 +116,14 @@ jobs:
       TN_GUEST: /mnt/tank/github/api-ci-testbed/jenkins/scripts/tn_guest.py
       TN_GUEST_PYTHON: /mnt/tank/github/venv/bin/python3
       # Lab facts that belong in the e2e-lab environment's variables and
-      # secrets rather than here: which pool holds the VMs, which ISO to
-      # install, and a credential for the box's own API.
+      # secrets rather than here: which pool holds the VMs and a credential
+      # for the box's own API. The ISO is resolved by a step below; setting
+      # E2E_TN_GUEST_ISO pins one file and turns that resolution off, except
+      # for a dispatch that asks for the newest nightly, which is a decision
+      # about this run and beats a standing pin.
       TN_GUEST_POOL: ${{ vars.E2E_TN_GUEST_POOL || 'tank' }}
-      TN_GUEST_ISO: ${{ vars.E2E_TN_GUEST_ISO }}
+      TN_GUEST_ISO: ${{ !inputs.refresh_iso && vars.E2E_TN_GUEST_ISO || '' }}
+      TN_GUEST_ISO_REFRESH: ${{ inputs.refresh_iso && '1' || '' }}
       TN_GUEST_HOST_USER: ${{ vars.E2E_TN_GUEST_HOST_USER || 'root' }}
       TN_GUEST_HOST_API_KEY: ${{ secrets.TN_GUEST_HOST_API_KEY }}
       TN_GUEST_HOST_PASSWORD: ${{ secrets.TN_GUEST_HOST_PASSWORD }}
@@ -186,6 +197,14 @@ jobs:
           [ -f dist/index.html ] || { echo "::error::yarn build:prod produced no dist/index.html"; exit 1; }
           $DOCKER pull --quiet "$NGINX_IMAGE"
           echo "UI_DIST=$GITHUB_WORKSPACE/dist" >> "$GITHUB_ENV"
+
+      # The newest v27 nightly, kept for a week and then replaced, so the
+      # appliance moves at the cadence its template is meant to and not under
+      # every run. Before the claim: a download that fails must not cost a VM.
+      - name: Resolve the install ISO
+        run: |
+          set -euo pipefail
+          ./e2e/ci/appliance.sh iso | tee -a "$GITHUB_ENV"
 
       - name: Claim an appliance
         run: |

--- a/e2e/ci/appliance.sh
+++ b/e2e/ci/appliance.sh
@@ -39,6 +39,7 @@
 #   TN_GUEST_HOST       the TrueNAS host to create VMs on (default: localhost)
 #   TN_GUEST_POOL       pool on that host for VM datasets and zvols
 #   TN_GUEST_ISO        install ISO, as a path on the host under /mnt/<pool>/…
+#                       Optional: unset, `iso` resolves one (below).
 #   TN_GUEST_HOST_USER  API user on the host (default: root)
 #   TN_GUEST_HOST_API_KEY or TN_GUEST_HOST_PASSWORD — credential for that user
 #   TN_GUEST_LIFETIME   VM lifetime, so a leaked one expires (default: 3h)
@@ -49,6 +50,20 @@
 #
 #   TN_GUEST_MEMORY_MB, TN_GUEST_VCPUS, TN_GUEST_OS_DISK_GB,
 #   TN_GUEST_DATA_DISK_COUNT, TN_GUEST_DATA_DISK_GB
+#
+# Nightly resolution (`iso`), when TN_GUEST_ISO is not pinned:
+#
+#   TN_GUEST_ISO_DIR           where nightlies live on the host
+#                              (default: /mnt/<pool>/iso — a child dataset)
+#   TN_GUEST_ISO_INDEX         the nightly index to read
+#                              (default: https://iso.sys.truenas.net/TrueNAS-27-Nightlies/)
+#   TN_GUEST_ISO_SERIES        the build series to follow (default: TrueNAS-27.0.0-MASTER)
+#   TN_GUEST_ISO_MAX_AGE_DAYS  how long the chosen nightly is kept before the
+#                              next newer one is fetched (default: 7)
+#   TN_GUEST_ISO_REFRESH       `1` fetches the newest nightly now, whatever the age
+#                              (the workflow also drops the pin for it)
+#   TN_GUEST_ISO_KEEP          nightlies of the series left on disk after a
+#                              fetch, newest first (default: 2)
 #
 # The password `claim` sets on the guest is generated per claim, and `release`
 # destroys the guest. Test artifacts on a public repository are world-readable
@@ -70,6 +85,16 @@ TN_GUEST_OS_DISK_GB="${TN_GUEST_OS_DISK_GB:-10}"
 # needs at least nine identical unused disks (see e2e/docs/status.md).
 TN_GUEST_DATA_DISK_COUNT="${TN_GUEST_DATA_DISK_COUNT:-10}"
 TN_GUEST_DATA_DISK_GB="${TN_GUEST_DATA_DISK_GB:-10}"
+
+TN_GUEST_ISO_DIR="${TN_GUEST_ISO_DIR:-/mnt/$TN_GUEST_POOL/iso}"
+TN_GUEST_ISO_INDEX="${TN_GUEST_ISO_INDEX:-https://iso.sys.truenas.net/TrueNAS-27-Nightlies/}"
+TN_GUEST_ISO_SERIES="${TN_GUEST_ISO_SERIES:-TrueNAS-27.0.0-MASTER}"
+TN_GUEST_ISO_MAX_AGE_DAYS="${TN_GUEST_ISO_MAX_AGE_DAYS:-7}"
+TN_GUEST_ISO_KEEP="${TN_GUEST_ISO_KEEP:-2}"
+
+# Which nightly `iso` last chose, kept beside the files. Its mtime is the
+# choice's age, which is what the refresh policy reads.
+currentNightlyFile=".current-nightly"
 
 # Where `claim` records the deployment name, so `release` can find it without
 # the caller.
@@ -117,7 +142,7 @@ claim() {
   # create a VM and find out at the CD-ROM attach.
   local isoProblem=""
   if [ -z "${TN_GUEST_ISO:-}" ]; then
-    isoProblem="TN_GUEST_ISO is not set"
+    isoProblem="TN_GUEST_ISO is not set (pin one, or run 'appliance.sh iso' first to resolve a nightly)"
   elif [ "$TN_GUEST_HOST" = "localhost" ] && [ ! -f "$TN_GUEST_ISO" ]; then
     isoProblem="TN_GUEST_ISO does not exist on this host: $TN_GUEST_ISO"
   fi
@@ -220,6 +245,160 @@ release() {
   return 0
 }
 
+# ─── Nightly resolution ──────────────────────────────────────────────────────
+#
+# Which ISO to install from, without anybody naming a file.
+#
+# A pinned TN_GUEST_ISO is honoured as it always was. Otherwise the newest
+# nightly of the series is kept on the host and reused until it is
+# TN_GUEST_ISO_MAX_AGE_DAYS old, then the newest one is fetched. A week is the
+# cadence the appliance template is meant to be rebuilt on; between rebuilds
+# every run installs the same build, so a failure that appears mid-week is a
+# UI change and not a moving appliance. A run that needs a middleware change
+# merged this morning asks for it with TN_GUEST_ISO_REFRESH=1 (the
+# `refresh_iso` input of the workflow) rather than waiting the week out.
+#
+# The index is a plain listing with cursor pagination and no useful order
+# across pages, so every page is read and the newest name wins: the series
+# names embed `+YYYYMMDD-HHMMSS`, which sorts as text. A `.iso.sha256` beside
+# the file is used when the index has one. The file is written world-readable
+# into the directory as a whole file, never a partial one: middleware refuses
+# an ISO that libvirt cannot read, and a run must never install from a
+# download that stopped halfway.
+#
+# Emits `TN_GUEST_ISO=<path>` on stdout for `>> "$GITHUB_ENV"`, plus
+# `TN_GUEST_ISO_SOURCE=pinned|reused|downloaded` so the log says which.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Every ISO name the index lists, one per line, across all of its pages.
+listIndex() {
+  local cursor="" previous="" page next
+  local i
+  for i in $(seq 1 100); do
+    page=$(curl -fsSL --retry 3 --retry-delay 5 "${TN_GUEST_ISO_INDEX}${cursor}") \
+      || die "could not read the nightly index at ${TN_GUEST_ISO_INDEX}${cursor}"
+    grep -oiE 'href="[^"]*\.iso\?download=1"' <<<"$page" \
+      | sed -E 's/^href="//; s/\?download=1"$//; s|^.*/||; s/&#43;/+/g; s/%2[bB]/+/g' || true
+    next=$(grep -oE 'href="[^"]*[?&]cursor=[^"&]*' <<<"$page" | head -1 | sed -E 's/.*cursor=//' || true)
+    [ -n "$next" ] && [ "$next" != "$previous" ] || return 0
+    previous="$next"
+    cursor="?cursor=$next"
+  done
+  die "the nightly index did not end after $i pages; refusing to loop forever"
+}
+
+# The newest nightly of the series the index offers.
+newestNightly() {
+  local pattern="^${TN_GUEST_ISO_SERIES//./\\.}\\+[0-9]{8}-[0-9]{6}\\.iso$"
+  listIndex | grep -E "$pattern" | sort | tail -1
+}
+
+# The URL a listed name downloads from. Only `+` needs encoding in these names.
+downloadUrl() {
+  local name="$1"
+  printf '%s%s?download=1' "$TN_GUEST_ISO_INDEX" "${name//+/%2B}"
+}
+
+# Fetch one nightly into TN_GUEST_ISO_DIR, verified when a checksum is published.
+fetchNightly() {
+  local name="$1"
+  local target="$TN_GUEST_ISO_DIR/$name" partial="$TN_GUEST_ISO_DIR/$name.part"
+
+  echo "appliance.sh: downloading $name to $TN_GUEST_ISO_DIR" >&2
+  # Resumable, so a network blip mid-way through 2.7GB costs the remainder,
+  # not the whole file. Silent: the progress meter is thousands of lines in a
+  # CI log, and errors still print.
+  curl -fsSL --retry 3 --retry-delay 10 -C - -o "$partial" "$(downloadUrl "$name")" \
+    || die "download of $name failed"
+
+  local published
+  if published=$(curl -fsSL --retry 2 "$(downloadUrl "$name.sha256")" 2>/dev/null | awk 'NR==1 {print $1}') \
+    && [ -n "$published" ]; then
+    local actual
+    actual=$(sha256sum "$partial" | awk '{print $1}')
+    [ "$actual" = "$published" ] \
+      || { rm -f "$partial"; die "checksum mismatch for $name: index says $published, file is $actual"; }
+    echo "appliance.sh: checksum verified" >&2
+  else
+    echo "appliance.sh: no checksum published for $name; installing it unverified" >&2
+  fi
+
+  chmod 0644 "$partial"
+  mv "$partial" "$target"
+}
+
+# Drop nightlies of the series beyond the newest TN_GUEST_ISO_KEEP. Only files
+# this resolver would have fetched match the pattern; anything else in the
+# directory is somebody's and is left alone.
+pruneNightlies() {
+  local pattern="^${TN_GUEST_ISO_SERIES//./\\.}\\+[0-9]{8}-[0-9]{6}\\.iso$"
+  local stale
+  stale=$(ls -1 "$TN_GUEST_ISO_DIR" 2>/dev/null | grep -E "$pattern" | sort -r | tail -n "+$((TN_GUEST_ISO_KEEP + 1))" || true)
+  local name
+  for name in $stale; do
+    echo "appliance.sh: pruning $name" >&2
+    rm -f "$TN_GUEST_ISO_DIR/$name"
+  done
+}
+
+# Age of the current choice in whole days, or a large number when there is none.
+currentNightlyAgeDays() {
+  local pointer="$TN_GUEST_ISO_DIR/$currentNightlyFile"
+  [ -f "$pointer" ] || { echo 999999; return; }
+  local now modified
+  now=$(date +%s)
+  modified=$(stat -c %Y "$pointer" 2>/dev/null || stat -f %m "$pointer")
+  echo $(( (now - modified) / 86400 ))
+}
+
+iso() {
+  if [ -n "${TN_GUEST_ISO:-}" ]; then
+    echo "appliance.sh: using pinned ISO $TN_GUEST_ISO" >&2
+    printf 'TN_GUEST_ISO=%s\nTN_GUEST_ISO_SOURCE=pinned\n' "$TN_GUEST_ISO"
+    return
+  fi
+
+  command -v curl > /dev/null || die "curl is required to resolve a nightly"
+  command -v sha256sum > /dev/null || die "sha256sum is required to verify a nightly"
+  [ -d "$TN_GUEST_ISO_DIR" ] \
+    || die "TN_GUEST_ISO_DIR does not exist: $TN_GUEST_ISO_DIR (it has to be a child dataset the runner can write)"
+  [ -w "$TN_GUEST_ISO_DIR" ] \
+    || die "TN_GUEST_ISO_DIR is not writable by $(id -un): $TN_GUEST_ISO_DIR"
+
+  local pointer="$TN_GUEST_ISO_DIR/$currentNightlyFile"
+  local current="" age
+  [ -f "$pointer" ] && current=$(cat "$pointer")
+  age=$(currentNightlyAgeDays)
+
+  if [ "${TN_GUEST_ISO_REFRESH:-}" != "1" ] && [ -n "$current" ] && [ -f "$TN_GUEST_ISO_DIR/$current" ] \
+    && [ "$age" -lt "$TN_GUEST_ISO_MAX_AGE_DAYS" ]; then
+    echo "appliance.sh: reusing $current, chosen $age day(s) ago (refreshes at $TN_GUEST_ISO_MAX_AGE_DAYS)" >&2
+    printf 'TN_GUEST_ISO=%s\nTN_GUEST_ISO_SOURCE=reused\n' "$TN_GUEST_ISO_DIR/$current"
+    return
+  fi
+
+  local newest
+  newest=$(newestNightly)
+  [ -n "$newest" ] || die "the index at $TN_GUEST_ISO_INDEX lists no $TN_GUEST_ISO_SERIES nightly"
+  echo "appliance.sh: newest nightly is $newest" >&2
+
+  local source="downloaded"
+  if [ -f "$TN_GUEST_ISO_DIR/$newest" ]; then
+    echo "appliance.sh: already on disk" >&2
+    source="reused"
+  else
+    fetchNightly "$newest"
+  fi
+
+  # The choice is recorded after the file is whole, and its clock starts now:
+  # a refresh that finds the same file still resets the week.
+  printf '%s\n' "$newest" > "$pointer"
+  touch "$pointer"
+  pruneNightlies
+
+  printf 'TN_GUEST_ISO=%s\nTN_GUEST_ISO_SOURCE=%s\n' "$TN_GUEST_ISO_DIR/$newest" "$source"
+}
+
 # Snapshot and revert (E1, E5). Not available: tn_guest.py has no such verbs,
 # and a VM behind hostfwd is reinstalled per run. Kept as named entry points so
 # the design's references still resolve to the place the work will go.
@@ -232,9 +411,10 @@ revert() { die "revert is not available with tn_guest.py yet (E1, E5)"; }
 # nothing.
 
 case "${1:-}" in
+  iso)          shift; iso "$@" ;;
   claim)        shift; claim "$@" ;;
   release)      shift; release "$@" ;;
   snapshot)     shift; snapshot "$@" ;;
   revert)       shift; revert "$@" ;;
-  *) die "usage: appliance.sh {claim|release|snapshot|revert} [args]" ;;
+  *) die "usage: appliance.sh {iso|claim|release|snapshot|revert} [args]" ;;
 esac

--- a/e2e/docs/05-ci.md
+++ b/e2e/docs/05-ci.md
@@ -26,12 +26,20 @@ One job, on a self-hosted runner that is itself a **TrueNAS box**. Per run:
    not the one baked into the ISO. Built before the claim so the lab is not
    held during the build and the build's memory is back before the guest
    starts.
-4. **Claim an appliance.** `appliance.sh claim fresh-install` drives
+4. **Resolve the install ISO.** `appliance.sh iso` picks the newest v27
+   nightly from <https://iso.sys.truenas.net/TrueNAS-27-Nightlies/>, fetches
+   it into `/mnt/tank/iso` once, and reuses it for a week before looking
+   again — the cadence the appliance template is meant to be rebuilt on, so
+   a mid-week failure is a UI change and not a moving appliance. The choice
+   is recorded in `.current-nightly` beside the files; older nightlies are
+   pruned to the newest two. `E2E_TN_GUEST_ISO` still pins one file and
+   skips all of this.
+5. **Claim an appliance.** `appliance.sh claim fresh-install` drives
    `tn_guest.py` (iXsystems/api-ci-testbed) against the box's own middleware
    API: create a nested VM, install TrueNAS from an ISO on the box, set a
    per-run admin password, wait for the API. It prints the suite's `TN_*`
    variables, which the workflow masks and loads into the job environment.
-5. **Serve the UI.** A stock `nginx` container with `dist/` mounted and the
+6. **Serve the UI.** A stock `nginx` container with `dist/` mounted and the
    repository's own `docker/nginx.conf`, the file the appliance serves the UI
    through: `/ui/` from disk, the API paths proxied to the appliance's
    forwarded port 80 through Docker's host gateway. Over TLS with a throwaway
@@ -40,30 +48,32 @@ One job, on a self-hosted runner that is itself a **TrueNAS box**. Per run:
    Host networking is not an option: nginx binds the ports the TrueNAS host's
    own UI is on. The step checks both the UI and the proxy answer before
    handing over.
-6. **Run the suite** inside the Playwright container with `--network host`,
+7. **Run the suite** inside the Playwright container with `--network host`,
    reusing the host's `node_modules`. The profile is `shipped` with
    `TN_UI_BASE_URL` pointing at the served UI: it *is* the production build
    at `/ui/` over https, just not from the appliance, and that profile is the
    one that tolerates a self-signed certificate. Credentials reach the
    container through an `--env-file` on the runner's dataset, never on the
    command line.
-7. **Upload JUnit**, always, and **traces, screenshots and video** for failed
+8. **Upload JUnit**, always, and **traces, screenshots and video** for failed
    tests. Publishing traces is safe because the credential they contain is
    per claim and the appliance is destroyed at release; do not copy that
    upload into a pipeline that reuses either.
-8. **Stop the UI container and release the appliance**, unconditionally:
+9. **Stop the UI container and release the appliance**, unconditionally:
    `tn_guest.py delete`. A claim that died before the workflow recorded the
    name is still released, because `claim` writes the nickname to a file first
    and `release` falls back to it.
 
 `workflow_dispatch` takes `ui: shipped` to run against the UI baked into the
-ISO instead.
+ISO instead, and `refresh_iso: true` to install from the newest nightly now
+rather than this week's or the pinned one — for a run that needs a middleware
+change merged this morning.
 
 ## When it runs
 
 | Trigger | Why |
 |---|---|
-| Nightly, 03:00 UTC | Master's UI against the configured ISO, which is one fixed nightly until rotation exists (see *Next*). |
+| Nightly, 03:00 UTC | Master's UI against this week's v27 nightly. |
 | Push to master touching `src/`, the suite, `playwright.config.ts`, the lockfile or the workflow | Every merged UI change gets a run. |
 | Pull request touching the suite or the workflow, same-repo only | Changes to the tests and the pipeline prove themselves. |
 | `gh workflow run e2e.yml --ref <branch>` | The opt-in for any other branch. Not every PR: one runner, one appliance, ~8 minutes a run, and a concurrency group that holds one pending run, so under normal PR volume most pushes would never run and nobody could tell which. |
@@ -83,7 +93,7 @@ On the runner box, outside this repository:
 | Runner | `/mnt/tank/github/actions-runner` | Label `truenas-lab`. Runs as a non-root user with `sudo -n docker` allowed. |
 | api-ci-testbed clone | `/mnt/tank/github/api-ci-testbed` | `jenkins/scripts/tn_guest.py` is what is called. |
 | Python venv | `/mnt/tank/github/venv` | Needs `truenas_api_client`, `aiohttp`, `requests`. |
-| Install ISO | `/mnt/tank/iso/<name>.iso` | Must be in a **child dataset**, world-readable. A directory in the pool root is rejected. Must be a **v27 nightly** (below). |
+| Install ISOs | `/mnt/tank/iso/` | A **child dataset**, writable by the runner user, in which `appliance.sh iso` keeps the newest two v27 nightlies (world-readable) and its `.current-nightly` pointer. A directory in the pool root is rejected by middleware. |
 | Docker | Apps configured with a pool | dockerd only runs once Apps has a pool. |
 | Virtualization | CPU extensions exposed to the box | If the box is itself a VM, nested virtualization must be on, or `vm.create` fails with "does not support virtualization". |
 | API account | user with **Full Admin** | An API key inherits its user's roles; a plain user authenticates and then gets `EACCES` on `vm.create`. |
@@ -92,7 +102,7 @@ In the repository's `e2e-lab` environment:
 
 | Kind | Name | Meaning |
 |---|---|---|
-| variable | `E2E_TN_GUEST_ISO` | Host path of the ISO. |
+| variable | `E2E_TN_GUEST_ISO` | Optional. Host path of one ISO to pin; unset, the newest nightly is resolved per week. |
 | variable | `E2E_TN_GUEST_HOST_USER` | The API account. |
 | variable | `E2E_TN_GUEST_POOL` | Pool for VM datasets and zvols. Default `tank`. |
 | secret | `TN_GUEST_HOST_API_KEY` | Key for that account. `TN_GUEST_HOST_PASSWORD` works instead. |
@@ -159,9 +169,9 @@ on a release image, which the design's 210s assumed.
 
 ## Next
 
-- **Rotate the ISO.** `E2E_TN_GUEST_ISO` names one nightly file, which goes
-  stale; the nightly run then tests master against an ageing appliance.
-  Deliberately deferred: how the box gets nightlies is still to be decided.
+- **Rebuild the appliance template on the same clock.** The ISO now rotates
+  weekly; a template built from `.current-nightly` on the same schedule would
+  make the install step a clone instead of a fresh install.
 - **Measure Q0b**, the rollback-and-boot cycle, by hand on the box. It decides
   whether the snapshot design in `04-environment-architecture.md` is worth
   building (its *Sequence*, step 2).


### PR DESCRIPTION
## Summary

The e2e pipeline installs its appliance from whatever `E2E_TN_GUEST_ISO` names, and that filename goes stale: the lab has been on a 2026-09-08 nightly while #14064 needs middleware merged on the 9th. This makes the pipeline find its own ISO.

- `appliance.sh iso` reads the nightly index at https://iso.sys.truenas.net/TrueNAS-27-Nightlies/ (all pages; it is not sorted across pages), picks the newest `TrueNAS-27.0.0-MASTER+*.iso`, downloads it into `/mnt/<pool>/iso` (resumable, verified against the published `.sha256`, written whole then made world-readable), records the choice in `.current-nightly`, and prunes the series down to the newest two.
- The choice is reused for **7 days** (`TN_GUEST_ISO_MAX_AGE_DAYS`) before the index is consulted again, the cadence the appliance template is meant to be rebuilt on, so a mid-week failure is a UI change rather than a moving appliance.
- A new `Resolve the install ISO` step runs before the claim and appends `TN_GUEST_ISO` to the job env.
- `workflow_dispatch` gains `refresh_iso: true` to fetch the newest nightly now, for a run that needs a middleware change merged this morning. It also beats a standing `E2E_TN_GUEST_ISO` pin.
- `E2E_TN_GUEST_ISO` still works as an explicit pin and turns the resolver off. After this merges it can be unset in the `e2e-lab` environment.

## Test plan

- [x] Index walk, newest-name selection, download URL and checksum URL verified locally against the live index (74 nightlies listed, newest `TrueNAS-27.0.0-MASTER+20260909-230223.iso`, 2.7 GB, sha256 published).
- [x] The PR's own run exercises the pinned path (`TN_GUEST_ISO_SOURCE=pinned`).
- [x] Run 34477238185: `refresh_iso=true` downloaded `TrueNAS-27.0.0-MASTER+20260909-230223.iso` (2.7 GB in 2 min), verified the checksum, pruned the 2026-09-02 nightly, then installed and passed the suite. `/mnt/tank/iso` needed `chown github` first, now done on the box.