### PR TITLE
NAS-143514 / 26.0.0-RC.1 / Follow S3 managed root dataset, bucket-managing access keys and last-used tracking (by william-gr)

### DIFF
--- a/src/app/helptext/sharing/s3/s3.ts
+++ b/src/app/helptext/sharing/s3/s3.ts
@@ -53,11 +53,17 @@ export const helptextSharingS3 = {
   regionTooltip: T('Region name echoed to clients. Leave empty to accept whatever a client signs for.'),
   logLevelTooltip: T('Least serious log record the S3 service keeps. <b>Info</b> adds one record per request.'),
   defaultAuditTooltip: T('Actions audited on every bucket that does not set its own audit mask.'),
+  managedRootDatasetTooltip: T('Dataset under which a bucket created by an S3 client (CreateBucket) gets a\
+ dataset of its own, named after the bucket. The dataset must already exist. Leave empty to refuse\
+ CreateBucket requests. Buckets added here choose their own parent dataset.'),
 
   accessKeyNameTooltip: T('Human-readable name for the access key.'),
   accessKeyUsernameTooltip: T('Account the access key belongs to. The S3 service runs requests signed with this \
  key as that account.'),
   accessKeyEnabledTooltip: T('A disabled key is refused by the S3 service.'),
+  accessKeyManageBucketsTooltip: T('Let clients signing with this key create and delete buckets through the S3\
+ protocol. The account must hold the SHARING_S3_WRITE role. Creating needs a managed root dataset on the S3\
+ service. Other keys of the same account are not affected.'),
 
   deleteBucketMessage: T('The bucket\'s dataset and every object in it are left in place. \
  The S3 service simply stops serving them.'),

--- a/src/app/interfaces/s3.interface.ts
+++ b/src/app/interfaces/s3.interface.ts
@@ -49,6 +49,11 @@ export interface S3Config {
   default_audit: S3AuditMask;
   default_audit_overflow: S3AuditOverflow;
   global_grants: S3GrantEntry[];
+  /**
+   * Dataset name (not a mount point) under which buckets created through the S3 protocol get their
+   * datasets. Must already exist. Empty means such CreateBucket requests are refused.
+   */
+  managed_root_dataset: string;
 }
 
 export interface S3ConfigUpdate extends Partial<Omit<S3Config, 'id' | 'global_grants'>> {
@@ -82,7 +87,10 @@ export interface S3Bucket {
 
 export interface S3BucketCreate extends Partial<Omit<S3Bucket, 'id' | 'owner_uid' | 'grants' | 'locked'>> {
   name: string;
-  dataset: string;
+  /**
+   * Omitted, the dataset is created under the service's `managed_root_dataset` and named after the bucket.
+   */
+  dataset?: string;
   owner: string;
   grants?: S3Grant[];
 }
@@ -103,6 +111,16 @@ export interface S3AccessKey {
   enabled: boolean;
   expires_at: ApiTimestamp | null;
   created_at: ApiTimestamp;
+  /**
+   * When the S3 service last accepted a request signed with this key. Reported at intervals, so a
+   * recent request may be missing for a short time. `null` if never used. Read-only.
+   */
+  last_used_at: ApiTimestamp | null;
+  /**
+   * Whether the key may create and delete buckets through the S3 protocol. Requires the owning
+   * account to hold `SHARING_S3_WRITE`, checked when turned on.
+   */
+  manage_buckets: boolean;
   status: S3AccessKeyStatus;
 }
 
@@ -113,11 +131,13 @@ export interface S3AccessKeyCreate {
   expires_at?: ApiTimestamp | null;
   access_key?: string | null;
   secret?: string | null;
+  manage_buckets?: boolean;
 }
 
 export interface S3AccessKeyUpdate {
   name?: string;
   enabled?: boolean;
   expires_at?: ApiTimestamp | null;
+  manage_buckets?: boolean;
   rotate?: boolean;
 }

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.html
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.html
@@ -38,6 +38,12 @@
         ></ix-checkbox>
 
         <ix-checkbox
+          formControlName="manage_buckets"
+          [label]="'Manage Buckets' | translate"
+          [tooltip]="helptext.accessKeyManageBucketsTooltip | translate"
+        ></ix-checkbox>
+
+        <ix-checkbox
           formControlName="nonExpiring"
           [label]="'Non-expiring' | translate"
         ></ix-checkbox>

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.spec.ts
@@ -41,6 +41,7 @@ describe('S3AccessKeyFormComponent', () => {
     name: 'backup-key',
     username: 'alice',
     enabled: false,
+    manage_buckets: true,
     expires_at: { $date: new Date('2030-01-15T00:00:00Z').getTime() },
   } as S3AccessKey;
 
@@ -84,6 +85,7 @@ describe('S3AccessKeyFormComponent', () => {
       await form.fillForm({
         Name: 'backup-key',
         User: 'alice',
+        'Manage Buckets': true,
         'Non-expiring': true,
       });
 
@@ -95,6 +97,7 @@ describe('S3AccessKeyFormComponent', () => {
         username: 'alice',
         enabled: true,
         expires_at: null,
+        manage_buckets: true,
       }]);
       expect(spectator.inject(SlideInRef).close).toHaveBeenCalledWith({ response: true });
       expect(spectator.inject(MatDialog).open).toHaveBeenCalledWith(
@@ -126,6 +129,7 @@ describe('S3AccessKeyFormComponent', () => {
         username: 'alice',
         enabled: true,
         expires_at: { $date: Date.UTC(2030, 0, 15) },
+        manage_buckets: false,
       }]);
     });
 
@@ -161,6 +165,7 @@ describe('S3AccessKeyFormComponent', () => {
         Name: 'backup-key',
         User: 'alice',
         Enabled: false,
+        'Manage Buckets': true,
         'Non-expiring': false,
       });
       expect(await form.getDisabledState()).toMatchObject({ User: true });
@@ -170,6 +175,7 @@ describe('S3AccessKeyFormComponent', () => {
       await form.fillForm({
         Name: 'renamed-key',
         Enabled: true,
+        'Manage Buckets': false,
         'Non-expiring': true,
       });
 
@@ -180,6 +186,7 @@ describe('S3AccessKeyFormComponent', () => {
         name: 'renamed-key',
         enabled: true,
         expires_at: null,
+        manage_buckets: false,
       }]);
       expect(spectator.inject(MatDialog).open).not.toHaveBeenCalled();
     });

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-form/s3-access-key-form.component.ts
@@ -73,6 +73,9 @@ export class S3AccessKeyFormComponent implements OnInit {
     name: ['', Validators.required],
     username: ['', Validators.required],
     enabled: [true],
+    // Off by default: the flag widens what the key may do, and middleware refuses it for an account
+    // without SHARING_S3_WRITE, with the error landing on this control.
+    manage_buckets: [false],
     // Keys expire unless the admin opts out, so a new key asks for a date up front.
     nonExpiring: [false],
     expires_at: [null as Date | null, Validators.required],
@@ -115,16 +118,18 @@ export class S3AccessKeyFormComponent implements OnInit {
 
   protected onSubmit(): void {
     const {
-      name, username, enabled, nonExpiring, expires_at: expiresAtDate,
+      name, username, enabled, manage_buckets: manageBuckets, nonExpiring, expires_at: expiresAtDate,
     } = this.form.getRawValue();
     const expiresAt = (nonExpiring || !expiresAtDate) ? null : { $date: expiresAtDate.getTime() };
 
     let request$: Observable<S3AccessKey>;
     if (this.existingKey) {
-      request$ = this.api.call('s3.accesskey.update', [this.existingKey.id, { name, enabled, expires_at: expiresAt }]);
+      request$ = this.api.call('s3.accesskey.update', [this.existingKey.id, {
+        name, enabled, expires_at: expiresAt, manage_buckets: manageBuckets,
+      }]);
     } else {
       request$ = this.api.call('s3.accesskey.create', [{
-        name, username, enabled, expires_at: expiresAt,
+        name, username, enabled, expires_at: expiresAt, manage_buckets: manageBuckets,
       }]);
     }
 
@@ -154,6 +159,7 @@ export class S3AccessKeyFormComponent implements OnInit {
       name: key.name,
       username: key.username ?? '',
       enabled: key.enabled,
+      manage_buckets: key.manage_buckets,
       nonExpiring: !key.expires_at?.$date,
       expires_at: key.expires_at?.$date ? new Date(key.expires_at.$date) : null,
     });

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.spec.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.spec.ts
@@ -44,6 +44,20 @@ describe('S3AccessKeyListComponent', () => {
       secret: 'secret',
       status: S3AccessKeyStatus.Enabled,
       expires_at: null,
+      last_used_at: null,
+      manage_buckets: false,
+      created_at: { $date: 1700000000000 },
+    },
+    {
+      id: 2,
+      name: 'restic-key',
+      username: 'bob',
+      access_key: 'AKIAEXAMPLE67890',
+      secret: 'secret',
+      status: S3AccessKeyStatus.Enabled,
+      expires_at: null,
+      last_used_at: { $date: Date.now() - 3 * 24 * 60 * 60 * 1000 },
+      manage_buckets: true,
       created_at: { $date: 1700000000000 },
     },
   ] as S3AccessKey[];
@@ -92,8 +106,9 @@ describe('S3AccessKeyListComponent', () => {
   it('shows table rows', async () => {
     const cells = await table.getCellTexts();
     expect(cells).toEqual([
-      ['Name', 'User', 'Access Key ID', 'Status', 'Expires On', ''],
-      ['backup-key', 'alice', 'AKIAEXAMPLE12345', 'Enabled', 'Never', ''],
+      ['Name', 'User', 'Access Key ID', 'Status', 'Expires On', 'Last Used', ''],
+      ['backup-key', 'alice', 'AKIAEXAMPLE12345', 'Enabled', 'Never', 'Never', ''],
+      ['restic-key', 'bob', 'AKIAEXAMPLE67890', 'Enabled', 'Never', '3 days ago', ''],
     ]);
   });
 

--- a/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.ts
+++ b/src/app/pages/credentials/s3-access-keys/s3-access-key-list/s3-access-key-list.component.ts
@@ -28,6 +28,7 @@ import { actionsWithMenuColumn } from 'app/modules/ix-table/components/ix-table-
 import { dateColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-date/ix-cell-date.component';
 import { relativeDateColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-relative-date/ix-cell-relative-date.component';
 import { textColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-text/ix-cell-text.component';
+import { yesNoColumn } from 'app/modules/ix-table/components/ix-table-body/cells/ix-cell-yes-no/ix-cell-yes-no.component';
 import { IxTableBodyComponent } from 'app/modules/ix-table/components/ix-table-body/ix-table-body.component';
 import { IxTableColumnsSelectorComponent } from 'app/modules/ix-table/components/ix-table-columns-selector/ix-table-columns-selector.component';
 import { IxTableHeadComponent } from 'app/modules/ix-table/components/ix-table-head/ix-table-head.component';
@@ -128,6 +129,17 @@ export class S3AccessKeyListComponent implements OnInit {
       title: this.translate.instant('Expires On'),
       propertyName: 'expires_at',
       getValue: (row) => row.expires_at?.$date || this.translate.instant('Never'),
+    }),
+    // The S3 service reports usage at intervals, so a recent request can lag here for a short time.
+    relativeDateColumn({
+      title: this.translate.instant('Last Used'),
+      propertyName: 'last_used_at',
+      getValue: (row) => row.last_used_at?.$date || this.translate.instant('Never'),
+    }),
+    yesNoColumn({
+      title: this.translate.instant('Manage Buckets'),
+      propertyName: 'manage_buckets',
+      hidden: true,
     }),
     dateColumn({
       title: this.translate.instant('Created'),

--- a/src/app/pages/services/components/service-s3/service-s3.component.html
+++ b/src/app/pages/services/components/service-s3/service-s3.component.html
@@ -81,6 +81,22 @@
         ></ix-select>
       </ix-fieldset>
 
+      <ix-fieldset [title]="'Protocol-Created Buckets' | translate">
+        <!--
+          Picked as a mount point under /mnt so the picker can offer "Create Dataset" (which hands back a
+          mount point); the component maps it to and from the dataset name middleware stores.
+        -->
+        <ix-explorer
+          formControlName="managed_root_dataset"
+          [label]="'Managed Root Dataset' | translate"
+          [tooltip]="helptext.managedRootDatasetTooltip | translate"
+          [nodeProvider]="treeNodeProvider"
+        >
+          <!-- The root must already exist: middleware never creates it. Offer to create it here instead. -->
+          <ix-explorer-create-dataset [datasetProperties]="createDatasetProps"></ix-explorer-create-dataset>
+        </ix-explorer>
+      </ix-fieldset>
+
       <ix-fieldset [title]="'Global Grants' | translate">
         <ix-s3-grants-list
           [formArray]="form.controls.global_grants"

--- a/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.spec.ts
@@ -2,6 +2,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatDialog } from '@angular/material/dialog';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
@@ -19,6 +20,7 @@ import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ServiceS3Component } from 'app/pages/services/components/service-s3/service-s3.component';
+import { FilesystemService } from 'app/services/filesystem.service';
 import { SystemGeneralService } from 'app/services/system-general.service';
 import { selectLicense } from 'app/store/system-info/system-info.selectors';
 
@@ -36,6 +38,7 @@ describe('ServiceS3Component', () => {
     log_level: S3LogLevel.Notice,
     default_audit: [],
     default_audit_overflow: S3AuditOverflow.Drop,
+    managed_root_dataset: 'tank/s3',
     global_grants: [
       {
         principal_type: S3PrincipalType.User, xid: 1000, name: 'alice', access: S3Access.Deny,
@@ -59,6 +62,10 @@ describe('ServiceS3Component', () => {
       mockProvider(SystemGeneralService, {
         getCertificates: () => of([{ id: 5, name: 's3-cert' }] as Certificate[]),
       }),
+      mockProvider(FilesystemService, {
+        getFilesystemNodeProvider: () => () => of([]),
+      }),
+      mockProvider(MatDialog),
       mockProvider(SlideInRef, {
         close: jest.fn(),
         requireConfirmationWhen: jest.fn(),
@@ -88,6 +95,7 @@ describe('ServiceS3Component', () => {
       Servers: '2',
       Region: 'us-east-1',
       'Log Level': 'Notice',
+      'Managed Root Dataset': '/mnt/tank/s3',
     });
 
     const grants = await loader.getHarness(IxListHarness.with({ label: 'Global Grants' }));
@@ -103,6 +111,7 @@ describe('ServiceS3Component', () => {
       Servers: 4,
       Region: '',
       'Log Level': 'Info',
+      'Managed Root Dataset': '/mnt/tank/buckets',
     });
 
     const listeners = await loader.getHarness(IxListHarness.with({ label: 'Listen Addresses' }));
@@ -125,9 +134,31 @@ describe('ServiceS3Component', () => {
       servers: 4,
       region: '',
       log_level: S3LogLevel.Info,
+      managed_root_dataset: 'tank/buckets',
       global_grants: [{ principal_type: S3PrincipalType.User, xid: 1000, access: S3Access.Deny }],
     }]);
     expect(spectator.inject(SnackbarService).success).toHaveBeenCalledWith('Service configuration saved');
     expect(spectator.inject(SlideInRef).close).toHaveBeenCalledWith({ response: true });
+  });
+
+  it('sends an empty managed root dataset when the field is cleared', async () => {
+    await form.fillForm({ 'Managed Root Dataset': '' });
+
+    const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+    await saveButton.click();
+
+    expect(spectator.inject(ApiService).call).toHaveBeenCalledWith('s3.update', [expect.objectContaining({
+      managed_root_dataset: '',
+    })]);
+  });
+
+  it('rejects the /mnt root as the managed root dataset', async () => {
+    await form.fillForm({ 'Managed Root Dataset': '/mnt' });
+
+    expect(spectator.component.form.controls.managed_root_dataset.errors).toMatchObject({
+      customValidator: { message: 'Select a pool or dataset. The /mnt directory itself is not a dataset.' },
+    });
+    const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save' }));
+    expect(await saveButton.isDisabled()).toBe(true);
   });
 });

--- a/src/app/pages/services/components/service-s3/service-s3.component.ts
+++ b/src/app/pages/services/components/service-s3/service-s3.component.ts
@@ -13,6 +13,8 @@ import {
   combineLatest, map, of, shareReplay,
 } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
+import { DatasetPreset } from 'app/enums/dataset.enum';
+import { mntPath } from 'app/enums/mnt-path.enum';
 import { Role } from 'app/enums/role.enum';
 import {
   S3AuditMode,
@@ -26,9 +28,14 @@ import {
 import { choicesToOptions, idNameArrayToOptions } from 'app/helpers/operators/options.operators';
 import { mapToOptions } from 'app/helpers/options.helper';
 import { helptextSharingS3 } from 'app/helptext/sharing';
+import { DatasetCreate } from 'app/interfaces/dataset.interface';
 import { S3AuditMask, S3Config, S3Listener } from 'app/interfaces/s3.interface';
 import { FormActionsComponent } from 'app/modules/forms/ix-forms/components/form-actions/form-actions.component';
 import { IxCheckboxComponent } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.component';
+import {
+  ExplorerCreateDatasetComponent,
+} from 'app/modules/forms/ix-forms/components/ix-explorer/explorer-create-dataset/explorer-create-dataset.component';
+import { IxExplorerComponent } from 'app/modules/forms/ix-forms/components/ix-explorer/ix-explorer.component';
 import { IxFieldsetComponent } from 'app/modules/forms/ix-forms/components/ix-fieldset/ix-fieldset.component';
 import { IxInputComponent } from 'app/modules/forms/ix-forms/components/ix-input/ix-input.component';
 import { IxListItemComponent } from 'app/modules/forms/ix-forms/components/ix-list/ix-list-item/ix-list-item.component';
@@ -38,6 +45,7 @@ import {
   WithManageCertificatesLinkComponent,
 } from 'app/modules/forms/ix-forms/components/with-manage-certificates-link/with-manage-certificates-link.component';
 import { FormErrorHandlerService } from 'app/modules/forms/ix-forms/services/form-error-handler.service';
+import { IxValidatorsService } from 'app/modules/forms/ix-forms/services/ix-validators.service';
 import { portRangeValidator, rangeValidator } from 'app/modules/forms/ix-forms/validators/range-validation/range-validation';
 import { ModalHeaderComponent } from 'app/modules/slide-ins/components/modal-header/modal-header.component';
 import { SlideInRef } from 'app/modules/slide-ins/slide-in-ref';
@@ -47,6 +55,7 @@ import { ApiService } from 'app/modules/websocket/api.service';
 import { createS3GrantFormGroup, S3GrantFormGroup, toS3Grants } from 'app/pages/sharing/s3/s3-grants-list/s3-grant-form-group';
 import { S3GrantsListComponent } from 'app/pages/sharing/s3/s3-grants-list/s3-grants-list.component';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+import { FilesystemService } from 'app/services/filesystem.service';
 import { SystemGeneralService } from 'app/services/system-general.service';
 import { AppState } from 'app/store';
 import { selectLicense } from 'app/store/system-info/system-info.selectors';
@@ -75,6 +84,8 @@ const defaultPort = 9000;
     IxCheckboxComponent,
     IxListComponent,
     IxListItemComponent,
+    IxExplorerComponent,
+    ExplorerCreateDatasetComponent,
     WithManageCertificatesLinkComponent,
     S3GrantsListComponent,
     FormActionsComponent,
@@ -92,6 +103,8 @@ export class ServiceS3Component implements OnInit {
   private formErrorHandler = inject(FormErrorHandlerService);
   private snackbar = inject(SnackbarService);
   private systemGeneralService = inject(SystemGeneralService);
+  private filesystemService = inject(FilesystemService);
+  private validatorsService = inject(IxValidatorsService);
   private store$ = inject(Store<AppState>);
   private destroyRef = inject(DestroyRef);
   slideInRef = inject<SlideInRef<undefined, boolean>>(SlideInRef);
@@ -111,11 +124,23 @@ export class ServiceS3Component implements OnInit {
     servers: [1, [Validators.required, rangeValidator(1, 8)]],
     region: [''],
     log_level: [S3LogLevel.Notice, Validators.required],
+    // Optional: empty refuses S3 protocol CreateBucket requests. Held as a mount point (see the template);
+    // the /mnt root itself is the one selection the picker offers that is not a dataset.
+    managed_root_dataset: ['', [
+      this.validatorsService.customValidator(
+        (control) => !control.value || String(control.value).startsWith(`${mntPath}/`),
+        this.translate.instant('Select a pool or dataset. The /mnt directory itself is not a dataset.'),
+      ),
+    ]],
     global_grants: this.fb.array<S3GrantFormGroup>([]),
     default_audit_mode: [S3AuditMode.None],
     default_audit_actions: [[] as string[]],
     default_audit_overflow: [S3AuditOverflow.Drop],
   });
+
+  /** Datasets only: the managed root must be one, not a plain directory. */
+  protected readonly treeNodeProvider = this.filesystemService.getFilesystemNodeProvider({ datasetsOnly: true });
+  protected readonly createDatasetProps: Omit<DatasetCreate, 'name'> = { share_type: DatasetPreset.Generic };
 
   /**
    * Loaded once and shared between the form population and the listener address options.
@@ -190,6 +215,7 @@ export class ServiceS3Component implements OnInit {
       servers: values.servers,
       region: values.region,
       log_level: values.log_level,
+      managed_root_dataset: this.toDatasetName(values.managed_root_dataset),
       global_grants: toS3Grants(this.form.controls.global_grants.controls),
       ...(this.isLicensed()
         ? {
@@ -222,10 +248,20 @@ export class ServiceS3Component implements OnInit {
       servers: config.servers,
       region: config.region,
       log_level: config.log_level,
+      managed_root_dataset: this.toMountPoint(config.managed_root_dataset),
       default_audit_mode: auditMode,
       default_audit_actions: auditActions,
       default_audit_overflow: config.default_audit_overflow,
     });
+  }
+
+  /** Middleware stores a dataset name (`tank/s3`); the picker works in mount points (`/mnt/tank/s3`). */
+  private toMountPoint(datasetName: string): string {
+    return datasetName ? `${mntPath}/${datasetName}` : '';
+  }
+
+  private toDatasetName(mountPoint: string): string {
+    return mountPoint.replace(new RegExp(`^${mntPath}/?`), '');
   }
 
   private auditMaskToForm(mask: S3AuditMask): [S3AuditMode, string[]] {

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -13,7 +13,7 @@ import {
 } from 'app/enums/s3.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { Group } from 'app/interfaces/group.interface';
-import { S3Bucket } from 'app/interfaces/s3.interface';
+import { S3Bucket, S3Config } from 'app/interfaces/s3.interface';
 import { User } from 'app/interfaces/user.interface';
 import { IxCheckboxHarness } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.harness';
 import { IxListHarness } from 'app/modules/forms/ix-forms/components/ix-list/ix-list.harness';
@@ -80,6 +80,7 @@ describe('S3BucketFormComponent', () => {
         mockCall('sharing.s3.update'),
         mockCall('sharing.s3.audit_choices', { GetObject: 'GetObject', PutObject: 'PutObject' }),
         mockCall('pool.filesystem_choices', ['tank', 'tank/buckets', 'tank/buckets/photos']),
+        mockCall('s3.config', { managed_root_dataset: 'tank/s3' } as S3Config),
         mockCall('group.query', [{ group: 'staff', gid: 1001 }] as Group[]),
       ]),
       mockAuth(),
@@ -134,6 +135,10 @@ describe('S3BucketFormComponent', () => {
       expect(advancedLabels).toContain('Versioning');
       expect(advancedLabels).toContain('Multipart ETag');
       expect(advancedLabels).not.toContain('Audit');
+    });
+
+    it('starts with the parent dataset set to the service managed root dataset', async () => {
+      expect(await form.getValues()).toMatchObject({ 'Parent Dataset': 'tank/s3' });
     });
 
     it('turns versioning on and defaults to Compliance retention when object lock is enabled', async () => {

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -10,7 +10,7 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  map, merge, Observable, of,
+  catchError, EMPTY, map, merge, Observable, of,
 } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
@@ -241,9 +241,28 @@ export class S3BucketFormComponent implements OnInit {
       this.setBucketForEdit(this.existingBucket);
     } else {
       this.setupExistingDatasetCheck();
+      this.prefillParentDataset();
     }
     this.setupObjectLockDependency();
     this.setupObjectOwnershipDependency();
+  }
+
+  /**
+   * The service's managed root dataset is where S3 protocol CreateBucket requests put their datasets,
+   * so it is the natural default here too. Only a starting point: the field stays editable, and a
+   * parent already typed before the config arrives is kept.
+   */
+  private prefillParentDataset(): void {
+    this.api.call('s3.config').pipe(
+      // A convenience only: the user can pick the parent themselves, so a failed read stays silent.
+      catchError(() => EMPTY),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((config) => {
+      const parent = this.form.controls.parent_dataset;
+      if (config.managed_root_dataset && !parent.value) {
+        parent.setValue(config.managed_root_dataset);
+      }
+    });
   }
 
   private setupExistingDatasetCheck(): void {


### PR DESCRIPTION
Catches the UI up with middleware PR https://github.com/truenas/middleware/pull/19670 (NAS-143505), which lets the S3 protocol create and delete buckets.

- **S3 service form**: new "Protocol-Created Buckets" section with a Managed Root Dataset explorer (`managed_root_dataset`). Optional; empty refuses S3 protocol CreateBucket. Rejects the `/mnt` root like the bucket form does.
- **Access key form**: "Manage Buckets" checkbox (`manage_buckets`), off by default, sent on create and update. Middleware's SHARING_S3_WRITE check lands on that control.
- **Access key list**: "Last Used" column from the read-only `last_used_at`, plus a hidden-by-default "Manage Buckets" column.
- **Bucket form**: `dataset` is now optional on `sharing.s3.create`. The form still sends an explicit dataset, but a new bucket starts with its parent dataset prefilled from the managed root when one is set.
- `S3_BUCKET_OWNER_ENFORCED` permissions model was removed upstream; the UI never offered it, so no change.

Specs updated for all four components.

Original PR: https://github.com/truenas/webui/pull/14101
