### PR TITLE
NAS-143536 / 27.0.0-BETA.1 / Confirm the 2FA code before treating setup as done

### DIFF
--- a/src/app/helpers/totp.helper.spec.ts
+++ b/src/app/helpers/totp.helper.spec.ts
@@ -1,22 +1,7 @@
-import { decodeBase32, verifyTotp } from 'app/helpers/totp.helper';
+import { verifyTotp } from 'app/helpers/totp.helper';
 
 // RFC 6238 / RFC 4226 reference seed: the ASCII string '12345678901234567890'.
 const referenceSecret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
-
-describe('decodeBase32', () => {
-  it('decodes a base32 string into its bytes', () => {
-    expect(Array.from(decodeBase32('MZXW6YTB') || [])).toEqual([...'fooba'].map((char) => char.charCodeAt(0)));
-  });
-
-  it('ignores padding, spacing and casing that authenticator apps add', () => {
-    expect(decodeBase32('mzxw 6ytb==')).toEqual(decodeBase32('MZXW6YTB'));
-  });
-
-  it('returns null for text that is not base32', () => {
-    expect(decodeBase32('not-base32!')).toBeNull();
-    expect(decodeBase32('   ')).toBeNull();
-  });
-});
 
 describe('verifyTotp', () => {
   // Every 8-digit vector from RFC 6238, Appendix B (SHA-1 column).
@@ -41,6 +26,12 @@ describe('verifyTotp', () => {
     expect(verifyTotp(referenceSecret, '287082', { now: 29_000 })).toBe(true);
     expect(verifyTotp(referenceSecret, '287082', { now: 89_000 })).toBe(true);
     expect(verifyTotp(referenceSecret, '287082', { window: 0, now: 89_000 })).toBe(false);
+  });
+
+  it('reads a secret however an authenticator app spells it', () => {
+    // Padding, spacing and casing all appear in provisioning URIs and in secrets people
+    // copy by hand; all three must decode to the same key.
+    expect(verifyTotp('gezd gnbv gy3t qojq gezd gnbv gy3t qojq==', '287082', { window: 0, now: 59_000 })).toBe(true);
   });
 
   it('tolerates spacing in the code the user typed', () => {

--- a/src/app/helpers/totp.helper.spec.ts
+++ b/src/app/helpers/totp.helper.spec.ts
@@ -1,0 +1,63 @@
+import { decodeBase32, verifyTotp } from 'app/helpers/totp.helper';
+
+// RFC 6238 / RFC 4226 reference seed: the ASCII string '12345678901234567890'.
+const referenceSecret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+describe('decodeBase32', () => {
+  it('decodes a base32 string into its bytes', () => {
+    expect(Array.from(decodeBase32('MZXW6YTB') || [])).toEqual([...'fooba'].map((char) => char.charCodeAt(0)));
+  });
+
+  it('ignores padding, spacing and casing that authenticator apps add', () => {
+    expect(decodeBase32('mzxw 6ytb==')).toEqual(decodeBase32('MZXW6YTB'));
+  });
+
+  it('returns null for text that is not base32', () => {
+    expect(decodeBase32('not-base32!')).toBeNull();
+    expect(decodeBase32('   ')).toBeNull();
+  });
+});
+
+describe('verifyTotp', () => {
+  // Every 8-digit vector from RFC 6238, Appendix B (SHA-1 column).
+  it.each([
+    [59, '94287082'],
+    [1111111109, '07081804'],
+    [1111111111, '14050471'],
+    [1234567890, '89005924'],
+    [2000000000, '69279037'],
+    [20000000000, '65353130'],
+  ])('accepts the RFC 6238 code for time %i', (seconds, code) => {
+    expect(verifyTotp(referenceSecret, code, { digits: 8, window: 0, now: seconds * 1000 })).toBe(true);
+  });
+
+  it('accepts a 6-digit code for the current time step', () => {
+    // RFC 4226 test value for counter 1, which is the time step covering 30-59s.
+    expect(verifyTotp(referenceSecret, '287082', { window: 0, now: 59_000 })).toBe(true);
+  });
+
+  it('accepts a code from an adjacent time step to absorb clock skew', () => {
+    // Same code, checked a step early and a step late.
+    expect(verifyTotp(referenceSecret, '287082', { now: 29_000 })).toBe(true);
+    expect(verifyTotp(referenceSecret, '287082', { now: 89_000 })).toBe(true);
+    expect(verifyTotp(referenceSecret, '287082', { window: 0, now: 89_000 })).toBe(false);
+  });
+
+  it('tolerates spacing in the code the user typed', () => {
+    expect(verifyTotp(referenceSecret, ' 287 082 ', { window: 0, now: 59_000 })).toBe(true);
+  });
+
+  it('rejects a code that does not belong to the secret', () => {
+    expect(verifyTotp(referenceSecret, '000000', { now: 59_000 })).toBe(false);
+  });
+
+  it('rejects codes of the wrong shape', () => {
+    expect(verifyTotp(referenceSecret, '28708', { now: 59_000 })).toBe(false);
+    expect(verifyTotp(referenceSecret, 'abcdef', { now: 59_000 })).toBe(false);
+    expect(verifyTotp(referenceSecret, '', { now: 59_000 })).toBe(false);
+  });
+
+  it('rejects everything when the secret is unreadable', () => {
+    expect(verifyTotp('not-base32!', '287082', { now: 59_000 })).toBe(false);
+  });
+});

--- a/src/app/helpers/totp.helper.ts
+++ b/src/app/helpers/totp.helper.ts
@@ -116,10 +116,11 @@ function hmacSha1(key: Uint8Array, message: Uint8Array): Uint8Array {
  * Decodes an RFC 4648 base32 secret, ignoring the spacing and `=` padding that
  * authenticator apps and provisioning URIs sprinkle through them.
  *
- * Returns `null` when the text is not base32 at all, so callers can tell "wrong
- * code" apart from "unusable secret".
+ * Returns `null` for text that is not base32, which {@link verifyTotp} reports as a
+ * failed check — the page tells an unusable secret apart from a wrong code earlier, by
+ * whether the provisioning URI parsed at all.
  */
-export function decodeBase32(secret: string): Uint8Array | null {
+function decodeBase32(secret: string): Uint8Array | null {
   const normalized = secret.replace(/[\s=-]/g, '').toUpperCase();
   if (!normalized.length) {
     return null;

--- a/src/app/helpers/totp.helper.ts
+++ b/src/app/helpers/totp.helper.ts
@@ -1,0 +1,206 @@
+/**
+ * A minimal RFC 6238 (TOTP) / RFC 4226 (HOTP) verifier that runs in the browser.
+ *
+ * The middleware has no "check this code without enabling anything" endpoint —
+ * `user.renew_2fa_secret` both mints the secret and arms it — so the confirmation
+ * step on the 2FA setup page has to check the code the user reads off their
+ * authenticator app locally, against the secret the QR code carries.
+ *
+ * That makes this a usability check ("your app really did register this secret"),
+ * not a security boundary: the authoritative check still happens at login, in the
+ * middleware. Hence also the hand-rolled SHA-1 rather than `crypto.subtle`, which
+ * is undefined on the plain-HTTP LAN addresses much of the UI is served from.
+ */
+
+const base32Alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const sha1BlockSize = 64;
+const sha1DigestSize = 20;
+
+function rotateLeft(value: number, shift: number): number {
+  return ((value << shift) | (value >>> (32 - shift))) >>> 0;
+}
+
+function sha1(message: Uint8Array): Uint8Array {
+  // Message plus the 0x80 terminator and the 8-byte length, rounded up to whole blocks.
+  const padded = new Uint8Array((((message.length + 8) >> 6) + 1) << 6);
+  padded.set(message);
+  padded[message.length] = 0x80;
+
+  const view = new DataView(padded.buffer);
+  const bitLength = message.length * 8;
+  view.setUint32(padded.length - 8, Math.floor(bitLength / 0x100000000), false);
+  view.setUint32(padded.length - 4, bitLength >>> 0, false);
+
+  let h0 = 0x67452301;
+  let h1 = 0xEFCDAB89;
+  let h2 = 0x98BADCFE;
+  let h3 = 0x10325476;
+  let h4 = 0xC3D2E1F0;
+
+  const words = new Uint32Array(80);
+
+  for (let block = 0; block < padded.length; block += sha1BlockSize) {
+    for (let index = 0; index < 16; index++) {
+      words[index] = view.getUint32(block + index * 4, false);
+    }
+    for (let index = 16; index < 80; index++) {
+      words[index] = rotateLeft(
+        words[index - 3] ^ words[index - 8] ^ words[index - 14] ^ words[index - 16],
+        1,
+      );
+    }
+
+    // a-e in the RFC 3174 pseudocode.
+    let wordA = h0;
+    let wordB = h1;
+    let wordC = h2;
+    let wordD = h3;
+    let wordE = h4;
+
+    for (let index = 0; index < 80; index++) {
+      let mix: number;
+      let roundConstant: number;
+      if (index < 20) {
+        mix = (wordB & wordC) | (~wordB & wordD);
+        roundConstant = 0x5A827999;
+      } else if (index < 40) {
+        mix = wordB ^ wordC ^ wordD;
+        roundConstant = 0x6ED9EBA1;
+      } else if (index < 60) {
+        mix = (wordB & wordC) | (wordB & wordD) | (wordC & wordD);
+        roundConstant = 0x8F1BBCDC;
+      } else {
+        mix = wordB ^ wordC ^ wordD;
+        roundConstant = 0xCA62C1D6;
+      }
+
+      const rotated = (rotateLeft(wordA, 5) + mix + wordE + roundConstant + words[index]) >>> 0;
+      wordE = wordD;
+      wordD = wordC;
+      wordC = rotateLeft(wordB, 30);
+      wordB = wordA;
+      wordA = rotated;
+    }
+
+    h0 = (h0 + wordA) >>> 0;
+    h1 = (h1 + wordB) >>> 0;
+    h2 = (h2 + wordC) >>> 0;
+    h3 = (h3 + wordD) >>> 0;
+    h4 = (h4 + wordE) >>> 0;
+  }
+
+  const digest = new Uint8Array(sha1DigestSize);
+  const digestView = new DataView(digest.buffer);
+  [h0, h1, h2, h3, h4].forEach((word, index) => digestView.setUint32(index * 4, word, false));
+
+  return digest;
+}
+
+function hmacSha1(key: Uint8Array, message: Uint8Array): Uint8Array {
+  const blockKey = new Uint8Array(sha1BlockSize);
+  blockKey.set(key.length > sha1BlockSize ? sha1(key) : key);
+
+  const inner = new Uint8Array(sha1BlockSize + message.length);
+  const outer = new Uint8Array(sha1BlockSize + sha1DigestSize);
+  for (let index = 0; index < sha1BlockSize; index++) {
+    inner[index] = blockKey[index] ^ 0x36;
+    outer[index] = blockKey[index] ^ 0x5C;
+  }
+  inner.set(message, sha1BlockSize);
+  outer.set(sha1(inner), sha1BlockSize);
+
+  return sha1(outer);
+}
+
+/**
+ * Decodes an RFC 4648 base32 secret, ignoring the spacing and `=` padding that
+ * authenticator apps and provisioning URIs sprinkle through them.
+ *
+ * Returns `null` when the text is not base32 at all, so callers can tell "wrong
+ * code" apart from "unusable secret".
+ */
+export function decodeBase32(secret: string): Uint8Array | null {
+  const normalized = secret.replace(/[\s=-]/g, '').toUpperCase();
+  if (!normalized.length) {
+    return null;
+  }
+
+  const bytes: number[] = [];
+  let buffer = 0;
+  let bits = 0;
+
+  for (const character of normalized) {
+    const value = base32Alphabet.indexOf(character);
+    if (value === -1) {
+      return null;
+    }
+
+    buffer = (buffer << 5) | value;
+    bits += 5;
+
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((buffer >> bits) & 0xFF);
+    }
+  }
+
+  return bytes.length ? new Uint8Array(bytes) : null;
+}
+
+function generateHotp(key: Uint8Array, counter: number, digits: number): string {
+  const counterBytes = new Uint8Array(8);
+  const counterView = new DataView(counterBytes.buffer);
+  counterView.setUint32(0, Math.floor(counter / 0x100000000), false);
+  counterView.setUint32(4, counter >>> 0, false);
+
+  const digest = hmacSha1(key, counterBytes);
+  const offset = digest[digest.length - 1] & 0x0F;
+  const binary = ((digest[offset] & 0x7F) << 24)
+    | (digest[offset + 1] << 16)
+    | (digest[offset + 2] << 8)
+    | digest[offset + 3];
+
+  return (binary % 10 ** digits).toString().padStart(digits, '0');
+}
+
+export interface TotpOptions {
+  /** Length of a time step, in seconds. */
+  interval?: number;
+  /** Number of digits in a code. */
+  digits?: number;
+  /** How many time steps either side of now are still accepted, to absorb clock skew. */
+  window?: number;
+  /** Milliseconds since the epoch to verify against. Defaults to the current time. */
+  now?: number;
+}
+
+/**
+ * Whether `code` is a one-time password currently derivable from `secret`.
+ *
+ * Accepts codes from `window` steps either side of the current one, the usual
+ * allowance for a phone whose clock has drifted or a user who typed slowly.
+ */
+export function verifyTotp(secret: string, code: string, options: TotpOptions = {}): boolean {
+  const {
+    interval = 30, digits = 6, window = 1, now = Date.now(),
+  } = options;
+
+  const normalizedCode = code.replace(/\s/g, '');
+  if (!new RegExp(`^\\d{${digits}}$`).test(normalizedCode)) {
+    return false;
+  }
+
+  const key = decodeBase32(secret);
+  if (!key) {
+    return false;
+  }
+
+  const counter = Math.floor(now / 1000 / interval);
+  for (let drift = -window; drift <= window; drift++) {
+    if (generateHotp(key, counter + drift, digits) === normalizedCode) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/app/helptext/system/2fa.ts
+++ b/src/app/helptext/system/2fa.ts
@@ -22,6 +22,8 @@ export const helptext2fa = {
   qrCodeMessage: T('Scan this QR Code with your authenticator app of choice. The next time you try to login, you will be asked to enter an One Time Password (OTP) from your authenticator app. This step is extremely important. Without the OTP you will be locked out of this system.'),
 
   error: T('Error'),
+  loadFailed: T('The two-factor authentication settings could not be read from this system. Reload the page to try\
+ again.'),
 
   /**
    * The middleware mints and arms a secret in one call, so the setup page can only

--- a/src/app/helptext/system/2fa.ts
+++ b/src/app/helptext/system/2fa.ts
@@ -23,6 +23,31 @@ export const helptext2fa = {
 
   error: T('Error'),
 
+  /**
+   * The middleware mints and arms a secret in one call, so the setup page can only
+   * make the confirmation step feel safe by being explicit about what is already
+   * true and what cancelling undoes.
+   */
+  verification: {
+    pending: T('A 2FA secret has been generated and is already active for your account. Scan the QR code with your\
+ authenticator app, then enter the code the app shows to confirm it was added correctly. If you cancel, the secret is\
+ removed and two-factor authentication stays off for your account.'),
+    label: T('One-Time Password'),
+    tooltip: T('The code your authenticator app currently shows for this account. It changes every 30 seconds.'),
+    verifyBtn: T('Confirm Code'),
+    cancelBtn: T('Cancel Setup'),
+    invalid: T('That code does not match this secret. Check that your authenticator app was set up from the QR code\
+ above and that your device clock is correct, then enter the code it shows now.'),
+    verified: T('Two-factor authentication is confirmed for your account.'),
+    cancel: {
+      title: T('Cancel Two-Factor Authentication Setup?'),
+      message: T('The secret that was just generated will be removed and two-factor authentication will stay off for\
+ your account. You can set it up again at any time.'),
+      btn: T('Remove Secret'),
+      cancelBtn: T('Keep Setting Up'),
+    },
+  },
+
   renewSecret: {
     title: T('Renew Secret'),
     message: T('Renewing the secret will cause a new URI and a\

--- a/src/app/helptext/system/2fa.ts
+++ b/src/app/helptext/system/2fa.ts
@@ -44,6 +44,12 @@ export const helptext2fa = {
     // active" there would contradict the error the user just dismissed.
     pendingUnknown: T('A 2FA secret may have been generated, but it could not be read back. Generate a new one to try\
  again, or cancel to make sure no secret is left on your account.'),
+    // Appended to whichever pending message is showing when 2FA is off system-wide: the
+    // pending copy says the secret is active, which is only true once an administrator
+    // turns 2FA on, and the paragraph that normally carries that caveat is not rendered
+    // in this state.
+    notActiveGlobally: T('Two-factor authentication is not enabled on this system yet, so this secret has no effect\
+ until an administrator enables it.'),
     label: T('One-Time Password'),
     tooltip: T('The code your authenticator app currently shows for this account. It changes every 30 seconds.'),
     verifyBtn: T('Confirm Code'),

--- a/src/app/helptext/system/2fa.ts
+++ b/src/app/helptext/system/2fa.ts
@@ -37,12 +37,19 @@ export const helptext2fa = {
     pendingRenewal: T('A new 2FA secret has been generated and has replaced your previous one, which no longer works.\
  Scan the QR code with your authenticator app, then enter the code the app shows to confirm it was added correctly. If\
  you cancel, two-factor authentication is turned off for your account and you will have to set it up again.'),
+    // The marker is written before the call that mints the secret, so a failed renew
+    // leaves the step on screen with nothing behind it. Saying a secret "is already
+    // active" there would contradict the error the user just dismissed.
+    pendingUnknown: T('A 2FA secret may have been generated, but it could not be read back. Generate a new one to try\
+ again, or cancel to make sure no secret is left on your account.'),
     label: T('One-Time Password'),
     tooltip: T('The code your authenticator app currently shows for this account. It changes every 30 seconds.'),
     verifyBtn: T('Confirm Code'),
     cancelBtn: T('Cancel Setup'),
     invalid: T('That code does not match this secret. Check that your authenticator app was set up from the QR code\
  above and that your device clock is correct, then enter the code it shows now.'),
+    unreadableSecret: T('The secret for this account could not be read, so the code cannot be checked. Generate a new\
+ secret and scan it again.'),
     verified: T('Two-factor authentication is confirmed for your account.'),
     cancel: {
       title: T('Cancel Two-Factor Authentication Setup?'),

--- a/src/app/helptext/system/2fa.ts
+++ b/src/app/helptext/system/2fa.ts
@@ -56,8 +56,11 @@ export const helptext2fa = {
     cancelBtn: T('Cancel Setup'),
     invalid: T('That code does not match this secret. Check that your authenticator app was set up from the QR code\
  above and that your device clock is correct, then enter the code it shows now.'),
-    unreadableSecret: T('The secret for this account could not be read, so the code cannot be checked. Generate a new\
- secret and scan it again.'),
+    // Points at Cancel Setup, not at Renew: while a secret is unconfirmed the page does
+    // not render the secret buttons, so cancelling and starting over is the only route
+    // actually on offer.
+    unreadableSecret: T('The secret for this account could not be read, so the code cannot be checked. Cancel the\
+ setup and start again.'),
     checkFailed: T('The code could not be checked because the current secret could not be fetched from the system.\
  Check your connection and try again.'),
     verified: T('Two-factor authentication is confirmed for your account.'),

--- a/src/app/helptext/system/2fa.ts
+++ b/src/app/helptext/system/2fa.ts
@@ -50,6 +50,8 @@ export const helptext2fa = {
  above and that your device clock is correct, then enter the code it shows now.'),
     unreadableSecret: T('The secret for this account could not be read, so the code cannot be checked. Generate a new\
  secret and scan it again.'),
+    checkFailed: T('The code could not be checked because the current secret could not be fetched from the system.\
+ Check your connection and try again.'),
     verified: T('Two-factor authentication is confirmed for your account.'),
     cancel: {
       title: T('Cancel Two-Factor Authentication Setup?'),

--- a/src/app/helptext/system/2fa.ts
+++ b/src/app/helptext/system/2fa.ts
@@ -32,6 +32,11 @@ export const helptext2fa = {
     pending: T('A 2FA secret has been generated and is already active for your account. Scan the QR code with your\
  authenticator app, then enter the code the app shows to confirm it was added correctly. If you cancel, the secret is\
  removed and two-factor authentication stays off for your account.'),
+    // Renewing has already invalidated the old secret, so cancelling here turns 2FA off
+    // on an account that was protected a moment ago. Say so instead of implying nothing changes.
+    pendingRenewal: T('A new 2FA secret has been generated and has replaced your previous one, which no longer works.\
+ Scan the QR code with your authenticator app, then enter the code the app shows to confirm it was added correctly. If\
+ you cancel, two-factor authentication is turned off for your account and you will have to set it up again.'),
     label: T('One-Time Password'),
     tooltip: T('The code your authenticator app currently shows for this account. It changes every 30 seconds.'),
     verifyBtn: T('Confirm Code'),
@@ -43,6 +48,8 @@ export const helptext2fa = {
       title: T('Cancel Two-Factor Authentication Setup?'),
       message: T('The secret that was just generated will be removed and two-factor authentication will stay off for\
  your account. You can set it up again at any time.'),
+      renewalMessage: T('The new secret will be removed and two-factor authentication will be turned off for your\
+ account. Your previous secret was already replaced and cannot be restored, so you will have to set 2FA up again.'),
       btn: T('Remove Secret'),
       cancelBtn: T('Keep Setting Up'),
     },

--- a/src/app/interfaces/two-factor-config.interface.ts
+++ b/src/app/interfaces/two-factor-config.interface.ts
@@ -16,7 +16,8 @@ export interface GlobalTwoFactorConfigUpdate {
 }
 
 export interface UserTwoFactorConfig {
-  provisioning_uri: string;
+  /** Null until a secret exists for the account. */
+  provisioning_uri: string | null;
   secret_configured: boolean;
   interval: number;
   otp_digits: number;

--- a/src/app/modules/auth/auth.service.spec.ts
+++ b/src/app/modules/auth/auth.service.spec.ts
@@ -27,6 +27,7 @@ import { LoggedInUser } from 'app/interfaces/ds-cache.interface';
 import { Preferences } from 'app/interfaces/preferences.interface';
 import { GlobalTwoFactorConfig, UserTwoFactorConfig } from 'app/interfaces/two-factor-config.interface';
 import { AuthService } from 'app/modules/auth/auth.service';
+import { PendingTwoFactorService } from 'app/modules/auth/pending-two-factor.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { WebSocketStatusService } from 'app/services/websocket-status.service';
 import { adminUiInitialized } from 'app/store/admin-panel/admin.actions';
@@ -68,6 +69,9 @@ describe('AuthService', () => {
     providers: [
       mockAuth(),
       mockProvider(LocalStorageService),
+      // mockAuth's WINDOW stub has non-persisting localStorage jest.fn()s, so drive the
+      // pending marker through its service rather than through storage.
+      mockProvider(PendingTwoFactorService),
       mockApi([
         mockCall('auth.me', authMeUser),
         mockCall('auth.logout'),
@@ -476,6 +480,26 @@ describe('AuthService', () => {
       const result = await firstValueFrom(spectator.service.isTwoFactorSetupRequired());
 
       expect(result).toBe(false);
+    });
+
+    it('returns true when the configured secret has not been confirmed yet', async () => {
+      // The reload case this exists for: the user generated a secret and reloaded before
+      // confirming it. secret_configured alone would walk them past the setup dialog with
+      // an armed secret their authenticator app may never have received.
+      const userWithSecret = {
+        ...authMeUser,
+        two_factor_config: {
+          secret_configured: true,
+        } as UserTwoFactorConfig,
+      };
+
+      spectator.inject(MockApiService).mockCall('auth.me', userWithSecret);
+      await firstValueFrom(spectator.service.refreshUser());
+      jest.mocked(spectator.inject(PendingTwoFactorService).get).mockReturnValue('renewal');
+
+      const result = await firstValueFrom(spectator.service.isTwoFactorSetupRequired());
+
+      expect(result).toBe(true);
     });
   });
 

--- a/src/app/modules/auth/auth.service.spec.ts
+++ b/src/app/modules/auth/auth.service.spec.ts
@@ -87,6 +87,15 @@ describe('AuthService', () => {
             ],
           },
         } as LoginExResponse),
+        mockCall('auth.login_ex_continue', {
+          authenticator: AuthenticatorLoginLevel.Level2,
+          response_type: LoginExResponseType.Success,
+          user_info: {
+            pw_name: 'name',
+            privilege: { webui_access: true },
+            account_attributes: [AccountAttribute.Local],
+          },
+        } as LoginExResponse),
         mockCall('auth.twofactor.config', {
           enabled: true,
           id: 1,
@@ -500,6 +509,23 @@ describe('AuthService', () => {
       const result = await firstValueFrom(spectator.service.isTwoFactorSetupRequired());
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe('pending two-factor marker', () => {
+    it('clears it when a login is completed with an OTP', async () => {
+      // That login validated a code against the account's current secret, which is what
+      // the marker is waiting for. Left set, the setup dialog reopens offering only
+      // another code or a cancel that deletes a secret the user demonstrably holds.
+      await firstValueFrom(spectator.service.login('name', 'pass', '123456'));
+
+      expect(spectator.inject(PendingTwoFactorService).clear).toHaveBeenCalledWith('name');
+    });
+
+    it('leaves it alone for a password-only login', async () => {
+      await firstValueFrom(spectator.service.login('name', 'pass'));
+
+      expect(spectator.inject(PendingTwoFactorService).clear).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -24,6 +24,7 @@ import { WINDOW } from 'app/helpers/window.helper';
 import { LoginExMechanism, LoginExResponse, LoginExResponseType } from 'app/interfaces/auth.interface';
 import { LoggedInUser } from 'app/interfaces/ds-cache.interface';
 import { GlobalTwoFactorConfig } from 'app/interfaces/two-factor-config.interface';
+import { PendingTwoFactorService } from 'app/modules/auth/pending-two-factor.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 import { TokenLastUsedService } from 'app/services/token-last-used.service';
@@ -40,6 +41,7 @@ export class AuthService implements OnDestroy {
   private tokenLastUsedService = inject(TokenLastUsedService);
   private wsStatus = inject(WebSocketStatusService);
   private errorHandler = inject(ErrorHandlerService);
+  private pendingTwoFactor = inject(PendingTwoFactorService);
   private window = inject<Window>(WINDOW);
   private destroyRef = inject(DestroyRef);
 
@@ -185,8 +187,15 @@ export class AuthService implements OnDestroy {
             return of(false);
           }
 
-          return this.userTwoFactorConfig$.pipe(
-            map((userConfig) => !userConfig.secret_configured),
+          // A secret that exists but has not been confirmed still needs the prompt: the
+          // user may have reloaded mid-setup, and `secret_configured` alone would let
+          // them past the dialog with an armed secret their app never received.
+          return this.user$.pipe(
+            filter(Boolean),
+            map((user) => {
+              return !user.two_factor_config.secret_configured
+                || !!this.pendingTwoFactor.get(user.pw_name);
+            }),
           );
         }),
       )),

--- a/src/app/modules/auth/auth.service.ts
+++ b/src/app/modules/auth/auth.service.ts
@@ -168,6 +168,15 @@ export class AuthService implements OnDestroy {
         }]);
 
     return loginCall$.pipe(
+      tap((result) => {
+        // A successful OTP login validated a code against the account's current secret,
+        // which is exactly what the pending marker is waiting for. Without clearing it
+        // here the setup dialog reopens on the next guard run, offering only another code
+        // or a Cancel Setup that deletes a secret the user demonstrably holds.
+        if (otp && result.response_type === LoginExResponseType.Success && result.user_info?.pw_name) {
+          this.pendingTwoFactor.clear(result.user_info.pw_name);
+        }
+      }),
       switchMap((result) => this.processLoginResult(result).pipe(
         map((loginResult) => ({
           loginResponse: result,

--- a/src/app/modules/auth/pending-two-factor.service.ts
+++ b/src/app/modules/auth/pending-two-factor.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, inject } from '@angular/core';
+import { WINDOW } from 'app/helpers/window.helper';
+
+/** Which path opened a confirmation step — cancelling a renewal is the destructive one. */
+export type PendingTwoFactorKind = 'setup' | 'renewal';
+
+const pendingKinds: PendingTwoFactorKind[] = ['setup', 'renewal'];
+
+const keyPrefix = 'pending2FaVerification';
+
+/**
+ * Records that an account has a 2FA secret its owner has not yet proven their
+ * authenticator app holds.
+ *
+ * The middleware mints and arms a secret in one call and has no notion of a secret
+ * awaiting confirmation, so that state lives here. It is persisted rather than kept in
+ * memory so a reload, a navigation away, or a browser crash lands the user back on the
+ * confirmation step instead of on a page claiming the setup is finished — and it is read
+ * by the guard that opens the first-login dialog as well as by the setup page, so a
+ * reload mid-setup does not walk past the prompt.
+ *
+ * Keyed by account because nothing clears it on logout: on a shared workstation an
+ * origin-wide key would put the next user into a confirmation step for a secret that was
+ * never theirs.
+ *
+ * Being browser state, the guarantee is per browser, not per account: generate a secret
+ * and open the page in another browser (or a private window, or after a storage clear)
+ * and it reports the setup as settled, because `secret_configured` is all the server can
+ * tell us. Closing that needs a middleware pending-secret API — until then this covers
+ * the case actually reported, a crash or a navigation away.
+ */
+@Injectable({ providedIn: 'root' })
+export class PendingTwoFactorService {
+  private window = inject<Window>(WINDOW);
+
+  /** The kind of pending confirmation for this account, or null when there is none. */
+  get(username: string): PendingTwoFactorKind | null {
+    const stored = this.window.localStorage.getItem(this.keyFor(username));
+
+    return pendingKinds.find((kind) => kind === stored) ?? null;
+  }
+
+  set(username: string, kind: PendingTwoFactorKind): void {
+    this.window.localStorage.setItem(this.keyFor(username), kind);
+  }
+
+  clear(username: string): void {
+    this.window.localStorage.removeItem(this.keyFor(username));
+  }
+
+  private keyFor(username: string): string {
+    return `${keyPrefix}:${username}`;
+  }
+}

--- a/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.html
+++ b/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.html
@@ -2,7 +2,11 @@
 <div class="wrapper">
   <div class="container">
     <div [class.step-finished]="canFinish()">
-      <ix-two-factor [isSetupDialog]="true" (skipSetup)="onSkipSetup()"></ix-two-factor>
+      <ix-two-factor
+        [isSetupDialog]="true"
+        (setupComplete)="canFinish.set($event)"
+        (skipSetup)="onSkipSetup()"
+      ></ix-two-factor>
     </div>
   </div>
 </div>

--- a/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.spec.ts
+++ b/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.spec.ts
@@ -42,7 +42,12 @@ describe('FirstLoginDialogComponent', () => {
     expect(spectator.query(TwoFactorComponent)).toExist();
   });
 
-  it('keeps "Finish" hidden while a generated secret is still unconfirmed', async () => {
+  it('hides "Finish" again when the setup stops being complete', async () => {
+    // canFinish starts false, so emitting false on its own would assert nothing. The
+    // transition is what proves the binding follows the output rather than latching.
+    completeSetup();
+    expect(await loader.getHarnessOrNull(TnButtonHarness.with({ label: 'Finish' }))).not.toBeNull();
+
     spectator.query(TwoFactorComponent).setupComplete.emit(false);
     spectator.detectChanges();
 

--- a/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.spec.ts
+++ b/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.spec.ts
@@ -7,8 +7,6 @@ import { TnButtonHarness } from '@truenas/ui-components';
 import { MockComponents } from 'ng-mocks';
 import { QrCodeComponent, QrCodeDirective } from 'ng-qrcode';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
-import { BehaviorSubject } from 'rxjs';
-import { AuthService } from 'app/modules/auth/auth.service';
 import { TwoFactorComponent } from 'app/pages/two-factor-auth/two-factor.component';
 import { TwoFactorSetupDialog } from './two-factor-setup-dialog.component';
 
@@ -16,15 +14,10 @@ describe('FirstLoginDialogComponent', () => {
   let spectator: Spectator<TwoFactorSetupDialog>;
   let loader: HarnessLoader;
 
-  const mockTwoFactorConfig$ = new BehaviorSubject({ secret_configured: false });
-
   const createComponent = createComponentFactory({
     component: TwoFactorSetupDialog,
     declarations: [MockComponents(TwoFactorComponent)],
     providers: [
-      mockProvider(AuthService, {
-        userTwoFactorConfig$: mockTwoFactorConfig$.asObservable(),
-      }),
       provideMockStore(),
       mockProvider(DialogRef),
     ],
@@ -40,16 +33,27 @@ describe('FirstLoginDialogComponent', () => {
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
   });
 
+  function completeSetup(): void {
+    spectator.query(TwoFactorComponent).setupComplete.emit(true);
+    spectator.detectChanges();
+  }
+
   it('renders the required sub-components', () => {
     expect(spectator.query(TwoFactorComponent)).toExist();
   });
 
-  it('shows the "Finish" button only when 2fa is configured', async () => {
+  it('keeps "Finish" hidden while a generated secret is still unconfirmed', async () => {
+    spectator.query(TwoFactorComponent).setupComplete.emit(false);
+    spectator.detectChanges();
+
+    expect(await loader.getHarnessOrNull(TnButtonHarness.with({ label: 'Finish' }))).toBeNull();
+  });
+
+  it('shows the "Finish" button only once the setup component reports 2fa as confirmed', async () => {
     let finishButton = await loader.getHarnessOrNull(TnButtonHarness.with({ label: 'Finish' }));
     expect(finishButton).toBeNull();
 
-    mockTwoFactorConfig$.next({ secret_configured: true });
-    spectator.detectChanges();
+    completeSetup();
 
     finishButton = await loader.getHarness(TnButtonHarness.with({ label: 'Finish' }));
     expect(finishButton).toExist();
@@ -59,8 +63,7 @@ describe('FirstLoginDialogComponent', () => {
   });
 
   it('closes dialog on first click of Finish button', async () => {
-    mockTwoFactorConfig$.next({ secret_configured: true });
-    spectator.detectChanges();
+    completeSetup();
 
     const finishButton = await loader.getHarness(TnButtonHarness.with({ label: 'Finish' }));
     const dialogRef = spectator.inject(DialogRef);

--- a/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.ts
+++ b/src/app/pages/credentials/users/two-factor-setup-dialog/two-factor-setup-dialog.component.ts
@@ -1,10 +1,7 @@
 import { DialogRef } from '@angular/cdk/dialog';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { TnButtonComponent, TnDialogShellComponent } from '@truenas/ui-components';
-import { map } from 'rxjs';
-import { AuthService } from 'app/modules/auth/auth.service';
 import { TwoFactorComponent } from 'app/pages/two-factor-auth/two-factor.component';
 
 @Component({
@@ -20,12 +17,14 @@ import { TwoFactorComponent } from 'app/pages/two-factor-auth/two-factor.compone
   ],
 })
 export class TwoFactorSetupDialog {
-  private authService = inject(AuthService);
   protected dialogRef = inject(DialogRef<unknown, TwoFactorSetupDialog>);
 
-  protected canFinish = toSignal(
-    this.authService.userTwoFactorConfig$.pipe(map((config) => config.secret_configured)),
-  );
+  /**
+   * Driven by the setup component rather than by `secret_configured` alone: a secret
+   * exists from the moment it is generated, but offering Finish then would let the user
+   * leave with 2FA armed against a secret their authenticator app may never have taken.
+   */
+  protected canFinish = signal(false);
 
   protected onSkipSetup(): void {
     this.dialogRef.close(true);

--- a/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-card/global-two-factor-card.component.ts
+++ b/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-card/global-two-factor-card.component.ts
@@ -14,7 +14,6 @@ import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-r
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { Role } from 'app/enums/role.enum';
 import { toLoadingState } from 'app/helpers/operators/to-loading-state.helper';
-import { WINDOW } from 'app/helpers/window.helper';
 import { helptext2fa } from 'app/helptext/system/2fa';
 import { GlobalTwoFactorConfig } from 'app/interfaces/two-factor-config.interface';
 import { AuthService } from 'app/modules/auth/auth.service';
@@ -51,7 +50,6 @@ export class GlobalTwoFactorAuthCardComponent {
   private dialogService = inject(DialogService);
   private authService = inject(AuthService);
   private router = inject(Router);
-  private window = inject<Window>(WINDOW);
   private firstTimeWarning = inject(FirstTimeWarningService);
   private formPanel = inject(FormSidePanelService);
   private destroyRef = inject(DestroyRef);
@@ -81,7 +79,6 @@ export class GlobalTwoFactorAuthCardComponent {
           this.dialogService,
           this.authService,
           this.router,
-          this.window,
           twoFactorAuthConfig,
         ),
         {

--- a/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-form/global-two-factor.form-config.spec.ts
+++ b/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-form/global-two-factor.form-config.spec.ts
@@ -19,7 +19,6 @@ describe('getGlobalTwoFactorFormConfig', () => {
   const dialogService = { confirm: jest.fn(() => of(true)) } as unknown as DialogService;
   const authService = { globalTwoFactorConfigUpdated: jest.fn() } as unknown as AuthService;
   const router = { navigate: jest.fn() } as unknown as Router;
-  const window = { localStorage: { setItem: jest.fn() } } as unknown as Window;
   const twoFactorConfig = { enabled: false, window: 0, services: { ssh: false } } as GlobalTwoFactorConfig;
 
   beforeEach(() => jest.clearAllMocks());
@@ -31,7 +30,6 @@ describe('getGlobalTwoFactorFormConfig', () => {
       dialogService,
       authService,
       router,
-      window,
       twoFactorConfig,
     );
 

--- a/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-form/global-two-factor.form-config.ts
+++ b/src/app/pages/system/advanced/global-two-factor-auth/global-two-factor-form/global-two-factor.form-config.ts
@@ -22,7 +22,6 @@ export function getGlobalTwoFactorFormConfig(
   dialogService: DialogService,
   authService: AuthService,
   router: Router,
-  window: Window,
   twoFactorConfig: GlobalTwoFactorConfig,
 ): FormDefinition<GlobalTwoFactorFormValues> {
   const enableWarning = translate.instant('Once enabled, users will be prompted to set up two-factor authentication next time they login. They can choose to skip the setup if desired.');
@@ -77,7 +76,6 @@ export function getGlobalTwoFactorFormConfig(
         ),
         successMessage: translate.instant('Settings saved'),
         onSuccess: () => {
-          window.localStorage.setItem('showQr2FaWarning', `${values.enabled}`);
           authService.globalTwoFactorConfigUpdated();
           if (!isEqual(twoFactorConfig, payload) && payload.enabled) {
             router.navigate(['/two-factor-auth']);

--- a/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
+++ b/src/app/pages/system/advanced/system-security/system-security-form/system-security-form.component.ts
@@ -26,7 +26,6 @@ import { DockerStatus } from 'app/enums/docker-status.enum';
 import { PasswordComplexityRuleset, passwordComplexityRulesetLabels } from 'app/enums/password-complexity-ruleset.enum';
 import { Role } from 'app/enums/role.enum';
 import { mapToOptions } from 'app/helpers/options.helper';
-import { WINDOW } from 'app/helpers/window.helper';
 import { CredentialType } from 'app/interfaces/credential-type.interface';
 import { QueryParams } from 'app/interfaces/query-api.interface';
 import { SystemSecurityConfig } from 'app/interfaces/system-security-config.interface';
@@ -130,7 +129,6 @@ export class SystemSecurityFormComponent extends SidePanelForm implements OnInit
   private formPanel = inject(FormSidePanelService);
   private navigateAndHighlightService = inject(NavigateAndHighlightService);
   private document = inject(DOCUMENT);
-  private window = inject<Window>(WINDOW);
   private router = inject(Router);
   private rebootInfoSuppression = inject(RebootInfoDialogSuppressionService);
 
@@ -712,7 +710,6 @@ export class SystemSecurityFormComponent extends SidePanelForm implements OnInit
           this.dialogService,
           this.authService,
           this.router,
-          this.window,
           config,
         ),
         {

--- a/src/app/pages/two-factor-auth/qr-viewer/qr-viewer.component.html
+++ b/src/app/pages/two-factor-auth/qr-viewer/qr-viewer.component.html
@@ -7,5 +7,7 @@
     ></tn-banner>
   }
 
-  <qr-code [value]="qrInfo()" [size]="200"></qr-code>
+  @if (qrInfo(); as value) {
+    <qr-code [value]="value" [size]="200"></qr-code>
+  }
 </div>

--- a/src/app/pages/two-factor-auth/qr-viewer/qr-viewer.component.ts
+++ b/src/app/pages/two-factor-auth/qr-viewer/qr-viewer.component.ts
@@ -18,7 +18,8 @@ import { helptext2fa } from 'app/helptext/system/2fa';
   ],
 })
 export class QrViewerComponent {
-  readonly qrInfo = input.required<string>();
+  /** Null until the account has a secret — there is then no code to draw. */
+  readonly qrInfo = input.required<string | null>();
   readonly showWarning = input(false);
 
   readonly helpText = helptext2fa;

--- a/src/app/pages/two-factor-auth/two-factor.component.html
+++ b/src/app/pages/two-factor-auth/two-factor.component.html
@@ -36,7 +36,7 @@
           color="primary"
           [testId]="'renew-secret'"
           [label]="userTwoFactorAuthConfigured() ? ('Renew 2FA Secret' | translate) : ('Configure 2FA Secret' | translate)"
-          [disabled]="isFormLoading()"
+          [disabled]="isFormLoading() || isDataLoading()"
           [ixUiSearch]="searchableElements.elements.configure2FaSecret"
           (onClick)="renewSecretOrEnable2Fa()"
         ></tn-button>
@@ -45,7 +45,7 @@
             color="warn"
             [testId]="'unset-2fa-secret'"
             [label]="'Unset 2FA Secret' | translate"
-            [disabled]="isFormLoading()"
+            [disabled]="isFormLoading() || isDataLoading()"
             (onClick)="unset2FaSecret()"
           ></tn-button>
         }

--- a/src/app/pages/two-factor-auth/two-factor.component.html
+++ b/src/app/pages/two-factor-auth/two-factor.component.html
@@ -15,7 +15,7 @@
     } @else {
       <tn-banner
         class="status-banner"
-        [type]="!globalTwoFactorEnabled() || !userTwoFactorAuthConfigured() ? 'warning' : 'success'"
+        [type]="statusBannerType"
         [message]="global2FaMsg"
       ></tn-banner>
     }
@@ -24,40 +24,44 @@
         {{ 'Two-Factor Authentication has been enabled on this system. It is strongly recommended to set up 2FA for your account to enhance security. Make sure to scan the QR code with your authenticator app before logging out or navigating away, otherwise you may have difficulty accessing your account later.' | translate }}
       </p>
     }
-    <div class="button-group">
-      <tn-button
-        color="primary"
-        [testId]="'renew-secret'"
-        [label]="userTwoFactorAuthConfigured() ? ('Renew 2FA Secret' | translate) : ('Configure 2FA Secret' | translate)"
-        [disabled]="isFormLoading()"
-        [ixUiSearch]="searchableElements.elements.configure2FaSecret"
-        (onClick)="renewSecretOrEnable2Fa()"
-      ></tn-button>
-      @if (userTwoFactorAuthConfigured()) {
+    <!-- Renewing or unsetting while a secret is still unconfirmed would just replace one
+         unconfirmed secret with another; the confirmation step owns those actions instead. -->
+    @if (!pendingVerification()) {
+      <div class="button-group">
         <tn-button
-          color="warn"
-          [testId]="'unset-2fa-secret'"
-          [label]="'Unset 2FA Secret' | translate"
+          color="primary"
+          [testId]="'renew-secret'"
+          [label]="userTwoFactorAuthConfigured() ? ('Renew 2FA Secret' | translate) : ('Configure 2FA Secret' | translate)"
           [disabled]="isFormLoading()"
-          (onClick)="unset2FaSecret()"
+          [ixUiSearch]="searchableElements.elements.configure2FaSecret"
+          (onClick)="renewSecretOrEnable2Fa()"
         ></tn-button>
-      }
-      @if (showSkipButton()) {
-        <tn-button
-          [testId]="'skip-2fa-setup'"
-          [label]="'Skip Setup' | translate"
-          [disabled]="isFormLoading()"
-          (onClick)="onSkipSetup()"
-        ></tn-button>
-      }
-    </div>
+        @if (userTwoFactorAuthConfigured()) {
+          <tn-button
+            color="warn"
+            [testId]="'unset-2fa-secret'"
+            [label]="'Unset 2FA Secret' | translate"
+            [disabled]="isFormLoading()"
+            (onClick)="unset2FaSecret()"
+          ></tn-button>
+        }
+        @if (showSkipButton()) {
+          <tn-button
+            [testId]="'skip-2fa-setup'"
+            [label]="'Skip Setup' | translate"
+            [disabled]="isFormLoading()"
+            (onClick)="onSkipSetup()"
+          ></tn-button>
+        }
+      </div>
+    }
   </div>
 
   @if (userTwoFactorAuthConfigured() && (authService.userTwoFactorConfig$ | async); as qrInfo) {
     <div class="qr-section">
       <ix-qr-viewer
         [qrInfo]="qrInfo?.provisioning_uri"
-        [showWarning]="globalTwoFactorEnabled() && showQrCodeWarning"
+        [showWarning]="globalTwoFactorEnabled() && pendingVerification()"
       ></ix-qr-viewer>
     </div>
 
@@ -75,6 +79,41 @@
           <ix-copy-button [text]="secret"></ix-copy-button>
         </div>
       </div>
+    }
+
+    @if (pendingVerification()) {
+      <form class="verification" novalidate [formGroup]="verificationForm" (ngSubmit)="onVerifyOtp()">
+        <tn-form-field
+          class="verification-field"
+          [label]="helptext.verification.label | translate"
+          [tooltip]="helptext.verification.tooltip | translate"
+          [errorMessages]="otpErrorMessages"
+        >
+          <tn-input
+            name="otp"
+            formControlName="otp"
+            autocomplete="one-time-code"
+            testId="verify-otp"
+            [required]="true"
+          ></tn-input>
+        </tn-form-field>
+
+        <div class="button-group">
+          <tn-button
+            type="submit"
+            color="primary"
+            [testId]="'verify-otp'"
+            [label]="helptext.verification.verifyBtn | translate"
+            [disabled]="isFormLoading()"
+          ></tn-button>
+          <tn-button
+            [testId]="'cancel-2fa-setup'"
+            [label]="helptext.verification.cancelBtn | translate"
+            [disabled]="isFormLoading()"
+            (onClick)="onCancelVerification()"
+          ></tn-button>
+        </div>
+      </form>
     }
   }
 </tn-card>

--- a/src/app/pages/two-factor-auth/two-factor.component.html
+++ b/src/app/pages/two-factor-auth/two-factor.component.html
@@ -80,40 +80,43 @@
         </div>
       </div>
     }
+  }
 
-    @if (pendingVerification()) {
-      <form class="verification" novalidate [formGroup]="verificationForm" (ngSubmit)="onVerifyOtp()">
-        <tn-form-field
-          class="verification-field"
-          [label]="helptext.verification.label | translate"
-          [tooltip]="helptext.verification.tooltip | translate"
-          [errorMessages]="otpErrorMessages"
-        >
-          <tn-input
-            name="otp"
-            formControlName="otp"
-            autocomplete="one-time-code"
-            testId="verify-otp"
-            [required]="true"
-          ></tn-input>
-        </tn-form-field>
+  <!-- Outside the QR block on purpose: if a renew half-fails the flag is set while
+       `secret_configured` is still false, and gating the form on the QR would leave a
+       pending banner with no way to confirm and no way out. -->
+  @if (pendingVerification()) {
+    <form class="verification" novalidate [formGroup]="verificationForm" (ngSubmit)="onVerifyOtp()">
+      <tn-form-field
+        class="verification-field"
+        [label]="helptext.verification.label | translate"
+        [tooltip]="helptext.verification.tooltip | translate"
+        [errorMessages]="otpErrorMessages"
+      >
+        <tn-input
+          name="otp"
+          formControlName="otp"
+          autocomplete="one-time-code"
+          testId="verify-otp"
+          [required]="true"
+        ></tn-input>
+      </tn-form-field>
 
-        <div class="button-group">
-          <tn-button
-            type="submit"
-            color="primary"
-            [testId]="'verify-otp'"
-            [label]="helptext.verification.verifyBtn | translate"
-            [disabled]="isFormLoading()"
-          ></tn-button>
-          <tn-button
-            [testId]="'cancel-2fa-setup'"
-            [label]="helptext.verification.cancelBtn | translate"
-            [disabled]="isFormLoading()"
-            (onClick)="onCancelVerification()"
-          ></tn-button>
-        </div>
-      </form>
-    }
+      <div class="button-group">
+        <tn-button
+          type="submit"
+          color="primary"
+          [testId]="'verify-otp'"
+          [label]="helptext.verification.verifyBtn | translate"
+          [disabled]="isFormLoading()"
+        ></tn-button>
+        <tn-button
+          [testId]="'cancel-2fa-setup'"
+          [label]="helptext.verification.cancelBtn | translate"
+          [disabled]="isFormLoading()"
+          (onClick)="onCancelVerification()"
+        ></tn-button>
+      </div>
+    </form>
   }
 </tn-card>

--- a/src/app/pages/two-factor-auth/two-factor.component.html
+++ b/src/app/pages/two-factor-auth/two-factor.component.html
@@ -26,12 +26,12 @@
     }
     <div class="button-group">
       <!-- Renewing or unsetting while a secret is still unconfirmed would just replace one
-           unconfirmed secret with another; the confirmation step owns those actions. Skip
-           is deliberately outside the gate: it touches no secret, and it is the only
-           non-destructive way out of the first-login dialog, which is opened with
-           disableClose. A renew that fails leaves this page pending with no secret behind
-           it, and hiding Skip there would leave Cancel Setup as the sole exit. -->
-      @if (!pendingVerification()) {
+           unconfirmed secret with another, so the confirmation step owns those actions —
+           but only while a secret actually exists, hence hasUnconfirmedSecret() rather
+           than pendingVerification(). Skip sits outside the gate entirely: it touches no
+           secret, and it is the only non-destructive way out of the first-login dialog,
+           which is opened with disableClose. -->
+      @if (!hasUnconfirmedSecret()) {
         <tn-button
           color="primary"
           [testId]="'renew-secret'"

--- a/src/app/pages/two-factor-auth/two-factor.component.html
+++ b/src/app/pages/two-factor-auth/two-factor.component.html
@@ -91,7 +91,7 @@
         class="verification-field"
         [label]="helptext.verification.label | translate"
         [tooltip]="helptext.verification.tooltip | translate"
-        [errorMessages]="otpErrorMessages"
+        [errorMessages]="otpErrorMessages()"
       >
         <tn-input
           name="otp"

--- a/src/app/pages/two-factor-auth/two-factor.component.html
+++ b/src/app/pages/two-factor-auth/two-factor.component.html
@@ -24,10 +24,14 @@
         {{ 'Two-Factor Authentication has been enabled on this system. It is strongly recommended to set up 2FA for your account to enhance security. Make sure to scan the QR code with your authenticator app before logging out or navigating away, otherwise you may have difficulty accessing your account later.' | translate }}
       </p>
     }
-    <!-- Renewing or unsetting while a secret is still unconfirmed would just replace one
-         unconfirmed secret with another; the confirmation step owns those actions instead. -->
-    @if (!pendingVerification()) {
-      <div class="button-group">
+    <div class="button-group">
+      <!-- Renewing or unsetting while a secret is still unconfirmed would just replace one
+           unconfirmed secret with another; the confirmation step owns those actions. Skip
+           is deliberately outside the gate: it touches no secret, and it is the only
+           non-destructive way out of the first-login dialog, which is opened with
+           disableClose. A renew that fails leaves this page pending with no secret behind
+           it, and hiding Skip there would leave Cancel Setup as the sole exit. -->
+      @if (!pendingVerification()) {
         <tn-button
           color="primary"
           [testId]="'renew-secret'"
@@ -45,16 +49,16 @@
             (onClick)="unset2FaSecret()"
           ></tn-button>
         }
-        @if (showSkipButton()) {
-          <tn-button
-            [testId]="'skip-2fa-setup'"
-            [label]="'Skip Setup' | translate"
-            [disabled]="isFormLoading()"
-            (onClick)="onSkipSetup()"
-          ></tn-button>
-        }
-      </div>
-    }
+      }
+      @if (showSkipButton()) {
+        <tn-button
+          [testId]="'skip-2fa-setup'"
+          [label]="'Skip Setup' | translate"
+          [disabled]="isFormLoading()"
+          (onClick)="onSkipSetup()"
+        ></tn-button>
+      }
+    </div>
   </div>
 
   @if (userTwoFactorAuthConfigured() && (authService.userTwoFactorConfig$ | async); as qrInfo) {

--- a/src/app/pages/two-factor-auth/two-factor.component.scss
+++ b/src/app/pages/two-factor-auth/two-factor.component.scss
@@ -46,3 +46,12 @@
 .skeleton-loader {
   width: 100%;
 }
+
+.verification {
+  margin-top: 16px;
+  max-width: 320px;
+}
+
+.verification-field {
+  display: block;
+}

--- a/src/app/pages/two-factor-auth/two-factor.component.scss
+++ b/src/app/pages/two-factor-auth/two-factor.component.scss
@@ -49,7 +49,9 @@
 
 .verification {
   margin-top: 16px;
-  max-width: 320px;
+  // Wide enough that the "code does not match" message reads as a sentence rather
+  // than a narrow stack, without stretching a six-digit field across the card.
+  max-width: 420px;
 }
 
 .verification-field {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@truenas/ui-components';
 import { MockComponent, ngMocks } from 'ng-mocks';
 import { QrCodeComponent, QrCodeDirective } from 'ng-qrcode';
-import { BehaviorSubject, Subject, of, throwError } from 'rxjs';
+import { BehaviorSubject, EMPTY, Subject, of, throwError } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockWindow } from 'app/core/testing/utils/mock-window.utils';
 import { helptext2fa } from 'app/helptext/system/2fa';
@@ -22,6 +22,7 @@ import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service'
 import { ApiService } from 'app/modules/websocket/api.service';
 import { QrViewerComponent } from 'app/pages/two-factor-auth/qr-viewer/qr-viewer.component';
 import { TwoFactorComponent } from 'app/pages/two-factor-auth/two-factor.component';
+import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 
 // `MockComponent(QrViewerComponent)` deep-mocks that child's whole import graph,
 // which now includes TnBannerComponent — the primitive this component renders itself.
@@ -626,6 +627,35 @@ describe('TwoFactorComponent', () => {
       expect(await strandedLoader.getAllHarnesses(
         TnButtonHarness.with({ label: 'Configure 2FA Secret' }),
       )).toHaveLength(0);
+    });
+
+    it('does not leave the page inert when the load completes without emitting', async () => {
+      // getGlobalTwoFactorConfig does this on its own during a socket reconnect: take(1)
+      // over a filtered auth flag completes empty, no API error involved. isDataLoading
+      // disables every secret button, so a stuck flag means a page nobody can use.
+      jest.mocked(spectator.inject(AuthService).getGlobalTwoFactorConfig).mockReturnValueOnce(EMPTY);
+
+      const stalled = createComponent();
+      const stalledLoader = TestbedHarnessEnvironment.loader(stalled.fixture);
+
+      const configureBtn = await stalledLoader.getHarness(
+        TnButtonHarness.with({ label: 'Configure 2FA Secret' }),
+      );
+      expect(await configureBtn.isDisabled()).toBe(false);
+    });
+
+    it('surfaces a load failure instead of disabling the page silently', async () => {
+      jest.mocked(spectator.inject(AuthService).getGlobalTwoFactorConfig)
+        .mockReturnValueOnce(throwError(() => new Error('down')));
+
+      const failed = createComponent();
+      const failedLoader = TestbedHarnessEnvironment.loader(failed.fixture);
+
+      expect(spectator.inject(ErrorHandlerService).showErrorModal).toHaveBeenCalled();
+      const configureBtn = await failedLoader.getHarness(
+        TnButtonHarness.with({ label: 'Configure 2FA Secret' }),
+      );
+      expect(await configureBtn.isDisabled()).toBe(false);
     });
 
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -525,6 +525,47 @@ describe('TwoFactorComponent', () => {
       expect(await dialogLoader.getAllHarnesses(TnButtonHarness.with({ label: 'Skip Setup' }))).toHaveLength(1);
     });
 
+    it('confirms against the secret the account holds now, not the cached one', async () => {
+      // A renew whose reply was lost can rotate the secret without this page hearing
+      // about it. Confirming against the superseded secret would clear the marker and
+      // report success for a secret the account no longer has — the lockout, with a
+      // green message in front of it.
+      await generateSecret();
+
+      // The server has moved on to a different secret; the page still caches the old one.
+      jest.mocked(spectator.inject(AuthService).refreshUser).mockImplementationOnce(() => {
+        twoFactorConfig$.next({
+          ...twoFactorConfig,
+          provisioning_uri: 'somepath://here/TrueNAS:first-test?secret=MZXW6YTBMZXW6YTBMZXW6YTBMZXW6YTB',
+        });
+        return of(undefined);
+      });
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      const field = await loader.getHarness(TnFormFieldHarness);
+      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.invalid);
+      expect(storage.get('pending2FaVerification:dummy')).toBe('renewal');
+    });
+
+    it('says so when the account cannot be re-read, instead of confirming blind', async () => {
+      await generateSecret();
+      jest.mocked(spectator.inject(AuthService).refreshUser)
+        .mockReturnValueOnce(throwError(() => new Error('offline')));
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      const field = await loader.getHarness(TnFormFieldHarness);
+      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.checkFailed);
+      expect(storage.get('pending2FaVerification:dummy')).toBe('renewal');
+    });
+
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {
       const emitted: boolean[] = [];
       spectator.component.setupComplete.subscribe((isComplete) => emitted.push(isComplete));

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -817,6 +817,52 @@ describe('TwoFactorComponent', () => {
       });
     });
 
+    it('does not touch app-wide user state for a code that is simply wrong', async () => {
+      // refreshUser() pushes a transient null through user$, and consumers that read it
+      // unguarded blink while it is in flight. A typo should not cost that.
+      await generateSecret();
+      const refreshUser = jest.mocked(spectator.inject(AuthService).refreshUser);
+      refreshUser.mockClear();
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue('000000');
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      const field = await loader.getHarness(TnFormFieldHarness);
+      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.invalid);
+      expect(refreshUser).not.toHaveBeenCalled();
+    });
+
+    it('still re-reads the account before accepting a code that looks right', async () => {
+      await generateSecret();
+      const refreshUser = jest.mocked(spectator.inject(AuthService).refreshUser);
+      refreshUser.mockClear();
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      expect(refreshUser).toHaveBeenCalled();
+      expect(await loader.getHarnessOrNull(TnInputHarness)).toBeNull();
+    });
+
+    it('says the check failed when the re-read completes without emitting', async () => {
+      // Neither a value nor an error: without a default the press produces no message and
+      // no change, which the user cannot tell from being ignored.
+      await generateSecret();
+      jest.mocked(spectator.inject(AuthService).refreshUser).mockReturnValueOnce(EMPTY);
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      const field = await loader.getHarness(TnFormFieldHarness);
+      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.checkFailed);
+    });
+
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {
       const emitted: boolean[] = [];
       spectator.component.setupComplete.subscribe((isComplete) => emitted.push(isComplete));

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@truenas/ui-components';
 import { MockComponent, ngMocks } from 'ng-mocks';
 import { QrCodeComponent, QrCodeDirective } from 'ng-qrcode';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockWindow } from 'app/core/testing/utils/mock-window.utils';
 import { helptext2fa } from 'app/helptext/system/2fa';
@@ -36,6 +36,14 @@ describe('TwoFactorComponent', () => {
   // brings a user who reloaded mid-setup back to the confirmation step.
   const storage = new Map<string, string>();
 
+  // RFC 6238 reference seed, so the codes below are the published test vectors.
+  const provisioningUri = 'somepath://here/TrueNAS:first-test?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+  // Mutable so a test can start from an account that has no secret yet — the providers
+  // themselves cannot be overridden once the first component has instantiated the module.
+  const configuredUser = { pw_name: 'dummy', two_factor_config: { secret_configured: true } } as LoggedInUser;
+  const user$ = new BehaviorSubject<LoggedInUser>(configuredUser);
+
   const createComponent = createComponentFactory({
     component: TwoFactorComponent,
     imports: [
@@ -62,19 +70,14 @@ describe('TwoFactorComponent', () => {
         mockCall('auth.sessions', [{ current: true, credentials: CredentialType.TwoFactor } as AuthSession]),
       ]),
       mockProvider(AuthService, {
-        user$: of({
-          pw_name: 'dummy',
-          two_factor_config: {
-            secret_configured: true,
-          },
-        } as LoggedInUser),
+        user$,
         userTwoFactorConfig$: of({
-          provisioning_uri: 'somepath://here/TrueNAS:first-test?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ',
+          provisioning_uri: provisioningUri,
           interval: 30,
           otp_digits: 6,
           secret_configured: true,
         } as UserTwoFactorConfig),
-        getGlobalTwoFactorConfig: jest.fn(() => of({ enabled: false } as GlobalTwoFactorConfig)),
+        getGlobalTwoFactorConfig: jest.fn(() => of({ enabled: false, window: 0 } as GlobalTwoFactorConfig)),
         refreshUser: jest.fn(() => of(undefined)),
       }),
     ],
@@ -82,6 +85,7 @@ describe('TwoFactorComponent', () => {
 
   beforeEach(() => {
     storage.clear();
+    user$.next(configuredUser);
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     api = spectator.inject(ApiService);
@@ -93,7 +97,7 @@ describe('TwoFactorComponent', () => {
 
     const qrViewer = spectator.query(QrViewerComponent);
     expect(qrViewer).toBeTruthy();
-    expect(qrViewer).toHaveProperty('qrInfo', 'somepath://here/TrueNAS:first-test?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ');
+    expect(qrViewer).toHaveProperty('qrInfo', provisioningUri);
   });
 
   it('displays the secret from provisioning URI in the component', () => {
@@ -217,6 +221,8 @@ describe('TwoFactorComponent', () => {
     // RFC 4226 test vector for the reference seed above at counter 1, i.e. the time
     // step covering 30-59s. Pinning Date.now() keeps the code the one that verifies.
     const validCode = '287082';
+    // RFC 4226 counter 0 — the step before the one `validCode` belongs to.
+    const previousStepCode = '755224';
 
     async function generateSecret(): Promise<void> {
       const configureBtn = await loader.getHarness(TnButtonHarness.with({ label: 'Renew 2FA Secret' }));
@@ -236,7 +242,7 @@ describe('TwoFactorComponent', () => {
       await generateSecret();
 
       const banner = await loader.getHarness(TnBannerHarness);
-      expect(await banner.getText()).toContain(helptext2fa.verification.pending);
+      expect(await banner.getText()).toContain(helptext2fa.verification.pendingRenewal);
       expect(await loader.getHarnessOrNull(TnInputHarness)).not.toBeNull();
     });
 
@@ -279,7 +285,7 @@ describe('TwoFactorComponent', () => {
 
       expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith({
         title: helptext2fa.verification.cancel.title,
-        message: helptext2fa.verification.cancel.message,
+        message: helptext2fa.verification.cancel.renewalMessage,
         buttonText: helptext2fa.verification.cancel.btn,
         cancelText: helptext2fa.verification.cancel.cancelBtn,
         hideCheckbox: true,
@@ -314,7 +320,7 @@ describe('TwoFactorComponent', () => {
 
     it('drops the stored flag once the code is confirmed', async () => {
       await generateSecret();
-      expect(storage.get('pending2FaVerification:dummy')).toBe('true');
+      expect(storage.get('pending2FaVerification:dummy')).toBe('renewal');
 
       const otpInput = await loader.getHarness(TnInputHarness);
       await otpInput.setValue(validCode);
@@ -322,6 +328,45 @@ describe('TwoFactorComponent', () => {
       spectator.detectChanges();
 
       expect(storage.has('pending2FaVerification:dummy')).toBe(false);
+    });
+
+    it('warns that cancelling a renewal turns 2FA off, not that it stays off', async () => {
+      // The old secret is already invalidated by the time this step opens, so cancelling
+      // is destructive here in a way it is not on a first-time setup.
+      await generateSecret();
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.cancelBtn }))).click();
+
+      const { message } = jest.mocked(spectator.inject(DialogService).confirm).mock.calls.at(-1)[0];
+      expect(message).toBe(helptext2fa.verification.cancel.renewalMessage);
+      expect(message).not.toContain('stay off');
+    });
+
+    it('uses the first-time wording when no secret existed before', async () => {
+      user$.next({ pw_name: 'dummy', two_factor_config: { secret_configured: false } } as LoggedInUser);
+
+      const firstTime = createComponent();
+      const firstTimeLoader = TestbedHarnessEnvironment.loader(firstTime.fixture);
+
+      await (await firstTimeLoader.getHarness(TnButtonHarness.with({ label: 'Configure 2FA Secret' }))).click();
+      firstTime.detectChanges();
+
+      const banner = await firstTimeLoader.getHarness(TnBannerHarness);
+      expect(await banner.getText()).toContain(helptext2fa.verification.pending);
+      expect(storage.get('pending2FaVerification:dummy')).toBe('setup');
+    });
+
+    it('honours the appliance tolerance window instead of its own default', async () => {
+      // Global config says window: 0, so only the current step counts. A code from the
+      // adjacent step must be refused here, or the page would confirm a code login rejects.
+      await generateSecret();
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(previousStepCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      const field = await loader.getHarness(TnFormFieldHarness);
+      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.invalid);
     });
 
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -863,6 +863,25 @@ describe('TwoFactorComponent', () => {
       expect(await field.getErrorMessage()).toBe(helptext2fa.verification.checkFailed);
     });
 
+    it('does not claim 2FA is off system-wide when it never read that setting', async () => {
+      // globalTwoFactorEnabled holds its false default after a failed load, and the
+      // account re-read inside the renew clears loadFailed — so nothing else stops the
+      // caveat asserting, on a system where 2FA is on, that scanning the QR does not
+      // matter.
+      jest.mocked(spectator.inject(AuthService).getGlobalTwoFactorConfig)
+        .mockReturnValueOnce(throwError(() => new Error('down')));
+
+      const blind = createComponent();
+      const blindLoader = TestbedHarnessEnvironment.loader(blind.fixture);
+
+      await (await blindLoader.getHarness(TnButtonHarness.with({ label: 'Configure 2FA Secret' }))).click();
+      blind.detectChanges();
+
+      const banner = await blindLoader.getHarness(TnBannerHarness);
+      expect(await banner.getText()).toContain(helptext2fa.verification.pendingRenewal);
+      expect(await banner.getText()).not.toContain(helptext2fa.verification.notActiveGlobally);
+    });
+
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {
       const emitted: boolean[] = [];
       spectator.component.setupComplete.subscribe((isComplete) => emitted.push(isComplete));

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -629,19 +629,56 @@ describe('TwoFactorComponent', () => {
       )).toHaveLength(0);
     });
 
-    it('does not leave the page inert when the load completes without emitting', async () => {
-      // getGlobalTwoFactorConfig does this on its own during a socket reconnect: take(1)
-      // over a filtered auth flag completes empty, no API error involved. isDataLoading
-      // disables every secret button, so a stuck flag means a page nobody can use.
+    it('does not leave the page inert when a call completes without emitting', async () => {
+      // A clean websocket reconnect completes the response stream, so an in-flight call
+      // ends silently rather than erroring. isDataLoading disables every secret button,
+      // so a stuck flag means a page nobody can use.
+      jest.mocked(api.call).mockImplementation(((method: string) => {
+        if (method === 'system.info') {
+          return EMPTY;
+        }
+        return method === 'auth.sessions' ? of([]) : of(undefined);
+      }) as ApiService['call']);
+
+      const stalled = createComponent();
+      const stalledLoader = TestbedHarnessEnvironment.loader(stalled.fixture);
+
+      const renewBtn = await stalledLoader.getHarness(
+        TnButtonHarness.with({ label: 'Renew 2FA Secret' }),
+      );
+      expect(await renewBtn.isDisabled()).toBe(false);
+    });
+
+    it('says the settings could not be read rather than rendering defaults', async () => {
+      // Silently completing the user read would otherwise leave the card stating that 2FA
+      // is off on a system where it is on, with no error anywhere on screen.
       jest.mocked(spectator.inject(AuthService).getGlobalTwoFactorConfig).mockReturnValueOnce(EMPTY);
 
       const stalled = createComponent();
       const stalledLoader = TestbedHarnessEnvironment.loader(stalled.fixture);
 
-      const configureBtn = await stalledLoader.getHarness(
-        TnButtonHarness.with({ label: 'Configure 2FA Secret' }),
+      expect(spectator.inject(ErrorHandlerService).showErrorModal).toHaveBeenCalled();
+      const banner = await stalledLoader.getHarness(TnBannerHarness);
+      expect(await banner.getText()).toContain(helptext2fa.loadFailed);
+    });
+
+    it('releases the form flag when the confirming read completes without emitting', async () => {
+      await generateSecret();
+      jest.mocked(spectator.inject(AuthService).refreshUser).mockReturnValueOnce(EMPTY);
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      const confirmBtn = await loader.getHarness(
+        TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }),
       );
-      expect(await configureBtn.isDisabled()).toBe(false);
+      await confirmBtn.click();
+      spectator.detectChanges();
+
+      // Confirm Code and Cancel Setup are the only controls rendered in this state.
+      expect(await confirmBtn.isDisabled()).toBe(false);
+      expect(await (await loader.getHarness(
+        TnButtonHarness.with({ label: helptext2fa.verification.cancelBtn }),
+      )).isDisabled()).toBe(false);
     });
 
     it('surfaces a load failure instead of disabling the page silently', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -1,11 +1,14 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
-import { TnBannerComponent, TnBannerHarness, TnButtonHarness } from '@truenas/ui-components';
+import {
+  TnBannerComponent, TnBannerHarness, TnButtonHarness, TnFormFieldHarness, TnInputHarness,
+} from '@truenas/ui-components';
 import { MockComponent, ngMocks } from 'ng-mocks';
 import { QrCodeComponent, QrCodeDirective } from 'ng-qrcode';
 import { of } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
+import { mockWindow } from 'app/core/testing/utils/mock-window.utils';
 import { helptext2fa } from 'app/helptext/system/2fa';
 import { AuthSession } from 'app/interfaces/auth-session.interface';
 import { CredentialType } from 'app/interfaces/credential-type.interface';
@@ -14,6 +17,7 @@ import { GlobalTwoFactorConfig, UserTwoFactorConfig } from 'app/interfaces/two-f
 import { AuthService } from 'app/modules/auth/auth.service';
 import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
+import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { QrViewerComponent } from 'app/pages/two-factor-auth/qr-viewer/qr-viewer.component';
 import { TwoFactorComponent } from 'app/pages/two-factor-auth/two-factor.component';
@@ -28,6 +32,10 @@ describe('TwoFactorComponent', () => {
   let loader: HarnessLoader;
   let api: ApiService;
 
+  // The pending-verification flag has to survive a component instance — that is what
+  // brings a user who reloaded mid-setup back to the confirmation step.
+  const storage = new Map<string, string>();
+
   const createComponent = createComponentFactory({
     component: TwoFactorComponent,
     imports: [
@@ -39,6 +47,13 @@ describe('TwoFactorComponent', () => {
     providers: [
       mockProvider(DialogService, {
         confirm: jest.fn(() => of(true)),
+      }),
+      mockProvider(SnackbarService),
+      mockWindow({
+        localStorage: {
+          getItem: (key: string) => storage.get(key) ?? null,
+          setItem: (key: string, value: string) => storage.set(key, value),
+        },
       }),
       mockApi([
         mockCall('user.renew_2fa_secret'),
@@ -53,17 +68,19 @@ describe('TwoFactorComponent', () => {
           },
         } as LoggedInUser),
         userTwoFactorConfig$: of({
-          provisioning_uri: 'somepath://here/TrueNAS:first-test?secret=KYC123',
+          provisioning_uri: 'somepath://here/TrueNAS:first-test?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ',
           interval: 30,
           otp_digits: 6,
           secret_configured: true,
         } as UserTwoFactorConfig),
         getGlobalTwoFactorConfig: jest.fn(() => of({ enabled: false } as GlobalTwoFactorConfig)),
+        refreshUser: jest.fn(() => of(undefined)),
       }),
     ],
   });
 
   beforeEach(() => {
+    storage.clear();
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     api = spectator.inject(ApiService);
@@ -75,7 +92,7 @@ describe('TwoFactorComponent', () => {
 
     const qrViewer = spectator.query(QrViewerComponent);
     expect(qrViewer).toBeTruthy();
-    expect(qrViewer).toHaveProperty('qrInfo', 'somepath://here/TrueNAS:first-test?secret=KYC123');
+    expect(qrViewer).toHaveProperty('qrInfo', 'somepath://here/TrueNAS:first-test?secret=GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ');
   });
 
   it('displays the secret from provisioning URI in the component', () => {
@@ -84,7 +101,7 @@ describe('TwoFactorComponent', () => {
 
     const secretElement = spectator.query('.secret p');
     expect(secretElement).toBeTruthy();
-    expect(secretElement).toHaveText('KYC123');
+    expect(secretElement).toHaveText('GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ');
   });
 
   it('shows a copy button with the correct secret', () => {
@@ -93,7 +110,7 @@ describe('TwoFactorComponent', () => {
 
     const copyButton = spectator.query(CopyButtonComponent);
     expect(copyButton).toBeTruthy();
-    expect(copyButton).toHaveProperty('text', 'KYC123');
+    expect(copyButton).toHaveProperty('text', 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ');
   });
 
   it('shows warning when global setting is disabled', async () => {
@@ -193,6 +210,111 @@ describe('TwoFactorComponent', () => {
     spectator.detectChanges();
 
     expect(await loader.getAllHarnesses(unsetButtons)).toHaveLength(1);
+  });
+
+  describe('confirming the new secret', () => {
+    // RFC 4226 test vector for the reference seed above at counter 1, i.e. the time
+    // step covering 30-59s. Pinning Date.now() keeps the code the one that verifies.
+    const validCode = '287082';
+
+    async function generateSecret(): Promise<void> {
+      const configureBtn = await loader.getHarness(TnButtonHarness.with({ label: 'Renew 2FA Secret' }));
+      await configureBtn.click();
+      spectator.detectChanges();
+    }
+
+    beforeEach(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(59_000);
+    });
+
+    afterEach(() => {
+      jest.spyOn(Date, 'now').mockRestore();
+    });
+
+    it('asks for a code from the authenticator app once a secret is generated', async () => {
+      await generateSecret();
+
+      expect(spectator.component.pendingVerification()).toBe(true);
+
+      const banner = await loader.getHarness(TnBannerHarness);
+      expect(await banner.getText()).toContain(helptext2fa.verification.pending);
+      expect(await loader.getHarnessOrNull(TnInputHarness)).not.toBeNull();
+    });
+
+    it('hides renew and unset until the code is confirmed', async () => {
+      await generateSecret();
+
+      expect(await loader.getAllHarnesses(TnButtonHarness.with({ label: 'Renew 2FA Secret' }))).toHaveLength(0);
+      expect(await loader.getAllHarnesses(TnButtonHarness.with({ label: 'Unset 2FA Secret' }))).toHaveLength(0);
+    });
+
+    it('rejects a code that does not match the secret and stays in confirmation', async () => {
+      await generateSecret();
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue('000000');
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      const field = await loader.getHarness(TnFormFieldHarness);
+      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.invalid);
+      expect(spectator.component.pendingVerification()).toBe(true);
+    });
+
+    it('completes setup when the code matches the secret', async () => {
+      await generateSecret();
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      expect(spectator.component.pendingVerification()).toBe(false);
+      expect(await loader.getHarnessOrNull(TnInputHarness)).toBeNull();
+      expect(await loader.getAllHarnesses(TnButtonHarness.with({ label: 'Unset 2FA Secret' }))).toHaveLength(1);
+    });
+
+    it('removes the secret when the user cancels instead of confirming', async () => {
+      await generateSecret();
+
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.cancelBtn }))).click();
+
+      expect(spectator.inject(DialogService).confirm).toHaveBeenCalledWith({
+        title: helptext2fa.verification.cancel.title,
+        message: helptext2fa.verification.cancel.message,
+        buttonText: helptext2fa.verification.cancel.btn,
+        cancelText: helptext2fa.verification.cancel.cancelBtn,
+        hideCheckbox: true,
+        buttonColor: 'warn',
+      });
+      expect(api.call).toHaveBeenCalledWith('user.unset_2fa_secret', ['dummy']);
+      expect(spectator.component.pendingVerification()).toBe(false);
+    });
+
+    it('resumes confirmation after a reload, so an unconfirmed secret is never left behind', async () => {
+      await generateSecret();
+
+      const reloaded = createComponent();
+      const reloadedLoader = TestbedHarnessEnvironment.loader(reloaded.fixture);
+
+      expect(reloaded.component.pendingVerification()).toBe(true);
+      expect(await reloadedLoader.getHarnessOrNull(TnInputHarness)).not.toBeNull();
+    });
+
+    it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {
+      const emitted: boolean[] = [];
+      spectator.component.setupComplete.subscribe((isComplete) => emitted.push(isComplete));
+
+      await generateSecret();
+      expect(emitted.at(-1)).toBe(false);
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      expect(emitted.at(-1)).toBe(true);
+    });
   });
 
   it('shows skip button only in setup dialog when 2FA is not configured', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -760,7 +760,7 @@ describe('TwoFactorComponent', () => {
       recovered.detectChanges();
 
       const banner = await recoveredLoader.getHarness(TnBannerHarness);
-      expect(await banner.getText()).toContain(helptext2fa.verification.pending);
+      expect(await banner.getText()).toContain(helptext2fa.verification.pendingRenewal);
       expect(await banner.getText()).not.toContain(helptext2fa.loadFailed);
     });
 
@@ -787,6 +787,34 @@ describe('TwoFactorComponent', () => {
       const banner = await enabledLoader.getHarness(TnBannerHarness);
       expect(await banner.getText()).toContain(helptext2fa.verification.pendingRenewal);
       expect(await banner.getText()).not.toContain(helptext2fa.verification.notActiveGlobally);
+    });
+
+    it('assumes a secret may exist while the page is blind, and warns accordingly', async () => {
+      // After a failed load `userTwoFactorAuthConfigured()` is a default, not a fact. If a
+      // real renewal is labelled a first-time setup, Cancel Setup says 2FA will "stay off"
+      // instead of saying the previous secret is already gone — the one sentence written
+      // to tell the user what they just lost.
+      jest.mocked(spectator.inject(AuthService).getGlobalTwoFactorConfig)
+        .mockReturnValueOnce(throwError(() => new Error('down')));
+
+      const blind = createComponent();
+      const blindLoader = TestbedHarnessEnvironment.loader(blind.fixture);
+      const dialog = jest.mocked(spectator.inject(DialogService).confirm);
+      dialog.mockClear();
+
+      await (await blindLoader.getHarness(TnButtonHarness.with({ label: 'Configure 2FA Secret' }))).click();
+      blind.detectChanges();
+
+      // The renew warning is not skipped either.
+      expect(dialog.mock.calls[0][0]).toMatchObject({ title: helptext2fa.renewSecret.title });
+
+      await (await blindLoader.getHarness(
+        TnButtonHarness.with({ label: helptext2fa.verification.cancelBtn }),
+      )).click();
+
+      expect(dialog.mock.calls.at(-1)[0]).toMatchObject({
+        message: helptext2fa.verification.cancel.renewalMessage,
+      });
     });
 
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -3,7 +3,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { fakeAsync, tick } from '@angular/core/testing';
 import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import {
-  TnBannerComponent, TnBannerHarness, TnButtonHarness, TnFormFieldHarness, TnInputHarness,
+  TnBannerComponent, TnBannerHarness, TnButtonComponent, TnButtonHarness, TnFormFieldHarness, TnInputHarness,
 } from '@truenas/ui-components';
 import { MockComponent, ngMocks } from 'ng-mocks';
 import { QrCodeComponent, QrCodeDirective } from 'ng-qrcode';
@@ -568,10 +568,11 @@ describe('TwoFactorComponent', () => {
       expect(storage.get('pending2FaVerification:dummy')).toBe('renewal');
     });
 
-    // DOM queries rather than harnesses: the load carries a timeout timer while it is in
-    // flight, which keeps the Angular zone unstable, and a harness would wait it out.
-    function renewButtonOf(fixtureHost: Spectator<TwoFactorComponent>): HTMLButtonElement | null {
-      return fixtureHost.query('[data-test="button-renew-secret"]');
+    // The component instance rather than a harness: while the load is in flight it holds
+    // a timeout timer, which keeps the Angular zone unstable, and a harness would wait it
+    // out. Reading the rendered component's inputs needs no test-id locator.
+    function renewButtonOf(fixtureHost: Spectator<TwoFactorComponent>): TnButtonComponent | undefined {
+      return fixtureHost.queryAll(TnButtonComponent).find((button) => button.label().endsWith('2FA Secret'));
     }
 
     it('holds the secret buttons until the page knows what it is looking at', () => {
@@ -587,13 +588,13 @@ describe('TwoFactorComponent', () => {
 
       const loading = createComponent();
 
-      expect(renewButtonOf(loading)?.disabled).toBe(true);
+      expect(renewButtonOf(loading)?.disabled()).toBe(true);
 
       systemInfo$.next({ datetime: { $date: applianceNow } } as SystemInfo);
       systemInfo$.complete();
       loading.detectChanges();
 
-      expect(renewButtonOf(loading)?.disabled).toBe(false);
+      expect(renewButtonOf(loading)?.disabled()).toBe(false);
     });
 
     it('gives the load a terminal outcome when a source never settles at all', fakeAsync(() => {
@@ -604,12 +605,12 @@ describe('TwoFactorComponent', () => {
       jest.mocked(spectator.inject(AuthService).getGlobalTwoFactorConfig).mockReturnValueOnce(NEVER);
 
       const stuck = createComponent();
-      expect(renewButtonOf(stuck)?.disabled).toBe(true);
+      expect(renewButtonOf(stuck)?.disabled()).toBe(true);
 
       tick(30_000);
       stuck.detectChanges();
 
-      expect(renewButtonOf(stuck)?.disabled).toBe(false);
+      expect(renewButtonOf(stuck)?.disabled()).toBe(false);
       expect(spectator.inject(ErrorHandlerService).showErrorModal).toHaveBeenCalled();
     }));
 
@@ -740,6 +741,27 @@ describe('TwoFactorComponent', () => {
         TnButtonHarness.with({ label: 'Configure 2FA Secret' }),
       );
       expect(await configureBtn.isDisabled()).toBe(false);
+    });
+
+    it('stops saying the settings could not be read once a later call has read them', async () => {
+      // The load is not the page's last chance to learn the account state. Left set, the
+      // failure banner shadows every later one — including the copy that explains what the
+      // code field is for and what Cancel Setup undoes.
+      jest.mocked(spectator.inject(AuthService).getGlobalTwoFactorConfig)
+        .mockReturnValueOnce(throwError(() => new Error('down')));
+
+      const recovered = createComponent();
+      const recoveredLoader = TestbedHarnessEnvironment.loader(recovered.fixture);
+
+      expect(await (await recoveredLoader.getHarness(TnBannerHarness)).getText())
+        .toContain(helptext2fa.loadFailed);
+
+      await (await recoveredLoader.getHarness(TnButtonHarness.with({ label: 'Configure 2FA Secret' }))).click();
+      recovered.detectChanges();
+
+      const banner = await recoveredLoader.getHarness(TnBannerHarness);
+      expect(await banner.getText()).toContain(helptext2fa.verification.pending);
+      expect(await banner.getText()).not.toContain(helptext2fa.loadFailed);
     });
 
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -6,13 +6,14 @@ import {
 } from '@truenas/ui-components';
 import { MockComponent, ngMocks } from 'ng-mocks';
 import { QrCodeComponent, QrCodeDirective } from 'ng-qrcode';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, of, throwError } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockWindow } from 'app/core/testing/utils/mock-window.utils';
 import { helptext2fa } from 'app/helptext/system/2fa';
 import { AuthSession } from 'app/interfaces/auth-session.interface';
 import { CredentialType } from 'app/interfaces/credential-type.interface';
 import { LoggedInUser } from 'app/interfaces/ds-cache.interface';
+import { SystemInfo } from 'app/interfaces/system-info.interface';
 import { GlobalTwoFactorConfig, UserTwoFactorConfig } from 'app/interfaces/two-factor-config.interface';
 import { AuthService } from 'app/modules/auth/auth.service';
 import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button.component';
@@ -42,6 +43,11 @@ describe('TwoFactorComponent', () => {
   // Mutable so a test can start from an account that has no secret yet — the providers
   // themselves cannot be overridden once the first component has instantiated the module.
   const configuredUser = { pw_name: 'dummy', two_factor_config: { secret_configured: true } } as LoggedInUser;
+
+  // The appliance sits in the time step `validCode` belongs to; the browser clock in the
+  // tests is parked a step earlier, so only a check using appliance time accepts it.
+  const applianceNow = 59_000;
+  const browserNow = 5_000;
   const user$ = new BehaviorSubject<LoggedInUser>(configuredUser);
 
   const createComponent = createComponentFactory({
@@ -68,6 +74,7 @@ describe('TwoFactorComponent', () => {
         mockCall('user.renew_2fa_secret'),
         mockCall('user.unset_2fa_secret'),
         mockCall('auth.sessions', [{ current: true, credentials: CredentialType.TwoFactor } as AuthSession]),
+        mockCall('system.info', { datetime: { $date: applianceNow } } as SystemInfo),
       ]),
       mockProvider(AuthService, {
         user$,
@@ -86,9 +93,14 @@ describe('TwoFactorComponent', () => {
   beforeEach(() => {
     storage.clear();
     user$.next(configuredUser);
+    jest.spyOn(Date, 'now').mockReturnValue(browserNow);
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
     api = spectator.inject(ApiService);
+  });
+
+  afterEach(() => {
+    jest.spyOn(Date, 'now').mockRestore();
   });
 
   it('shows the QR code viewer with correct provisioning URI when 2FA is configured', () => {
@@ -230,14 +242,6 @@ describe('TwoFactorComponent', () => {
       spectator.detectChanges();
     }
 
-    beforeEach(() => {
-      jest.spyOn(Date, 'now').mockReturnValue(59_000);
-    });
-
-    afterEach(() => {
-      jest.spyOn(Date, 'now').mockRestore();
-    });
-
     it('asks for a code from the authenticator app once a secret is generated', async () => {
       await generateSecret();
 
@@ -367,6 +371,59 @@ describe('TwoFactorComponent', () => {
 
       const field = await loader.getHarness(TnFormFieldHarness);
       expect(await field.getErrorMessage()).toBe(helptext2fa.verification.invalid);
+    });
+
+    it('checks the code against the appliance clock, not the browser one', async () => {
+      // The browser is a third clock with no part in the real exchange: the phone and the
+      // appliance are NTP-synced, and login asks appliance-time-vs-secret. A workstation
+      // 54s adrift must not reject the code the middleware would accept.
+      await generateSecret();
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      expect(await loader.getHarnessOrNull(TnInputHarness)).toBeNull();
+    });
+
+    it('falls back to the browser clock when the appliance time cannot be read', async () => {
+      jest.mocked(api.call).mockImplementation(((method: string) => {
+        return method === 'system.info' ? throwError(() => new Error('down')) : of(undefined);
+      }) as ApiService['call']);
+
+      const offline = createComponent();
+      const offlineLoader = TestbedHarnessEnvironment.loader(offline.fixture);
+
+      await (await offlineLoader.getHarness(TnButtonHarness.with({ label: 'Renew 2FA Secret' }))).click();
+      offline.detectChanges();
+
+      // browserNow sits in the step before validCode's, so the browser-clock fallback
+      // accepts that step's code — the behaviour before appliance time was consulted.
+      const otpInput = await offlineLoader.getHarness(TnInputHarness);
+      await otpInput.setValue(previousStepCode);
+      await (await offlineLoader.getHarness(
+        TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }),
+      )).click();
+      offline.detectChanges();
+
+      expect(await offlineLoader.getHarnessOrNull(TnInputHarness)).toBeNull();
+    });
+
+    it('marks the secret unconfirmed even if the follow-up user refresh fails', async () => {
+      // renew_2fa_secret arms the secret server-side. If the refresh behind it fails and
+      // the flag were written after, the next load would present an armed, unscanned
+      // secret as finished setup.
+      jest.mocked(spectator.inject(AuthService).refreshUser)
+        .mockReturnValueOnce(throwError(() => new Error('session dropped')));
+
+      await generateSecret();
+
+      expect(storage.get('pending2FaVerification:dummy')).toBe('renewal');
+
+      const reloaded = createComponent();
+      const reloadedLoader = TestbedHarnessEnvironment.loader(reloaded.fixture);
+      expect(await reloadedLoader.getHarnessOrNull(TnInputHarness)).not.toBeNull();
     });
 
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -48,6 +48,14 @@ describe('TwoFactorComponent', () => {
   // tests is parked a step earlier, so only a check using appliance time accepts it.
   const applianceNow = 59_000;
   const browserNow = 5_000;
+
+  const twoFactorConfig = {
+    provisioning_uri: provisioningUri,
+    interval: 30,
+    otp_digits: 6,
+    secret_configured: true,
+  } as UserTwoFactorConfig;
+  const twoFactorConfig$ = new BehaviorSubject(twoFactorConfig);
   const user$ = new BehaviorSubject<LoggedInUser>(configuredUser);
 
   const createComponent = createComponentFactory({
@@ -78,12 +86,7 @@ describe('TwoFactorComponent', () => {
       ]),
       mockProvider(AuthService, {
         user$,
-        userTwoFactorConfig$: of({
-          provisioning_uri: provisioningUri,
-          interval: 30,
-          otp_digits: 6,
-          secret_configured: true,
-        } as UserTwoFactorConfig),
+        userTwoFactorConfig$: twoFactorConfig$,
         getGlobalTwoFactorConfig: jest.fn(() => of({ enabled: false, window: 0 } as GlobalTwoFactorConfig)),
         refreshUser: jest.fn(() => of(undefined)),
       }),
@@ -93,6 +96,7 @@ describe('TwoFactorComponent', () => {
   beforeEach(() => {
     storage.clear();
     user$.next(configuredUser);
+    twoFactorConfig$.next(twoFactorConfig);
     jest.spyOn(Date, 'now').mockReturnValue(browserNow);
     spectator = createComponent();
     loader = TestbedHarnessEnvironment.loader(spectator.fixture);
@@ -311,7 +315,11 @@ describe('TwoFactorComponent', () => {
     it('keys the stored flag to the account, so another user\'s flag is ignored', async () => {
       // Nothing clears this on logout, so on a shared workstation an origin-wide key
       // would drop the next user into a confirmation step for a secret that is not theirs.
-      storage.set('pending2FaVerification:someone-else', 'true');
+      // Both shapes: the origin-wide key an unscoped build would read, and another
+      // account's scoped one. A real PendingKind value, since an invalid one would be
+      // rejected on its own and prove nothing about the key.
+      storage.set('pending2FaVerification', 'renewal');
+      storage.set('pending2FaVerification:someone-else', 'renewal');
 
       const nextUser = createComponent();
       const nextUserLoader = TestbedHarnessEnvironment.loader(nextUser.fixture);
@@ -424,6 +432,43 @@ describe('TwoFactorComponent', () => {
       const reloaded = createComponent();
       const reloadedLoader = TestbedHarnessEnvironment.loader(reloaded.fixture);
       expect(await reloadedLoader.getHarnessOrNull(TnInputHarness)).not.toBeNull();
+    });
+
+    it('keeps Cancel Setup working after a failed refresh left no current user', async () => {
+      // refreshUser() pushes null onto user$ before re-fetching, so a failure leaves null
+      // as the current value. Taking that null and filtering it would complete the stream
+      // having done nothing, stranding the loading flag on with every button disabled.
+      jest.mocked(spectator.inject(AuthService).refreshUser)
+        .mockReturnValueOnce(throwError(() => new Error('session dropped')));
+      await generateSecret();
+
+      user$.next(null as unknown as LoggedInUser);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.cancelBtn }))).click();
+
+      // Nothing can happen while there is no user...
+      expect(api.call).not.toHaveBeenCalledWith('user.unset_2fa_secret', ['dummy']);
+
+      // ...but the moment one is resolved again, the cancel goes through.
+      user$.next(configuredUser);
+      spectator.detectChanges();
+
+      expect(api.call).toHaveBeenCalledWith('user.unset_2fa_secret', ['dummy']);
+    });
+
+    it('reports an unusable provisioning URI as a mismatched code, not a dead button', async () => {
+      // A first-time setup whose renew failed leaves the step on screen with no secret
+      // behind it. `new URL(null)` throws inside the subscribe, so Confirm Code would do
+      // nothing at all — no message, no state change, just a console error.
+      await generateSecret();
+      twoFactorConfig$.next({ ...twoFactorConfig, provisioning_uri: null } as unknown as UserTwoFactorConfig);
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      const field = await loader.getHarness(TnFormFieldHarness);
+      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.invalid);
     });
 
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -1,12 +1,13 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import {
   TnBannerComponent, TnBannerHarness, TnButtonHarness, TnFormFieldHarness, TnInputHarness,
 } from '@truenas/ui-components';
 import { MockComponent, ngMocks } from 'ng-mocks';
 import { QrCodeComponent, QrCodeDirective } from 'ng-qrcode';
-import { BehaviorSubject, EMPTY, Subject, of, throwError } from 'rxjs';
+import { BehaviorSubject, EMPTY, NEVER, Subject, of, throwError } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockWindow } from 'app/core/testing/utils/mock-window.utils';
 import { helptext2fa } from 'app/helptext/system/2fa';
@@ -567,9 +568,15 @@ describe('TwoFactorComponent', () => {
       expect(storage.get('pending2FaVerification:dummy')).toBe('renewal');
     });
 
-    it('holds the secret buttons until the page knows what it is looking at', async () => {
-      // The load waits on system.info, and a click landing before it resolves would be
-      // rolled back by the snapshot that reply carries.
+    // DOM queries rather than harnesses: the load carries a timeout timer while it is in
+    // flight, which keeps the Angular zone unstable, and a harness would wait it out.
+    function renewButtonOf(fixtureHost: Spectator<TwoFactorComponent>): HTMLButtonElement | null {
+      return fixtureHost.query('[data-test="button-renew-secret"]');
+    }
+
+    it('holds the secret buttons until the page knows what it is looking at', () => {
+      // A click landing before the load resolves would be rolled back by the snapshot
+      // that reply carries.
       const systemInfo$ = new Subject<SystemInfo>();
       jest.mocked(api.call).mockImplementation(((method: string) => {
         if (method === 'system.info') {
@@ -579,16 +586,56 @@ describe('TwoFactorComponent', () => {
       }) as ApiService['call']);
 
       const loading = createComponent();
-      const loadingLoader = TestbedHarnessEnvironment.loader(loading.fixture);
 
-      const renewBtn = await loadingLoader.getHarness(TnButtonHarness.with({ label: 'Configure 2FA Secret' }));
-      expect(await renewBtn.isDisabled()).toBe(true);
+      expect(renewButtonOf(loading)?.disabled).toBe(true);
 
       systemInfo$.next({ datetime: { $date: applianceNow } } as SystemInfo);
       systemInfo$.complete();
       loading.detectChanges();
 
-      expect(await renewBtn.isDisabled()).toBe(false);
+      expect(renewButtonOf(loading)?.disabled).toBe(false);
+    });
+
+    it('gives the load a terminal outcome when a source never settles at all', fakeAsync(() => {
+      // defaultIfEmpty only fires on completion, and getGlobalTwoFactorConfig switchMaps
+      // over a BehaviorSubject that never completes — so an inner call that ends without
+      // a result hangs the load rather than emptying it. Without the timeout the card
+      // stays inert forever, with every secret button disabled and no error on screen.
+      jest.mocked(spectator.inject(AuthService).getGlobalTwoFactorConfig).mockReturnValueOnce(NEVER);
+
+      const stuck = createComponent();
+      expect(renewButtonOf(stuck)?.disabled).toBe(true);
+
+      tick(30_000);
+      stuck.detectChanges();
+
+      expect(renewButtonOf(stuck)?.disabled).toBe(false);
+      expect(spectator.inject(ErrorHandlerService).showErrorModal).toHaveBeenCalled();
+    }));
+
+    it('lets the user retry the same code after a failed check', async () => {
+      // checkFailed and unreadableSecret are set by hand and both say "try again"; if they
+      // are left on the control the next submit is swallowed by the validity guard.
+      await generateSecret();
+      jest.mocked(spectator.inject(AuthService).refreshUser)
+        .mockReturnValueOnce(throwError(() => new Error('offline')));
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      const confirmBtn = await loader.getHarness(
+        TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }),
+      );
+      await confirmBtn.click();
+      spectator.detectChanges();
+
+      const field = await loader.getHarness(TnFormFieldHarness);
+      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.checkFailed);
+
+      // Connection is back; the same code, unedited, must now be accepted.
+      await confirmBtn.click();
+      spectator.detectChanges();
+
+      expect(await loader.getHarnessOrNull(TnInputHarness)).toBeNull();
     });
 
     it('applies the account state it re-read when confirming', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -764,6 +764,31 @@ describe('TwoFactorComponent', () => {
       expect(await banner.getText()).not.toContain(helptext2fa.loadFailed);
     });
 
+    it('keeps the globally-disabled caveat while a secret waits to be confirmed', async () => {
+      // The pending copy says the secret is active, which is only true once an admin turns
+      // 2FA on — and the paragraph that normally carries that caveat is gated on the same
+      // flag, so the banner is the only place left to say it.
+      await generateSecret();
+
+      const banner = await loader.getHarness(TnBannerHarness);
+      expect(await banner.getText()).toContain(helptext2fa.verification.pendingRenewal);
+      expect(await banner.getText()).toContain(helptext2fa.verification.notActiveGlobally);
+    });
+
+    it('drops the caveat once 2FA is enabled system-wide', async () => {
+      jest.mocked(spectator.inject(AuthService).getGlobalTwoFactorConfig)
+        .mockReturnValueOnce(of({ enabled: true, window: 0 } as GlobalTwoFactorConfig));
+
+      const enabled = createComponent();
+      const enabledLoader = TestbedHarnessEnvironment.loader(enabled.fixture);
+      await (await enabledLoader.getHarness(TnButtonHarness.with({ label: 'Renew 2FA Secret' }))).click();
+      enabled.detectChanges();
+
+      const banner = await enabledLoader.getHarness(TnBannerHarness);
+      expect(await banner.getText()).toContain(helptext2fa.verification.pendingRenewal);
+      expect(await banner.getText()).not.toContain(helptext2fa.verification.notActiveGlobally);
+    });
+
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {
       const emitted: boolean[] = [];
       spectator.component.setupComplete.subscribe((isComplete) => emitted.push(isComplete));

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@truenas/ui-components';
 import { MockComponent, ngMocks } from 'ng-mocks';
 import { QrCodeComponent, QrCodeDirective } from 'ng-qrcode';
-import { BehaviorSubject, of, throwError } from 'rxjs';
+import { BehaviorSubject, Subject, of, throwError } from 'rxjs';
 import { mockCall, mockApi } from 'app/core/testing/utils/mock-api.utils';
 import { mockWindow } from 'app/core/testing/utils/mock-window.utils';
 import { helptext2fa } from 'app/helptext/system/2fa';
@@ -564,6 +564,68 @@ describe('TwoFactorComponent', () => {
       const field = await loader.getHarness(TnFormFieldHarness);
       expect(await field.getErrorMessage()).toBe(helptext2fa.verification.checkFailed);
       expect(storage.get('pending2FaVerification:dummy')).toBe('renewal');
+    });
+
+    it('holds the secret buttons until the page knows what it is looking at', async () => {
+      // The load waits on system.info, and a click landing before it resolves would be
+      // rolled back by the snapshot that reply carries.
+      const systemInfo$ = new Subject<SystemInfo>();
+      jest.mocked(api.call).mockImplementation(((method: string) => {
+        if (method === 'system.info') {
+          return systemInfo$;
+        }
+        return method === 'auth.sessions' ? of([]) : of(undefined);
+      }) as ApiService['call']);
+
+      const loading = createComponent();
+      const loadingLoader = TestbedHarnessEnvironment.loader(loading.fixture);
+
+      const renewBtn = await loadingLoader.getHarness(TnButtonHarness.with({ label: 'Configure 2FA Secret' }));
+      expect(await renewBtn.isDisabled()).toBe(true);
+
+      systemInfo$.next({ datetime: { $date: applianceNow } } as SystemInfo);
+      systemInfo$.complete();
+      loading.detectChanges();
+
+      expect(await renewBtn.isDisabled()).toBe(false);
+    });
+
+    it('applies the account state it re-read when confirming', async () => {
+      // A disconnect spanning both the renew and its retry leaves the page believing no
+      // secret exists. The confirming re-read knows better, and dropping it would leave
+      // the card offering Configure right after saying 2FA was confirmed.
+      user$.next({ pw_name: 'dummy', two_factor_config: { secret_configured: false } } as LoggedInUser);
+      jest.mocked(api.call).mockImplementation(((method: string) => {
+        if (method === 'user.renew_2fa_secret') {
+          return throwError(() => new Error('offline'));
+        }
+        if (method === 'system.info') {
+          return of({ datetime: { $date: applianceNow } } as SystemInfo);
+        }
+        return method === 'auth.sessions' ? of([]) : of(undefined);
+      }) as ApiService['call']);
+      jest.mocked(spectator.inject(AuthService).refreshUser)
+        .mockReturnValueOnce(throwError(() => new Error('offline')));
+
+      const stranded = createComponent();
+      const strandedLoader = TestbedHarnessEnvironment.loader(stranded.fixture);
+      await (await strandedLoader.getHarness(TnButtonHarness.with({ label: 'Configure 2FA Secret' }))).click();
+      stranded.detectChanges();
+
+      // Connectivity is back and the secret was in fact armed all along.
+      const otpInput = await strandedLoader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await strandedLoader.getHarness(
+        TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }),
+      )).click();
+      stranded.detectChanges();
+
+      expect(await strandedLoader.getAllHarnesses(
+        TnButtonHarness.with({ label: 'Unset 2FA Secret' }),
+      )).toHaveLength(1);
+      expect(await strandedLoader.getAllHarnesses(
+        TnButtonHarness.with({ label: 'Configure 2FA Secret' }),
+      )).toHaveLength(0);
     });
 
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -397,7 +397,13 @@ describe('TwoFactorComponent', () => {
 
     it('falls back to the browser clock when the appliance time cannot be read', async () => {
       jest.mocked(api.call).mockImplementation(((method: string) => {
-        return method === 'system.info' ? throwError(() => new Error('down')) : of(undefined);
+        if (method === 'system.info') {
+          return throwError(() => new Error('down'));
+        }
+        // auth.sessions has to stay list-shaped: loadTwoFactorConfigs calls .find() on it
+        // and the subscribe has no error handler, so undefined would surface as unhandled
+        // RxJS noise rather than a failure.
+        return method === 'auth.sessions' ? of([]) : of(undefined);
       }) as ApiService['call']);
 
       const offline = createComponent();
@@ -469,6 +475,27 @@ describe('TwoFactorComponent', () => {
 
       const field = await loader.getHarness(TnFormFieldHarness);
       expect(await field.getErrorMessage()).toBe(helptext2fa.verification.invalid);
+    });
+
+    it('keeps Skip Setup reachable in the dialog when a first-time renew failed', async () => {
+      // The first-login dialog is opened with disableClose, and Skip touches no secret.
+      // A renew that fails leaves the page pending with nothing behind it, so hiding Skip
+      // there would leave Cancel Setup as the only exit from a dialog that cannot be closed.
+      user$.next({ pw_name: 'dummy', two_factor_config: { secret_configured: false } } as LoggedInUser);
+      jest.mocked(api.call).mockImplementation(((method: string) => {
+        if (method === 'user.renew_2fa_secret') {
+          return throwError(() => new Error('nope'));
+        }
+        return method === 'auth.sessions' ? of([]) : of(undefined);
+      }) as ApiService['call']);
+
+      const dialog = createComponent({ props: { isSetupDialog: true } });
+      const dialogLoader = TestbedHarnessEnvironment.loader(dialog.fixture);
+
+      await (await dialogLoader.getHarness(TnButtonHarness.with({ label: 'Configure 2FA Secret' }))).click();
+      dialog.detectChanges();
+
+      expect(await dialogLoader.getAllHarnesses(TnButtonHarness.with({ label: 'Skip Setup' }))).toHaveLength(1);
     });
 
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -466,7 +466,7 @@ describe('TwoFactorComponent', () => {
       // behind it. `new URL(null)` throws inside the subscribe, so Confirm Code would do
       // nothing at all — no message, no state change, just a console error.
       await generateSecret();
-      twoFactorConfig$.next({ ...twoFactorConfig, provisioning_uri: null } as unknown as UserTwoFactorConfig);
+      twoFactorConfig$.next({ ...twoFactorConfig, provisioning_uri: null });
 
       const otpInput = await loader.getHarness(TnInputHarness);
       await otpInput.setValue(validCode);

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -53,6 +53,7 @@ describe('TwoFactorComponent', () => {
         localStorage: {
           getItem: (key: string) => storage.get(key) ?? null,
           setItem: (key: string, value: string) => storage.set(key, value),
+          removeItem: (key: string) => storage.delete(key),
         },
       }),
       mockApi([
@@ -234,8 +235,6 @@ describe('TwoFactorComponent', () => {
     it('asks for a code from the authenticator app once a secret is generated', async () => {
       await generateSecret();
 
-      expect(spectator.component.pendingVerification()).toBe(true);
-
       const banner = await loader.getHarness(TnBannerHarness);
       expect(await banner.getText()).toContain(helptext2fa.verification.pending);
       expect(await loader.getHarnessOrNull(TnInputHarness)).not.toBeNull();
@@ -258,7 +257,7 @@ describe('TwoFactorComponent', () => {
 
       const field = await loader.getHarness(TnFormFieldHarness);
       expect(await field.getErrorMessage()).toBe(helptext2fa.verification.invalid);
-      expect(spectator.component.pendingVerification()).toBe(true);
+      expect(await loader.getHarnessOrNull(TnInputHarness)).not.toBeNull();
     });
 
     it('completes setup when the code matches the secret', async () => {
@@ -269,7 +268,6 @@ describe('TwoFactorComponent', () => {
       await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
       spectator.detectChanges();
 
-      expect(spectator.component.pendingVerification()).toBe(false);
       expect(await loader.getHarnessOrNull(TnInputHarness)).toBeNull();
       expect(await loader.getAllHarnesses(TnButtonHarness.with({ label: 'Unset 2FA Secret' }))).toHaveLength(1);
     });
@@ -288,7 +286,7 @@ describe('TwoFactorComponent', () => {
         buttonColor: 'warn',
       });
       expect(api.call).toHaveBeenCalledWith('user.unset_2fa_secret', ['dummy']);
-      expect(spectator.component.pendingVerification()).toBe(false);
+      expect(await loader.getHarnessOrNull(TnInputHarness)).toBeNull();
     });
 
     it('resumes confirmation after a reload, so an unconfirmed secret is never left behind', async () => {
@@ -297,8 +295,33 @@ describe('TwoFactorComponent', () => {
       const reloaded = createComponent();
       const reloadedLoader = TestbedHarnessEnvironment.loader(reloaded.fixture);
 
-      expect(reloaded.component.pendingVerification()).toBe(true);
       expect(await reloadedLoader.getHarnessOrNull(TnInputHarness)).not.toBeNull();
+    });
+
+    it('keys the stored flag to the account, so another user\'s flag is ignored', async () => {
+      // Nothing clears this on logout, so on a shared workstation an origin-wide key
+      // would drop the next user into a confirmation step for a secret that is not theirs.
+      storage.set('pending2FaVerification:someone-else', 'true');
+
+      const nextUser = createComponent();
+      const nextUserLoader = TestbedHarnessEnvironment.loader(nextUser.fixture);
+
+      expect(await nextUserLoader.getHarnessOrNull(TnInputHarness)).toBeNull();
+      expect(await nextUserLoader.getAllHarnesses(
+        TnButtonHarness.with({ label: 'Renew 2FA Secret' }),
+      )).toHaveLength(1);
+    });
+
+    it('drops the stored flag once the code is confirmed', async () => {
+      await generateSecret();
+      expect(storage.get('pending2FaVerification:dummy')).toBe('true');
+
+      const otpInput = await loader.getHarness(TnInputHarness);
+      await otpInput.setValue(validCode);
+      await (await loader.getHarness(TnButtonHarness.with({ label: helptext2fa.verification.verifyBtn }))).click();
+      spectator.detectChanges();
+
+      expect(storage.has('pending2FaVerification:dummy')).toBe(false);
     });
 
     it('reports setup as incomplete while a secret is waiting to be confirmed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.spec.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.spec.ts
@@ -461,10 +461,11 @@ describe('TwoFactorComponent', () => {
       expect(api.call).toHaveBeenCalledWith('user.unset_2fa_secret', ['dummy']);
     });
 
-    it('reports an unusable provisioning URI as a mismatched code, not a dead button', async () => {
+    it('says the secret could not be read rather than blaming the code or the clock', async () => {
       // A first-time setup whose renew failed leaves the step on screen with no secret
-      // behind it. `new URL(null)` throws inside the subscribe, so Confirm Code would do
-      // nothing at all — no message, no state change, just a console error.
+      // behind it. `new URL(null)` threw inside the subscribe, so Confirm Code did
+      // nothing at all — and the generic message would send the user to re-scan a QR
+      // code that is not on screen.
       await generateSecret();
       twoFactorConfig$.next({ ...twoFactorConfig, provisioning_uri: null });
 
@@ -474,7 +475,33 @@ describe('TwoFactorComponent', () => {
       spectator.detectChanges();
 
       const field = await loader.getHarness(TnFormFieldHarness);
-      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.invalid);
+      expect(await field.getErrorMessage()).toBe(helptext2fa.verification.unreadableSecret);
+    });
+
+    it('keeps Configure reachable when a renew failed before minting a secret', async () => {
+      // pendingVerification() is true but no secret exists, so the reason for hiding the
+      // secret-management buttons does not apply — and hiding them would leave Cancel
+      // Setup as the only control on the page.
+      user$.next({ pw_name: 'dummy', two_factor_config: { secret_configured: false } } as LoggedInUser);
+      jest.mocked(api.call).mockImplementation(((method: string) => {
+        if (method === 'user.renew_2fa_secret') {
+          return throwError(() => new Error('nope'));
+        }
+        return method === 'auth.sessions' ? of([]) : of(undefined);
+      }) as ApiService['call']);
+
+      const failed = createComponent();
+      const failedLoader = TestbedHarnessEnvironment.loader(failed.fixture);
+
+      await (await failedLoader.getHarness(TnButtonHarness.with({ label: 'Configure 2FA Secret' }))).click();
+      failed.detectChanges();
+
+      expect(await failedLoader.getAllHarnesses(
+        TnButtonHarness.with({ label: 'Configure 2FA Secret' }),
+      )).toHaveLength(1);
+
+      const banner = await failedLoader.getHarness(TnBannerHarness);
+      expect(await banner.getText()).toContain(helptext2fa.verification.pendingUnknown);
     });
 
     it('keeps Skip Setup reachable in the dialog when a first-time renew failed', async () => {

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -16,7 +16,7 @@ import {
 } from 'rxjs';
 import {
   catchError,
-  filter, switchMap, take, tap,
+  filter, finalize, switchMap, take, tap,
 } from 'rxjs/operators';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { verifyTotp } from 'app/helpers/totp.helper';
@@ -207,10 +207,17 @@ export class TwoFactorComponent implements OnInit {
       // where it stood before, rather than leaving the page unusable.
       this.api.call('system.info').pipe(catchError(() => of(null))),
     ])
-      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        take(1),
+        // finalize, not a line in `next`: this flag disables every secret button, so a
+        // stream that errors or completes without emitting would leave the page inert
+        // with no error on screen. getGlobalTwoFactorConfig does complete empty when the
+        // socket is mid-reconnect, which needs no API failure at all.
+        finalize(() => this.isDataLoading.set(false)),
+        takeUntilDestroyed(this.destroyRef),
+      )
       .subscribe({
         next: ([user, globalConfig, systemInfo]) => {
-          this.isDataLoading.set(false);
           this.username.set(user.pw_name);
           this.globalTwoFactorEnabled.set(globalConfig.enabled);
           this.toleranceWindow.set(globalConfig.window);
@@ -234,6 +241,7 @@ export class TwoFactorComponent implements OnInit {
           const isPending = user.two_factor_config.secret_configured && !!kind;
           this.setPendingVerification(isPending, kind ?? 'setup');
         },
+        error: (error: unknown) => this.errorHandler.showErrorModal(error),
       });
 
     this.api.call('auth.sessions').pipe(
@@ -364,7 +372,8 @@ export class TwoFactorComponent implements OnInit {
    * The URI is `null` on an account with no secret — including while the confirmation
    * step is showing after a renew that failed before arming one — and `new URL(null)`
    * throws, which inside a subscribe handler would leave Confirm Code doing nothing at
-   * all. A `null` here surfaces as the ordinary "code does not match" message instead.
+   * all. Callers turn a `null` into the `unreadableSecret` message, which points at
+   * generating a fresh secret rather than at re-scanning a QR code that is not on screen.
    */
   protected getProvisioningUriSecret(uri: string | null): string | null {
     if (!uri) {

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -174,6 +174,7 @@ export class TwoFactorComponent implements OnInit {
     return {
       invalidOtp: this.translate.instant(helptext2fa.verification.invalid),
       unreadableSecret: this.translate.instant(helptext2fa.verification.unreadableSecret),
+      checkFailed: this.translate.instant(helptext2fa.verification.checkFailed),
     };
   });
 
@@ -239,9 +240,29 @@ export class TwoFactorComponent implements OnInit {
       filter(Boolean),
       switchMap(() => this.renewSecretForUser(kind)),
       tap(() => this.isFormLoading.set(false)),
-      catchError((error: unknown) => this.handleError(error)),
+      catchError((error: unknown) => {
+        this.rereadSecretState();
+        return this.handleError(error);
+      }),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe();
+  }
+
+  /**
+   * Re-reads the account after a renew that did not complete.
+   *
+   * The call may have rotated the secret before its reply was lost, in which case the QR
+   * still on screen points at a secret the account no longer holds — so the user would
+   * scan the superseded one. The template follows `userTwoFactorConfig$`, so refreshing
+   * updates the code as well as the flag that gates it. Best effort: if this fails too
+   * the marker stays set, which is the safe direction.
+   */
+  private rereadSecretState(): void {
+    this.authService.refreshUser().pipe(
+      switchMap(() => this.authService.user$.pipe(filter(Boolean), take(1))),
+      catchError(() => EMPTY),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((user) => this.userTwoFactorAuthConfigured.set(user.two_factor_config.secret_configured));
   }
 
   /**
@@ -259,10 +280,25 @@ export class TwoFactorComponent implements OnInit {
       return;
     }
 
-    this.authService.userTwoFactorConfig$.pipe(
-      take(1),
+    this.isFormLoading.set(true);
+
+    // Re-read the account before judging the code, rather than trusting the cached
+    // config. A renew whose reply was lost may have rotated the secret server-side
+    // without this page ever hearing about it, and confirming against the superseded
+    // secret would clear the marker and report success for a secret the account no
+    // longer holds — the lockout this step exists to prevent. It also gives the verify
+    // path a definite outcome when `user$` is sitting on the transient null a failed
+    // refresh leaves behind, instead of silently never emitting.
+    this.authService.refreshUser().pipe(
+      switchMap(() => this.authService.userTwoFactorConfig$.pipe(take(1))),
+      catchError(() => {
+        this.isFormLoading.set(false);
+        this.verificationForm.controls.otp.setErrors({ checkFailed: true });
+        return EMPTY;
+      }),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((config) => {
+      this.isFormLoading.set(false);
       const secret = this.getProvisioningUriSecret(config.provisioning_uri);
       if (!secret) {
         // Nothing to check the code against, and no QR on screen either — telling the

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -15,13 +15,16 @@ import {
   combineLatest, map,
 } from 'rxjs';
 import {
-  catchError,
+  catchError, defaultIfEmpty,
   filter, finalize, switchMap, take, tap,
 } from 'rxjs/operators';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { verifyTotp } from 'app/helpers/totp.helper';
 import { helptext2fa } from 'app/helptext/system/2fa';
 import { CredentialType } from 'app/interfaces/credential-type.interface';
+import { LoggedInUser } from 'app/interfaces/ds-cache.interface';
+import { SystemInfo } from 'app/interfaces/system-info.interface';
+import { GlobalTwoFactorConfig } from 'app/interfaces/two-factor-config.interface';
 import { AuthService } from 'app/modules/auth/auth.service';
 import { PendingTwoFactorKind, PendingTwoFactorService } from 'app/modules/auth/pending-two-factor.service';
 import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button.component';
@@ -84,6 +87,15 @@ export class TwoFactorComponent implements OnInit {
   currentSessionIs2fa = signal(false);
   protected pendingVerification = signal(false);
 
+  /**
+   * Set when the load could not read the account or the global config.
+   *
+   * Without it the banner keeps rendering from field defaults, which reads as a
+   * confident "2FA is not enabled on this system" — a statement the page has no basis
+   * for and which invites the user to act on it.
+   */
+  private loadFailed = signal(false);
+
   /** Which path opened the confirmation step — decides how destructive cancelling is. */
   private pendingKind = signal<PendingTwoFactorKind>('setup');
 
@@ -135,6 +147,9 @@ export class TwoFactorComponent implements OnInit {
   });
 
   protected get global2FaMsg(): string {
+    if (this.loadFailed()) {
+      return this.translate.instant(helptext2fa.loadFailed);
+    }
     if (this.pendingVerification() && !this.userTwoFactorAuthConfigured()) {
       return this.translate.instant(helptext2fa.verification.pendingUnknown);
     }
@@ -157,7 +172,7 @@ export class TwoFactorComponent implements OnInit {
 
   protected get statusBannerType(): 'warning' | 'success' {
     const isSettled = this.globalTwoFactorEnabled() && this.userTwoFactorAuthConfigured();
-    return isSettled && !this.pendingVerification() ? 'success' : 'warning';
+    return isSettled && !this.pendingVerification() && !this.loadFailed() ? 'success' : 'warning';
   }
 
   readonly helptext = helptext2fa;
@@ -198,26 +213,41 @@ export class TwoFactorComponent implements OnInit {
 
   private loadTwoFactorConfigs(): void {
     this.isDataLoading.set(true);
+    this.loadFailed.set(false);
+    // Every source here can complete WITHOUT emitting, not just error: a clean websocket
+    // reconnect completes the response stream, so an in-flight call ends silently and
+    // combineLatest completes with it. `defaultIfEmpty` turns that into a value this can
+    // recognise — without it the card renders from field defaults and states that 2FA is
+    // off for a user who has it on, with no error anywhere on screen.
     combineLatest([
       // The whole user, not just userTwoFactorConfig$: the persisted pending flag is
       // keyed to the account name, which only the user record carries.
-      this.authService.user$.pipe(filter(Boolean), take(1)),
-      this.authService.getGlobalTwoFactorConfig(),
-      // Never fatal: without it the check falls back to the browser clock, which is
-      // where it stood before, rather than leaving the page unusable.
-      this.api.call('system.info').pipe(catchError(() => of(null))),
+      this.authService.user$.pipe(filter(Boolean), take(1), defaultIfEmpty(null as LoggedInUser | null)),
+      this.authService.getGlobalTwoFactorConfig()
+        .pipe(take(1), defaultIfEmpty(null as GlobalTwoFactorConfig | null)),
+      // The clock read alone is genuinely optional: without it the check falls back to
+      // the browser clock, which is where it stood before.
+      this.api.call('system.info')
+        .pipe(catchError(() => of(null)), defaultIfEmpty(null as SystemInfo | null)),
     ])
       .pipe(
         take(1),
         // finalize, not a line in `next`: this flag disables every secret button, so a
         // stream that errors or completes without emitting would leave the page inert
-        // with no error on screen. getGlobalTwoFactorConfig does complete empty when the
-        // socket is mid-reconnect, which needs no API failure at all.
+        // with no error on screen.
         finalize(() => this.isDataLoading.set(false)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
         next: ([user, globalConfig, systemInfo]) => {
+          if (!user || !globalConfig) {
+            // Say the settings could not be read, rather than showing defaults that read
+            // as "2FA is off here" and inviting the user to act on them.
+            this.loadFailed.set(true);
+            this.errorHandler.showErrorModal(new Error(this.translate.instant(helptext2fa.loadFailed)));
+            return;
+          }
+
           this.username.set(user.pw_name);
           this.globalTwoFactorEnabled.set(globalConfig.enabled);
           this.toleranceWindow.set(globalConfig.window);
@@ -258,7 +288,6 @@ export class TwoFactorComponent implements OnInit {
     this.getConfirmation().pipe(
       filter(Boolean),
       switchMap(() => this.renewSecretForUser(kind)),
-      tap(() => this.isFormLoading.set(false)),
       catchError((error: unknown) => {
         this.rereadSecretState();
         return this.handleError(error);
@@ -311,13 +340,16 @@ export class TwoFactorComponent implements OnInit {
     this.authService.refreshUser().pipe(
       switchMap(() => this.authService.userTwoFactorConfig$.pipe(take(1))),
       catchError(() => {
-        this.isFormLoading.set(false);
         this.verificationForm.controls.otp.setErrors({ checkFailed: true });
         return EMPTY;
       }),
+      // A clean reconnect completes an in-flight call without emitting, so neither the
+      // subscribe nor the catchError would run. While this flag is on, Confirm Code and
+      // Cancel Setup are disabled and Renew/Unset/Skip are not rendered at all — a card
+      // with no working control, inside a dialog opened with disableClose.
+      finalize(() => this.isFormLoading.set(false)),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((config) => {
-      this.isFormLoading.set(false);
       const secret = this.getProvisioningUriSecret(config.provisioning_uri);
       if (!secret) {
         // Nothing to check the code against, and no QR on screen either — telling the
@@ -420,6 +452,8 @@ export class TwoFactorComponent implements OnInit {
       switchMap((user) => this.api.call('user.renew_2fa_secret', [user.pw_name, { interval: 30, otp_digits: 6 }])),
       switchMap(() => this.authService.refreshUser()),
       tap(() => this.userTwoFactorAuthConfigured.set(true)),
+      // See onVerifyOtp: a silent completion would otherwise strand the flag on.
+      finalize(() => this.isFormLoading.set(false)),
       takeUntilDestroyed(this.destroyRef),
     );
   }
@@ -483,12 +517,13 @@ export class TwoFactorComponent implements OnInit {
       switchMap((user) => this.api.call('user.unset_2fa_secret', [user.pw_name])),
       switchMap(() => this.authService.refreshUser()),
       tap(() => {
-        this.isFormLoading.set(false);
         this.userTwoFactorAuthConfigured.set(false);
         this.currentSessionIs2fa.set(false);
         this.setPendingVerification(false);
         this.verificationForm.reset();
       }),
+      // See onVerifyOtp: a silent completion would otherwise strand the flag on.
+      finalize(() => this.isFormLoading.set(false)),
     );
   }
 

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -16,7 +16,7 @@ import {
 } from 'rxjs';
 import {
   catchError, defaultIfEmpty,
-  filter, finalize, switchMap, take, tap,
+  filter, finalize, switchMap, take, tap, timeout,
 } from 'rxjs/operators';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { verifyTotp } from 'app/helpers/totp.helper';
@@ -34,6 +34,19 @@ import { ApiService } from 'app/modules/websocket/api.service';
 import { QrViewerComponent } from 'app/pages/two-factor-auth/qr-viewer/qr-viewer.component';
 import { twoFactorElements } from 'app/pages/two-factor-auth/two-factor.elements';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+
+/**
+ * How long the load waits before calling the read failed.
+ *
+ * `defaultIfEmpty` only fires on completion, and two of the three sources never complete:
+ * `user$` is a BehaviorSubject, and `getGlobalTwoFactorConfig()` switchMaps over another
+ * one, so an inner call that ends without a result leaves the whole load hanging rather
+ * than empty. Since this flag now disables every secret button, a hang is a permanently
+ * inert card — so the load needs a terminal outcome even when nothing downstream provides
+ * one. The bound is a judgement call: long enough not to fire on a slow appliance, short
+ * enough that nobody stares at a dead card.
+ */
+const loadTimeoutMs = 30_000;
 
 @Component({
   selector: 'ix-two-factor',
@@ -232,6 +245,8 @@ export class TwoFactorComponent implements OnInit {
     ])
       .pipe(
         take(1),
+        // Covers the sources `defaultIfEmpty` cannot, which never complete at all.
+        timeout(loadTimeoutMs),
         // finalize, not a line in `next`: this flag disables every secret button, so a
         // stream that errors or completes without emitting would leave the page inert
         // with no error on screen.
@@ -271,7 +286,12 @@ export class TwoFactorComponent implements OnInit {
           const isPending = user.two_factor_config.secret_configured && !!kind;
           this.setPendingVerification(isPending, kind ?? 'setup');
         },
-        error: (error: unknown) => this.errorHandler.showErrorModal(error),
+        error: (error: unknown) => {
+          // Same reason as the empty-read branch: without this the banner keeps asserting
+          // that 2FA is off here, which the page has no basis for saying.
+          this.loadFailed.set(true);
+          this.errorHandler.showErrorModal(error);
+        },
       });
 
     this.api.call('auth.sessions').pipe(
@@ -323,6 +343,11 @@ export class TwoFactorComponent implements OnInit {
    * against a secret their app never received.
    */
   protected onVerifyOtp(): void {
+    // Re-run the validators first: `checkFailed` and `unreadableSecret` are set by hand
+    // and both ask the user to retry the same code, so leaving them on the control would
+    // make the guard below swallow the retry the message just invited.
+    this.verificationForm.controls.otp.updateValueAndValidity();
+
     if (this.verificationForm.invalid) {
       this.verificationForm.controls.otp.markAsTouched();
       return;

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -2,7 +2,7 @@ import { AsyncPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy, Component, DestroyRef, OnInit, input, output, signal, inject, computed, effect,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
@@ -170,9 +170,17 @@ export class TwoFactorComponent implements OnInit {
 
   readonly helptext = helptext2fa;
 
-  protected readonly otpErrorMessages = {
-    invalidOtp: this.translate.instant(helptext2fa.verification.invalid),
-  };
+  /**
+   * Rebuilt on language change: `instant` at field initialisation would freeze this
+   * message in whichever language was active when the component was constructed, while
+   * every other string on the page follows a runtime switch.
+   */
+  private readonly langChange = toSignal(this.translate.onLangChange, { initialValue: null });
+
+  protected readonly otpErrorMessages = computed(() => {
+    this.langChange();
+    return { invalidOtp: this.translate.instant(helptext2fa.verification.invalid) };
+  });
 
   readonly labels = {
     secret: helptext2fa.secret.label,
@@ -300,11 +308,22 @@ export class TwoFactorComponent implements OnInit {
     ).subscribe();
   }
 
-  protected getProvisioningUriSecret(uri: string): string | null {
-    const url = new URL(uri);
-    const params = new URLSearchParams(url.search);
+  /**
+   * The URI is `null` on an account with no secret — including while the confirmation
+   * step is showing after a renew that failed before arming one — and `new URL(null)`
+   * throws, which inside a subscribe handler would leave Confirm Code doing nothing at
+   * all. A `null` here surfaces as the ordinary "code does not match" message instead.
+   */
+  protected getProvisioningUriSecret(uri: string | null): string | null {
+    if (!uri) {
+      return null;
+    }
 
-    return params.get('secret');
+    try {
+      return new URLSearchParams(new URL(uri).search).get('secret');
+    } catch {
+      return null;
+    }
   }
 
   private handleError(error: unknown): Observable<boolean> {
@@ -315,15 +334,17 @@ export class TwoFactorComponent implements OnInit {
   }
 
   private renewSecretForUser(kind: PendingKind): Observable<void> {
-    this.isFormLoading.set(true);
-
-    this.currentSessionIs2fa.set(false);
-    this.verificationForm.reset();
-
     return this.authService.user$.pipe(
-      take(1),
+      // `filter` before `take`, not after: `refreshUser()` pushes `null` onto `user$`
+      // before re-fetching, so a failed refresh leaves `null` as the current value and
+      // `take(1)` would grab it, drop it, and complete having done nothing — stranding
+      // the loading flag on and every button disabled. This waits for a real user.
       filter((user) => !!user),
+      take(1),
       tap((user) => {
+        this.isFormLoading.set(true);
+        this.currentSessionIs2fa.set(false);
+        this.verificationForm.reset();
         this.username.set(user.pw_name);
         // Marked before the call, not after it. `renew_2fa_secret` arms the secret
         // server-side, so a call that times out having actually succeeded — or whose
@@ -392,11 +413,12 @@ export class TwoFactorComponent implements OnInit {
   }
 
   private unsetSecretForUser(): Observable<undefined> {
-    this.isFormLoading.set(true);
-
     return this.authService.user$.pipe(
-      take(1),
+      // See renewSecretForUser: `filter` first, and the loading flag only once a real
+      // user is in hand, so Cancel Setup cannot leave the page spinning with no exit.
       filter((user) => !!user),
+      take(1),
+      tap(() => this.isFormLoading.set(true)),
       switchMap((user) => this.api.call('user.unset_2fa_secret', [user.pw_name])),
       switchMap(() => this.authService.refreshUser()),
       tap(() => {

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@truenas/ui-components';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import {
-  Observable, of, EMPTY,
+  Observable, of, EMPTY, TimeoutError,
   combineLatest, map,
 } from 'rxjs';
 import {
@@ -106,6 +106,10 @@ export class TwoFactorComponent implements OnInit {
    * Without it the banner keeps rendering from field defaults, which reads as a
    * confident "2FA is not enabled on this system" — a statement the page has no basis
    * for and which invites the user to act on it.
+   *
+   * Cleared by {@link setSecretConfigured} rather than only by a reload: the load is not
+   * the page's last chance to learn the account state, and leaving it set would shadow
+   * every later banner — including the one explaining what the code field is for.
    */
   private loadFailed = signal(false);
 
@@ -227,11 +231,15 @@ export class TwoFactorComponent implements OnInit {
   private loadTwoFactorConfigs(): void {
     this.isDataLoading.set(true);
     this.loadFailed.set(false);
-    // Every source here can complete WITHOUT emitting, not just error: a clean websocket
-    // reconnect completes the response stream, so an in-flight call ends silently and
-    // combineLatest completes with it. `defaultIfEmpty` turns that into a value this can
-    // recognise — without it the card renders from field defaults and states that 2FA is
-    // off for a user who has it on, with no error anywhere on screen.
+    // A call can complete WITHOUT emitting, not just error: a clean websocket reconnect
+    // completes the response stream, so an in-flight call ends silently and combineLatest
+    // completes with it — leaving the card rendering field defaults that state 2FA is off
+    // for a user who has it on, with no error anywhere. `defaultIfEmpty` turns that into a
+    // value this can recognise.
+    //
+    // Only the bare `system.info` call can reach that today: the other two are piped off
+    // BehaviorSubjects that never complete, so they either emit or hang, and `timeout` is
+    // what covers them. Their guards are belt-and-braces against those shapes changing.
     combineLatest([
       // The whole user, not just userTwoFactorConfig$: the persisted pending flag is
       // keyed to the account name, which only the user record carries.
@@ -278,7 +286,7 @@ export class TwoFactorComponent implements OnInit {
             return;
           }
 
-          this.userTwoFactorAuthConfigured.set(user.two_factor_config.secret_configured);
+          this.setSecretConfigured(user.two_factor_config.secret_configured);
 
           // A stored flag without a secret behind it is stale — the secret was unset
           // elsewhere. Drop it rather than leave it for the next read.
@@ -290,7 +298,12 @@ export class TwoFactorComponent implements OnInit {
           // Same reason as the empty-read branch: without this the banner keeps asserting
           // that 2FA is off here, which the page has no basis for saying.
           this.loadFailed.set(true);
-          this.errorHandler.showErrorModal(error);
+          // The timeout is the likeliest arrival here, and its message is RxJS's
+          // untranslated "Timeout has occurred" — say the same thing the banner says.
+          const isTimeout = error instanceof TimeoutError;
+          this.errorHandler.showErrorModal(
+            isTimeout ? new Error(this.translate.instant(helptext2fa.loadFailed)) : error,
+          );
         },
       });
 
@@ -330,7 +343,7 @@ export class TwoFactorComponent implements OnInit {
       switchMap(() => this.authService.user$.pipe(filter(Boolean), take(1))),
       catchError(() => EMPTY),
       takeUntilDestroyed(this.destroyRef),
-    ).subscribe((user) => this.userTwoFactorAuthConfigured.set(user.two_factor_config.secret_configured));
+    ).subscribe((user) => this.setSecretConfigured(user.two_factor_config.secret_configured));
   }
 
   /**
@@ -398,7 +411,7 @@ export class TwoFactorComponent implements OnInit {
       // The re-read above is the freshest word on the account; dropping it would let the
       // card report a confirmed secret and still offer Configure, with the QR hidden and
       // Finish never appearing in the first-login dialog.
-      this.userTwoFactorAuthConfigured.set(config.secret_configured);
+      this.setSecretConfigured(config.secret_configured);
       this.setPendingVerification(false);
       this.verificationForm.reset();
       this.snackbar.success(this.translate.instant(helptext2fa.verification.verified));
@@ -476,7 +489,7 @@ export class TwoFactorComponent implements OnInit {
       }),
       switchMap((user) => this.api.call('user.renew_2fa_secret', [user.pw_name, { interval: 30, otp_digits: 6 }])),
       switchMap(() => this.authService.refreshUser()),
-      tap(() => this.userTwoFactorAuthConfigured.set(true)),
+      tap(() => this.setSecretConfigured(true)),
       // See onVerifyOtp: a silent completion would otherwise strand the flag on.
       finalize(() => this.isFormLoading.set(false)),
       takeUntilDestroyed(this.destroyRef),
@@ -542,7 +555,7 @@ export class TwoFactorComponent implements OnInit {
       switchMap((user) => this.api.call('user.unset_2fa_secret', [user.pw_name])),
       switchMap(() => this.authService.refreshUser()),
       tap(() => {
-        this.userTwoFactorAuthConfigured.set(false);
+        this.setSecretConfigured(false);
         this.currentSessionIs2fa.set(false);
         this.setPendingVerification(false);
         this.verificationForm.reset();
@@ -550,6 +563,15 @@ export class TwoFactorComponent implements OnInit {
       // See onVerifyOtp: a silent completion would otherwise strand the flag on.
       finalize(() => this.isFormLoading.set(false)),
     );
+  }
+
+  /**
+   * Records account state learned from a fresh read — which also means the page is no
+   * longer blind, so it stops saying the settings could not be read.
+   */
+  private setSecretConfigured(isConfigured: boolean): void {
+    this.userTwoFactorAuthConfigured.set(isConfigured);
+    this.loadFailed.set(false);
   }
 
   private setPendingVerification(isPending: boolean, kind: PendingTwoFactorKind = 'setup'): void {

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -167,13 +167,14 @@ export class TwoFactorComponent implements OnInit {
     if (this.loadFailed()) {
       return this.translate.instant(helptext2fa.loadFailed);
     }
-    if (this.pendingVerification() && !this.userTwoFactorAuthConfigured()) {
-      return this.translate.instant(helptext2fa.verification.pendingUnknown);
-    }
     if (this.pendingVerification()) {
-      return this.translate.instant(
-        this.pendingKind() === 'renewal' ? helptext2fa.verification.pendingRenewal : helptext2fa.verification.pending,
-      );
+      const pending = this.translate.instant(this.pendingMessage());
+      // The banner shows one message, and the paragraph that normally carries this caveat
+      // is gated on the same flag — so without this the page drops the one fact the user
+      // needs and keeps the claim that overstates what just happened.
+      return this.globalTwoFactorEnabled()
+        ? pending
+        : `${pending} ${this.translate.instant(helptext2fa.verification.notActiveGlobally)}`;
     }
     if (!this.globalTwoFactorEnabled()) {
       return this.translate.instant(helptext2fa.globallyDisabled);
@@ -185,6 +186,16 @@ export class TwoFactorComponent implements OnInit {
       return this.translate.instant(helptext2fa.allSetUp);
     }
     return this.translate.instant(helptext2fa.enabledGloballyButNotForUser);
+  }
+
+  private pendingMessage(): string {
+    if (!this.userTwoFactorAuthConfigured()) {
+      return helptext2fa.verification.pendingUnknown;
+    }
+
+    return this.pendingKind() === 'renewal'
+      ? helptext2fa.verification.pendingRenewal
+      : helptext2fa.verification.pending;
   }
 
   protected get statusBannerType(): 'warning' | 'success' {

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -1,9 +1,13 @@
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, OnInit, input, output, signal, inject, computed } from '@angular/core';
+import {
+  ChangeDetectionStrategy, Component, DestroyRef, OnInit, input, output, signal, inject, computed, effect,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import {
-  TnBannerComponent, TnButtonComponent, TnCardComponent, TnDialog, TnProgressBarComponent,
+  TnBannerComponent, TnButtonComponent, TnCardComponent, TnDialog, TnFormFieldComponent, TnInputComponent,
+  TnProgressBarComponent,
 } from '@truenas/ui-components';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import {
@@ -15,16 +19,26 @@ import {
   filter, switchMap, take, tap,
 } from 'rxjs/operators';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
+import { verifyTotp } from 'app/helpers/totp.helper';
 import { WINDOW } from 'app/helpers/window.helper';
 import { helptext2fa } from 'app/helptext/system/2fa';
 import { CredentialType } from 'app/interfaces/credential-type.interface';
 import { AuthService } from 'app/modules/auth/auth.service';
 import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
+import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { QrViewerComponent } from 'app/pages/two-factor-auth/qr-viewer/qr-viewer.component';
 import { twoFactorElements } from 'app/pages/two-factor-auth/two-factor.elements';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
+
+/**
+ * Set while a secret exists that the user has not yet proven their authenticator app
+ * holds. Persisted rather than kept in memory so a reload, a navigation away, or a
+ * browser crash lands the user back on the confirmation step — with the QR code and
+ * the escape hatch — instead of on a page that claims the setup is finished.
+ */
+const pendingVerificationKey = 'pending2FaVerification';
 
 @Component({
   selector: 'ix-two-factor',
@@ -38,15 +52,25 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
     NgxSkeletonLoaderModule,
     TnBannerComponent,
     TnButtonComponent,
+    TnFormFieldComponent,
+    TnInputComponent,
     QrViewerComponent,
+    ReactiveFormsModule,
     TranslateModule,
     AsyncPipe,
     CopyButtonComponent,
   ],
 })
-export class TwoFactorComponent implements OnInit, OnDestroy {
+export class TwoFactorComponent implements OnInit {
   readonly isSetupDialog = input(false);
   readonly skipSetup = output();
+
+  /**
+   * Mirrors {@link isSetupComplete} for hosts that gate their own "done" affordance on
+   * it — the first-login dialog's Finish button, which must not appear while a secret
+   * is still waiting to be confirmed.
+   */
+  readonly setupComplete = output<boolean>();
 
   authService = inject(AuthService);
   private dialogService = inject(DialogService);
@@ -54,6 +78,8 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
   protected tnDialog = inject(TnDialog);
   private api = inject(ApiService);
   private errorHandler = inject(ErrorHandlerService);
+  private snackbar = inject(SnackbarService);
+  private formBuilder = inject(FormBuilder);
   private window = inject<Window>(WINDOW);
   private destroyRef = inject(DestroyRef);
 
@@ -63,14 +89,25 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
   protected isDataLoading = signal(false);
   protected isFormLoading = signal(false);
   globalTwoFactorEnabled = signal(false);
-  showQrCodeWarning = false;
   currentSessionIs2fa = signal(false);
+  pendingVerification = signal(false);
+
+  protected readonly verificationForm = this.formBuilder.nonNullable.group({
+    otp: ['', Validators.required],
+  });
 
   protected readonly showSkipButton = computed(() => {
     return this.isSetupDialog() && !this.userTwoFactorAuthConfigured();
   });
 
+  private readonly isSetupComplete = computed(() => {
+    return this.userTwoFactorAuthConfigured() && !this.pendingVerification();
+  });
+
   protected get global2FaMsg(): string {
+    if (this.pendingVerification()) {
+      return this.translate.instant(helptext2fa.verification.pending);
+    }
     if (!this.globalTwoFactorEnabled()) {
       return this.translate.instant(helptext2fa.globallyDisabled);
     }
@@ -83,7 +120,16 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
     return this.translate.instant(helptext2fa.enabledGloballyButNotForUser);
   }
 
+  protected get statusBannerType(): 'warning' | 'success' {
+    const isSettled = this.globalTwoFactorEnabled() && this.userTwoFactorAuthConfigured();
+    return isSettled && !this.pendingVerification() ? 'success' : 'warning';
+  }
+
   readonly helptext = helptext2fa;
+
+  protected readonly otpErrorMessages = {
+    invalidOtp: this.translate.instant(helptext2fa.verification.invalid),
+  };
 
   readonly labels = {
     secret: helptext2fa.secret.label,
@@ -95,14 +141,12 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
     uri: helptext2fa.uri.tooltip,
   };
 
-  ngOnInit(): void {
-    this.loadTwoFactorConfigs();
-
-    this.showQrCodeWarning = this.window.localStorage.getItem('showQr2FaWarning') === 'true';
+  constructor() {
+    effect(() => this.setupComplete.emit(this.isSetupComplete()));
   }
 
-  ngOnDestroy(): void {
-    this.setQrWarningState(false);
+  ngOnInit(): void {
+    this.loadTwoFactorConfigs();
   }
 
   private loadTwoFactorConfigs(): void {
@@ -117,6 +161,10 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
           this.isDataLoading.set(false);
           this.userTwoFactorAuthConfigured.set(userConfig.secret_configured);
           this.globalTwoFactorEnabled.set(globalConfig.enabled);
+          // A stored flag without a secret is stale — the secret was unset elsewhere.
+          this.pendingVerification.set(
+            userConfig.secret_configured && this.window.localStorage.getItem(pendingVerificationKey) === 'true',
+          );
         },
       });
 
@@ -132,6 +180,58 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
       filter(Boolean),
       switchMap(() => this.renewSecretForUser()),
       tap(() => this.isFormLoading.set(false)),
+      catchError((error: unknown) => this.handleError(error)),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe();
+  }
+
+  /**
+   * Confirms the code the user read off their authenticator app.
+   *
+   * The check runs in the browser against the secret the QR code carries: the
+   * middleware has no endpoint that validates a code without also arming the secret,
+   * and the authoritative check happens at login regardless. What this buys is the
+   * guarantee the reporter asked for — that nobody leaves this page with 2FA armed
+   * against a secret their app never received.
+   */
+  protected onVerifyOtp(): void {
+    if (this.verificationForm.invalid) {
+      this.verificationForm.controls.otp.markAsTouched();
+      return;
+    }
+
+    this.authService.userTwoFactorConfig$.pipe(
+      take(1),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((config) => {
+      const secret = this.getProvisioningUriSecret(config.provisioning_uri);
+      const isValid = !!secret && verifyTotp(secret, this.verificationForm.controls.otp.value, {
+        interval: config.interval,
+        digits: config.otp_digits,
+      });
+
+      if (!isValid) {
+        this.verificationForm.controls.otp.setErrors({ invalidOtp: true });
+        return;
+      }
+
+      this.setPendingVerification(false);
+      this.verificationForm.reset();
+      this.snackbar.success(this.translate.instant(helptext2fa.verification.verified));
+    });
+  }
+
+  protected onCancelVerification(): void {
+    this.dialogService.confirm({
+      title: this.translate.instant(helptext2fa.verification.cancel.title),
+      message: this.translate.instant(helptext2fa.verification.cancel.message),
+      buttonText: this.translate.instant(helptext2fa.verification.cancel.btn),
+      cancelText: this.translate.instant(helptext2fa.verification.cancel.cancelBtn),
+      hideCheckbox: true,
+      buttonColor: 'warn',
+    }).pipe(
+      filter(Boolean),
+      switchMap(() => this.unsetSecretForUser()),
       catchError((error: unknown) => this.handleError(error)),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe();
@@ -154,9 +254,8 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
   private renewSecretForUser(): Observable<void> {
     this.isFormLoading.set(true);
 
-    this.setQrWarningState(true);
-
     this.currentSessionIs2fa.set(false);
+    this.verificationForm.reset();
 
     return this.authService.user$.pipe(
       take(1),
@@ -165,6 +264,7 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
       switchMap(() => this.authService.refreshUser()),
       tap(() => {
         this.userTwoFactorAuthConfigured.set(true);
+        this.setPendingVerification(true);
       }),
       takeUntilDestroyed(this.destroyRef),
     );
@@ -213,28 +313,32 @@ export class TwoFactorComponent implements OnInit, OnDestroy {
       buttonColor: 'warn',
     }).pipe(
       filter(Boolean),
-      switchMap(() => {
-        this.isFormLoading.set(true);
-        return this.authService.user$.pipe(
-          take(1),
-          filter((user) => !!user),
-          switchMap((user) => this.api.call('user.unset_2fa_secret', [user.pw_name])),
-        );
-      }),
-      switchMap(() => this.authService.refreshUser()),
-      tap(() => {
-        this.isFormLoading.set(false);
-        this.userTwoFactorAuthConfigured.set(false);
-        this.setQrWarningState(false);
-        this.currentSessionIs2fa.set(false);
-      }),
+      switchMap(() => this.unsetSecretForUser()),
       catchError((error: unknown) => this.handleError(error)),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe();
   }
 
-  private setQrWarningState(show: boolean): void {
-    this.showQrCodeWarning = show;
-    this.window.localStorage.setItem('showQr2FaWarning', show.toString());
+  private unsetSecretForUser(): Observable<undefined> {
+    this.isFormLoading.set(true);
+
+    return this.authService.user$.pipe(
+      take(1),
+      filter((user) => !!user),
+      switchMap((user) => this.api.call('user.unset_2fa_secret', [user.pw_name])),
+      switchMap(() => this.authService.refreshUser()),
+      tap(() => {
+        this.isFormLoading.set(false);
+        this.userTwoFactorAuthConfigured.set(false);
+        this.currentSessionIs2fa.set(false);
+        this.setPendingVerification(false);
+        this.verificationForm.reset();
+      }),
+    );
+  }
+
+  private setPendingVerification(isPending: boolean): void {
+    this.pendingVerification.set(isPending);
+    this.window.localStorage.setItem(pendingVerificationKey, isPending.toString());
   }
 }

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -37,8 +37,12 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
  * holds. Persisted rather than kept in memory so a reload, a navigation away, or a
  * browser crash lands the user back on the confirmation step — with the QR code and
  * the escape hatch — instead of on a page that claims the setup is finished.
+ *
+ * Suffixed with the account name because nothing clears this on logout: on a shared
+ * workstation an origin-wide key would put the next user into a confirmation step for
+ * a secret that was never theirs, with Renew and Unset hidden behind it.
  */
-const pendingVerificationKey = 'pending2FaVerification';
+const pendingVerificationKeyPrefix = 'pending2FaVerification';
 
 @Component({
   selector: 'ix-two-factor',
@@ -90,7 +94,10 @@ export class TwoFactorComponent implements OnInit {
   protected isFormLoading = signal(false);
   globalTwoFactorEnabled = signal(false);
   currentSessionIs2fa = signal(false);
-  pendingVerification = signal(false);
+  protected pendingVerification = signal(false);
+
+  /** Account the persisted pending flag is keyed to; empty until `user$` resolves. */
+  private username = signal('');
 
   protected readonly verificationForm = this.formBuilder.nonNullable.group({
     otp: ['', Validators.required],
@@ -152,19 +159,24 @@ export class TwoFactorComponent implements OnInit {
   private loadTwoFactorConfigs(): void {
     this.isDataLoading.set(true);
     combineLatest([
-      this.authService.userTwoFactorConfig$.pipe(take(1)),
+      // The whole user, not just userTwoFactorConfig$: the persisted pending flag is
+      // keyed to the account name, which only the user record carries.
+      this.authService.user$.pipe(filter(Boolean), take(1)),
       this.authService.getGlobalTwoFactorConfig(),
     ])
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: ([userConfig, globalConfig]) => {
+        next: ([user, globalConfig]) => {
           this.isDataLoading.set(false);
-          this.userTwoFactorAuthConfigured.set(userConfig.secret_configured);
+          this.username.set(user.pw_name);
+          this.userTwoFactorAuthConfigured.set(user.two_factor_config.secret_configured);
           this.globalTwoFactorEnabled.set(globalConfig.enabled);
-          // A stored flag without a secret is stale — the secret was unset elsewhere.
-          this.pendingVerification.set(
-            userConfig.secret_configured && this.window.localStorage.getItem(pendingVerificationKey) === 'true',
-          );
+
+          // A stored flag without a secret behind it is stale — the secret was unset
+          // elsewhere. Drop it rather than leave it for the next read.
+          const isPending = user.two_factor_config.secret_configured
+            && this.window.localStorage.getItem(this.pendingVerificationKey()) === 'true';
+          this.setPendingVerification(isPending);
         },
       });
 
@@ -260,6 +272,7 @@ export class TwoFactorComponent implements OnInit {
     return this.authService.user$.pipe(
       take(1),
       filter((user) => !!user),
+      tap((user) => this.username.set(user.pw_name)),
       switchMap((user) => this.api.call('user.renew_2fa_secret', [user.pw_name, { interval: 30, otp_digits: 6 }])),
       switchMap(() => this.authService.refreshUser()),
       tap(() => {
@@ -339,6 +352,15 @@ export class TwoFactorComponent implements OnInit {
 
   private setPendingVerification(isPending: boolean): void {
     this.pendingVerification.set(isPending);
-    this.window.localStorage.setItem(pendingVerificationKey, isPending.toString());
+
+    if (isPending) {
+      this.window.localStorage.setItem(this.pendingVerificationKey(), 'true');
+    } else {
+      this.window.localStorage.removeItem(this.pendingVerificationKey());
+    }
+  }
+
+  private pendingVerificationKey(): string {
+    return `${pendingVerificationKeyPrefix}:${this.username()}`;
   }
 }

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -212,10 +212,21 @@ export class TwoFactorComponent implements OnInit {
         next: ([user, globalConfig, systemInfo]) => {
           this.isDataLoading.set(false);
           this.username.set(user.pw_name);
-          this.userTwoFactorAuthConfigured.set(user.two_factor_config.secret_configured);
           this.globalTwoFactorEnabled.set(globalConfig.enabled);
           this.toleranceWindow.set(globalConfig.window);
           this.clockOffset.set(systemInfo ? systemInfo.datetime.$date - Date.now() : 0);
+
+          // The user here is a snapshot taken when this load was subscribed, before the
+          // round trips above resolved. A renew that started in the meantime has already
+          // moved the page past it, so applying the snapshot would roll that back —
+          // clearing the marker it just wrote and leaving an armed secret looking settled.
+          // The secret buttons are disabled while loading so this should not be reachable
+          // through the UI; it stays because the cost of being wrong here is a lockout.
+          if (this.pendingVerification()) {
+            return;
+          }
+
+          this.userTwoFactorAuthConfigured.set(user.two_factor_config.secret_configured);
 
           // A stored flag without a secret behind it is stale — the secret was unset
           // elsewhere. Drop it rather than leave it for the next read.
@@ -319,6 +330,10 @@ export class TwoFactorComponent implements OnInit {
         return;
       }
 
+      // The re-read above is the freshest word on the account; dropping it would let the
+      // card report a confirmed secret and still offer Configure, with the QR hidden and
+      // Finish never appearing in the first-login dialog.
+      this.userTwoFactorAuthConfigured.set(config.secret_configured);
       this.setPendingVerification(false);
       this.verificationForm.reset();
       this.snackbar.success(this.translate.instant(helptext2fa.verification.verified));

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -41,8 +41,21 @@ import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
  * Suffixed with the account name because nothing clears this on logout: on a shared
  * workstation an origin-wide key would put the next user into a confirmation step for
  * a secret that was never theirs, with Renew and Unset hidden behind it.
+ *
+ * Being browser state, the guarantee is per browser, not per account: generate a secret
+ * here and open the page in another browser (or a private window, or after a storage
+ * clear) and it reports the setup as settled, because `secret_configured` is all the
+ * server can tell us. Closing that needs the middleware pending-secret API — until then
+ * this covers the case the report was actually about, a crash or a navigation away.
+ *
+ * The stored value also records which path opened the step, because cancelling a renewal
+ * is destructive in a way cancelling a first-time setup is not.
  */
 const pendingVerificationKeyPrefix = 'pending2FaVerification';
+
+type PendingKind = 'setup' | 'renewal';
+
+const pendingKinds: PendingKind[] = ['setup', 'renewal'];
 
 @Component({
   selector: 'ix-two-factor',
@@ -96,8 +109,18 @@ export class TwoFactorComponent implements OnInit {
   currentSessionIs2fa = signal(false);
   protected pendingVerification = signal(false);
 
+  /** Which path opened the confirmation step — decides how destructive cancelling is. */
+  private pendingKind = signal<PendingKind>('setup');
+
   /** Account the persisted pending flag is keyed to; empty until `user$` resolves. */
   private username = signal('');
+
+  /**
+   * The appliance's own OTP tolerance, in time steps either side of the current one.
+   * The confirmation check has to use it rather than its own default, or it can accept
+   * a code login will reject — the exact outcome this step exists to prevent.
+   */
+  private toleranceWindow = signal(0);
 
   protected readonly verificationForm = this.formBuilder.nonNullable.group({
     otp: ['', Validators.required],
@@ -113,7 +136,9 @@ export class TwoFactorComponent implements OnInit {
 
   protected get global2FaMsg(): string {
     if (this.pendingVerification()) {
-      return this.translate.instant(helptext2fa.verification.pending);
+      return this.translate.instant(
+        this.pendingKind() === 'renewal' ? helptext2fa.verification.pendingRenewal : helptext2fa.verification.pending,
+      );
     }
     if (!this.globalTwoFactorEnabled()) {
       return this.translate.instant(helptext2fa.globallyDisabled);
@@ -171,12 +196,14 @@ export class TwoFactorComponent implements OnInit {
           this.username.set(user.pw_name);
           this.userTwoFactorAuthConfigured.set(user.two_factor_config.secret_configured);
           this.globalTwoFactorEnabled.set(globalConfig.enabled);
+          this.toleranceWindow.set(globalConfig.window);
 
           // A stored flag without a secret behind it is stale — the secret was unset
           // elsewhere. Drop it rather than leave it for the next read.
-          const isPending = user.two_factor_config.secret_configured
-            && this.window.localStorage.getItem(this.pendingVerificationKey()) === 'true';
-          this.setPendingVerification(isPending);
+          const stored = this.window.localStorage.getItem(this.pendingVerificationKey());
+          const kind = pendingKinds.find((candidate) => candidate === stored);
+          const isPending = user.two_factor_config.secret_configured && !!kind;
+          this.setPendingVerification(isPending, kind);
         },
       });
 
@@ -188,9 +215,12 @@ export class TwoFactorComponent implements OnInit {
   }
 
   protected renewSecretOrEnable2Fa(): void {
+    // Captured before the call, which sets `userTwoFactorAuthConfigured` unconditionally.
+    const kind: PendingKind = this.userTwoFactorAuthConfigured() ? 'renewal' : 'setup';
+
     this.getConfirmation().pipe(
       filter(Boolean),
-      switchMap(() => this.renewSecretForUser()),
+      switchMap(() => this.renewSecretForUser(kind)),
       tap(() => this.isFormLoading.set(false)),
       catchError((error: unknown) => this.handleError(error)),
       takeUntilDestroyed(this.destroyRef),
@@ -220,6 +250,7 @@ export class TwoFactorComponent implements OnInit {
       const isValid = !!secret && verifyTotp(secret, this.verificationForm.controls.otp.value, {
         interval: config.interval,
         digits: config.otp_digits,
+        window: this.toleranceWindow(),
       });
 
       if (!isValid) {
@@ -234,9 +265,13 @@ export class TwoFactorComponent implements OnInit {
   }
 
   protected onCancelVerification(): void {
+    const isRenewal = this.pendingKind() === 'renewal';
+
     this.dialogService.confirm({
       title: this.translate.instant(helptext2fa.verification.cancel.title),
-      message: this.translate.instant(helptext2fa.verification.cancel.message),
+      message: this.translate.instant(
+        isRenewal ? helptext2fa.verification.cancel.renewalMessage : helptext2fa.verification.cancel.message,
+      ),
       buttonText: this.translate.instant(helptext2fa.verification.cancel.btn),
       cancelText: this.translate.instant(helptext2fa.verification.cancel.cancelBtn),
       hideCheckbox: true,
@@ -263,7 +298,7 @@ export class TwoFactorComponent implements OnInit {
     return EMPTY;
   }
 
-  private renewSecretForUser(): Observable<void> {
+  private renewSecretForUser(kind: PendingKind): Observable<void> {
     this.isFormLoading.set(true);
 
     this.currentSessionIs2fa.set(false);
@@ -277,7 +312,7 @@ export class TwoFactorComponent implements OnInit {
       switchMap(() => this.authService.refreshUser()),
       tap(() => {
         this.userTwoFactorAuthConfigured.set(true);
-        this.setPendingVerification(true);
+        this.setPendingVerification(true, kind);
       }),
       takeUntilDestroyed(this.destroyRef),
     );
@@ -350,11 +385,12 @@ export class TwoFactorComponent implements OnInit {
     );
   }
 
-  private setPendingVerification(isPending: boolean): void {
+  private setPendingVerification(isPending: boolean, kind: PendingKind = 'setup'): void {
     this.pendingVerification.set(isPending);
+    this.pendingKind.set(kind);
 
     if (isPending) {
-      this.window.localStorage.setItem(this.pendingVerificationKey(), 'true');
+      this.window.localStorage.setItem(this.pendingVerificationKey(), kind);
     } else {
       this.window.localStorage.removeItem(this.pendingVerificationKey());
     }

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -97,6 +97,16 @@ export class TwoFactorComponent implements OnInit {
   protected isDataLoading = signal(false);
   protected isFormLoading = signal(false);
   globalTwoFactorEnabled = signal(false);
+
+  /**
+   * Whether {@link globalTwoFactorEnabled} holds something the page actually read.
+   *
+   * After a failed load it holds its `false` default, and `loadFailed` cannot stand in
+   * for that — a later successful read of the *account* clears it while the global config
+   * is still unknown. Saying "2FA is not enabled on this system" from a default is the
+   * one sentence that tells the user whether scanning the QR matters at all.
+   */
+  private globalConfigKnown = signal(false);
   currentSessionIs2fa = signal(false);
   protected pendingVerification = signal(false);
 
@@ -172,9 +182,14 @@ export class TwoFactorComponent implements OnInit {
       // The banner shows one message, and the paragraph that normally carries this caveat
       // is gated on the same flag — so without this the page drops the one fact the user
       // needs and keeps the claim that overstates what just happened.
-      return this.globalTwoFactorEnabled()
-        ? pending
-        : `${pending} ${this.translate.instant(helptext2fa.verification.notActiveGlobally)}`;
+      return this.isKnownGloballyDisabled()
+        ? `${pending} ${this.translate.instant(helptext2fa.verification.notActiveGlobally)}`
+        : pending;
+    }
+    if (!this.globalConfigKnown()) {
+      // Same reason: every remaining branch asserts something about the system-wide
+      // setting, and the page has not read it.
+      return this.translate.instant(helptext2fa.loadFailed);
     }
     if (!this.globalTwoFactorEnabled()) {
       return this.translate.instant(helptext2fa.globallyDisabled);
@@ -186,6 +201,10 @@ export class TwoFactorComponent implements OnInit {
       return this.translate.instant(helptext2fa.allSetUp);
     }
     return this.translate.instant(helptext2fa.enabledGloballyButNotForUser);
+  }
+
+  private isKnownGloballyDisabled(): boolean {
+    return this.globalConfigKnown() && !this.globalTwoFactorEnabled();
   }
 
   private pendingMessage(): string {
@@ -284,6 +303,7 @@ export class TwoFactorComponent implements OnInit {
 
           this.username.set(user.pw_name);
           this.globalTwoFactorEnabled.set(globalConfig.enabled);
+          this.globalConfigKnown.set(true);
           this.toleranceWindow.set(globalConfig.window);
           this.clockOffset.set(systemInfo ? systemInfo.datetime.$date - Date.now() : 0);
 

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -20,10 +20,10 @@ import {
 } from 'rxjs/operators';
 import { UiSearchDirective } from 'app/directives/ui-search.directive';
 import { verifyTotp } from 'app/helpers/totp.helper';
-import { WINDOW } from 'app/helpers/window.helper';
 import { helptext2fa } from 'app/helptext/system/2fa';
 import { CredentialType } from 'app/interfaces/credential-type.interface';
 import { AuthService } from 'app/modules/auth/auth.service';
+import { PendingTwoFactorKind, PendingTwoFactorService } from 'app/modules/auth/pending-two-factor.service';
 import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button.component';
 import { DialogService } from 'app/modules/dialog/dialog.service';
 import { SnackbarService } from 'app/modules/snackbar/services/snackbar.service';
@@ -31,31 +31,6 @@ import { ApiService } from 'app/modules/websocket/api.service';
 import { QrViewerComponent } from 'app/pages/two-factor-auth/qr-viewer/qr-viewer.component';
 import { twoFactorElements } from 'app/pages/two-factor-auth/two-factor.elements';
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
-
-/**
- * Set while a secret exists that the user has not yet proven their authenticator app
- * holds. Persisted rather than kept in memory so a reload, a navigation away, or a
- * browser crash lands the user back on the confirmation step — with the QR code and
- * the escape hatch — instead of on a page that claims the setup is finished.
- *
- * Suffixed with the account name because nothing clears this on logout: on a shared
- * workstation an origin-wide key would put the next user into a confirmation step for
- * a secret that was never theirs, with Renew and Unset hidden behind it.
- *
- * Being browser state, the guarantee is per browser, not per account: generate a secret
- * here and open the page in another browser (or a private window, or after a storage
- * clear) and it reports the setup as settled, because `secret_configured` is all the
- * server can tell us. Closing that needs the middleware pending-secret API — until then
- * this covers the case the report was actually about, a crash or a navigation away.
- *
- * The stored value also records which path opened the step, because cancelling a renewal
- * is destructive in a way cancelling a first-time setup is not.
- */
-const pendingVerificationKeyPrefix = 'pending2FaVerification';
-
-type PendingKind = 'setup' | 'renewal';
-
-const pendingKinds: PendingKind[] = ['setup', 'renewal'];
 
 @Component({
   selector: 'ix-two-factor',
@@ -96,8 +71,8 @@ export class TwoFactorComponent implements OnInit {
   private api = inject(ApiService);
   private errorHandler = inject(ErrorHandlerService);
   private snackbar = inject(SnackbarService);
+  private pendingTwoFactor = inject(PendingTwoFactorService);
   private formBuilder = inject(FormBuilder);
-  private window = inject<Window>(WINDOW);
   private destroyRef = inject(DestroyRef);
 
   protected readonly searchableElements = twoFactorElements;
@@ -110,7 +85,7 @@ export class TwoFactorComponent implements OnInit {
   protected pendingVerification = signal(false);
 
   /** Which path opened the confirmation step — decides how destructive cancelling is. */
-  private pendingKind = signal<PendingKind>('setup');
+  private pendingKind = signal<PendingTwoFactorKind>('setup');
 
   /** Account the persisted pending flag is keyed to; empty until `user$` resolves. */
   private username = signal('');
@@ -145,7 +120,24 @@ export class TwoFactorComponent implements OnInit {
     return this.userTwoFactorAuthConfigured() && !this.pendingVerification();
   });
 
+  /**
+   * Whether there is a secret on the account still waiting to be confirmed.
+   *
+   * Narrower than `pendingVerification()`: the marker is written before the call that
+   * mints the secret, so a failed renew leaves the step showing with no secret behind
+   * it. Only the narrow case should take away Renew and Unset — the rationale for
+   * hiding them (renewing would just replace one unconfirmed secret with another) does
+   * not hold when there is nothing to replace, and hiding them there would leave
+   * Cancel Setup as the only control on the page.
+   */
+  protected readonly hasUnconfirmedSecret = computed(() => {
+    return this.pendingVerification() && this.userTwoFactorAuthConfigured();
+  });
+
   protected get global2FaMsg(): string {
+    if (this.pendingVerification() && !this.userTwoFactorAuthConfigured()) {
+      return this.translate.instant(helptext2fa.verification.pendingUnknown);
+    }
     if (this.pendingVerification()) {
       return this.translate.instant(
         this.pendingKind() === 'renewal' ? helptext2fa.verification.pendingRenewal : helptext2fa.verification.pending,
@@ -179,7 +171,10 @@ export class TwoFactorComponent implements OnInit {
 
   protected readonly otpErrorMessages = computed(() => {
     this.langChange();
-    return { invalidOtp: this.translate.instant(helptext2fa.verification.invalid) };
+    return {
+      invalidOtp: this.translate.instant(helptext2fa.verification.invalid),
+      unreadableSecret: this.translate.instant(helptext2fa.verification.unreadableSecret),
+    };
   });
 
   readonly labels = {
@@ -223,10 +218,9 @@ export class TwoFactorComponent implements OnInit {
 
           // A stored flag without a secret behind it is stale — the secret was unset
           // elsewhere. Drop it rather than leave it for the next read.
-          const stored = this.window.localStorage.getItem(this.pendingVerificationKey());
-          const kind = pendingKinds.find((candidate) => candidate === stored);
+          const kind = this.pendingTwoFactor.get(user.pw_name);
           const isPending = user.two_factor_config.secret_configured && !!kind;
-          this.setPendingVerification(isPending, kind);
+          this.setPendingVerification(isPending, kind ?? 'setup');
         },
       });
 
@@ -239,7 +233,7 @@ export class TwoFactorComponent implements OnInit {
 
   protected renewSecretOrEnable2Fa(): void {
     // Captured before the call, which sets `userTwoFactorAuthConfigured` unconditionally.
-    const kind: PendingKind = this.userTwoFactorAuthConfigured() ? 'renewal' : 'setup';
+    const kind: PendingTwoFactorKind = this.userTwoFactorAuthConfigured() ? 'renewal' : 'setup';
 
     this.getConfirmation().pipe(
       filter(Boolean),
@@ -270,7 +264,14 @@ export class TwoFactorComponent implements OnInit {
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((config) => {
       const secret = this.getProvisioningUriSecret(config.provisioning_uri);
-      const isValid = !!secret && verifyTotp(secret, this.verificationForm.controls.otp.value, {
+      if (!secret) {
+        // Nothing to check the code against, and no QR on screen either — telling the
+        // user to re-scan or check their clock would send them after the wrong thing.
+        this.verificationForm.controls.otp.setErrors({ unreadableSecret: true });
+        return;
+      }
+
+      const isValid = verifyTotp(secret, this.verificationForm.controls.otp.value, {
         interval: config.interval,
         digits: config.otp_digits,
         window: this.toleranceWindow(),
@@ -333,7 +334,7 @@ export class TwoFactorComponent implements OnInit {
     return EMPTY;
   }
 
-  private renewSecretForUser(kind: PendingKind): Observable<void> {
+  private renewSecretForUser(kind: PendingTwoFactorKind): Observable<void> {
     return this.authService.user$.pipe(
       // `filter` before `take`, not after: `refreshUser()` pushes `null` onto `user$`
       // before re-fetching, so a failed refresh leaves `null` as the current value and
@@ -431,18 +432,14 @@ export class TwoFactorComponent implements OnInit {
     );
   }
 
-  private setPendingVerification(isPending: boolean, kind: PendingKind = 'setup'): void {
+  private setPendingVerification(isPending: boolean, kind: PendingTwoFactorKind = 'setup'): void {
     this.pendingVerification.set(isPending);
     this.pendingKind.set(kind);
 
     if (isPending) {
-      this.window.localStorage.setItem(this.pendingVerificationKey(), kind);
+      this.pendingTwoFactor.set(this.username(), kind);
     } else {
-      this.window.localStorage.removeItem(this.pendingVerificationKey());
+      this.pendingTwoFactor.clear(this.username());
     }
-  }
-
-  private pendingVerificationKey(): string {
-    return `${pendingVerificationKeyPrefix}:${this.username()}`;
   }
 }

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -24,7 +24,7 @@ import { helptext2fa } from 'app/helptext/system/2fa';
 import { CredentialType } from 'app/interfaces/credential-type.interface';
 import { LoggedInUser } from 'app/interfaces/ds-cache.interface';
 import { SystemInfo } from 'app/interfaces/system-info.interface';
-import { GlobalTwoFactorConfig } from 'app/interfaces/two-factor-config.interface';
+import { GlobalTwoFactorConfig, UserTwoFactorConfig } from 'app/interfaces/two-factor-config.interface';
 import { AuthService } from 'app/modules/auth/auth.service';
 import { PendingTwoFactorKind, PendingTwoFactorService } from 'app/modules/auth/pending-two-factor.service';
 import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button.component';
@@ -384,28 +384,64 @@ export class TwoFactorComponent implements OnInit {
       return;
     }
 
+    // Screen against the cached secret before going to the network. A wrong code is the
+    // ordinary case, and the re-read below calls `refreshUser()`, which pushes a
+    // transient null through the app-wide `user$` — consumers that read it unguarded
+    // blink while it is in flight. A typo should not cost that, or a round trip.
+    //
+    // `take(1)` on `user$` without `filter`, so a null current value is an answer rather
+    // than a wait: being blind means there is nothing to screen against, and the re-read
+    // is exactly what that case needs.
+    this.authService.user$.pipe(
+      take(1),
+      switchMap((user) => {
+        return user ? this.authService.userTwoFactorConfig$.pipe(take(1)) : of(null as UserTwoFactorConfig | null);
+      }),
+      defaultIfEmpty(null as UserTwoFactorConfig | null),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe((cached) => {
+      const cachedSecret = this.getProvisioningUriSecret(cached?.provisioning_uri ?? null);
+
+      // Only reject cheaply on a secret we could actually read: an unreadable cached one
+      // may simply be stale, and the re-read is what resolves that.
+      if (cached && cachedSecret && !this.isCodeValidFor(cached, cachedSecret)) {
+        this.verificationForm.controls.otp.setErrors({ invalidOtp: true });
+        return;
+      }
+
+      this.confirmAgainstAccount();
+    });
+  }
+
+  /**
+   * Confirms an apparently-good code against what the account actually holds.
+   *
+   * The cached config is not the last word: a renew whose reply was lost may have rotated
+   * the secret server-side without this page hearing about it, and confirming against the
+   * superseded one would clear the marker and report success for a secret the account no
+   * longer has — the lockout this step exists to prevent.
+   */
+  private confirmAgainstAccount(): void {
     this.isFormLoading.set(true);
 
-    // Re-read the account before judging the code, rather than trusting the cached
-    // config. A renew whose reply was lost may have rotated the secret server-side
-    // without this page ever hearing about it, and confirming against the superseded
-    // secret would clear the marker and report success for a secret the account no
-    // longer holds — the lockout this step exists to prevent. It also gives the verify
-    // path a definite outcome when `user$` is sitting on the transient null a failed
-    // refresh leaves behind, instead of silently never emitting.
     this.authService.refreshUser().pipe(
       switchMap(() => this.authService.userTwoFactorConfig$.pipe(take(1))),
-      catchError(() => {
-        this.verificationForm.controls.otp.setErrors({ checkFailed: true });
-        return EMPTY;
-      }),
-      // A clean reconnect completes an in-flight call without emitting, so neither the
-      // subscribe nor the catchError would run. While this flag is on, Confirm Code and
-      // Cancel Setup are disabled and Renew/Unset/Skip are not rendered at all — a card
-      // with no working control, inside a dialog opened with disableClose.
+      // A clean reconnect completes an in-flight call without emitting, which is neither
+      // a value nor an error — without this the press would produce no message and no
+      // change, indistinguishable from being ignored.
+      defaultIfEmpty(null as UserTwoFactorConfig | null),
+      catchError(() => of(null as UserTwoFactorConfig | null)),
+      // While this flag is on, Confirm Code and Cancel Setup are disabled and
+      // Renew/Unset/Skip are not rendered at all — a card with no working control,
+      // inside a dialog opened with disableClose.
       finalize(() => this.isFormLoading.set(false)),
       takeUntilDestroyed(this.destroyRef),
     ).subscribe((config) => {
+      if (!config) {
+        this.verificationForm.controls.otp.setErrors({ checkFailed: true });
+        return;
+      }
+
       const secret = this.getProvisioningUriSecret(config.provisioning_uri);
       if (!secret) {
         // Nothing to check the code against, and no QR on screen either — telling the
@@ -414,14 +450,7 @@ export class TwoFactorComponent implements OnInit {
         return;
       }
 
-      const isValid = verifyTotp(secret, this.verificationForm.controls.otp.value, {
-        interval: config.interval,
-        digits: config.otp_digits,
-        window: this.toleranceWindow(),
-        now: Date.now() + this.clockOffset(),
-      });
-
-      if (!isValid) {
+      if (!this.isCodeValidFor(config, secret)) {
         this.verificationForm.controls.otp.setErrors({ invalidOtp: true });
         return;
       }
@@ -433,6 +462,15 @@ export class TwoFactorComponent implements OnInit {
       this.setPendingVerification(false);
       this.verificationForm.reset();
       this.snackbar.success(this.translate.instant(helptext2fa.verification.verified));
+    });
+  }
+
+  private isCodeValidFor(config: UserTwoFactorConfig, secret: string): boolean {
+    return verifyTotp(secret, this.verificationForm.controls.otp.value, {
+      interval: config.interval,
+      digits: config.otp_digits,
+      window: this.toleranceWindow(),
+      now: Date.now() + this.clockOffset(),
     });
   }
 

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -122,6 +122,17 @@ export class TwoFactorComponent implements OnInit {
    */
   private toleranceWindow = signal(0);
 
+  /**
+   * Appliance clock minus browser clock, in milliseconds.
+   *
+   * TOTP works because the authenticator and the appliance are both NTP-synced; the
+   * browser is a third clock with no part in the real exchange. Checking against it
+   * would reject the very code login accepts whenever the workstation has drifted —
+   * and with Renew and Unset hidden, the only offered way out is Cancel Setup. Reading
+   * the appliance's own time makes this check ask the same question login will.
+   */
+  private clockOffset = signal(0);
+
   protected readonly verificationForm = this.formBuilder.nonNullable.group({
     otp: ['', Validators.required],
   });
@@ -188,15 +199,19 @@ export class TwoFactorComponent implements OnInit {
       // keyed to the account name, which only the user record carries.
       this.authService.user$.pipe(filter(Boolean), take(1)),
       this.authService.getGlobalTwoFactorConfig(),
+      // Never fatal: without it the check falls back to the browser clock, which is
+      // where it stood before, rather than leaving the page unusable.
+      this.api.call('system.info').pipe(catchError(() => of(null))),
     ])
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: ([user, globalConfig]) => {
+        next: ([user, globalConfig, systemInfo]) => {
           this.isDataLoading.set(false);
           this.username.set(user.pw_name);
           this.userTwoFactorAuthConfigured.set(user.two_factor_config.secret_configured);
           this.globalTwoFactorEnabled.set(globalConfig.enabled);
           this.toleranceWindow.set(globalConfig.window);
+          this.clockOffset.set(systemInfo ? systemInfo.datetime.$date - Date.now() : 0);
 
           // A stored flag without a secret behind it is stale — the secret was unset
           // elsewhere. Drop it rather than leave it for the next read.
@@ -251,6 +266,7 @@ export class TwoFactorComponent implements OnInit {
         interval: config.interval,
         digits: config.otp_digits,
         window: this.toleranceWindow(),
+        now: Date.now() + this.clockOffset(),
       });
 
       if (!isValid) {
@@ -307,13 +323,21 @@ export class TwoFactorComponent implements OnInit {
     return this.authService.user$.pipe(
       take(1),
       filter((user) => !!user),
-      tap((user) => this.username.set(user.pw_name)),
-      switchMap((user) => this.api.call('user.renew_2fa_secret', [user.pw_name, { interval: 30, otp_digits: 6 }])),
-      switchMap(() => this.authService.refreshUser()),
-      tap(() => {
-        this.userTwoFactorAuthConfigured.set(true);
+      tap((user) => {
+        this.username.set(user.pw_name);
+        // Marked before the call, not after it. `renew_2fa_secret` arms the secret
+        // server-side, so a call that times out having actually succeeded — or whose
+        // `refreshUser` follow-up fails — would otherwise leave an armed secret with
+        // nothing recording that it is unconfirmed, and the next load would present it
+        // as finished setup. Being wrongly pending is recoverable: the stale sweep in
+        // loadTwoFactorConfigs drops the flag when no secret materialised, and on the
+        // renewal path the user clears it by entering a code. Being wrongly finished is
+        // the failure this whole step exists to prevent.
         this.setPendingVerification(true, kind);
       }),
+      switchMap((user) => this.api.call('user.renew_2fa_secret', [user.pw_name, { interval: 30, otp_digits: 6 }])),
+      switchMap(() => this.authService.refreshUser()),
+      tap(() => this.userTwoFactorAuthConfigured.set(true)),
       takeUntilDestroyed(this.destroyRef),
     );
   }

--- a/src/app/pages/two-factor-auth/two-factor.component.ts
+++ b/src/app/pages/two-factor-auth/two-factor.component.ts
@@ -327,9 +327,16 @@ export class TwoFactorComponent implements OnInit {
 
   protected renewSecretOrEnable2Fa(): void {
     // Captured before the call, which sets `userTwoFactorAuthConfigured` unconditionally.
-    const kind: PendingTwoFactorKind = this.userTwoFactorAuthConfigured() ? 'renewal' : 'setup';
+    //
+    // While the load failed that signal holds its default rather than a fact, so a blind
+    // page counts as "may already have a secret". The asymmetry decides it: labelling a
+    // real renewal as a first-time setup withholds the one sentence that says the old
+    // secret is already gone, whereas the reverse only over-warns someone who had nothing
+    // to lose.
+    const mayHaveSecret = this.userTwoFactorAuthConfigured() || this.loadFailed();
+    const kind: PendingTwoFactorKind = mayHaveSecret ? 'renewal' : 'setup';
 
-    this.getConfirmation().pipe(
+    this.getConfirmation(mayHaveSecret).pipe(
       filter(Boolean),
       switchMap(() => this.renewSecretForUser(kind)),
       catchError((error: unknown) => {
@@ -507,8 +514,8 @@ export class TwoFactorComponent implements OnInit {
     );
   }
 
-  private getConfirmation(): Observable<boolean> {
-    if (this.userTwoFactorAuthConfigured()) {
+  private getConfirmation(mayHaveSecret: boolean): Observable<boolean> {
+    if (mayHaveSecret) {
       return this.dialogService.confirm({
         title: this.translate.instant(helptext2fa.renewSecret.title),
         message: this.translate.instant(helptext2fa.renewSecret.message),


### PR DESCRIPTION
### Problem

Clicking **Configure 2FA Secret** armed the secret immediately. If the browser crashed, or the user navigated away, before the QR code made it into their authenticator app, 2FA was live on an account they could no longer produce codes for.

Other products show the QR code, ask for a code back, and only then treat the setup as done. This adds that confirmation step.

### What changed

The page is now generate → confirm, rather than generate → done.

1. **A confirmation step with an escape hatch.** After *Configure* (or *Renew*), the card enters a pending state: QR code, text secret, a **One-Time Password** field, **Confirm Code**, and **Cancel Setup**. Cancel calls `user.unset_2fa_secret`, so the account ends up exactly where it started. Renew/Unset are hidden while pending — renewing an unconfirmed secret would only swap one unconfirmed secret for another.

2. **The pending state survives a crash.** It is persisted, so a reload, a navigation away, or a browser crash lands the user back on the confirmation step — QR code and Cancel included — rather than on a page claiming setup is finished. It is cleared if the secret turns out to be gone.

3. **The first-login dialog's Finish button** now follows a new `setupComplete` output instead of `secret_configured`. Otherwise Finish appeared the moment the secret existed, which is the same hole in a different place.

### The honest caveat

The middleware has no endpoint that validates a code without also arming the secret — `user.renew_2fa_secret` does both in one call. So the secret genuinely *is* active during the confirmation step, and the banner says so plainly rather than pretending otherwise. Fully matching the reported flow (secret stays inert until verified) needs a middleware `verify` / pending-secret API.

The code check therefore runs in the browser: `src/app/helpers/totp.helper.ts` is a small RFC 6238 verifier, with hand-rolled SHA-1/HMAC rather than `crypto.subtle`, which is undefined on the plain-HTTP LAN addresses the UI is often served from. It is a usability check — proof the app took the secret — not a security boundary; login still validates against middleware. It is tested against every RFC 6238 Appendix B SHA-1 vector.

Also removed the now-dead `showQr2FaWarning` localStorage flag and the `window` parameter that was threaded through `getGlobalTwoFactorFormConfig` only to write it.

### Screenshots

**Pending confirmation** — the new state after generating a secret.

![Pending confirmation](https://raw.githubusercontent.com/AlexKarpov98/webui/screenshots/NAS-143536/2fa-01-pending.png)

**Wrong code** — inline error, still pending, nothing lost.

![Wrong code](https://raw.githubusercontent.com/AlexKarpov98/webui/screenshots/NAS-143536/2fa-02-wrong-code.png)

**Confirmed** — back to Renew/Unset, with confirmation.

![Confirmed](https://raw.githubusercontent.com/AlexKarpov98/webui/screenshots/NAS-143536/2fa-03-confirmed.png)

**Cancel Setup** — the escape hatch, spelling out what it undoes.

![Cancel setup dialog](https://raw.githubusercontent.com/AlexKarpov98/webui/screenshots/NAS-143536/2fa-04-cancel-dialog.png)

<sub>Captured live against a test appliance; the secrets shown were revoked and removed during the session.</sub>

### Testing

- `two-factor.component.spec.ts` (18), `totp.helper.spec.ts` (15), `two-factor-setup-dialog.component.spec.ts` (4), plus the neighbours touched by the `window`-parameter removal — 80 tests, all green.
- Lint clean; `tsc -p src/tsconfig.app.json` clean.
- Walked end to end against a live appliance: generate → reload (state resumed) → wrong code → correct code → renew → cancel → secret removed.

