### PR TITLE
NAS-143108 / 26.0.0-RC.1 / Don't reset the page when a checkbox is ticked or the list reloads (by AlexKarpov98)

### DIFF
--- a/src/app/modules/ix-table/classes/async-data-provider/async-data-provider.ts
+++ b/src/app/modules/ix-table/classes/async-data-provider/async-data-provider.ts
@@ -30,7 +30,7 @@ export class AsyncDataProvider<T> extends BaseDataProvider<T> {
     );
   }
 
-  override setFilter(filter: TableFilter<T>): void {
-    super.setFilter({ ...filter, list: filter.list || this.loadedRows });
+  override setFilter(filter: TableFilter<T>, options?: { keepPage?: boolean }): void {
+    super.setFilter({ ...filter, list: filter.list || this.loadedRows }, options);
   }
 }

--- a/src/app/modules/ix-table/classes/base-data-provider.ts
+++ b/src/app/modules/ix-table/classes/base-data-provider.ts
@@ -73,8 +73,19 @@ export class BaseDataProvider<T> implements DataProvider<T> {
     this.sortingOrPaginationUpdate.emit();
   }
 
-  setFilter(filter: TableFilter<T>): void {
-    this.resetPaginationToFirstPage();
+  /**
+   * Applies a filter and, by default, sends the user back to the first page — the right
+   * move when the QUERY changed, since the rows they were reading are no longer the ones
+   * the table holds.
+   *
+   * Pass `keepPage` when the same query is being re-run against refreshed rows, e.g. a
+   * background reload the user did not ask for. Resetting there reads as the table losing
+   * their place mid-task, which is what NAS-143108 reported.
+   */
+  setFilter(filter: TableFilter<T>, { keepPage = false }: { keepPage?: boolean } = {}): void {
+    if (!keepPage) {
+      this.resetPaginationToFirstPage();
+    }
     const filteredRows = filterTableRows(filter);
     this.setRows(filteredRows);
   }

--- a/src/app/modules/ix-table/classes/base-data-provider.ts
+++ b/src/app/modules/ix-table/classes/base-data-provider.ts
@@ -79,6 +79,20 @@ export class BaseDataProvider<T> implements DataProvider<T> {
     this.setRows(filteredRows);
   }
 
+  /**
+   * Re-emits the current page so the table re-renders, leaving the filter, the sort and
+   * the pagination alone.
+   *
+   * A checkbox column keeps its state ON the row (`row.selected`) and mutates it in
+   * place, so nothing in the table's OnPush tree learns about it. Re-running the filter
+   * does force the re-render, but `setFilter` also resets to the first page — which is
+   * why ticking a checkbox on page 2 used to snap the user back to page 1 (NAS-143108).
+   */
+  refreshCurrentPage(): void {
+    this.currentPage$.next([]);
+    this.updateCurrentPage(this.allRows);
+  }
+
   protected resetPaginationToFirstPage(): void {
     if (this.pagination.pageNumber !== null) {
       this.pagination.pageNumber = 1;

--- a/src/app/pages/apps/components/docker-images/docker-images-list/docker-images-list.component.ts
+++ b/src/app/pages/apps/components/docker-images/docker-images-list/docker-images-list.component.ts
@@ -86,8 +86,9 @@ export class DockerImagesListComponent implements OnInit {
         if (imageToSelect) {
           imageToSelect.selected = checked;
         }
-        this.dataProvider.setRows([]);
-        this.onListFiltered(this.searchQuery());
+        // Only re-render. Re-running the filter would reset the pagination and drop the
+        // user back on page 1 the moment they ticked a box on any later page.
+        this.dataProvider.refreshCurrentPage();
       },
       onColumnCheck: (checked) => {
         this.dataProvider.currentPage$.pipe(
@@ -95,8 +96,7 @@ export class DockerImagesListComponent implements OnInit {
           takeUntilDestroyed(this.destroyRef),
         ).subscribe((images) => {
           images.forEach((image) => image.selected = checked);
-          this.dataProvider.setRows([]);
-          this.onListFiltered(this.searchQuery());
+          this.dataProvider.refreshCurrentPage();
         });
       },
       cssClass: 'checkboxs-column',

--- a/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.spec.ts
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.spec.ts
@@ -2,6 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { ActivatedRoute } from '@angular/router';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
@@ -14,6 +15,7 @@ import { DialogService } from 'app/modules/dialog/dialog.service';
 import { IxSlideToggleHarness } from 'app/modules/forms/ix-forms/components/ix-slide-toggle/ix-slide-toggle.harness';
 import { BasicSearchComponent } from 'app/modules/forms/search-input/components/basic-search/basic-search.component';
 import { IxTableHarness } from 'app/modules/ix-table/components/ix-table/ix-table.harness';
+import { IxTablePagerComponent } from 'app/modules/ix-table/components/ix-table-pager/ix-table-pager.component';
 import { IxTableDetailsRowDirective } from 'app/modules/ix-table/directives/ix-table-details-row.directive';
 import { PageHeaderComponent } from 'app/modules/page-header/page-title-header/page-header.component';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
@@ -294,5 +296,82 @@ describe('SnapshotListComponent', () => {
       columnKeys: ['dataset'],
       exact: true,
     });
+  });
+});
+
+
+describe('SnapshotListComponent — paging', () => {
+  // Enough snapshots for three pages at the default page size of 50.
+  const manySnapshots: ZfsSnapshot[] = Array.from({ length: 120 }, (_, index) => ({
+    id: String(index),
+    name: `test-dataset@snap-${String(index).padStart(3, '0')}`,
+    dataset: 'test-dataset',
+    snapshot_name: `snap-${String(index).padStart(3, '0')}`,
+  } as ZfsSnapshot));
+
+  let spectator: Spectator<SnapshotListComponent>;
+  let loader: HarnessLoader;
+  let pager: IxTablePagerComponent<ZfsSnapshot>;
+
+  const createComponent = createComponentFactory({
+    component: SnapshotListComponent,
+    imports: [
+      MockComponent(PageHeaderComponent),
+      BasicSearchComponent,
+      ReactiveFormsModule,
+      IxTableDetailsRowDirective,
+    ],
+    providers: [
+      mockAuth(),
+      mockApi([mockCall('pool.snapshot.query', manySnapshots)]),
+      mockProvider(DialogService, { confirm: jest.fn(() => of(true)) }),
+      mockProvider(SlideIn, { open: jest.fn() }),
+      provideMockStore({
+        selectors: [
+          { selector: selectSnapshotState, value: snapshotsInitialState },
+          { selector: selectSnapshots, value: manySnapshots },
+          { selector: selectSnapshotsTotal, value: manySnapshots.length },
+          { selector: selectPreferences, value: { showSnapshotExtraColumns: false } },
+          { selector: selectGeneralConfig, value: { timezone: 'Europe/Kiev' } },
+        ],
+      }),
+      {
+        provide: ActivatedRoute,
+        useValue: { snapshot: { paramMap: { get: (): string | null => null } } },
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createComponent();
+    loader = TestbedHarnessEnvironment.loader(spectator.fixture);
+    pager = spectator.query(IxTablePagerComponent);
+    pager.goToPage(2);
+    spectator.detectChanges();
+  });
+
+  it('stays on the page the user is reading when a row there is ticked', async () => {
+    const checkbox = await loader.getHarness(MatCheckboxHarness.with({ ancestor: 'tbody' }));
+    await checkbox.check();
+    spectator.detectChanges();
+
+    expect(pager.currentPage()).toBe(2);
+    expect(spectator.component.dataProvider.pagination.pageNumber).toBe(2);
+    expect(await checkbox.isChecked()).toBe(true);
+    expect(spectator.component.selectedSnapshots).toHaveLength(1);
+  });
+
+  it('stays on the page the user is reading when they select the whole page', async () => {
+    const header = await loader.getHarness(MatCheckboxHarness.with({ ancestor: 'thead' }));
+    await header.check();
+    spectator.detectChanges();
+
+    expect(pager.currentPage()).toBe(2);
+    expect(spectator.component.selectedSnapshots).toHaveLength(50);
+
+    // The rows the user just selected must also render as checked. Before the fix the
+    // table had already jumped to page 1, so they were looking at 50 unticked boxes.
+    const boxes = await loader.getAllHarnesses(MatCheckboxHarness.with({ ancestor: 'tbody' }));
+    expect(await Promise.all(boxes.map((box) => box.isChecked()))).not.toContain(false);
   });
 });

--- a/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.spec.ts
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.spec.ts
@@ -5,7 +5,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { ActivatedRoute } from '@angular/router';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { provideMockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
@@ -172,7 +172,7 @@ describe('SnapshotListComponent', () => {
       query: 'test-dataset',
       columnKeys: ['dataset'],
       exact: true,
-    });
+    }, { keepPage: false });
   });
 
   it('should fallback to name-based filtering when dataset exact match fails', () => {
@@ -205,12 +205,12 @@ describe('SnapshotListComponent', () => {
       query: 'test-dataset',
       columnKeys: ['dataset'],
       exact: true,
-    });
+    }, { keepPage: false });
     expect(setFilterSpy).toHaveBeenNthCalledWith(2, {
       list: component.snapshots,
       query: 'test-dataset',
       columnKeys: ['name'],
-    });
+    }, { keepPage: false });
   });
 
   it('filters only by name when the extra columns are hidden', () => {
@@ -226,7 +226,7 @@ describe('SnapshotListComponent', () => {
       list: component.snapshots,
       query: '1.49',
       columnKeys: ['name'],
-    });
+    }, { keepPage: false });
   });
 
   it('also filters by the extra columns (used/referenced/created) when they are visible', async () => {
@@ -295,7 +295,7 @@ describe('SnapshotListComponent', () => {
       query: 'dozer/boom',
       columnKeys: ['dataset'],
       exact: true,
-    });
+    }, { keepPage: false });
   });
 });
 
