### PR TITLE
NAS-e2e: Add the with-pool baseline as a configured template

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,6 +81,13 @@ on:
         type: choice
         default: built
         options: [built, shipped]
+      baseline:
+        description: >-
+          Which baseline to claim. `with-pool` boots with a pool named `tank`
+          present; `fresh-install` has nothing, for first-run journeys.
+        type: choice
+        default: with-pool
+        options: [with-pool, fresh-install]
       refresh_iso:
         description: >-
           Install from the newest v27 nightly now, instead of the one chosen
@@ -130,7 +137,7 @@ jobs:
       # With the template password set, a claim clones a template instead of
       # installing from the ISO, building the template first when the host
       # has none or the resolved ISO is newer than it. See e2e/ci/appliance.sh.
-      TN_GUEST_TEMPLATE: ${{ vars.E2E_TN_GUEST_TEMPLATE || 'e2e-template' }}
+      TN_GUEST_TEMPLATE_PREFIX: ${{ vars.E2E_TN_GUEST_TEMPLATE_PREFIX || 'e2e' }}
       TN_GUEST_TEMPLATE_PASSWORD: ${{ secrets.TN_GUEST_TEMPLATE_PASSWORD }}
       # Serves the built UI. Debian-based on purpose: docker/nginx.conf runs
       # as `www-data`, which the alpine image does not have.
@@ -211,10 +218,14 @@ jobs:
           set -euo pipefail
           ./e2e/ci/appliance.sh iso | tee -a "$GITHUB_ENV"
 
+      # `with-pool` unless a dispatch asked otherwise: a scheduled or push run
+      # tests the suite as a whole, and the suite as a whole wants a pool.
       - name: Claim an appliance
+        env:
+          TN_BASELINE_REQUESTED: ${{ inputs.baseline || 'with-pool' }}
         run: |
           set -euo pipefail
-          ./e2e/ci/appliance.sh claim fresh-install > "$RUNNER_TEMP/appliance.env"
+          ./e2e/ci/appliance.sh claim "$TN_BASELINE_REQUESTED" > "$RUNNER_TEMP/appliance.env"
           # The appliance password is generated per claim, not a GitHub secret,
           # so nothing masks it automatically. Register it before it can reach
           # a log.

--- a/e2e/ci/appliance.sh
+++ b/e2e/ci/appliance.sh
@@ -33,6 +33,10 @@
 #                      --nickname <name> --lifetime <duration>   -> JSON
 #   tn_guest.py create (...) --template --iso <path> --admin-pass <template's>
 #                      --nickname <template nickname>            -> JSON
+#                      (--leave-running: stop before the snapshot, for a
+#                      baseline script to configure the guest)
+#   tn_guest.py freeze --host H (...) <template nickname>
+#   tn_guest.py list   --host H --pool P (...) --json
 #   tn_guest.py delete --host H --pool P (...) <name or nickname>
 #
 # With a template password configured, a claim clones the template (seconds,
@@ -55,11 +59,15 @@
 #   TN_GUEST_HOST_USER  API user on the host (default: root)
 #   TN_GUEST_HOST_API_KEY or TN_GUEST_HOST_PASSWORD — credential for that user
 #   TN_GUEST_LIFETIME   VM lifetime, so a leaked one expires (default: 3h)
-#   TN_GUEST_TEMPLATE   nickname of the template to clone (default: e2e-template)
+#   TN_GUEST_TEMPLATE_PREFIX
+#                       templates are nicknamed <prefix>-<baseline>, one per
+#                       baseline (default: e2e, so e2e-fresh-install,
+#                       e2e-with-pool)
 #   TN_GUEST_TEMPLATE_PASSWORD
-#                       the template's admin password. Set: claims clone the
-#                       template and rotate the password per claim. Unset:
-#                       every claim installs from the ISO.
+#                       the templates' admin password. Set: claims clone the
+#                       baseline's template and rotate the password per claim.
+#                       Unset: every claim installs from the ISO, and only
+#                       `fresh-install` is available.
 #
 # Guest sizing, all with defaults below. The host is shared with the runner,
 # Docker and the browser, so memory and the OS disk are deliberately smaller
