### PR TITLE
NAS-143522 / 26.0.0-RC.1 / Fix premature validation error and broken help text in the Rsync Task panel (by AlexKarpov98)

### DIFF
--- a/src/app/helptext/data-protection/rsync/rsync-form.ts
+++ b/src/app/helptext/data-protection/rsync/rsync-form.ts
@@ -6,58 +6,58 @@ export const helptextRsyncForm = {
  limits which might affect how they can be used as sources or\
  destinations.'),
   rsyncUserTooltip: T('Select the user to run the rsync task. The user\
-                selected must have permissions to write to the\
-                specified directory on the remote host.'),
+ selected must have permissions to write to the\
+ specified directory on the remote host.'),
   rsyncRemotehostTooltip: T('Enter the IP address or hostname of the remote\
  system that will store the copy. Use the format\
  <i>username@remote_host</i> if the username differs\
  on the remote host.'),
   sshKeyscanTooltip: T('Scan remote host key.'),
   rsyncRemoteportTooltip: T('Enter the SSH Port of the remote system.'),
-  rsyncModeTooltip: T('Choose to either use a custom-defined remote module \
+  rsyncModeTooltip: T('Choose to either use a custom-defined remote module\
  of the rsync server or to use an SSH configuration for the rsync task.'),
   rsyncRemotemoduleTooltip: T('At least one module must be defined in <a\
-                href="https://www.samba.org/ftp/rsync/rsyncd.conf.html"\
-                target="_blank">rsyncd.conf(5)</a> of the rsync\
-                server or in the <b>Rsync Modules</b> of another\
-                system.'),
+ href="https://www.samba.org/ftp/rsync/rsyncd.conf.html"\
+ target="_blank">rsyncd.conf(5)</a> of the rsync\
+ server or in the <b>Rsync Modules</b> of another\
+ system.'),
   rsyncValidateRpathTooltip: T('Set to automatically create the defined <b>Remote\
-                Path</b> if it does not exist.'),
+ Path</b> if it does not exist.'),
   rsyncDirectionTooltip: T('Direct the flow of data to or from the remote host.'),
   rsyncPickerTooltip: T('Select a schedule preset or choose <i>Custom</i>\
-                to open the advanced scheduler.'),
+ to open the advanced scheduler.'),
   rsyncRecursiveTooltip: T('Set to include all subdirectories of the specified\
-                directory. When unset, only the specified directory\
-                is included.'),
+ directory. When unset, only the specified directory\
+ is included.'),
   rsyncTimesTooltip: T('Set to preserve modification times of files.'),
   rsyncCompressTooltip: T('Set to reduce the size of data to transmit.\
-                Recommended for slow connections.'),
+ Recommended for slow connections.'),
   rsyncArchiveTooltip: T('When set, rsync is run recursively, preserving\
-                symlinks, permissions, modification times, group,\
-                and special files. When run as root, owner, device\
-                files, and special files are also preserved.\
-                Equivalent to passing the flags <i>-rlptgoD</i> to\
-                rsync.'),
+ symlinks, permissions, modification times, group,\
+ and special files. When run as root, owner, device\
+ files, and special files are also preserved.\
+ Equivalent to passing the flags <i>-rlptgoD</i> to\
+ rsync.'),
   rsyncDeleteTooltip: T('Delete files in the destination directory\
-                that do not exist in the source directory.'),
+ that do not exist in the source directory.'),
   rsyncQuietTooltip: T('Set to suppress informational messages from the\
-                remote server.'),
+ remote server.'),
   rsyncPreservepermTooltip: T('Set to preserve original file permissions. This is\
-                useful when the user is set to <i>root</i>.'),
+ useful when the user is set to <i>root</i>.'),
   rsyncPreserveattrTooltip: T('<a href="https://en.wikipedia.org/wiki/Extended_file_attributes"\
-                target="_blank">Extended attributes</a> are\
-                preserved, but must be supported by both systems.'),
+ target="_blank">Extended attributes</a> are\
+ preserved, but must be supported by both systems.'),
   rsyncDelayupdatesTooltip: T('Set to save the temporary file from each updated\
-                file to a holding directory until the end of the\
-                transfer when all transferred files are renamed\
-                into place.'),
-  rsyncExtraTooltip: T('Additional \
-     <a href="https://download.samba.org/pub/rsync/rsync.1" target="_blank">rsync(1)</a> \
-     options to include. Separate entries by pressing <code>Enter</code>.<br> \
-     Note: The "*" character must be escaped with a backslash (\\*.txt) or used \
-     inside single quotes (\'*.txt\').'),
-  rsyncSshConnectModeTooltip: T('Choose to connect using either SSH private key stored \
-  in user\'s home directory or SSH connection from the keychain'),
-  rsyncSshCredentialsTooltip: T('Select an existing SSH connection to a remote system or \
-  choose Create New to create a new SSH connection.'),
+ file to a holding directory until the end of the\
+ transfer when all transferred files are renamed\
+ into place.'),
+  rsyncExtraTooltip: T('Additional\
+ <a href="https://download.samba.org/pub/rsync/rsync.1" target="_blank">rsync(1)</a>\
+ options to include. Separate entries by pressing <code>Enter</code>.<br>\
+ Note: The "*" character must be escaped with a backslash (\\*.txt) or used\
+ inside single quotes (\'*.txt\').'),
+  rsyncSshConnectModeTooltip: T('Choose to connect using either SSH private key stored\
+ in user\'s home directory or SSH connection from the keychain'),
+  rsyncSshCredentialsTooltip: T('Select an existing SSH connection to a remote system or\
+ choose Create New to create a new SSH connection.'),
 };

--- a/src/app/modules/forms/ix-forms/components/ix-group-chips/ix-group-chips.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-group-chips/ix-group-chips.component.ts
@@ -7,6 +7,7 @@ import { ChipsProvider } from 'app/modules/forms/ix-forms/components/ix-chips/ch
 import { IxChipsComponent } from 'app/modules/forms/ix-forms/components/ix-chips/ix-chips.component';
 import { registeredDirectiveConfig } from 'app/modules/forms/ix-forms/directives/registered-control.directive';
 import { defaultDebounceTimeMs } from 'app/modules/forms/ix-forms/ix-forms.constants';
+import { attachAsyncValidator } from 'app/modules/forms/ix-forms/validators/attach-async-validator';
 import { UserGroupExistenceValidationService } from 'app/modules/forms/ix-forms/validators/user-group-existence-validation.service';
 import { TranslatedString } from 'app/modules/translate/translate.helper';
 import { UserService } from 'app/services/user.service';
@@ -66,12 +67,13 @@ export class IxGroupChipsComponent implements AfterViewInit, ControlValueAccesso
     // so validation is always needed to ensure typed groups exist.
     const control = this.controlDirective.control;
     if (control) {
-      control.addAsyncValidators([
-        this.existenceValidator.validateGroupsExist(this.debounceTime()),
-      ]);
-      // Don't call updateValueAndValidity() here to avoid showing validation errors
-      // immediately on form load. Validation will run automatically when the user
-      // interacts with the field or when the form is submitted.
+      // Attached silently: `addAsyncValidators()` would route through the
+      // `@ngneat/reactive-forms` override of `setAsyncValidators`, which runs
+      // `updateValueAndValidity()` and so emits a status change. On an untouched,
+      // empty, required control that emission is enough for `ix-errors` to render
+      // "<field> is required" before the user has reached the field (NAS-143522).
+      // Validation still runs when the user edits the field or the form is submitted.
+      attachAsyncValidator(control, this.existenceValidator.validateGroupsExist(this.debounceTime()));
     }
   }
 

