### PR TITLE
NAS-143616 / 27.0.0-BETA.1 / Move the e2e suite to @truenas/api-client 6.0

### DIFF
--- a/e2e/fixtures/s3.ts
+++ b/e2e/fixtures/s3.ts
@@ -7,9 +7,10 @@
  * things, and a stopped S3 service so the post-save "Start S3 Service" prompt
  * is deterministic.
  *
- * The S3 methods arrived in `@truenas/api-client` 5.0; the entry shapes below
- * are named off the directory the same way `fixtures/storage.ts` names its ACL
- * entry, so they follow the generated types rather than restating them.
+ * The S3 methods arrived in `@truenas/api-client` 5.0 and their current fields
+ * in 6.0; the entry shapes below are named off the directory the same way
+ * `fixtures/storage.ts` names its ACL entry, so they follow the generated
+ * types rather than restating them.
  */
 import type { CallResponse, QueryEntity } from '@truenas/api-client';
 import { firstValueFrom, timeout } from 'rxjs';
@@ -17,27 +18,9 @@ import { ensureServiceRunning, ensureServiceStopped, queryService, type ServiceS
 import type { E2eApiClient, E2eApiDirectory } from '../support/api/client';
 import { readTimeoutMs, slowCallTimeoutMs } from '../support/timeouts';
 
-/**
- * Fields middleware has that `@truenas/api-client` 5.0.2 does not yet type:
- * object ownership (middleware #19661), bucket-managing keys (#19670) and the
- * managed root dataset (#19670). Declared here, once, and intersected onto the
- * generated entry types below, so the journeys can assert on them without
- * `any`. Delete this block when the client is regenerated.
- */
-interface S3BucketLatestFields {
-  object_ownership?: 'BUCKET_OWNER_ENFORCED' | 'BUCKET_OWNER_PREFERRED' | 'OBJECT_WRITER';
-}
-interface S3AccessKeyLatestFields {
-  manage_buckets?: boolean;
-}
-interface S3ConfigLatestFields {
-  /** A dataset name, or an empty string for "refuse protocol CreateBucket". */
-  managed_root_dataset?: string;
-}
-
-export type S3BucketEntry = QueryEntity<E2eApiDirectory['call'], 'sharing.s3.query'> & S3BucketLatestFields;
-export type S3AccessKeyEntry = QueryEntity<E2eApiDirectory['call'], 's3.accesskey.query'> & S3AccessKeyLatestFields;
-export type S3ConfigEntry = CallResponse<E2eApiDirectory, 's3.config'> & S3ConfigLatestFields;
+export type S3BucketEntry = QueryEntity<E2eApiDirectory['call'], 'sharing.s3.query'>;
+export type S3AccessKeyEntry = QueryEntity<E2eApiDirectory['call'], 's3.accesskey.query'>;
+export type S3ConfigEntry = CallResponse<E2eApiDirectory, 's3.config'>;
 
 /**
  * Middleware's name for the service; the UI calls it "S3". Renamed from
@@ -249,13 +232,11 @@ export async function readS3Config(client: E2eApiClient): Promise<S3ConfigEntry>
 
 /**
  * Sets the service's managed root dataset over the API, or clears it with an
- * empty string. The field is one `@truenas/api-client` 5.0.2 does not type on
- * `s3.update`, hence the cast at the call; see `S3ConfigLatestFields`.
+ * empty string.
  */
 export async function setS3ManagedRootDataset(client: E2eApiClient, dataset: string): Promise<void> {
-  const update: S3ConfigLatestFields = { managed_root_dataset: dataset };
   await firstValueFrom(
-    client.api.call('s3.update', [update as never]).pipe(timeout(slowCallTimeoutMs)),
+    client.api.call('s3.update', [{ managed_root_dataset: dataset }]).pipe(timeout(slowCallTimeoutMs)),
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "@angular-eslint/template-parser": "~21.2.0",
     "@mdi/js": "~7.4.47",
     "@playwright/test": "~1.56.0",
-    "@truenas/api-client": "~5.0.0",
+    "@truenas/api-client": "~6.0.0",
     "@typescript-eslint/types": "~8.41.0",
     "@typescript-eslint/utils": "~8.41.0",
     "prettier": "~3.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4514,12 +4514,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@truenas/api-client@npm:~5.0.0":
-  version: 5.0.0
-  resolution: "@truenas/api-client@npm:5.0.0"
+"@truenas/api-client@npm:~6.0.0":
+  version: 6.0.0
+  resolution: "@truenas/api-client@npm:6.0.0"
   peerDependencies:
     rxjs: ^7.8.0
-  checksum: 10/6e166b004085a36801079bdeba378097f6f2ab26acf00b0f9cbdf721ac87442a429a693fbe4d3c84539fd013ce9fbd0cdd8fdd061052998b427ad72695324cd9
+  checksum: 10/7ead31edf4fbdc23780914c7da06f95c88a1739e1d72cefad85e4478af78f0cb8eb5a52dc7d58471e41ccee7b1a5fee58b22fa44f3e7f3eec4cfeeaa0321a1f4
   languageName: node
   linkType: hard
 
@@ -16100,7 +16100,7 @@ __metadata:
     "@shopify/eslint-plugin": "npm:~50.0.0"
     "@smarttools/eslint-plugin-rxjs": "npm:~1.0.22"
     "@stylistic/eslint-plugin": "npm:~2.9.0"
-    "@truenas/api-client": "npm:~5.0.0"
+    "@truenas/api-client": "npm:~6.0.0"
     "@truenas/common-typescript": "github:truenas/tn-common-typescript#master"
     "@truenas/ui-components": "npm:~0.7.5"
     "@types/cheerio": "npm:~0.22.35"


### PR DESCRIPTION
## Summary

`@truenas/api-client` 6.0.0 regenerates the directory from the 2026-09-10 middleware dump, which is the first release to type the three S3 fields the e2e journeys assert on: `object_ownership`, `manage_buckets` and `managed_root_dataset` (declared in `v26_0_0`, inherited by `v27_0_0`).

- Pin bumped `~5.0.0` → `~6.0.0`.
- The local typing block in `e2e/fixtures/s3.ts` that intersected those fields onto the generated entry types is deleted, and the `as never` on the `s3.update` call with it. `e2e:typecheck` passes on the generated types alone.
- Nothing under `src/` imports the client.

## Test plan

- [x] `yarn e2e:typecheck` and lint clean on 6.0.0.
- [x] Run 34622296185: the 19 journeys pass unchanged on the new types.