### PR TITLE
NAS-143514 / 27.0.0-BETA.1 / Follow S3 managed root dataset, bucket-managing access keys and last-used tracking

### DIFF
--- a/src/app/helptext/sharing/s3/s3.ts
+++ b/src/app/helptext/sharing/s3/s3.ts
@@ -52,11 +52,17 @@ export const helptextSharingS3 = {
   regionTooltip: T('Region name echoed to clients. Leave empty to accept whatever a client signs for.'),
   logLevelTooltip: T('Least serious log record the S3 service keeps. <b>Info</b> adds one record per request.'),
   defaultAuditTooltip: T('Actions audited on every bucket that does not set its own audit mask.'),
+  managedRootDatasetTooltip: T('Dataset under which a bucket created by an S3 client (CreateBucket) gets a\
+ dataset of its own, named after the bucket. The dataset must already exist. Leave empty to refuse\
+ CreateBucket requests. Buckets added here choose their own parent dataset.'),
 
   accessKeyNameTooltip: T('Human-readable name for the access key.'),
   accessKeyUsernameTooltip: T('Account the access key belongs to. The S3 service runs requests signed with this\
  key as that account.'),
   accessKeyEnabledTooltip: T('A disabled key is refused by the S3 service.'),
+  accessKeyManageBucketsTooltip: T('Let clients signing with this key create and delete buckets through the S3\
+ protocol. The account must hold the SHARING_S3_WRITE role. Creating needs a managed root dataset on the S3\
+ service. Other keys of the same account are not affected.'),
 
   deleteBucketMessage: T('The bucket\'s dataset and every object in it are left in place.\
  The S3 service simply stops serving them.'),

--- a/src/app/interfaces/s3.interface.ts
+++ b/src/app/interfaces/s3.interface.ts
@@ -49,6 +49,11 @@ export interface S3Config {
   default_audit: S3AuditMask;
   default_audit_overflow: S3AuditOverflow;
   global_grants: S3GrantEntry[];
+  /**
+   * Dataset name (not a mount point) under which buckets created through the S3 protocol get their
+   * datasets. Must already exist. Empty means such CreateBucket requests are refused.
+   */
+  managed_root_dataset: string;
 }
 
 export interface S3ConfigUpdate extends Partial<Omit<S3Config, 'id' | 'global_grants'>> {
@@ -82,7 +87,10 @@ export interface S3Bucket {
 
 export interface S3BucketCreate extends Partial<Omit<S3Bucket, 'id' | 'owner_uid' | 'grants' | 'locked'>> {
   name: string;
-  dataset: string;
+  /**
+   * Omitted, the dataset is created under the service's `managed_root_dataset` and named after the bucket.
+   */
+  dataset?: string;
   owner: string;
   grants?: S3Grant[];
 }
@@ -103,6 +111,16 @@ export interface S3AccessKey {
   enabled: boolean;
   expires_at: ApiTimestamp | null;
   created_at: ApiTimestamp;
+  /**
+   * When the S3 service last accepted a request signed with this key. Reported at intervals, so a
+   * recent request may be missing for a short time. `null` if never used. Read-only.
+   */
+  last_used_at: ApiTimestamp | null;
+  /**
+   * Whether the key may create and delete buckets through the S3 protocol. Requires the owning
+   * account to hold `SHARING_S3_WRITE`, checked when turned on.
+   */
+  manage_buckets: boolean;
   status: S3AccessKeyStatus;
 }
 
@@ -113,11 +131,13 @@ export interface S3AccessKeyCreate {
   expires_at?: ApiTimestamp | null;
   access_key?: string | null;
   secret?: string | null;
+  manage_buckets?: boolean;
 }
 
 export interface S3AccessKeyUpdate {
   name?: string;
   enabled?: boolean;
   expires_at?: ApiTimestamp | null;
+  manage_buckets?: boolean;
   rotate?: boolean;
 }

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.html
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.html
@@ -36,6 +36,10 @@
       <tn-checkbox formControlName="enabled" [label]="'Enabled' | translate"></tn-checkbox>
     </tn-form-field>
 
+    <tn-form-field [tooltip]="helptext.accessKeyManageBucketsTooltip | translate">
+      <tn-checkbox formControlName="manage_buckets" [label]="'Manage Buckets' | translate"></tn-checkbox>
+    </tn-form-field>
+
     <tn-form-field>
       <tn-checkbox formControlName="nonExpiring" [label]="'Non-expiring' | translate"></tn-checkbox>
     </tn-form-field>

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
@@ -42,6 +42,7 @@ describe('S3AccessKeyFormComponent', () => {
     name: 'backup-key',
     username: 'alice',
     enabled: false,
+    manage_buckets: true,
     expires_at: { $date: parseISO('2030-01-15T00:00:00Z').getTime() },
   } as S3AccessKey;
 
@@ -95,6 +96,7 @@ describe('S3AccessKeyFormComponent', () => {
       await (await getInput('name')).setValue('backup-key');
       await setUser('alice');
       await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Non-expiring' }))).check();
+      await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Manage Buckets' }))).check();
 
       spectator.component.submit();
 
@@ -103,6 +105,7 @@ describe('S3AccessKeyFormComponent', () => {
         username: 'alice',
         enabled: true,
         expires_at: null,
+        manage_buckets: true,
       }]);
       expect(closed).toHaveBeenCalledWith(true);
       expect(spectator.inject(TnDialog).open).toHaveBeenCalledWith(
@@ -159,12 +162,14 @@ describe('S3AccessKeyFormComponent', () => {
       expect(await username.getValue()).toBe('alice');
       expect(await username.isDisabled()).toBe(true);
       expect(await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Enabled' }))).isChecked()).toBe(false);
+      expect(await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Manage Buckets' }))).isChecked()).toBe(true);
       expect(await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Non-expiring' }))).isChecked()).toBe(false);
     });
 
     it('updates the key without changing the user and does not show credentials', async () => {
       await (await getInput('name')).setValue('renamed-key');
       await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Enabled' }))).check();
+      await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Manage Buckets' }))).uncheck();
       await (await loader.getHarness(TnCheckboxHarness.with({ label: 'Non-expiring' }))).check();
 
       spectator.component.submit();
@@ -173,6 +178,7 @@ describe('S3AccessKeyFormComponent', () => {
         name: 'renamed-key',
         enabled: true,
         expires_at: null,
+        manage_buckets: false,
       }]);
       expect(spectator.inject(TnDialog).open).not.toHaveBeenCalled();
     });

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.ts
@@ -63,6 +63,9 @@ export class S3AccessKeyFormComponent extends SidePanelForm implements OnInit {
     name: ['', Validators.required],
     username: ['', Validators.required],
     enabled: [true],
+    // Off by default: the flag widens what the key may do, and middleware refuses it for an account
+    // without SHARING_S3_WRITE, with the error landing on this control.
+    manage_buckets: [false],
     // Keys expire unless the admin opts out, so a new key asks for a date up front.
     nonExpiring: [false],
     expires_at: [null as Date | null],
@@ -96,17 +99,19 @@ export class S3AccessKeyFormComponent extends SidePanelForm implements OnInit {
 
   protected onSubmit(): void {
     const {
-      name, username, enabled, nonExpiring, expires_at: expiresAtDate,
+      name, username, enabled, manage_buckets: manageBuckets, nonExpiring, expires_at: expiresAtDate,
     } = this.form.getRawValue();
     const expiresAt = (nonExpiring || !expiresAtDate) ? null : { $date: expiresAtDate.getTime() };
     const accessKey = this.accessKey();
 
     let request$: Observable<S3AccessKey>;
     if (accessKey) {
-      request$ = this.api.call('s3.accesskey.update', [accessKey.id, { name, enabled, expires_at: expiresAt }]);
+      request$ = this.api.call('s3.accesskey.update', [accessKey.id, {
+        name, enabled, expires_at: expiresAt, manage_buckets: manageBuckets,
+      }]);
     } else {
       request$ = this.api.call('s3.accesskey.create', [{
-        name, username, enabled, expires_at: expiresAt,
+        name, username, enabled, expires_at: expiresAt, manage_buckets: manageBuckets,
       }]);
     }
 
@@ -136,6 +141,7 @@ export class S3AccessKeyFormComponent extends SidePanelForm implements OnInit {
       name: key.name,
       username: key.username ?? '',
       enabled: key.enabled,
+      manage_buckets: key.manage_buckets,
       nonExpiring: !key.expires_at?.$date,
       expires_at: key.expires_at?.$date ? new Date(key.expires_at.$date) : null,
     });

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.html
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.html
@@ -102,6 +102,26 @@
         </ng-template>
       </ng-container>
 
+      <ng-container [tnColumnDef]="'last_used_at'">
+        <ng-template tnHeaderCellDef>{{ 'Last Used' | translate }}</ng-template>
+        <ng-template let-row tnCellDef>
+          <span
+            tnTestIdType="text"
+            [tnTestId]="[('Last Used' | translate), uniqueRowTag(row), 'row-text']"
+          >{{ lastUsedLabel(row) }}</span>
+        </ng-template>
+      </ng-container>
+
+      <ng-container [tnColumnDef]="'manage_buckets'">
+        <ng-template tnHeaderCellDef>{{ 'Manage Buckets' | translate }}</ng-template>
+        <ng-template let-row tnCellDef>
+          <span
+            tnTestIdType="text"
+            [tnTestId]="[('Manage Buckets' | translate), uniqueRowTag(row), 'row-text']"
+          >{{ row.manage_buckets | yesNo }}</span>
+        </ng-template>
+      </ng-container>
+
       <ng-container [tnColumnDef]="'created_at'">
         <ng-template tnHeaderCellDef>{{ 'Created' | translate }}</ng-template>
         <ng-template let-row tnCellDef>

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.spec.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.spec.ts
@@ -3,7 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
 import {
-  TnButtonHarness, TnDialog, TnIconButtonHarness, TnMenuHarness, TnMenuTesting, TnTableHarness,
+  TnButtonHarness, TnDialog, TnIconButtonHarness, TnMenuHarness, TnMenuTesting, TnSelectHarness, TnTableHarness,
 } from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
@@ -40,6 +40,18 @@ describe('S3AccessKeyListComponent', () => {
       expires_at: null,
       last_used_at: null,
       manage_buckets: false,
+      created_at: { $date: 1700000000000 },
+    },
+    {
+      id: 2,
+      name: 'restic-key',
+      username: 'bob',
+      access_key: 'AKIAEXAMPLE67890',
+      secret: 'secret',
+      status: S3AccessKeyStatus.Enabled,
+      expires_at: null,
+      last_used_at: { $date: Date.now() - 3 * 24 * 60 * 60 * 1000 },
+      manage_buckets: true,
       created_at: { $date: 1700000000000 },
     },
   ] as S3AccessKey[];
@@ -94,7 +106,19 @@ describe('S3AccessKeyListComponent', () => {
     ]);
     expect(await table.getAllRowTexts()).toEqual([
       ['backup-key', 'alice', 'AKIAEXAMPLE12345', 'Enabled', 'Never', 'Never', ''],
+      ['restic-key', 'bob', 'AKIAEXAMPLE67890', 'Enabled', 'Never', '3 days ago', ''],
     ]);
+  });
+
+  it('shows the Manage Buckets column once it is enabled in the column picker', async () => {
+    const picker = await loader.getHarness(TnSelectHarness.with({ ancestor: 'ix-table-column-picker' }));
+    await picker.open();
+    await picker.selectOption('Manage Buckets');
+
+    expect(await table.getHeaderTexts()).toContain('Manage Buckets');
+    const rows = await table.getAllRowTexts();
+    expect(rows[0]).toContain('No');
+    expect(rows[1]).toContain('Yes');
   });
 
   it('opens the access key form when Add is pressed', async () => {

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.spec.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.spec.ts
@@ -38,6 +38,8 @@ describe('S3AccessKeyListComponent', () => {
       secret: 'secret',
       status: S3AccessKeyStatus.Enabled,
       expires_at: null,
+      last_used_at: null,
+      manage_buckets: false,
       created_at: { $date: 1700000000000 },
     },
   ] as S3AccessKey[];
@@ -88,10 +90,10 @@ describe('S3AccessKeyListComponent', () => {
 
   it('shows table rows', async () => {
     expect(await table.getHeaderTexts()).toEqual([
-      'Name', 'User', 'Access Key ID', 'Status', 'Expires On', '',
+      'Name', 'User', 'Access Key ID', 'Status', 'Expires On', 'Last Used', '',
     ]);
     expect(await table.getAllRowTexts()).toEqual([
-      ['backup-key', 'alice', 'AKIAEXAMPLE12345', 'Enabled', 'Never', ''],
+      ['backup-key', 'alice', 'AKIAEXAMPLE12345', 'Enabled', 'Never', 'Never', ''],
     ]);
   });
 

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.ts
@@ -23,6 +23,7 @@ import { DialogService } from 'app/modules/dialog/dialog.service';
 import { EmptyService } from 'app/modules/empty/empty.service';
 import { BasicSearchComponent } from 'app/modules/forms/search-input/components/basic-search/basic-search.component';
 import { LoaderService } from 'app/modules/loader/loader.service';
+import { YesNoPipe } from 'app/modules/pipes/yes-no/yes-no.pipe';
 import { FormSidePanelService } from 'app/modules/slide-ins/form-side-panel/form-side-panel.service';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { AsyncDataProvider } from 'app/modules/tn-table/classes/async-data-provider/async-data-provider';
@@ -65,6 +66,7 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
     TableActionsCellComponent,
     TnTablePagerComponent,
     IxDateComponent,
+    YesNoPipe,
     TranslateModule,
   ],
 })
@@ -141,6 +143,15 @@ export class S3AccessKeyListComponent implements OnInit {
       propertyName: 'expires_at',
     }),
     column({
+      title: this.translate.instant('Last Used'),
+      propertyName: 'last_used_at',
+    }),
+    column({
+      title: this.translate.instant('Manage Buckets'),
+      propertyName: 'manage_buckets',
+      hidden: true,
+    }),
+    column({
       title: this.translate.instant('Created'),
       propertyName: 'created_at',
       hidden: true,
@@ -171,6 +182,13 @@ export class S3AccessKeyListComponent implements OnInit {
   protected expiresLabel(row: S3AccessKey): string {
     return row.expires_at?.$date
       ? formatDistanceToNowShortened(row.expires_at.$date)
+      : this.translate.instant('Never');
+  }
+
+  /** The S3 service reports usage at intervals, so a recent request can lag here for a short time. */
+  protected lastUsedLabel(row: S3AccessKey): string {
+    return row.last_used_at?.$date
+      ? formatDistanceToNowShortened(row.last_used_at.$date)
       : this.translate.instant('Never');
   }
 

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.ts
@@ -17,6 +17,7 @@ import { EmptyType } from 'app/enums/empty-type.enum';
 import { Role } from 'app/enums/role.enum';
 import { s3AccessKeyStatusLabels } from 'app/enums/s3.enum';
 import { formatDistanceToNowShortened } from 'app/helpers/format-distance-to-now-shortened';
+import { ApiTimestamp } from 'app/interfaces/api-date.interface';
 import { S3AccessKey } from 'app/interfaces/s3.interface';
 import { IxDateComponent } from 'app/modules/dates/pipes/ix-date/ix-date.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
@@ -180,15 +181,17 @@ export class S3AccessKeyListComponent implements OnInit {
   }
 
   protected expiresLabel(row: S3AccessKey): string {
-    return row.expires_at?.$date
-      ? formatDistanceToNowShortened(row.expires_at.$date)
-      : this.translate.instant('Never');
+    return this.relativeOrNever(row.expires_at);
   }
 
   /** The S3 service reports usage at intervals, so a recent request can lag here for a short time. */
   protected lastUsedLabel(row: S3AccessKey): string {
-    return row.last_used_at?.$date
-      ? formatDistanceToNowShortened(row.last_used_at.$date)
+    return this.relativeOrNever(row.last_used_at);
+  }
+
+  private relativeOrNever(timestamp: ApiTimestamp | null): string {
+    return timestamp?.$date
+      ? formatDistanceToNowShortened(timestamp.$date)
       : this.translate.instant('Never');
   }
 

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -77,7 +77,10 @@
       [label]="'Managed Root Dataset' | translate"
       [tooltip]="helptext.managedRootDatasetTooltip | translate"
       [nodeProvider]="treeNodeProvider"
-    ></ix-explorer>
+    >
+      <!-- The root must already exist: middleware never creates it. Offer to create it here instead. -->
+      <ix-explorer-create-dataset></ix-explorer-create-dataset>
+    </ix-explorer>
   </tn-form-section>
 
   <tn-form-section [heading]="'Global Grants' | translate">

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -71,6 +71,15 @@
     </tn-form-field>
   </tn-form-section>
 
+  <tn-form-section [heading]="'Protocol-Created Buckets' | translate">
+    <ix-explorer
+      formControlName="managed_root_dataset"
+      [label]="'Managed Root Dataset' | translate"
+      [tooltip]="helptext.managedRootDatasetTooltip | translate"
+      [nodeProvider]="treeNodeProvider"
+    ></ix-explorer>
+  </tn-form-section>
+
   <tn-form-section [heading]="'Global Grants' | translate">
     <ix-s3-grants-list
       [formArray]="form.controls.global_grants"

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -72,10 +72,15 @@
   </tn-form-section>
 
   <tn-form-section [heading]="'Protocol-Created Buckets' | translate">
+    <!--
+      Dataset names, not mount points: the empty root keeps the explorer in that space, so a dataset
+      created from the picker comes back as `tank/s3` rather than `/mnt/tank/s3`.
+    -->
     <ix-explorer
       formControlName="managed_root_dataset"
       [label]="'Managed Root Dataset' | translate"
       [tooltip]="helptext.managedRootDatasetTooltip | translate"
+      [rootNodes]="emptyRootNode"
       [nodeProvider]="treeNodeProvider"
     >
       <!-- The root must already exist: middleware never creates it. Offer to create it here instead. -->

--- a/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
@@ -15,6 +15,9 @@ import {
 import { Certificate } from 'app/interfaces/certificate.interface';
 import { S3Config } from 'app/interfaces/s3.interface';
 import { User } from 'app/interfaces/user.interface';
+import {
+  ExplorerCreateDatasetComponent,
+} from 'app/modules/forms/ix-forms/components/ix-explorer/explorer-create-dataset/explorer-create-dataset.component';
 import { IxExplorerHarness } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.harness';
 import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
@@ -145,6 +148,10 @@ describe('ServiceS3Component', () => {
       global_grants: [{ principal_type: S3PrincipalType.User, xid: 1000, access: S3Access.Deny }],
     }]);
     expect(closed).toHaveBeenCalledWith(true);
+  });
+
+  it('offers to create the managed root dataset from the explorer', () => {
+    expect(spectator.query(ExplorerCreateDatasetComponent)).toBeTruthy();
   });
 
   it('rejects the /mnt root as the managed root dataset', async () => {

--- a/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
@@ -15,9 +15,12 @@ import {
 import { Certificate } from 'app/interfaces/certificate.interface';
 import { S3Config } from 'app/interfaces/s3.interface';
 import { User } from 'app/interfaces/user.interface';
+import { IxExplorerHarness } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.harness';
 import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
+import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ServiceS3Component } from 'app/pages/services/components/service-s3/service-s3.component';
+import { DatasetService } from 'app/services/dataset/dataset.service';
 import { SystemGeneralService } from 'app/services/system-general.service';
 import { selectLicense } from 'app/store/system-info/system-info.selectors';
 
@@ -35,6 +38,7 @@ describe('ServiceS3Component', () => {
     log_level: S3LogLevel.Notice,
     default_audit: [],
     default_audit_overflow: S3AuditOverflow.Drop,
+    managed_root_dataset: 'tank/s3',
     global_grants: [
       {
         principal_type: S3PrincipalType.User, xid: 1000, name: 'alice', access: S3Access.Deny,
@@ -71,6 +75,9 @@ describe('ServiceS3Component', () => {
       mockProvider(SystemGeneralService, {
         getCertificates: () => of([{ id: 5, name: 's3-cert' }] as Certificate[]),
       }),
+      mockProvider(DatasetService, {
+        getDatasetNodeProvider: () => () => of([]),
+      }),
       mockProvider(TnDialog, {
         open: jest.fn(() => ({ closed: of(true) })),
       }),
@@ -98,6 +105,8 @@ describe('ServiceS3Component', () => {
     expect(await (await getInput('servers')).getValue()).toBe('2');
     expect(await (await getInput('region')).getValue()).toBe('us-east-1');
     expect(await (await getSelect('log_level')).getDisplayText()).toBe('Notice');
+    const form = await loader.getHarness(IxFormHarness);
+    expect(await form.getValues()).toMatchObject({ 'Managed Root Dataset': 'tank/s3' });
 
     expect(await (await getSelect('principal_type')).getDisplayText()).toBe('User');
     const principal = await loader.getHarness(TnAutocompleteHarness);
@@ -109,6 +118,8 @@ describe('ServiceS3Component', () => {
     await (await getInput('servers')).setValue('4');
     await (await getInput('region')).setValue('eu-west-1');
     await (await getSelect('log_level')).selectOption('Info');
+    const form = await loader.getHarness(IxFormHarness);
+    await form.fillForm({ 'Managed Root Dataset': 'tank/buckets' });
 
     const listeners = await loader.getHarness(TnFormListHarness.with({ label: 'Listen Addresses' }));
     await listeners.add();
@@ -130,8 +141,17 @@ describe('ServiceS3Component', () => {
       servers: 4,
       region: 'eu-west-1',
       log_level: S3LogLevel.Info,
+      managed_root_dataset: 'tank/buckets',
       global_grants: [{ principal_type: S3PrincipalType.User, xid: 1000, access: S3Access.Deny }],
     }]);
     expect(closed).toHaveBeenCalledWith(true);
+  });
+
+  it('rejects the /mnt root as the managed root dataset', async () => {
+    const explorer = await loader.getHarness(IxExplorerHarness.with({ label: 'Managed Root Dataset' }));
+    await explorer.setValue('/mnt');
+
+    expect(await explorer.getErrorText()).toBe('Select a pool or dataset. The /mnt directory itself is not a dataset.');
+    expect(spectator.component.canSubmit()).toBe(false);
   });
 });

--- a/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
@@ -7,6 +7,7 @@ import {
   TnAutocompleteHarness, TnCheckboxHarness, TnDialog, TnFormListHarness, TnInputHarness, TnSelectHarness,
 } from '@truenas/ui-components';
 import { of } from 'rxjs';
+import { emptyRootNode } from 'app/constants/basic-root-nodes.constant';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
 import { mockAuth } from 'app/core/testing/utils/mock-auth.utils';
 import {
@@ -18,7 +19,7 @@ import { User } from 'app/interfaces/user.interface';
 import {
   ExplorerCreateDatasetComponent,
 } from 'app/modules/forms/ix-forms/components/ix-explorer/explorer-create-dataset/explorer-create-dataset.component';
-import { IxExplorerHarness } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.harness';
+import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
 import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
 import { ApiService } from 'app/modules/websocket/api.service';
@@ -150,15 +151,10 @@ describe('ServiceS3Component', () => {
     expect(closed).toHaveBeenCalledWith(true);
   });
 
-  it('offers to create the managed root dataset from the explorer', () => {
+  it('offers to create the managed root dataset from a dataset-name explorer', () => {
     expect(spectator.query(ExplorerCreateDatasetComponent)).toBeTruthy();
-  });
-
-  it('rejects the /mnt root as the managed root dataset', async () => {
-    const explorer = await loader.getHarness(IxExplorerHarness.with({ label: 'Managed Root Dataset' }));
-    await explorer.setValue('/mnt');
-
-    expect(await explorer.getErrorText()).toBe('Select a pool or dataset. The /mnt directory itself is not a dataset.');
-    expect(spectator.component.canSubmit()).toBe(false);
+    // The empty root keeps the explorer in dataset-name space, so the path a created dataset comes
+    // back with is stripped of /mnt before it lands in the control (see IxExplorerComponent).
+    expect(spectator.query(IxExplorerComponent)!.rootNodes()).toEqual([emptyRootNode]);
   });
 });

--- a/src/app/pages/services/components/service-s3/service-s3.component.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.ts
@@ -31,15 +31,18 @@ import { S3AuditMask, S3Config, S3Listener } from 'app/interfaces/s3.interface';
 import {
   WithManageCertificatesLinkComponent,
 } from 'app/modules/forms/controls/with-manage-certificates-link/with-manage-certificates-link.component';
+import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
 import { IxFormHostForm } from 'app/modules/forms/ix-forms/components/ix-form/ix-form-host-form.directive';
 import {
   FormSubmitEvent, IxFormComponent, SubmitResult,
 } from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
+import { IxValidatorsService } from 'app/modules/forms/ix-forms/services/ix-validators.service';
 import { portRangeValidator, rangeValidator } from 'app/modules/forms/ix-forms/validators/range-validation/range-validation';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { serviceConfigSavedMessage } from 'app/pages/services/components/service-config-forms.constants';
 import { createS3GrantFormGroup, S3GrantFormGroup, toS3Grants } from 'app/pages/sharing/s3/s3-grants-list/s3-grant-form-group';
 import { S3GrantsListComponent } from 'app/pages/sharing/s3/s3-grants-list/s3-grants-list.component';
+import { DatasetService } from 'app/services/dataset/dataset.service';
 import { SystemGeneralService } from 'app/services/system-general.service';
 import { AppState } from 'app/store';
 import { selectLicense } from 'app/store/system-info/system-info.selectors';
@@ -55,13 +58,25 @@ const defaultPort = 9000;
 // Built here rather than inline in the component, and left with an inferred return type — see
 // the `V` type parameter on IxFormHostForm for why.
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function createS3ServiceForm(fb: NonNullableFormBuilder) {
+function createS3ServiceForm(
+  fb: NonNullableFormBuilder,
+  validatorsService: IxValidatorsService,
+  translate: TranslateService,
+) {
   return fb.group({
     listeners: fb.array<ListenerFormGroup>([]),
     certificate: [null as number | null],
     servers: [1, [Validators.required, rangeValidator(1, 8)]],
     region: [''],
     log_level: [S3LogLevel.Notice, Validators.required],
+    // Optional: empty refuses S3 protocol CreateBucket requests. The explorer offers the /mnt root
+    // as a node, and a dataset name never starts with a slash, so that is the one selection to refuse.
+    managed_root_dataset: ['', [
+      validatorsService.customValidator(
+        (control) => !String(control.value ?? '').startsWith('/'),
+        translate.instant('Select a pool or dataset. The /mnt directory itself is not a dataset.'),
+      ),
+    ]],
     global_grants: fb.array<S3GrantFormGroup>([]),
     default_audit_mode: [S3AuditMode.None],
     default_audit_actions: [[] as string[]],
@@ -86,6 +101,7 @@ type S3ServiceFormValue = ReturnType<ReturnType<typeof createS3ServiceForm>['get
     TnFormListComponent,
     TnFormListItemComponent,
     WithManageCertificatesLinkComponent,
+    IxExplorerComponent,
     S3GrantsListComponent,
     TranslateModule,
   ],
@@ -94,7 +110,9 @@ export class ServiceS3Component extends IxFormHostForm<boolean, S3ServiceFormVal
   private api = inject(ApiService);
   private fb = inject(NonNullableFormBuilder);
   private translate = inject(TranslateService);
+  private validatorsService = inject(IxValidatorsService);
   private systemGeneralService = inject(SystemGeneralService);
+  private datasetService = inject(DatasetService);
   private store$ = inject(Store<AppState>);
 
   protected readonly requiredRoles = [Role.SharingS3Write, Role.SharingWrite];
@@ -107,7 +125,9 @@ export class ServiceS3Component extends IxFormHostForm<boolean, S3ServiceFormVal
    */
   protected readonly isLicensed = toSignal(this.store$.select(selectLicense).pipe(map((license) => !!license)));
 
-  protected readonly form = createS3ServiceForm(this.fb);
+  protected readonly form = createS3ServiceForm(this.fb, this.validatorsService, this.translate);
+
+  protected readonly treeNodeProvider = this.datasetService.getDatasetNodeProvider();
 
   /**
    * Listener rows are pushed after first render (once `s3.config` resolves) into an array whose
@@ -194,6 +214,7 @@ export class ServiceS3Component extends IxFormHostForm<boolean, S3ServiceFormVal
       servers: values.servers,
       region: values.region,
       log_level: values.log_level,
+      managed_root_dataset: values.managed_root_dataset,
       global_grants: toS3Grants(this.form.controls.global_grants.controls),
       ...(this.isLicensed()
         ? {
@@ -221,6 +242,7 @@ export class ServiceS3Component extends IxFormHostForm<boolean, S3ServiceFormVal
       servers: config.servers,
       region: config.region,
       log_level: config.log_level,
+      managed_root_dataset: config.managed_root_dataset,
       default_audit_mode: auditMode,
       default_audit_actions: auditActions,
       default_audit_overflow: config.default_audit_overflow,

--- a/src/app/pages/services/components/service-s3/service-s3.component.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.ts
@@ -14,6 +14,7 @@ import {
 import {
   combineLatest, map, shareReplay, startWith,
 } from 'rxjs';
+import { emptyRootNode } from 'app/constants/basic-root-nodes.constant';
 import { Role } from 'app/enums/role.enum';
 import {
   S3AuditMode,
@@ -39,7 +40,6 @@ import { IxFormHostForm } from 'app/modules/forms/ix-forms/components/ix-form/ix
 import {
   FormSubmitEvent, IxFormComponent, SubmitResult,
 } from 'app/modules/forms/ix-forms/components/ix-form/ix-form.component';
-import { IxValidatorsService } from 'app/modules/forms/ix-forms/services/ix-validators.service';
 import { portRangeValidator, rangeValidator } from 'app/modules/forms/ix-forms/validators/range-validation/range-validation';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { serviceConfigSavedMessage } from 'app/pages/services/components/service-config-forms.constants';
@@ -61,25 +61,15 @@ const defaultPort = 9000;
 // Built here rather than inline in the component, and left with an inferred return type — see
 // the `V` type parameter on IxFormHostForm for why.
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function createS3ServiceForm(
-  fb: NonNullableFormBuilder,
-  validatorsService: IxValidatorsService,
-  translate: TranslateService,
-) {
+function createS3ServiceForm(fb: NonNullableFormBuilder) {
   return fb.group({
     listeners: fb.array<ListenerFormGroup>([]),
     certificate: [null as number | null],
     servers: [1, [Validators.required, rangeValidator(1, 8)]],
     region: [''],
     log_level: [S3LogLevel.Notice, Validators.required],
-    // Optional: empty refuses S3 protocol CreateBucket requests. The explorer offers the /mnt root
-    // as a node, and a dataset name never starts with a slash, so that is the one selection to refuse.
-    managed_root_dataset: ['', [
-      validatorsService.customValidator(
-        (control) => !String(control.value ?? '').startsWith('/'),
-        translate.instant('Select a pool or dataset. The /mnt directory itself is not a dataset.'),
-      ),
-    ]],
+    // Optional: empty refuses S3 protocol CreateBucket requests.
+    managed_root_dataset: [''],
     global_grants: fb.array<S3GrantFormGroup>([]),
     default_audit_mode: [S3AuditMode.None],
     default_audit_actions: [[] as string[]],
@@ -114,7 +104,6 @@ export class ServiceS3Component extends IxFormHostForm<boolean, S3ServiceFormVal
   private api = inject(ApiService);
   private fb = inject(NonNullableFormBuilder);
   private translate = inject(TranslateService);
-  private validatorsService = inject(IxValidatorsService);
   private systemGeneralService = inject(SystemGeneralService);
   private datasetService = inject(DatasetService);
   private store$ = inject(Store<AppState>);
@@ -129,9 +118,10 @@ export class ServiceS3Component extends IxFormHostForm<boolean, S3ServiceFormVal
    */
   protected readonly isLicensed = toSignal(this.store$.select(selectLicense).pipe(map((license) => !!license)));
 
-  protected readonly form = createS3ServiceForm(this.fb, this.validatorsService, this.translate);
+  protected readonly form = createS3ServiceForm(this.fb);
 
   protected readonly treeNodeProvider = this.datasetService.getDatasetNodeProvider();
+  protected readonly emptyRootNode = [emptyRootNode];
 
   /**
    * Listener rows are pushed after first render (once `s3.config` resolves) into an array whose

--- a/src/app/pages/services/components/service-s3/service-s3.component.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.ts
@@ -31,6 +31,9 @@ import { S3AuditMask, S3Config, S3Listener } from 'app/interfaces/s3.interface';
 import {
   WithManageCertificatesLinkComponent,
 } from 'app/modules/forms/controls/with-manage-certificates-link/with-manage-certificates-link.component';
+import {
+  ExplorerCreateDatasetComponent,
+} from 'app/modules/forms/ix-forms/components/ix-explorer/explorer-create-dataset/explorer-create-dataset.component';
 import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
 import { IxFormHostForm } from 'app/modules/forms/ix-forms/components/ix-form/ix-form-host-form.directive';
 import {
@@ -102,6 +105,7 @@ type S3ServiceFormValue = ReturnType<ReturnType<typeof createS3ServiceForm>['get
     TnFormListItemComponent,
     WithManageCertificatesLinkComponent,
     IxExplorerComponent,
+    ExplorerCreateDatasetComponent,
     S3GrantsListComponent,
     TranslateModule,
   ],

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -16,7 +16,7 @@ import {
 } from 'app/enums/s3.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { Group } from 'app/interfaces/group.interface';
-import { S3Bucket } from 'app/interfaces/s3.interface';
+import { S3Bucket, S3Config } from 'app/interfaces/s3.interface';
 import { User } from 'app/interfaces/user.interface';
 import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
@@ -95,6 +95,7 @@ describe('S3BucketFormComponent', () => {
         mockCall('sharing.s3.update'),
         mockCall('sharing.s3.audit_choices', { GetObject: 'GetObject', PutObject: 'PutObject' }),
         mockCall('pool.filesystem_choices', ['tank', 'tank/buckets', 'tank/buckets/photos']),
+        mockCall('s3.config', { managed_root_dataset: 'tank/s3' } as S3Config),
         mockCall('user.query', [
           { username: 'alice', uid: 1000 },
           { username: 'bob', uid: 1001 },
@@ -140,6 +141,11 @@ describe('S3BucketFormComponent', () => {
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Versioning' }))).toBe(true);
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Multipart ETag' }))).toBe(true);
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Audit' }))).toBe(false);
+    });
+
+    it('starts with the parent dataset set to the service managed root dataset', async () => {
+      expect(await form.getValues()).toMatchObject({ 'Parent Dataset': 'tank/s3' });
+      expect(spectator.component.form.controls.parent_dataset.value).toBe('tank/s3');
     });
 
     it('turns versioning on and defaults to Compliance retention when object lock is enabled', async () => {

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -145,7 +145,6 @@ describe('S3BucketFormComponent', () => {
 
     it('starts with the parent dataset set to the service managed root dataset', async () => {
       expect(await form.getValues()).toMatchObject({ 'Parent Dataset': 'tank/s3' });
-      expect(spectator.component.form.controls.parent_dataset.value).toBe('tank/s3');
     });
 
     it('turns versioning on and defaults to Compliance retention when object lock is enabled', async () => {

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -282,6 +282,7 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
       this.setBucketForEdit(bucket);
     } else {
       this.setupExistingDatasetCheck();
+      this.prefillParentDataset();
     }
     this.setupObjectLockDependency();
     this.setupObjectOwnershipDependency();
@@ -319,6 +320,20 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
     // The check spans two fields, so a parent change has to re-run the name's validators.
     this.form.controls.parent_dataset.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.form.controls.name.updateValueAndValidity();
+    });
+  }
+
+  /**
+   * The service's managed root dataset is where S3 protocol CreateBucket requests put their datasets,
+   * so it is the natural default here too. Only a starting point: the field stays editable, and a
+   * parent already typed before the config arrives is kept.
+   */
+  private prefillParentDataset(): void {
+    this.api.call('s3.config').pipe(takeUntilDestroyed(this.destroyRef)).subscribe((config) => {
+      const parent = this.form.controls.parent_dataset;
+      if (config.managed_root_dataset && !parent.value) {
+        parent.setValue(config.managed_root_dataset);
+      }
     });
   }
 

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -12,7 +12,7 @@ import {
   TnInputComponent, TnSelectComponent, type TnSelectOption,
 } from '@truenas/ui-components';
 import {
-  map, merge, Observable, startWith,
+  catchError, EMPTY, map, merge, Observable, startWith,
 } from 'rxjs';
 import { Role } from 'app/enums/role.enum';
 import {
@@ -329,7 +329,11 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
    * parent already typed before the config arrives is kept.
    */
   private prefillParentDataset(): void {
-    this.api.call('s3.config').pipe(takeUntilDestroyed(this.destroyRef)).subscribe((config) => {
+    this.api.call('s3.config').pipe(
+      // A convenience only: the user can pick the parent themselves, so a failed read stays silent.
+      catchError(() => EMPTY),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((config) => {
       const parent = this.form.controls.parent_dataset;
       if (config.managed_root_dataset && !parent.value) {
         parent.setValue(config.managed_root_dataset);


### PR DESCRIPTION
Catches the UI up with middleware PR https://github.com/truenas/middleware/pull/19670 (NAS-143505), which lets the S3 protocol create and delete buckets.

- **S3 service form**: new "Protocol-Created Buckets" section with a Managed Root Dataset explorer (`managed_root_dataset`). Optional; empty refuses S3 protocol CreateBucket. Rejects the `/mnt` root like the bucket form does.
- **Access key form**: "Manage Buckets" checkbox (`manage_buckets`), off by default, sent on create and update. Middleware's SHARING_S3_WRITE check lands on that control.
- **Access key list**: "Last Used" column from the read-only `last_used_at`, plus a hidden-by-default "Manage Buckets" column.
- **Bucket form**: `dataset` is now optional on `sharing.s3.create`. The form still sends an explicit dataset, but a new bucket starts with its parent dataset prefilled from the managed root when one is set.
- `S3_BUCKET_OWNER_ENFORCED` permissions model was removed upstream; the UI never offered it, so no change.

Specs updated for all four components.