### PR TITLE
NAS-143514 / 27.0.0-BETA.1 / Do not prefill the bucket parent dataset from the managed root

### DIFF
--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.spec.ts
@@ -16,7 +16,7 @@ import {
 } from 'app/enums/s3.enum';
 import { ServiceName } from 'app/enums/service-name.enum';
 import { Group } from 'app/interfaces/group.interface';
-import { S3Bucket, S3Config } from 'app/interfaces/s3.interface';
+import { S3Bucket } from 'app/interfaces/s3.interface';
 import { User } from 'app/interfaces/user.interface';
 import { ixFormTestingProviders } from 'app/modules/forms/ix-forms/testing/ix-form-testing.helpers';
 import { IxFormHarness } from 'app/modules/forms/ix-forms/testing/ix-form.harness';
@@ -95,7 +95,6 @@ describe('S3BucketFormComponent', () => {
         mockCall('sharing.s3.update'),
         mockCall('sharing.s3.audit_choices', { GetObject: 'GetObject', PutObject: 'PutObject' }),
         mockCall('pool.filesystem_choices', ['tank', 'tank/buckets', 'tank/buckets/photos']),
-        mockCall('s3.config', { managed_root_dataset: 'tank/s3' } as S3Config),
         mockCall('user.query', [
           { username: 'alice', uid: 1000 },
           { username: 'bob', uid: 1001 },
@@ -141,10 +140,6 @@ describe('S3BucketFormComponent', () => {
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Versioning' }))).toBe(true);
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Multipart ETag' }))).toBe(true);
       expect(await loader.hasHarness(TnFormFieldHarness.with({ label: 'Audit' }))).toBe(false);
-    });
-
-    it('starts with the parent dataset set to the service managed root dataset', async () => {
-      expect(await form.getValues()).toMatchObject({ 'Parent Dataset': 'tank/s3' });
     });
 
     it('turns versioning on and defaults to Compliance retention when object lock is enabled', async () => {

--- a/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
+++ b/src/app/pages/sharing/s3/s3-bucket-form/s3-bucket-form.component.ts
@@ -12,7 +12,7 @@ import {
   TnInputComponent, TnSelectComponent, type TnSelectOption,
 } from '@truenas/ui-components';
 import {
-  catchError, EMPTY, map, merge, Observable, startWith,
+  map, merge, Observable, startWith,
 } from 'rxjs';
 import { Role } from 'app/enums/role.enum';
 import {
@@ -282,7 +282,6 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
       this.setBucketForEdit(bucket);
     } else {
       this.setupExistingDatasetCheck();
-      this.prefillParentDataset();
     }
     this.setupObjectLockDependency();
     this.setupObjectOwnershipDependency();
@@ -320,24 +319,6 @@ export class S3BucketFormComponent extends IxFormHostForm implements OnInit {
     // The check spans two fields, so a parent change has to re-run the name's validators.
     this.form.controls.parent_dataset.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.form.controls.name.updateValueAndValidity();
-    });
-  }
-
-  /**
-   * The service's managed root dataset is where S3 protocol CreateBucket requests put their datasets,
-   * so it is the natural default here too. Only a starting point: the field stays editable, and a
-   * parent already typed before the config arrives is kept.
-   */
-  private prefillParentDataset(): void {
-    this.api.call('s3.config').pipe(
-      // A convenience only: the user can pick the parent themselves, so a failed read stays silent.
-      catchError(() => EMPTY),
-      takeUntilDestroyed(this.destroyRef),
-    ).subscribe((config) => {
-      const parent = this.form.controls.parent_dataset;
-      if (config.managed_root_dataset && !parent.value) {
-        parent.setValue(config.managed_root_dataset);
-      }
     });
   }
 


### PR DESCRIPTION
Follow-up to #14101: a new bucket should start with an empty Parent Dataset, not one prefilled from the S3 service's managed root dataset. Removes the prefill and its spec. Same change is going to stable/26 (#14111) and release/26.0.0-RC.1 (#14112).