@@ -359,6 +359,20 @@ describe('SnapshotListComponent — paging', () => {
     expect(spectator.component.dataProvider.pagination.pageNumber).toBe(2);
     expect(await checkbox.isChecked()).toBe(true);
     expect(spectator.component.selectedSnapshots).toHaveLength(1);
+  });
+
+  it('stays on the page the user is reading when the store reloads underneath them', () => {
+    const store$ = spectator.inject(MockStore);
+
+    // The page subscribes to pool.snapshot.query, so a periodic snapshot task firing
+    // anywhere on the system re-emits here. Nobody asked for it, and it used to re-run the
+    // search filter, which resets the pagination.
+    store$.overrideSelector(selectSnapshots, manySnapshots.map((snapshot) => ({ ...snapshot })));
+    store$.refreshState();
+    spectator.detectChanges();
+
+    expect(pager.currentPage()).toBe(2);
+    expect(spectator.component.dataProvider.pagination.pageNumber).toBe(2);
   });
 
   it('stays on the page the user is reading when they select the whole page', async () => {

--- a/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.ts
@@ -247,7 +247,10 @@ export class SnapshotListComponent implements OnInit {
       }),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe(() => {
-      this.onListFiltered(this.searchQuery());
+      // A reload is not something the user asked for — the page subscribes to
+      // pool.snapshot.query, so a periodic snapshot task firing anywhere is enough to
+      // trigger one — and it must not cost them the page they are reading.
+      this.onListFiltered(this.searchQuery(), { keepPage: true });
       this.cdr.markForCheck();
     });
   }