--- a/src/app/modules/forms/ix-forms/components/ix-group-combobox/ix-group-combobox.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-group-combobox/ix-group-combobox.component.ts
@@ -6,6 +6,7 @@ import { GroupComboboxProvider } from 'app/modules/forms/ix-forms/classes/group-
 import { IxComboboxComponent } from 'app/modules/forms/ix-forms/components/ix-combobox/ix-combobox.component';
 import { registeredDirectiveConfig } from 'app/modules/forms/ix-forms/directives/registered-control.directive';
 import { defaultDebounceTimeMs } from 'app/modules/forms/ix-forms/ix-forms.constants';
+import { attachAsyncValidator } from 'app/modules/forms/ix-forms/validators/attach-async-validator';
 import { UserGroupExistenceValidationService } from 'app/modules/forms/ix-forms/validators/user-group-existence-validation.service';
 import { TranslatedString } from 'app/modules/translate/translate.helper';
 import { UserService } from 'app/services/user.service';
@@ -62,12 +63,13 @@ export class IxGroupComboboxComponent implements AfterViewInit, ControlValueAcce
     // suggestions which are guaranteed to exist, making validation redundant.
     const control = this.controlDirective.control;
     if (control && this.allowCustomValue()) {
-      control.addAsyncValidators([
-        this.existenceValidator.validateGroupExists(this.debounceTime()),
-      ]);
-      // Don't call updateValueAndValidity() here to avoid showing validation errors
-      // immediately on form load. Validation will run automatically when the user
-      // interacts with the field or when the form is submitted.
+      // Attached silently: `addAsyncValidators()` would route through the
+      // `@ngneat/reactive-forms` override of `setAsyncValidators`, which runs
+      // `updateValueAndValidity()` and so emits a status change. On an untouched,
+      // empty, required control that emission is enough for `ix-errors` to render
+      // "<field> is required" before the user has reached the field (NAS-143522).
+      // Validation still runs when the user edits the field or the form is submitted.
+      attachAsyncValidator(control, this.existenceValidator.validateGroupExists(this.debounceTime()));
     }
   }
 

