### PR TITLE
NAS-143552 / 26.0.0-RC.1 / Follow the S3 service rename to s3 and mark S3 sharing as experimental

### DIFF
--- a/src/app/enums/service-name.enum.ts
+++ b/src/app/enums/service-name.enum.ts
@@ -9,7 +9,7 @@ export enum ServiceName {
   Http = 'http',
   NvmeOf = 'nvmet',
   WebShare = 'webshare',
-  S3 = 'truenas_s3',
+  S3 = 's3',
 }
 
 export const serviceNames = new Map<ServiceName, string>([

--- a/src/app/pages/sharing/components/shares-dashboard/s3-card/s3-card.component.html
+++ b/src/app/pages/sharing/components/shares-dashboard/s3-card/s3-card.component.html
@@ -17,6 +17,7 @@
           <ix-card-alert-badge [menuPath]="cardMenuPath" />
         </h3>
       </a>
+      <span class="experimental-badge">{{ 'Experimental' | translate }}</span>
 
       <ix-service-state-button
         [service]="(service$ | async) || undefined"

--- a/src/app/pages/sharing/components/shares-dashboard/s3-card/s3-card.component.scss
+++ b/src/app/pages/sharing/components/shares-dashboard/s3-card/s3-card.component.scss
@@ -1,5 +1,14 @@
+@import '../../experimental-badge';
+
+@include experimental-badge;
+
 mat-card {
   height: 100%;
+}
+
+// The badge sits outside the title link so it doesn't bloat the link's accessible name.
+.toolbar-row-title .experimental-badge {
+  margin-left: 5px;
 }
 
 .card-title {
@@ -8,6 +17,12 @@ mat-card {
 
   tn-icon {
     margin-left: 5px;
+  }
+
+  // The alert badge host keeps its 8px side margins even when it renders nothing,
+  // pushing the experimental badge too far from the title. Collapse it when empty.
+  ix-card-alert-badge:empty {
+    margin: 0;
   }
 }
 

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.html
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.html
@@ -1,7 +1,10 @@
 <mat-card>
   <ix-fake-progress-bar [loading]="!!(dataProvider.isLoading$ | async)"></ix-fake-progress-bar>
   <mat-toolbar-row>
-    <h3>{{ 'S3 Buckets' | translate }}</h3>
+    <h3>
+      {{ 'S3 Buckets' | translate }}
+      <span class="experimental-badge">{{ 'Experimental' | translate }}</span>
+    </h3>
     <div class="actions action-icon">
       <ix-basic-search
         [query]="searchQuery()"

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.scss
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.scss
@@ -1,0 +1,8 @@
+@import '../../components/experimental-badge';
+
+@include experimental-badge;
+
+h3 .experimental-badge {
+  margin-left: 4px;
+  vertical-align: middle;
+}

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.spec.ts
@@ -78,6 +78,11 @@ describe('S3BucketListComponent', () => {
     table = await loader.getHarness(IxTableHarness);
   });
 
+  it('shows the page title with the experimental badge', () => {
+    expect(spectator.query('h3')).toHaveText('S3 Buckets');
+    expect(spectator.query('.experimental-badge')).toHaveText('Experimental');
+  });
+
   it('shows table rows', async () => {
     const cells = await table.getCellTexts();
     expect(cells).toEqual([

--- a/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-list/s3-bucket-list.component.ts
@@ -50,6 +50,7 @@ import { poolStore } from 'app/services/global-store/stores.constant';
 @Component({
   selector: 'ix-s3-bucket-list',
   templateUrl: './s3-bucket-list.component.html',
+  styleUrls: ['./s3-bucket-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     MatCard,


### PR DESCRIPTION
Manual backport of #14102 to the Material-era S3 list and dashboard card (the master commit does not cherry-pick cleanly here).

- **Service name**: `ServiceName.S3` is `s3`, matching middleware. Every call site goes through the enum.
- **Experimental badge**: the S3 bucket list and the shares-dashboard S3 card carry the same "Experimental" badge WebShare has on this branch, sharing its SCSS partial and placement.