@@ -320,7 +323,11 @@ export class SnapshotListComponent implements OnInit {
       });
   }
 
-  protected onListFiltered(query: string): void {
+  /**
+   * @param options `keepPage` re-runs the same query without moving the user — see
+   * `BaseDataProvider.setFilter`. A query the user typed always starts at page 1.
+   */
+  protected onListFiltered(query: string, { keepPage = false }: { keepPage?: boolean } = {}): void {
     this.searchQuery.set(query);
     const datasetParam = this.route.snapshot.paramMap.get('dataset');
 
@@ -330,13 +337,13 @@ export class SnapshotListComponent implements OnInit {
         query,
         columnKeys: ['dataset'],
         exact: true,
-      });
+      }, { keepPage });
 
       if (this.dataProvider.totalRows === 0) {
-        this.dataProvider.setFilter(this.buildSearchFilter(query));
+        this.dataProvider.setFilter(this.buildSearchFilter(query), { keepPage });
       }
     } else {
-      this.dataProvider.setFilter(this.buildSearchFilter(query));
+      this.dataProvider.setFilter(this.buildSearchFilter(query), { keepPage });
     }
   }
 

--- a/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.ts
+++ b/src/app/pages/datasets/modules/snapshots/snapshot-list/snapshot-list.component.ts
@@ -151,8 +151,9 @@ export class SnapshotListComponent implements OnInit {
         if (snapshotToSelect) {
           snapshotToSelect.selected = checked;
         }
-        this.dataProvider.setRows([]);
-        this.onListFiltered(this.searchQuery());
+        // Only re-render. Re-running the filter would reset the pagination and drop the
+        // user back on page 1 the moment they ticked a box on any later page.
+        this.dataProvider.refreshCurrentPage();
       },
       onColumnCheck: (checked) => {
         this.dataProvider.currentPage$.pipe(
@@ -160,8 +161,7 @@ export class SnapshotListComponent implements OnInit {
           takeUntilDestroyed(this.destroyRef),
         ).subscribe((snapshots) => {
           snapshots.forEach((snapshot) => snapshot.selected = checked);
-          this.dataProvider.setRows([]);
-          this.onListFiltered(this.searchQuery());
+          this.dataProvider.refreshCurrentPage();
         });
       },
       cssClass: 'checkboxs-column',

--- a/src/app/pages/storage/modules/disks/components/disk-list/disk-list.component.ts
+++ b/src/app/pages/storage/modules/disks/components/disk-list/disk-list.component.ts
@@ -108,8 +108,9 @@ export class DiskListComponent implements OnInit {
         if (diskToSelect) {
           diskToSelect.selected = checked;
         }
-        this.dataProvider.setRows([]);
-        this.onListFiltered(this.searchQuery());
+        // Only re-render. Re-running the filter would reset the pagination and drop the
+        // user back on page 1 the moment they ticked a box on any later page.
+        this.dataProvider.refreshCurrentPage();
       },
       onColumnCheck: (checked) => {
         this.dataProvider.currentPage$.pipe(
@@ -117,8 +118,7 @@ export class DiskListComponent implements OnInit {
           takeUntilDestroyed(this.destroyRef),
         ).subscribe((disks) => {
           disks.forEach((disk) => disk.selected = checked);
-          this.dataProvider.setRows([]);
-          this.onListFiltered(this.searchQuery());
+          this.dataProvider.refreshCurrentPage();
         });
       },
     }),