@@ -95,7 +103,36 @@ TN_GUEST_HOST="${TN_GUEST_HOST:-localhost}"
 TN_GUEST_POOL="${TN_GUEST_POOL:-tank}"
 TN_GUEST_HOST_USER="${TN_GUEST_HOST_USER:-root}"
 TN_GUEST_LIFETIME="${TN_GUEST_LIFETIME:-3h}"
-TN_GUEST_TEMPLATE="${TN_GUEST_TEMPLATE:-e2e-template}"
+TN_GUEST_TEMPLATE_PREFIX="${TN_GUEST_TEMPLATE_PREFIX:-e2e}"
+
+# The baselines a claim can ask for, and what each is.
+#
+#   fresh-install  a bare install: admin user set, nothing else. For journeys
+#                  about first-run things — building the first pool.
+#   with-pool      fresh-install plus one striped pool named `tank`, so every
+#                  other journey has somewhere to put a dataset without
+#                  building it first.
+#
+# A baseline beyond fresh-install is a script under baselines/, run against
+# the template guest's API between `create --template --leave-running` and
+# `freeze`. Adding one is adding a script and a line here.
+baselines="fresh-install with-pool"
+
+# Where the baseline scripts live: beside this script.
+baselineDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/baselines"
+
+knownBaseline() {
+  local baseline="$1" candidate
+  for candidate in $baselines; do
+    [ "$candidate" = "$baseline" ] && return 0
+  done
+  return 1
+}
+
+# The template a baseline is cloned from, by nickname.
+templateNickname() {
+  printf '%s-%s' "$TN_GUEST_TEMPLATE_PREFIX" "$1"
+}
 TN_GUEST_MEMORY_MB="${TN_GUEST_MEMORY_MB:-6144}"
 TN_GUEST_VCPUS="${TN_GUEST_VCPUS:-4}"
 TN_GUEST_OS_DISK_GB="${TN_GUEST_OS_DISK_GB:-10}"
