### PR TITLE
NAS-143514 / 26.0.0-RC.1 / Do not prefill the bucket parent dataset from the managed root

### DIFF
--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -13,7 +13,7 @@ import {
 } from 'app/enums/s3.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { Group } from 'app/interfaces/group.interface';
-import { S3Bucket, S3Config } from 'app/interfaces/s3.interface';
+import { S3Bucket } from 'app/interfaces/s3.interface';
 import { User } from 'app/interfaces/user.interface';
 import { IxCheckboxHarness } from 'app/modules/forms/ix-forms/components/ix-checkbox/ix-checkbox.harness';
 import { IxListHarness } from 'app/modules/forms/ix-forms/components/ix-list/ix-list.harness';
@@ -80,7 +80,6 @@ describe('S3BucketFormComponent', () => {
         mockCall('sharing.s3.update'),
         mockCall('sharing.s3.audit_choices', { GetObject: 'GetObject', PutObject: 'PutObject' }),
         mockCall('pool.filesystem_choices', ['tank', 'tank/buckets', 'tank/buckets/photos']),
-        mockCall('s3.config', { managed_root_dataset: 'tank/s3' } as S3Config),
         mockCall('group.query', [{ group: 'staff', gid: 1001 }] as Group[]),
       ]),
       mockAuth(),
@@ -135,10 +134,6 @@ describe('S3BucketFormComponent', () => {
       expect(advancedLabels).toContain('Versioning');
       expect(advancedLabels).toContain('Multipart ETag');
       expect(advancedLabels).not.toContain('Audit');
-    });
-
-    it('starts with the parent dataset set to the service managed root dataset', async () => {
-      expect(await form.getValues()).toMatchObject({ 'Parent Dataset': 'tank/s3' });
     });
 
     it('turns versioning on and defaults to Compliance retention when object lock is enabled', async () => {

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -10,7 +10,7 @@ import { MatCard, MatCardContent } from '@angular/material/card';
 import { Store } from '@ngrx/store';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
-  catchError, EMPTY, map, merge, Observable, of,
+  map, merge, Observable, of,
 } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
 import { Role } from 'app/enums/role.enum';
@@ -241,28 +241,9 @@ export class S3BucketFormComponent implements OnInit {
       this.setBucketForEdit(this.existingBucket);
     } else {
       this.setupExistingDatasetCheck();
-      this.prefillParentDataset();
     }
     this.setupObjectLockDependency();
     this.setupObjectOwnershipDependency();
-  }
-
-  /**
-   * The service's managed root dataset is where S3 protocol CreateBucket requests put their datasets,
-   * so it is the natural default here too. Only a starting point: the field stays editable, and a
-   * parent already typed before the config arrives is kept.
-   */
-  private prefillParentDataset(): void {
-    this.api.call('s3.config').pipe(
-      // A convenience only: the user can pick the parent themselves, so a failed read stays silent.
-      catchError(() => EMPTY),
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe((config) => {
-      const parent = this.form.controls.parent_dataset;
-      if (config.managed_root_dataset && !parent.value) {
-        parent.setValue(config.managed_root_dataset);
-      }
-    });
   }
 
   private setupExistingDatasetCheck(): void {


### PR DESCRIPTION
Follow-up to the NAS-143514 backport: a new bucket should start with an empty Parent Dataset, not one prefilled from the S3 service's managed root dataset. Removes the prefill and its spec; the bucket form is back to what it was before the backport.