--- a/src/app/pages/system/bootenv/bootenv-list/bootenv-list.component.ts
+++ b/src/app/pages/system/bootenv/bootenv-list/bootenv-list.component.ts
@@ -103,8 +103,9 @@ export class BootEnvironmentListComponent implements OnInit {
         if (bootEnvToSelect) {
           bootEnvToSelect.selected = checked;
         }
-        this.dataProvider.setRows([]);
-        this.onListFiltered(this.searchQuery());
+        // Only re-render. Re-running the filter would reset the pagination and drop the
+        // user back on page 1 the moment they ticked a box on any later page.
+        this.dataProvider.refreshCurrentPage();
       },
       onColumnCheck: (checked) => {
         this.dataProvider.currentPage$.pipe(
@@ -112,8 +113,7 @@ export class BootEnvironmentListComponent implements OnInit {
           takeUntilDestroyed(this.destroyRef),
         ).subscribe((bootEnvs) => {
           bootEnvs.forEach((bootEnv) => bootEnv.selected = checked);
-          this.dataProvider.setRows([]);
-          this.onListFiltered(this.searchQuery());
+          this.dataProvider.refreshCurrentPage();
         });
       },
       cssClass: 'checkboxs-column',


### PR DESCRIPTION
## Problem

Ticking a snapshot checkbox on page 2 of **Datasets → Snapshots** sends the user back to page 1. The row they aimed at vanishes and a page-1 row sits there looking selected instead — which reads as "the wrong snapshot got selected", right before a batch Delete.

There turned out to be **two independent ways** to lose your place on this page. One commit each.

## 1. Ticking a checkbox

The ix-table checkbox columns keep their state **on the row** (`row.selected`) and mutate it in place, so nothing in the table's OnPush tree learns about it. To force the re-render they nuked the rows and re-ran the search filter:

```ts
this.dataProvider.setRows([]);
this.onListFiltered(this.searchQuery());
```

`setFilter` resets to the first page. `setRows([])` also drops `totalRows` to zero on the way through, which makes the pager independently correct itself off a now-out-of-range page — a second route to the same place.

Selecting the **whole page** was worse than reported: it snapped to page 1 *and* left the user looking at 50 unticked boxes over a 50-row selection.

**Fix:** `BaseDataProvider.refreshCurrentPage()` does the re-render on its own and leaves the filter, the sort and the pagination alone. The empty emission it starts with is load-bearing — it is what rebuilds the row cell components, and without it select-all stops rendering as checked at all.

Snapshots is the reported page. **Disks**, **Boot Environments** and **Docker Images** carry the same copy-pasted handlers and the same bug, so they move over too — happy to trim those back to snapshots-only if you'd rather keep this narrow.

## 2. A background reload

`getSnapshots()` subscribes to the store, and the effects subscribe to `pool.snapshot.query` — so a snapshot created, changed or destroyed **anywhere on the system** re-emits here, and the subscription re-ran the search filter, resetting the pagination just the same.

This one matters for retesting: the repro steps call for a dataset with 100+ snapshots, which is exactly the kind of system that has periodic snapshot tasks running. Without this commit, QA could retest the checkbox fix, have a task fire mid-test, and see "snapped back to page 1" again.

**Fix:** `setFilter` takes a `keepPage` option for the case where the same query is re-run against refreshed rows. A query the user *typed* still starts at page 1, which is the right behaviour there.

## Known limitation

**Selections still don't survive a reload.** The reload rebuilds every row with `selected: false`, so a background snapshot event drops whatever the user had ticked. Retaining it is a further change and is deliberately not in this PR — say the word if you want it here rather than on master.

The equivalent work for master is truenas/webui#14057 (blocked on a `@truenas/ui-components` release), which fixes cross-page selection along with a pager bug that doesn't exist on this branch. Neither is a prerequisite for this PR.

## Testing

Three regression tests on the snapshot list, each verified to fail with its fix reverted:

- ticking a row on page 2 leaves the pager and the provider on page 2
- selecting the whole page stays on page 2 **and** every row renders checked
- a store re-emission leaves the user on page 2

561 tests pass across `ix-table`, datasets, disks, bootenv, docker-images and jobs. Lint and `yarn buildng` clean.

Original PR: https://github.com/truenas/webui/pull/14056
