### PR TITLE
NAS-143552 / 27.0.0-BETA.1 / Follow the S3 service rename to s3

### DIFF
--- a/src/app/enums/service-name.enum.ts
+++ b/src/app/enums/service-name.enum.ts
@@ -9,7 +9,7 @@ export enum ServiceName {
   Http = 'http',
   NvmeOf = 'nvmet',
   WebShare = 'webshare',
-  S3 = 'truenas_s3',
+  S3 = 's3',
 }
 
 export const serviceNames = new Map<ServiceName, string>([

--- a/src/app/pages/sharing/components/shares-dashboard/s3-card/s3-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/s3-card/s3-card.component.html
@@ -5,25 +5,27 @@
   [headerMenu]="serviceMenu()"
   [headerMenuTriggerTestId]="headerMenuTriggerTestId()"
 >
-  <a
-    tnCardHeader
-    class="card-title-link"
-    tnTestIdType="link"
-    [tnTestId]="['s3-bucket', 'open-in-new']"
-    [routerLink]="['/sharing', 's3']"
-    [tnTooltip]="'Open S3 list in full page' | translate"
-  >
-    <h3 class="tn-card__title">
-      {{ 'Object Storage (S3) Buckets' | translate }}
-      <tn-icon
-        name="open-in-new"
-        library="mdi"
-        class="title-icon"
-        [attr.aria-label]="'Open S3 list in full page' | translate"
-      ></tn-icon>
-      <ix-card-alert-badge [menuPath]="cardMenuPath" />
-    </h3>
-  </a>
+  <div tnCardHeader class="card-header-title">
+    <a
+      class="card-title-link"
+      tnTestIdType="link"
+      [tnTestId]="['s3-bucket', 'open-in-new']"
+      [routerLink]="['/sharing', 's3']"
+      [tnTooltip]="'Open S3 list in full page' | translate"
+    >
+      <h3 class="tn-card__title">
+        {{ 'Object Storage (S3) Buckets' | translate }}
+        <tn-icon
+          name="open-in-new"
+          library="mdi"
+          class="title-icon"
+          [attr.aria-label]="'Open S3 list in full page' | translate"
+        ></tn-icon>
+        <ix-card-alert-badge [menuPath]="cardMenuPath" />
+      </h3>
+    </a>
+    <span class="experimental-badge">{{ 'Experimental' | translate }}</span>
+  </div>
 
   <ng-template tnCardHeaderActions>
     @if (service(); as service) {

--- a/src/app/pages/sharing/components/shares-dashboard/s3-card/s3-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/s3-card/s3-card.component.scss
@@ -1,8 +1,20 @@
 @import '../card-flush-table';
 @import '../card-service-toggle';
+@import '../../experimental-badge';
 
 @include card-flush-table;
 @include card-service-toggle;
+@include experimental-badge;
+
+// The badge sits outside the title link so it doesn't bloat the link's accessible name.
+.card-header-title {
+  align-items: center;
+  display: inline-flex;
+
+  .experimental-badge {
+    margin-left: 8px;
+  }
+}
 
 .card-title-link {
   color: inherit;

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.html
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.html
@@ -1,4 +1,9 @@
-<tn-card [padContent]="false" [title]="'S3 Buckets' | translate">
+<tn-card [padContent]="false">
+  <div tnCardHeader class="header-title">
+    <h3 class="tn-card__title">{{ 'S3 Buckets' | translate }}</h3>
+    <span class="experimental-badge">{{ 'Experimental' | translate }}</span>
+  </div>
+
   <ng-template tnCardHeaderActions>
     <div class="actions">
       <ix-basic-search

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.scss
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.scss
@@ -1,10 +1,18 @@
 @import '../../components/tn-table-in-card';
+@import '../../components/experimental-badge';
 
 @include tn-table-in-card;
+@include experimental-badge;
 
 :host {
   display: block;
   max-width: 1080px;
+}
+
+.header-title {
+  align-items: center;
+  display: flex;
+  gap: 8px;
 }
 
 .actions {

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
@@ -3,8 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
 import {
-  TnButtonHarness, TnCardComponent, TnIconButtonHarness, TnMenuHarness, TnMenuTesting, TnSlideToggleHarness,
-  TnTableHarness,
+  TnButtonHarness, TnIconButtonHarness, TnMenuHarness, TnMenuTesting, TnSlideToggleHarness, TnTableHarness,
 } from '@truenas/ui-components';
 import { Subject, of } from 'rxjs';
 import { mockApi, mockCall } from 'app/core/testing/utils/mock-api.utils';
@@ -79,9 +78,9 @@ describe('S3BucketListComponent', () => {
     table = await loader.getHarness(TnTableHarness);
   });
 
-  it('shows the page title', () => {
-    // White-box: no TnCardHarness in @truenas/ui-components yet.
-    expect(spectator.query(TnCardComponent)!.title()).toBe('S3 Buckets');
+  it('shows the page title with the experimental badge', () => {
+    expect(spectator.query('.tn-card__title')).toHaveText('S3 Buckets');
+    expect(spectator.query('.experimental-badge')).toHaveText('Experimental');
   });
 
   it('shows table rows', async () => {

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
@@ -5,7 +5,7 @@ import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  tnIconMarker, TnButtonComponent, TnCardComponent, TnCardHeaderActionsDirective,
+  tnIconMarker, TnButtonComponent, TnCardComponent, TnCardHeaderActionsDirective, TnCardHeaderDirective,
   TnCellDefDirective, TnEmptyComponent, TnHeaderCellDefDirective,
   TnTableColumnDirective, TnTableComponent, TnTablePagerComponent, TnTestIdDirective, TnTooltipDirective,
   type TnSortEvent,
@@ -48,6 +48,7 @@ import { poolStore } from 'app/services/global-store/stores.constant';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     TnCardComponent,
+    TnCardHeaderDirective,
     TnCardHeaderActionsDirective,
     BasicSearchComponent,
     TableColumnPickerComponent,


### PR DESCRIPTION
Two small follow-ups on the S3 sharing UI.
- **Service name**: middleware's S3 service is registered as `s3`, not `truenas_s3`. Only the `ServiceName.S3` enum value changes; every call site goes through the enum.
- **Experimental badge**: the S3 bucket list card and the shares-dashboard S3 card carry the same "Experimental" badge WebShare uses, sharing its SCSS partial. On the dashboard card the badge sits outside the title link so the link's accessible name stays clean.