--- a/src/app/modules/forms/ix-forms/components/ix-user-chips/ix-user-chips.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-user-chips/ix-user-chips.component.ts
@@ -7,6 +7,7 @@ import { ChipsProvider } from 'app/modules/forms/ix-forms/components/ix-chips/ch
 import { IxChipsComponent } from 'app/modules/forms/ix-forms/components/ix-chips/ix-chips.component';
 import { registeredDirectiveConfig } from 'app/modules/forms/ix-forms/directives/registered-control.directive';
 import { defaultDebounceTimeMs } from 'app/modules/forms/ix-forms/ix-forms.constants';
+import { attachAsyncValidator } from 'app/modules/forms/ix-forms/validators/attach-async-validator';
 import { UserGroupExistenceValidationService } from 'app/modules/forms/ix-forms/validators/user-group-existence-validation.service';
 import { TranslatedString } from 'app/modules/translate/translate.helper';
 import { UserService } from 'app/services/user.service';
@@ -66,12 +67,13 @@ export class IxUserChipsComponent implements AfterViewInit, ControlValueAccessor
     // so validation is always needed to ensure typed users exist.
     const control = this.controlDirective.control;
     if (control) {
-      control.addAsyncValidators([
-        this.existenceValidator.validateUsersExist(this.debounceTime()),
-      ]);
-      // Don't call updateValueAndValidity() here to avoid showing validation errors
-      // immediately on form load. Validation will run automatically when the user
-      // interacts with the field or when the form is submitted.
+      // Attached silently: `addAsyncValidators()` would route through the
+      // `@ngneat/reactive-forms` override of `setAsyncValidators`, which runs
+      // `updateValueAndValidity()` and so emits a status change. On an untouched,
+      // empty, required control that emission is enough for `ix-errors` to render
+      // "<field> is required" before the user has reached the field (NAS-143522).
+      // Validation still runs when the user edits the field or the form is submitted.
+      attachAsyncValidator(control, this.existenceValidator.validateUsersExist(this.debounceTime()));
     }
   }
 

--- a/src/app/modules/forms/ix-forms/components/ix-user-combobox/ix-user-combobox.component.spec.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-user-combobox/ix-user-combobox.component.spec.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormControl } from '@ngneat/reactive-forms';
 import { createComponentFactory, Spectator, mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { mockApi } from 'app/core/testing/utils/mock-api.utils';
@@ -16,7 +17,9 @@ import { UserService } from 'app/services/user.service';
   imports: [IxUserComboboxComponent, ReactiveFormsModule],
 })
 class TestHostComponent {
-  control = new FormControl<string>('');
+  // `@ngneat/reactive-forms`, like every real form in the app: its `setAsyncValidators`
+  // override is what made attaching the existence validator emit a status change.
+  control = new FormControl<string>('', Validators.required);
   label = 'Test User' as TranslatedString;
 }
 
@@ -48,5 +51,18 @@ describe('IxUserComboboxComponent', () => {
   it('renders combobox input', () => {
     const input = spectator.query('input');
     expect(input).toExist();
+  });
+
+  // NAS-143522: "Add Rsync Task" opened with "User is required" already in red. Attaching
+  // the existence validator emitted a status change, which ix-errors turned into a visible
+  // message — and marked the untouched control touched on the way.
+  it('does not surface a validation error before the field is interacted with', () => {
+    expect(spectator.component.control.touched).toBe(false);
+    expect(spectator.component.control.dirty).toBe(false);
+    expect(spectator.query('.form-error')).not.toExist();
+  });
+
+  it('still attaches the user existence validator', () => {
+    expect(spectator.component.control.asyncValidator).toBeTruthy();
   });
 });