@@ -149,10 +186,12 @@ checkTools() {
 # and eventually the suite's own fixture. Everything else goes to stderr.
 claim() {
   local baseline="${1:?baseline name required}"
-  # tn_guest.py installs from an ISO every time, so a clean install is the
-  # only baseline it can produce. Anything else is the snapshot design (E5).
-  [ "$baseline" = "fresh-install" ] \
-    || die "baseline '$baseline' is not available: tn_guest.py can only produce 'fresh-install'"
+  knownBaseline "$baseline" \
+    || die "baseline '$baseline' is not one of: $baselines"
+  # Without templates every claim is an ISO install, and an ISO install is a
+  # fresh install: the configured baselines only exist as templates.
+  [ -n "${TN_GUEST_TEMPLATE_PASSWORD:-}" ] || [ "$baseline" = "fresh-install" ] \
+    || die "baseline '$baseline' needs templates: set TN_GUEST_TEMPLATE_PASSWORD"
   checkTools
 
   # The ISO is a path on the host. When the host is this machine, which is the
@@ -203,16 +242,17 @@ claim() {
     # a pin changes) the next claim pays one install and every claim after
     # it clones the new build. That is the whole rotation policy; nothing
     # rebuilds on a calendar.
-    local built
-    if ! built=$(templateCreated); then
-      echo "appliance.sh: no template named '$TN_GUEST_TEMPLATE' on the host, building it first" >&2
-      build_template fresh-install
+    local template built
+    template=$(templateNickname "$baseline")
+    if ! built=$(templateCreated "$template"); then
+      echo "appliance.sh: no frozen template named '$template' on the host, building it first" >&2
+      build_template "$baseline"
     elif templatePredatesIso "$built"; then
-      echo "appliance.sh: template '$TN_GUEST_TEMPLATE' (built $built) predates $TN_GUEST_ISO, rebuilding it first" >&2
-      build_template fresh-install
+      echo "appliance.sh: template '$template' (built $built) predates $TN_GUEST_ISO, rebuilding it first" >&2
+      build_template "$baseline"
     fi
-    echo "appliance.sh: cloning template '$TN_GUEST_TEMPLATE' into '$nickname' on $TN_GUEST_HOST" >&2
-    json=$(tnGuest clone "$TN_GUEST_TEMPLATE" \
+    echo "appliance.sh: cloning template '$template' into '$nickname' on $TN_GUEST_HOST" >&2
+    json=$(tnGuest clone "$template" \
       --admin-pass "$TN_GUEST_TEMPLATE_PASSWORD" \
       --rotate-admin-pass "$password" \
       --nickname "$nickname" \
@@ -264,17 +304,24 @@ TN_BASELINE=$baseline
 EOF
 }
 
-# Whether a template with the configured nickname exists on the host.
+# Whether a template with nickname $1 exists on the host, frozen or not.
 templateExists() {
-  templateCreated > /dev/null
+  tnGuest list --json 2>/dev/null \
+    | jq -e --arg n "$1" \
+        'map(select(.nickname == $n and .template == "true")) | length > 0' > /dev/null
 }
 
-# When the template with the configured nickname was built, as the ISO 8601
+# When the frozen template with nickname $1 was built, as the ISO 8601
 # timestamp tn_guest.py recorded on its dataset. Fails when there is none.
+#
+# Frozen only: a template that was created and never froze — a baseline
+# script that failed, a build interrupted between the two — has no snapshot
+# to clone from, and a claim that finds one must rebuild it rather than ask
+# `clone` for it and be refused.
 templateCreated() {
   tnGuest list --json 2>/dev/null \
-    | jq -re --arg n "$TN_GUEST_TEMPLATE" \
-        'map(select(.nickname == $n and .template == "true")) | first | .created // empty'
+    | jq -re --arg n "$1" \
+        'map(select(.nickname == $n and .template == "true" and (.snapshot // "") != "")) | first | .created // empty'
 }
 
 # Whether a template built at $1 is older than the ISO a claim would install
@@ -291,18 +338,26 @@ templatePredatesIso() {
   [ "$builtEpoch" -lt "$isoEpoch" ]
 }
 
-# Build the template every claim clones: a bare install from the ISO, shut
-# down after its first boot and snapshotted. Replaces the previous template of
-# the same nickname, which is only possible when nothing is cloned from it —
-# the e2e-lab concurrency group guarantees that, since every run destroys its
-# clone before releasing the group.
+# Build the template a baseline's claims clone. `fresh-install` is an install
+# from the ISO, shut down after its first boot and snapshotted. Every other
+# baseline is that install left running, its script from baselines/ run
+# against the guest's API, then the same shutdown and snapshot (`freeze`).
+# Replaces the previous template of the same nickname, which is only possible
+# when nothing is cloned from it — the e2e-lab concurrency group guarantees
+# that, since every run destroys its clone before releasing the group.
 #
 # Emits nothing on stdout. The template's password is the one in
 # TN_GUEST_TEMPLATE_PASSWORD; clones rotate away from it, so it never reaches
-# a trace.
+# a trace. The baseline script gets it through the environment, not argv.
 build_template() {
-  [ "${1:-fresh-install}" = "fresh-install" ] \
-    || die "only the 'fresh-install' template is defined so far"
+  local baseline="${1:-fresh-install}"
+  knownBaseline "$baseline" \
+    || die "baseline '$baseline' is not one of: $baselines"
+  local template script
+  template=$(templateNickname "$baseline")
+  script="$baselineDir/$baseline.py"
+  [ "$baseline" = "fresh-install" ] || [ -f "$script" ] \
+    || die "baseline '$baseline' has no script at $script"
   checkTools
   [ -n "${TN_GUEST_ISO:-}" ] || die "TN_GUEST_ISO is required to build a template"
   [ "$TN_GUEST_HOST" != "localhost" ] || [ -f "$TN_GUEST_ISO" ] \
@@ -311,18 +366,21 @@ build_template() {
   [ -n "${TN_GUEST_HOST_API_KEY:-}${TN_GUEST_HOST_PASSWORD:-}" ] \
     || die "TN_GUEST_HOST_API_KEY or TN_GUEST_HOST_PASSWORD is required"
 
-  if templateExists; then
-    echo "appliance.sh: replacing template '$TN_GUEST_TEMPLATE'" >&2
-    tnGuest delete "$TN_GUEST_TEMPLATE" > /dev/null \
-      || die "could not delete the existing template '$TN_GUEST_TEMPLATE' — clones of it may still exist"
+  if templateExists "$template"; then
+    echo "appliance.sh: replacing template '$template'" >&2
+    tnGuest delete "$template" > /dev/null \
+      || die "could not delete the existing template '$template' — clones of it may still exist"
   fi
 
-  echo "appliance.sh: building template '$TN_GUEST_TEMPLATE' from $TN_GUEST_ISO" >&2
+  local leaveRunning=()
+  [ "$baseline" = "fresh-install" ] || leaveRunning=(--leave-running)
+
+  echo "appliance.sh: building template '$template' ($baseline) from $TN_GUEST_ISO" >&2
   local json
-  json=$(tnGuest create --template \
+  json=$(tnGuest create --template "${leaveRunning[@]}" \
     --iso "$TN_GUEST_ISO" \
     --admin-pass "$TN_GUEST_TEMPLATE_PASSWORD" \
-    --nickname "$TN_GUEST_TEMPLATE" \
+    --nickname "$template" \
     --memory-mb "$TN_GUEST_MEMORY_MB" \
     --vcpus "$TN_GUEST_VCPUS" \
     --os-disk-gb "$TN_GUEST_OS_DISK_GB" \
@@ -330,7 +388,31 @@ build_template() {
     --data-disk-gb "$TN_GUEST_DATA_DISK_GB" \
     --network hostfwd) \
     || die "tn_guest.py create --template failed"
-  echo "appliance.sh: template '$TN_GUEST_TEMPLATE' is $(jq -r '.name' <<<"$json")" >&2
+  local name
+  name=$(jq -r '.name' <<<"$json")
+
+  if [ "$baseline" != "fresh-install" ]; then
+    local adminUser apiHost httpPort
+    adminUser=$(jq -re '.admin_user' <<<"$json")           || die "create output has no .admin_user"
+    apiHost=$(jq -re '.nodes[0].api_host' <<<"$json")      || die "create output has no .nodes[0].api_host"
+    httpPort=$(jq -re '.nodes[0].api_port_http' <<<"$json") || die "create output has no .nodes[0].api_port_http"
+
+    # A template that fails to configure is deleted, not left: unfrozen, it
+    # cannot be cloned, and the next claim would only find it in the way.
+    echo "appliance.sh: configuring '$template' with $script" >&2
+    if ! TN_ADMIN_PASSWORD="$TN_GUEST_TEMPLATE_PASSWORD" "$TN_GUEST_PYTHON" "$script" \
+        --uri "ws://$apiHost:$httpPort/api/current" --user "$adminUser"; then
+      tnGuest delete "$template" > /dev/null || true
+      die "baseline script failed for '$template'; the template was deleted"
+    fi
+
+    echo "appliance.sh: freezing '$template'" >&2
+    if ! tnGuest freeze "$template" > /dev/null; then
+      tnGuest delete "$template" > /dev/null || true
+      die "tn_guest.py freeze failed for '$template'; the template was deleted"
+    fi
+  fi
+  echo "appliance.sh: template '$template' is $name" >&2
 }
 
 # Destroy an appliance. Safe to call twice, and safe to call when claim

--- a/e2e/ci/baselines/with-pool.py
+++ b/e2e/ci/baselines/with-pool.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Configure a running template guest into the `with-pool` baseline.
+
+One striped pool named `tank` on the first unused disk, and nothing else. It
+runs between `tn_guest.py create --template --leave-running` and
+`tn_guest.py freeze`, over the guest's own API, so every clone of the
+template boots with a pool present and no journey has to build one. Journeys
+about building a pool ask for the `fresh-install` baseline instead.
+
+The pool is `tank` rather than the suite's own `e2e_shared_tank` on purpose:
+the suite's pool fixture prefers any pool that is not its own, and only
+exports the one it built. A baked pool is the appliance's, and stays.
+
+Arguments: the guest API URI and the admin user. The admin password comes
+from TN_ADMIN_PASSWORD in the environment, never the command line.
+"""
+import argparse
+import os
+import sys
+
+from truenas_api_client import Client
+
+POOL_NAME = "tank"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--uri", required=True, help="ws://host:port/api/current")
+    parser.add_argument("--user", required=True, help="admin user on the guest")
+    args = parser.parse_args()
+
+    password = os.environ.get("TN_ADMIN_PASSWORD")
+    if not password:
+        print("with-pool: TN_ADMIN_PASSWORD is not set", file=sys.stderr)
+        return 2
+
+    client = Client(uri=args.uri, verify_ssl=False)
+    try:
+        response = client.call(
+            "auth.login_ex",
+            {"mechanism": "PASSWORD_PLAIN", "username": args.user, "password": password},
+        )
+        if response.get("response_type") != "SUCCESS":
+            print(f"with-pool: login as {args.user} failed: {response}", file=sys.stderr)
+            return 1
+
+        if client.call("pool.query", [["name", "=", POOL_NAME]]):
+            print(f"with-pool: pool {POOL_NAME!r} already exists", file=sys.stderr)
+            return 1
+
+        disks = client.call("disk.get_unused")
+        if not disks:
+            print("with-pool: the guest has no unused disk to build the pool from", file=sys.stderr)
+            return 1
+        disk = disks[0]["devname"]
+
+        print(f"with-pool: creating pool {POOL_NAME!r} on {disk}", file=sys.stderr)
+        client.call(
+            "pool.create",
+            {"name": POOL_NAME, "topology": {"data": [{"type": "STRIPE", "disks": [disk]}]}},
+            job=True,
+        )
+
+        pools = client.call("pool.query", [["name", "=", POOL_NAME]])
+        if not pools or pools[0].get("status") != "ONLINE":
+            print(f"with-pool: pool {POOL_NAME!r} is not ONLINE after creation: {pools}", file=sys.stderr)
+            return 1
+        print(f"with-pool: pool {POOL_NAME!r} is ONLINE", file=sys.stderr)
+        return 0
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e/docs/04-environment-architecture.md
+++ b/e2e/docs/04-environment-architecture.md
@@ -376,7 +376,12 @@ the bare install, shuts it down and snapshots its deployment dataset;
 `tn_guest.py clone` uses middleware's `vm.clone`, which copies the VM record,
 its UEFI NVRAM state and every zvol from that snapshot, then rewrites the
 clone's ports and boots it. `appliance.sh claim` clones it, rebuilding it
-first whenever the resolved ISO is newer than the template. Baselines beyond `fresh-install` are the
+first whenever the resolved ISO is newer than the template.
+
+*Implemented for `with-pool`:* the same, with `create --template
+--leave-running`, a script from `e2e/ci/baselines/` run against the guest's
+API, and `tn_guest.py freeze` for the shutdown and snapshot. Any further
+baseline is another script. Baselines beyond `fresh-install` are the
 same mechanism with a configuration step before the shutdown.
 
 **Baselines age with the nightly.** A baseline built from one ISO is that

--- a/e2e/docs/05-ci.md
+++ b/e2e/docs/05-ci.md
@@ -34,7 +34,8 @@ One job, on a self-hosted runner that is itself a **TrueNAS box**. Per run:
    is recorded in `.current-nightly` beside the files; older nightlies are
    pruned to the newest two. `E2E_TN_GUEST_ISO` still pins one file and
    skips all of this.
-5. **Claim an appliance.** `appliance.sh claim fresh-install` drives
+5. **Claim an appliance.** `appliance.sh claim with-pool` (or the baseline a
+   dispatch asked for) drives
    `tn_guest.py` (iXsystems/api-ci-testbed) against the box's own middleware
    API. With a template on the host it **clones** it: middleware's `vm.clone`
    copies the VM record, its UEFI NVRAM and every zvol from the template's
@@ -45,12 +46,17 @@ One job, on a self-hosted runner that is itself a **TrueNAS box**. Per run:
    the suite's `TN_*` variables, which the workflow masks and loads into the
    job environment.
 
-   The template is a bare install, shut down after first boot and
-   snapshotted. It is keyed on the ISO, not on a calendar: a claim that finds
-   the template older than the resolved ISO rebuilds it before cloning, so
-   the weekly ISO rotation above is also the template's rotation, and
-   `refresh_iso` moves both at once. `appliance.sh build-template` rebuilds
-   it by hand. It is E5 of the design in its first form.
+   There is one template per baseline, nicknamed `e2e-<baseline>`.
+   `fresh-install` is a bare install, shut down after first boot and
+   snapshotted. `with-pool` is that install left running, a striped pool
+   named `tank` created over its API by `e2e/ci/baselines/with-pool.py`, then
+   the same shutdown and snapshot (`tn_guest.py freeze`). A new baseline is a
+   script in that directory and a line in `appliance.sh`. Templates are keyed
+   on the ISO, not on a calendar: a claim that finds its baseline's template
+   older than the resolved ISO rebuilds it before cloning, so the weekly ISO
+   rotation above is also the templates' rotation, and `refresh_iso` moves
+   both at once. `appliance.sh build-template <baseline>` rebuilds one by
+   hand. This is E5 of the design in its first form.
 6. **Serve the UI.** A stock `nginx` container with `dist/` mounted and the
    repository's own `docker/nginx.conf`, the file the appliance serves the UI
    through: `/ui/` from disk, the API paths proxied to the appliance's
@@ -77,7 +83,8 @@ One job, on a self-hosted runner that is itself a **TrueNAS box**. Per run:
    and `release` falls back to it.
 
 `workflow_dispatch` takes `ui: shipped` to run against the UI baked into the
-ISO instead, and `refresh_iso: true` to install from the newest nightly now
+ISO instead, `baseline: fresh-install` for an appliance with no pool, and
+`refresh_iso: true` to install from the newest nightly now
 rather than this week's or the pinned one — for a run that needs a middleware
 change merged this morning.
 
@@ -119,7 +126,7 @@ In the repository's `e2e-lab` environment:
 | variable | `E2E_TN_GUEST_POOL` | Pool for VM datasets and zvols. Default `tank`. |
 | secret | `TN_GUEST_HOST_API_KEY` | Key for that account. `TN_GUEST_HOST_PASSWORD` works instead. |
 | secret | `TN_GUEST_TEMPLATE_PASSWORD` | Admin password baked into the template. Set: claims clone the template and rotate away from it. Unset: every claim installs from the ISO. |
-| variable | `E2E_TN_GUEST_TEMPLATE` | Template nickname. Default `e2e-template`. |
+| variable | `E2E_TN_GUEST_TEMPLATE_PREFIX` | Templates are nicknamed `<prefix>-<baseline>`. Default `e2e`. |
 
 Guest sizing lives in `appliance.sh` as environment overrides: 6GB RAM,
 4 vCPUs, 10GB OS disk, ten 10GB data disks (sparse zvols, so the count is free


### PR DESCRIPTION
Stacked on #14094 (templates), which is stacked on #14093 (ISO resolver). Needs iXsystems/api-ci-testbed#337 (`create --template --leave-running` and `freeze`) on the lab box before its first run.

## Summary

Every journey that is not about building a pool has to build one before it can start. This bakes the pool into the appliance instead.

- **One template per baseline**, nicknamed `<prefix>-<baseline>` (`e2e-fresh-install`, `e2e-with-pool`). `TN_GUEST_TEMPLATE` becomes `TN_GUEST_TEMPLATE_PREFIX` (variable `E2E_TN_GUEST_TEMPLATE_PREFIX`, default `e2e`).
- **`with-pool`** is `fresh-install` left running (`create --template --leave-running`), `e2e/ci/baselines/with-pool.py` run against the guest's API to create one striped pool named `tank` on the first unused disk, then `tn_guest.py freeze` for the shutdown and snapshot. A baseline script that fails, or a freeze that fails, deletes the half-built template so the next claim rebuilds rather than trips over it; an unfrozen template is never treated as present.
- **The pool is `tank`, not `e2e_shared_tank`**, so the suite's pool fixture adopts it as the appliance's and never exports it.
- The workflow claims `with-pool` by default and gains a `baseline` dispatch input; `fresh-install` remains for first-run journeys.
- Adding a baseline is a script under `e2e/ci/baselines/` and a line in `appliance.sh`.

Both templates are ISO-keyed the same way as before (#14094).

## Test plan

- [x] `bash -n`, and the branch's `templateCreated` now requires a `snapshot` property so an unfrozen leftover is rebuilt.
- [ ] After api-ci-testbed#337 is on the box: dispatch on this branch builds `e2e-with-pool` (install, pool, freeze) and clones it; the clone shows `tank` ONLINE.
- [ ] `baseline: fresh-install` dispatch builds `e2e-fresh-install` and the suite passes without a pool.
- [ ] Delete the old `e2e-template` on the box by hand once nothing needs it: `tn_guest.py delete e2e-template`.