--- a/src/app/modules/forms/ix-forms/components/ix-user-combobox/ix-user-combobox.component.ts
+++ b/src/app/modules/forms/ix-forms/components/ix-user-combobox/ix-user-combobox.component.ts
@@ -6,6 +6,7 @@ import { UserComboboxProvider } from 'app/modules/forms/ix-forms/classes/user-co
 import { IxComboboxComponent } from 'app/modules/forms/ix-forms/components/ix-combobox/ix-combobox.component';
 import { registeredDirectiveConfig } from 'app/modules/forms/ix-forms/directives/registered-control.directive';
 import { defaultDebounceTimeMs } from 'app/modules/forms/ix-forms/ix-forms.constants';
+import { attachAsyncValidator } from 'app/modules/forms/ix-forms/validators/attach-async-validator';
 import { UserGroupExistenceValidationService } from 'app/modules/forms/ix-forms/validators/user-group-existence-validation.service';
 import { TranslatedString } from 'app/modules/translate/translate.helper';
 import { UserService } from 'app/services/user.service';
@@ -62,12 +63,13 @@ export class IxUserComboboxComponent implements AfterViewInit, ControlValueAcces
     // suggestions which are guaranteed to exist, making validation redundant.
     const control = this.controlDirective.control;
     if (control && this.allowCustomValue()) {
-      control.addAsyncValidators([
-        this.existenceValidator.validateUserExists(this.debounceTime()),
-      ]);
-      // Don't call updateValueAndValidity() here to avoid showing validation errors
-      // immediately on form load. Validation will run automatically when the user
-      // interacts with the field or when the form is submitted.
+      // Attached silently: `addAsyncValidators()` would route through the
+      // `@ngneat/reactive-forms` override of `setAsyncValidators`, which runs
+      // `updateValueAndValidity()` and so emits a status change. On an untouched,
+      // empty, required control that emission is enough for `ix-errors` to render
+      // "<field> is required" before the user has reached the field (NAS-143522).
+      // Validation still runs when the user edits the field or the form is submitted.
+      attachAsyncValidator(control, this.existenceValidator.validateUserExists(this.debounceTime()));
     }
   }
 

--- a/src/app/modules/forms/ix-forms/validators/attach-async-validator.ts
+++ b/src/app/modules/forms/ix-forms/validators/attach-async-validator.ts
@@ -1,0 +1,37 @@
+import { AbstractControl, AsyncValidatorFn } from '@angular/forms';
+
+/**
+ * `@ngneat/reactive-forms` widens `setAsyncValidators` with an options argument
+ * that Angular's own signature does not carry. Angular's implementation ignores
+ * extra arguments, so passing it is safe for either control.
+ */
+type SetAsyncValidatorsWithOptions = (
+  validators: AsyncValidatorFn[],
+  options?: { emitEvent?: boolean },
+) => void;
+
+/**
+ * Adds an async validator to `control` without the attachment itself counting as
+ * a validation event.
+ *
+ * `AbstractControl.addAsyncValidators()` looks like it should be inert — Angular's
+ * own version only stores the validator. But `@ngneat/reactive-forms` (which every
+ * form built through its `FormBuilder` uses) overrides `setAsyncValidators` to also
+ * run `updateValueAndValidity()`, and `addAsyncValidators` routes through that
+ * override with no options. So merely attaching a validator emits a status change.
+ *
+ * On an untouched, empty, required control that emission is enough for `ix-errors`
+ * to mark the control touched and render "<field> is required" — before the user
+ * has reached the field at all. That is NAS-143522: opening "Add Rsync Task" showed
+ * the error under User, and only under User, because it is the one field whose
+ * component attaches an async validator on init.
+ *
+ * Passing `{ emitEvent: false }` keeps the validator attached and the control's
+ * validity up to date while leaving `statusChanges` silent, which is what the
+ * call sites always intended.
+ */
+export function attachAsyncValidator(control: AbstractControl, validator: AsyncValidatorFn): void {
+  const validators = control.asyncValidator ? [control.asyncValidator, validator] : [validator];
+
+  (control.setAsyncValidators as SetAsyncValidatorsWithOptions)(validators, { emitEvent: false });
+}

--- a/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.spec.ts
+++ b/src/app/pages/data-protection/rsync-task/rsync-task-form/rsync-task-form.component.spec.ts
@@ -1,4 +1,4 @@
-import { HarnessLoader } from '@angular/cdk/testing';
+import { HarnessLoader, parallel } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
@@ -20,6 +20,7 @@ import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harnes
 import { LocaleService } from 'app/modules/language/locale.service';
 import { SlideIn } from 'app/modules/slide-ins/slide-in';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
+import { TooltipHarness } from 'app/modules/tooltip/tooltip.harness';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { FilesystemService } from 'app/services/filesystem.service';
 import { UserService } from 'app/services/user.service';
@@ -168,6 +169,27 @@ describe('RsyncTaskFormComponent', () => {
         user: 'steven',
       }]);
       expect(slideInRef.close).toHaveBeenCalledWith({ response: existingTask });
+    });
+
+    // NAS-143522: the panel opened with "User is required" already in red, before the user
+    // had reached the field. Errors must wait for the control to be dirty or touched.
+    it('shows no validation errors before the user interacts with the form', async () => {
+      const errors = await parallel(() => spectator.queryAll('ix-errors .form-error')
+        .map((element) => Promise.resolve(element.textContent?.trim())));
+
+      expect(errors.filter(Boolean)).toEqual([]);
+      expect(spectator.component.form.controls.user.touched).toBe(false);
+      expect(spectator.component.form.controls.user.dirty).toBe(false);
+    });
+
+    // NAS-143522: the help bubbles rendered with runs of blank space mid-sentence, from
+    // line-continuation indentation baked into the helptext strings.
+    it('renders help text without whitespace artifacts', async () => {
+      const tooltips = await loader.getAllHarnesses(TooltipHarness);
+      const messages = await parallel(() => tooltips.map((tooltip) => tooltip.getMessage()));
+
+      expect(messages.length).toBeGreaterThan(0);
+      expect(messages.filter((message) => /\s{2}|\n/.test(message))).toEqual([]);
     });
   });
 


### PR DESCRIPTION
### Problem

Opening **Add Rsync Task** on 26.0.0-RC.1 shows two defects on the same screen:

1. **"User is required"** renders in red immediately, before the user has touched the field.
2. Several help bubbles (User, Remote Module Name, Schedule, Recursive, More Options) render with runs of blank space mid-sentence.

Both reproduce on `stable/26`; neither reproduces on `master`.

### Issue 1 — premature validation error

`ix-user-combobox` attaches its existence validator in `ngAfterViewInit` and carries a comment saying it deliberately skips `updateValueAndValidity()` "to avoid showing validation errors immediately on form load". That intent was silently defeated:

```
IxUserComboboxComponent.ngAfterViewInit
  → FormControl.addAsyncValidators          @angular/forms
    → FormControl.setAsyncValidators        @ngneat/reactive-forms  ← override
      → updateValueAndValidity()            @angular/forms
        → statusChanges.emit()
          → IxErrorsComponent.handleErrors
            → markAllAsTouched()            → the error becomes visible
```

`@ngneat/reactive-forms` overrides `setAsyncValidators` to also run `updateValueAndValidity()`, and Angular's `addAsyncValidators()` routes through that override **with no options** — so merely attaching a validator emits a status change. `IxErrorsComponent.handleErrors()` turns any non-PENDING emission into a message and marks the control touched on the way.

Only **User** was affected because it is the one field on this panel whose component attaches an async validator on init.

**Fix:** a new `attachAsyncValidator()` helper that recomposes `control.asyncValidator` and calls `setAsyncValidators(v, { emitEvent: false })` — making the existing comment true. The same bug was present in `ix-group-combobox`, `ix-user-chips` and `ix-group-chips`, so all four call sites are fixed. Angular-native controls ignore the extra argument and never emitted anyway, so it is safe for both control types.

### Issue 2 — help text

The rsync helptext strings used line continuations indented to match the source, so the indentation survived into the string, and `ix-tooltip` renders with `white-space: pre-wrap`. Normalized to single spaces — the same change made on `master` by NAS-140058.

> **Note for the reviewer:** 16 of these strings are translation keys, so this PR deliberately leaves `src/assets/i18n/` untouched. Locales that had them translated (ru, fr, ja, de and 12 others) fall back to English on those tooltips until the next extract.

### Verification

Reproduced and verified in a real browser against a live system, not only in Jest:

- Panel opens with zero visible errors; all 17 tooltip messages come back free of whitespace runs.
- Validation still works: a non-existent name reports `User "..." does not exist`, and a real user clears it.
- Baseline check — blurring an empty required field never showed an error for *any* field on this form, so User now behaves like its siblings rather than losing feedback.

### Tests

Three regression tests, each confirmed to fail without the fix:

- `ix-user-combobox` — no error before interaction, and the validator is still attached. The host uses an `@ngneat/reactive-forms` `FormControl`, since Angular's own does not reproduce the bug.
- `rsync-task-form` — no visible errors on load; no `\s{2}` or newline in any rendered tooltip.

27 specs pass across the four pickers and rsync-task; lint clean.


Original PR: https://github.com/truenas/webui/pull/14090
