### PR TITLE
NAS-143615 / 27.0.0-BETA.1 / Brand unlicensed Enterprise systems as Community Edition

### DIFF
--- a/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.spec.ts
+++ b/src/app/modules/alerts/components/alerts-panel/alerts-panel.component.spec.ts
@@ -97,6 +97,7 @@ describe('AlertsPanelComponent', () => {
             productType: ProductType.Enterprise,
             isIxHardware: false,
             buildYear: 2024,
+            licenseLoadFailed: false,
           },
         },
       }),

--- a/src/app/modules/layout/admin-layout/admin-layout.component.html
+++ b/src/app/modules/layout/admin-layout/admin-layout.component.html
@@ -53,18 +53,18 @@
           }
 
           <p class="product-type">
-            @if (!isEnterprise()) {
+            @if (hasCommunityBranding()) {
               <a
                 tnTestIdType="link"
                 target="_blank"
                 [tnTestId]="'navigate-to-enterprise-marketing-link'"
                 [href]="currentMessageHref()"
               >
-                {{ productTypeText }}
+                {{ productTypeText() }}
               </a>
             } @else {
               <span>
-                {{ productTypeText }}
+                {{ productTypeText() }}
               </span>
             }
           </p>

--- a/src/app/modules/layout/admin-layout/admin-layout.component.ts
+++ b/src/app/modules/layout/admin-layout/admin-layout.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@truenas/ui-components';
 import { filter, map, pairwise, startWith } from 'rxjs';
 import { exploreNasEnterpriseLink } from 'app/constants/explore-nas-enterprise-link.constant';
-import { productTypeLabels } from 'app/enums/product-type.enum';
+import { ProductType, productTypeLabels } from 'app/enums/product-type.enum';
 import { hashMessage } from 'app/helpers/hash-message';
 import { SubMenuItem } from 'app/interfaces/menu-item.interface';
 import { AlertsPanelComponent } from 'app/modules/alerts/components/alerts-panel/alerts-panel.component';
@@ -37,7 +37,7 @@ import { AppState } from 'app/store';
 import { waitForPreferences } from 'app/store/preferences/preferences.selectors';
 import { selectHasConsoleFooter } from 'app/store/system-config/system-config.selectors';
 import {
-  selectCopyrightHtml, selectIsEnterprise, selectProductType, waitForSystemInfo,
+  selectCopyrightHtml, selectHasCommunityBranding, selectProductType, waitForSystemInfo,
 } from 'app/store/system-info/system-info.selectors';
 
 @Component({
@@ -85,12 +85,27 @@ export class AdminLayoutComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly hasConsoleFooter$ = this.store$.select(selectHasConsoleFooter);
   readonly copyrightHtml = toSignal(this.store$.select(selectCopyrightHtml));
   readonly productType = toSignal(this.store$.select(selectProductType));
-  readonly isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
+  readonly hasCommunityBranding = toSignal(this.store$.select(selectHasCommunityBranding));
+  private readonly brandedProductType = computed(() => {
+    return this.hasCommunityBranding() ? ProductType.CommunityEdition : this.productType();
+  });
+
   // angular tooltips are unable to display HTML content, so we just remove the `<br>` tags
   // credit <https://github.com/JackW6809> for the replace pattern!
   readonly copyrightText = computed(() => this.copyrightHtml().replace(/<br\s*\/?>/gi, '\n'));
 
-  protected currentMessageHref = computed(() => `${exploreNasEnterpriseLink}?m=${hashMessage(this.productType())}`);
+  protected currentMessageHref = computed(() => {
+    return `${exploreNasEnterpriseLink}?m=${hashMessage(this.brandedProductType())}`;
+  });
+
+  protected productTypeText = computed(() => {
+    const productType = this.brandedProductType();
+    if (!productType) {
+      return '';
+    }
+
+    return productTypeLabels.get(productType) || productType;
+  });
 
   get sidenavWidth(): string {
     return this.sidenavService.sidenavWidth;
@@ -118,15 +133,6 @@ export class AdminLayoutComponent implements OnInit, AfterViewInit, OnDestroy {
 
   get menuName(): string {
     return this.sidenavService.menuName;
-  }
-
-  get productTypeText(): string {
-    const productType = this.productType();
-    if (!productType) {
-      return '';
-    }
-
-    return productTypeLabels.get(productType) || productType;
   }
 
   ngOnInit(): void {

--- a/src/app/modules/layout/admin-layout/admin-layout.component.ts
+++ b/src/app/modules/layout/admin-layout/admin-layout.component.ts
@@ -84,8 +84,8 @@ export class AdminLayoutComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly isAlertPanelOpen$ = this.store$.select(selectIsAlertPanelOpen);
   readonly hasConsoleFooter$ = this.store$.select(selectHasConsoleFooter);
   readonly copyrightHtml = toSignal(this.store$.select(selectCopyrightHtml));
-  readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
-  readonly hasCommunityBranding = toSignal(this.store$.select(selectHasCommunityBranding));
+  private readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
+  protected readonly hasCommunityBranding = toSignal(this.store$.select(selectHasCommunityBranding));
 
   // angular tooltips are unable to display HTML content, so we just remove the `<br>` tags
   // credit <https://github.com/JackW6809> for the replace pattern!

--- a/src/app/modules/layout/admin-layout/admin-layout.component.ts
+++ b/src/app/modules/layout/admin-layout/admin-layout.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@truenas/ui-components';
 import { filter, map, pairwise, startWith } from 'rxjs';
 import { exploreNasEnterpriseLink } from 'app/constants/explore-nas-enterprise-link.constant';
-import { ProductType, productTypeLabels } from 'app/enums/product-type.enum';
+import { productTypeLabels } from 'app/enums/product-type.enum';
 import { hashMessage } from 'app/helpers/hash-message';
 import { SubMenuItem } from 'app/interfaces/menu-item.interface';
 import { AlertsPanelComponent } from 'app/modules/alerts/components/alerts-panel/alerts-panel.component';
@@ -37,7 +37,7 @@ import { AppState } from 'app/store';
 import { waitForPreferences } from 'app/store/preferences/preferences.selectors';
 import { selectHasConsoleFooter } from 'app/store/system-config/system-config.selectors';
 import {
-  selectCopyrightHtml, selectHasCommunityBranding, selectProductType, waitForSystemInfo,
+  selectBrandedProductType, selectCopyrightHtml, selectHasCommunityBranding, waitForSystemInfo,
 } from 'app/store/system-info/system-info.selectors';
 
 @Component({
@@ -84,11 +84,8 @@ export class AdminLayoutComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly isAlertPanelOpen$ = this.store$.select(selectIsAlertPanelOpen);
   readonly hasConsoleFooter$ = this.store$.select(selectHasConsoleFooter);
   readonly copyrightHtml = toSignal(this.store$.select(selectCopyrightHtml));
-  readonly productType = toSignal(this.store$.select(selectProductType));
+  readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
   readonly hasCommunityBranding = toSignal(this.store$.select(selectHasCommunityBranding));
-  private readonly brandedProductType = computed(() => {
-    return this.hasCommunityBranding() ? ProductType.CommunityEdition : this.productType();
-  });
 
   // angular tooltips are unable to display HTML content, so we just remove the `<br>` tags
   // credit <https://github.com/JackW6809> for the replace pattern!

--- a/src/app/modules/layout/copyright-line/copyright-line.component.spec.ts
+++ b/src/app/modules/layout/copyright-line/copyright-line.component.spec.ts
@@ -2,10 +2,11 @@ import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { environment } from 'environments/environment';
 import { ProductType } from 'app/enums/product-type.enum';
+import { License } from 'app/interfaces/system-info.interface';
 import { CopyrightLineComponent } from 'app/modules/layout/copyright-line/copyright-line.component';
 import { MapValuePipe } from 'app/modules/pipes/map-value/map-value.pipe';
 import { AppState } from 'app/store';
-import { selectProductType } from 'app/store/system-info/system-info.selectors';
+import { selectLicense, selectProductType } from 'app/store/system-info/system-info.selectors';
 
 describe('CopyrightLineComponent', () => {
   let spectator: Spectator<CopyrightLineComponent>;
@@ -18,10 +19,10 @@ describe('CopyrightLineComponent', () => {
     imports: [MapValuePipe],
     providers: [
       provideMockStore({
-        selectors: [{
-          selector: selectProductType,
-          value: null,
-        }],
+        selectors: [
+          { selector: selectProductType, value: null },
+          { selector: selectLicense, value: null },
+        ],
       }),
     ],
   });
@@ -53,11 +54,22 @@ describe('CopyrightLineComponent', () => {
 
   it('shows copyright line with enterprise product type and year of build', () => {
     store$.overrideSelector(selectProductType, ProductType.Enterprise);
+    store$.overrideSelector(selectLicense, { id: 'license-1' } as License);
     store$.refreshState();
     spectator.detectChanges();
 
     expect(spectator.fixture.nativeElement).toHaveText(`TrueNAS® Enterprise  © ${buildYear} iXsystems, Inc. dba  TrueNAS`);
     expect(spectator.fixture.nativeElement).toHaveText('iXsystems, Inc');
     expect(spectator.query('a')).toHaveAttribute('href', 'https://truenas.com/production');
+  });
+
+  it('brands an unlicensed enterprise system as Community Edition', () => {
+    store$.overrideSelector(selectProductType, ProductType.Enterprise);
+    store$.overrideSelector(selectLicense, null);
+    store$.refreshState();
+    spectator.detectChanges();
+
+    expect(spectator.fixture.nativeElement).toHaveText(`TrueNAS® Community Edition  © ${buildYear} iXsystems, Inc. dba  TrueNAS`);
+    expect(spectator.query('a')).toHaveAttribute('href', 'https://truenas.com/testdrive');
   });
 });

--- a/src/app/modules/layout/copyright-line/copyright-line.component.spec.ts
+++ b/src/app/modules/layout/copyright-line/copyright-line.component.spec.ts
@@ -42,7 +42,7 @@ describe('CopyrightLineComponent', () => {
 
     expect(spectator.fixture.nativeElement).toHaveText(`TrueNAS®  © ${buildYear} iXsystems, Inc. dba  TrueNAS`);
     expect(spectator.fixture.nativeElement).toHaveText('iXsystems, Inc');
-    expect(spectator.query('a')).toHaveAttribute('href', 'https://truenas.com/testdrive');
+    expect(spectator.query('a')).toHaveAttribute('href', 'https://truenas.com/');
   });
 
   it('shows copyright line with product type and year of build', () => {
@@ -74,5 +74,15 @@ describe('CopyrightLineComponent', () => {
 
     expect(spectator.fixture.nativeElement).toHaveText(`TrueNAS® Community Edition  © ${buildYear} iXsystems, Inc. dba  TrueNAS`);
     expect(spectator.query('a')).toHaveAttribute('href', 'https://truenas.com/testdrive');
+  });
+
+  it('shows no edition and a neutral link while an Enterprise license is still unknown', () => {
+    store$.overrideSelector(selectProductType, ProductType.Enterprise);
+    store$.overrideSelector(selectSystemInfo, null);
+    store$.refreshState();
+    spectator.detectChanges();
+
+    expect(spectator.fixture.nativeElement).toHaveText(`TrueNAS®  © ${buildYear} iXsystems, Inc. dba  TrueNAS`);
+    expect(spectator.query('a')).toHaveAttribute('href', 'https://truenas.com/');
   });
 });

--- a/src/app/modules/layout/copyright-line/copyright-line.component.spec.ts
+++ b/src/app/modules/layout/copyright-line/copyright-line.component.spec.ts
@@ -2,11 +2,13 @@ import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { environment } from 'environments/environment';
 import { ProductType } from 'app/enums/product-type.enum';
-import { License } from 'app/interfaces/system-info.interface';
+import { License, SystemInfo } from 'app/interfaces/system-info.interface';
 import { CopyrightLineComponent } from 'app/modules/layout/copyright-line/copyright-line.component';
 import { MapValuePipe } from 'app/modules/pipes/map-value/map-value.pipe';
 import { AppState } from 'app/store';
-import { selectLicense, selectProductType } from 'app/store/system-info/system-info.selectors';
+import {
+  selectLicenseLoadFailed, selectProductType, selectSystemInfo,
+} from 'app/store/system-info/system-info.selectors';
 
 describe('CopyrightLineComponent', () => {
   let spectator: Spectator<CopyrightLineComponent>;
@@ -21,7 +23,8 @@ describe('CopyrightLineComponent', () => {
       provideMockStore({
         selectors: [
           { selector: selectProductType, value: null },
-          { selector: selectLicense, value: null },
+          { selector: selectSystemInfo, value: { license: null } as SystemInfo },
+          { selector: selectLicenseLoadFailed, value: false },
         ],
       }),
     ],
@@ -54,7 +57,7 @@ describe('CopyrightLineComponent', () => {
 
   it('shows copyright line with enterprise product type and year of build', () => {
     store$.overrideSelector(selectProductType, ProductType.Enterprise);
-    store$.overrideSelector(selectLicense, { id: 'license-1' } as License);
+    store$.overrideSelector(selectSystemInfo, { license: { id: 'license-1' } as License } as SystemInfo);
     store$.refreshState();
     spectator.detectChanges();
 
@@ -65,7 +68,7 @@ describe('CopyrightLineComponent', () => {
 
   it('brands an unlicensed enterprise system as Community Edition', () => {
     store$.overrideSelector(selectProductType, ProductType.Enterprise);
-    store$.overrideSelector(selectLicense, null);
+    store$.overrideSelector(selectSystemInfo, { license: null } as SystemInfo);
     store$.refreshState();
     spectator.detectChanges();
 

--- a/src/app/modules/layout/copyright-line/copyright-line.component.spec.ts
+++ b/src/app/modules/layout/copyright-line/copyright-line.component.spec.ts
@@ -42,7 +42,7 @@ describe('CopyrightLineComponent', () => {
 
     expect(spectator.fixture.nativeElement).toHaveText(`TrueNAS®  © ${buildYear} iXsystems, Inc. dba  TrueNAS`);
     expect(spectator.fixture.nativeElement).toHaveText('iXsystems, Inc');
-    expect(spectator.query('a')).toHaveAttribute('href', 'https://truenas.com/');
+    expect(spectator.query('a')).toHaveAttribute('href', 'https://truenas.com/testdrive');
   });
 
   it('shows copyright line with product type and year of build', () => {

--- a/src/app/modules/layout/copyright-line/copyright-line.component.ts
+++ b/src/app/modules/layout/copyright-line/copyright-line.component.ts
@@ -5,7 +5,9 @@ import { ProductType } from 'app/enums/product-type.enum';
 import { getCopyrightHtml } from 'app/helpers/copyright-text.helper';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AppState } from 'app/store';
-import { selectBrandedProductType, selectCopyrightHtml } from 'app/store/system-info/system-info.selectors';
+import {
+  selectBrandedProductType, selectCopyrightHtml, selectProductType,
+} from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-copyright-line',
@@ -22,6 +24,7 @@ export class CopyrightLineComponent {
   readonly copyrightHtml = toSignal(this.store$.select(selectCopyrightHtml));
   readonly copyrightText = computed(() => (this.skipType() ? getCopyrightHtml() : this.copyrightHtml()));
 
+  private readonly productType = toSignal(this.store$.select(selectProductType));
   private readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
   readonly targetHref = computed(() => {
     switch (this.brandedProductType()) {
@@ -30,8 +33,10 @@ export class CopyrightLineComponent {
       case ProductType.CommunityEdition:
         return 'https://truenas.com/testdrive';
       default:
-        // Edition not known yet (or unknown): link to the neutral home page.
-        return 'https://truenas.com/';
+        // Enterprise whose license is not known yet: neutral home page rather than
+        // guessing an edition. Otherwise (e.g. sign-in page, where the product type
+        // is never loaded) keep the historical testdrive link.
+        return this.productType() === ProductType.Enterprise ? 'https://truenas.com/' : 'https://truenas.com/testdrive';
     }
   });
 }

--- a/src/app/modules/layout/copyright-line/copyright-line.component.ts
+++ b/src/app/modules/layout/copyright-line/copyright-line.component.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectionStrategy, Component, computed, input, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
+import { ProductType } from 'app/enums/product-type.enum';
 import { getCopyrightHtml } from 'app/helpers/copyright-text.helper';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AppState } from 'app/store';
-import { selectCopyrightHtml, selectIsEnterprise } from 'app/store/system-info/system-info.selectors';
+import { selectBrandedProductType, selectCopyrightHtml } from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-copyright-line',
@@ -21,8 +22,10 @@ export class CopyrightLineComponent {
   readonly copyrightHtml = toSignal(this.store$.select(selectCopyrightHtml));
   readonly copyrightText = computed(() => (this.skipType() ? getCopyrightHtml() : this.copyrightHtml()));
 
-  readonly isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
+  private readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
   readonly targetHref = computed(() => {
-    return this.isEnterprise() ? 'https://truenas.com/production' : 'https://truenas.com/testdrive';
+    return this.brandedProductType() === ProductType.Enterprise
+      ? 'https://truenas.com/production'
+      : 'https://truenas.com/testdrive';
   });
 }

--- a/src/app/modules/layout/copyright-line/copyright-line.component.ts
+++ b/src/app/modules/layout/copyright-line/copyright-line.component.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectionStrategy, Component, computed, input, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
+import { ProductType } from 'app/enums/product-type.enum';
 import { getCopyrightHtml } from 'app/helpers/copyright-text.helper';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AppState } from 'app/store';
-import { selectCopyrightHtml, selectHasEnterpriseBranding } from 'app/store/system-info/system-info.selectors';
+import { selectBrandedProductType, selectCopyrightHtml } from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-copyright-line',
@@ -21,8 +22,16 @@ export class CopyrightLineComponent {
   readonly copyrightHtml = toSignal(this.store$.select(selectCopyrightHtml));
   readonly copyrightText = computed(() => (this.skipType() ? getCopyrightHtml() : this.copyrightHtml()));
 
-  private readonly hasEnterpriseBranding = toSignal(this.store$.select(selectHasEnterpriseBranding));
+  private readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
   readonly targetHref = computed(() => {
-    return this.hasEnterpriseBranding() ? 'https://truenas.com/production' : 'https://truenas.com/testdrive';
+    switch (this.brandedProductType()) {
+      case ProductType.Enterprise:
+        return 'https://truenas.com/production';
+      case ProductType.CommunityEdition:
+        return 'https://truenas.com/testdrive';
+      default:
+        // Edition not known yet (or unknown): link to the neutral home page.
+        return 'https://truenas.com/';
+    }
   });
 }

--- a/src/app/modules/layout/copyright-line/copyright-line.component.ts
+++ b/src/app/modules/layout/copyright-line/copyright-line.component.ts
@@ -1,11 +1,10 @@
 import { ChangeDetectionStrategy, Component, computed, input, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
-import { ProductType } from 'app/enums/product-type.enum';
 import { getCopyrightHtml } from 'app/helpers/copyright-text.helper';
 import { TestDirective } from 'app/modules/test-id/test.directive';
 import { AppState } from 'app/store';
-import { selectBrandedProductType, selectCopyrightHtml } from 'app/store/system-info/system-info.selectors';
+import { selectCopyrightHtml, selectHasEnterpriseBranding } from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-copyright-line',
@@ -22,10 +21,8 @@ export class CopyrightLineComponent {
   readonly copyrightHtml = toSignal(this.store$.select(selectCopyrightHtml));
   readonly copyrightText = computed(() => (this.skipType() ? getCopyrightHtml() : this.copyrightHtml()));
 
-  private readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
+  private readonly hasEnterpriseBranding = toSignal(this.store$.select(selectHasEnterpriseBranding));
   readonly targetHref = computed(() => {
-    return this.brandedProductType() === ProductType.Enterprise
-      ? 'https://truenas.com/production'
-      : 'https://truenas.com/testdrive';
+    return this.hasEnterpriseBranding() ? 'https://truenas.com/production' : 'https://truenas.com/testdrive';
   });
 }

--- a/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.spec.ts
+++ b/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.spec.ts
@@ -115,6 +115,19 @@ describe('TruenasLogoComponent', () => {
     expect(await icons[0].getName()).toBe('app-truenas-logo-ce-color');
   });
 
+  it('enterprise with license not yet known: shows the plain full logo', async () => {
+    const store$ = spectator.inject(MockStore);
+    store$.overrideSelector(selectSystemInfoState, {
+      productType: ProductType.Enterprise,
+      systemInfo: null,
+    } as SystemInfoState);
+    store$.refreshState();
+    spectator.setInput('fullSize', true);
+    icons = await loader.getAllHarnesses(TnIconHarness);
+
+    expect(await icons[0].getName()).toBe('app-truenas-logo');
+  });
+
   it('checks white color', async () => {
     spectator.setInput('color', 'white');
     const [mark, text] = icons;

--- a/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.spec.ts
+++ b/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.spec.ts
@@ -8,6 +8,7 @@ import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TnIconHarness } from '@truenas/ui-components';
 import { of } from 'rxjs';
 import { ProductType } from 'app/enums/product-type.enum';
+import { License, SystemInfo } from 'app/interfaces/system-info.interface';
 import { TruenasLogoComponent } from 'app/modules/layout/topbar/truenas-logo/truenas-logo.component';
 import { ThemeService } from 'app/modules/theme/theme.service';
 import { SystemInfoState } from 'app/store/system-info/system-info.reducer';
@@ -17,6 +18,11 @@ describe('TruenasLogoComponent', () => {
   let spectator: Spectator<TruenasLogoComponent>;
   let loader: HarnessLoader;
   let icons: TnIconHarness[];
+
+  const licensedEnterpriseState = {
+    productType: ProductType.Enterprise,
+    systemInfo: { license: { id: 'license-1' } as License } as SystemInfo,
+  } as SystemInfoState;
 
   const createComponent = createComponentFactory({
     component: TruenasLogoComponent,
@@ -67,9 +73,7 @@ describe('TruenasLogoComponent', () => {
 
   it('enterprise: shows a logotype', async () => {
     const store$ = spectator.inject(MockStore);
-    store$.overrideSelector(selectSystemInfoState, {
-      productType: ProductType.Enterprise,
-    });
+    store$.overrideSelector(selectSystemInfoState, licensedEnterpriseState);
     store$.refreshState();
 
     const [mark, text] = icons;
@@ -79,9 +83,7 @@ describe('TruenasLogoComponent', () => {
 
   it('enterprise: shows full logo in color', async () => {
     const store$ = spectator.inject(MockStore);
-    store$.overrideSelector(selectSystemInfoState, {
-      productType: ProductType.Enterprise,
-    });
+    store$.overrideSelector(selectSystemInfoState, licensedEnterpriseState);
     store$.refreshState();
     spectator.setInput('fullSize', true);
     icons = await loader.getAllHarnesses(TnIconHarness);
@@ -91,15 +93,26 @@ describe('TruenasLogoComponent', () => {
 
   it('enterprise: shows full logo in white', async () => {
     const store$ = spectator.inject(MockStore);
-    store$.overrideSelector(selectSystemInfoState, {
-      productType: ProductType.Enterprise,
-    });
+    store$.overrideSelector(selectSystemInfoState, licensedEnterpriseState);
     store$.refreshState();
     spectator.setInput('fullSize', true);
     spectator.setInput('color', 'white');
     icons = await loader.getAllHarnesses(TnIconHarness);
 
     expect(await icons[0].getName()).toBe('app-truenas-logo-enterprise');
+  });
+
+  it('unlicensed enterprise: shows community edition full logo', async () => {
+    const store$ = spectator.inject(MockStore);
+    store$.overrideSelector(selectSystemInfoState, {
+      productType: ProductType.Enterprise,
+      systemInfo: { license: null } as SystemInfo,
+    } as SystemInfoState);
+    store$.refreshState();
+    spectator.setInput('fullSize', true);
+    icons = await loader.getAllHarnesses(TnIconHarness);
+
+    expect(await icons[0].getName()).toBe('app-truenas-logo-ce-color');
   });
 
   it('checks white color', async () => {

--- a/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.ts
+++ b/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.ts
@@ -3,10 +3,9 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { tnIconMarker, TnIconComponent } from '@truenas/ui-components';
-import { ProductType } from 'app/enums/product-type.enum';
 import { ThemeService } from 'app/modules/theme/theme.service';
 import { AppState } from 'app/store';
-import { selectBrandedProductType } from 'app/store/system-info/system-info.selectors';
+import { selectHasEnterpriseBranding } from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-truenas-logo',
@@ -25,7 +24,7 @@ export class TruenasLogoComponent {
   readonly color = input<'primary' | 'white'>('primary');
   readonly fullSize = input(false);
   readonly hideText = input(false);
-  private readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
+  private readonly hasEnterpriseBranding = toSignal(this.store$.select(selectHasEnterpriseBranding));
   protected readonly activeTheme = toSignal(this.themeService.activeTheme$);
 
   protected useWhiteLogo = computed(() => {
@@ -50,7 +49,7 @@ export class TruenasLogoComponent {
   });
 
   readonly fullSizeIcon = computed(() => {
-    if (this.brandedProductType() === ProductType.Enterprise) {
+    if (this.hasEnterpriseBranding()) {
       return this.useWhite()
         ? tnIconMarker('truenas-logo-enterprise', 'custom')
         : tnIconMarker('truenas-logo-enterprise-color', 'custom');

--- a/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.ts
+++ b/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.ts
@@ -3,9 +3,10 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { tnIconMarker, TnIconComponent } from '@truenas/ui-components';
+import { ProductType } from 'app/enums/product-type.enum';
 import { ThemeService } from 'app/modules/theme/theme.service';
 import { AppState } from 'app/store';
-import { selectHasEnterpriseBranding } from 'app/store/system-info/system-info.selectors';
+import { selectBrandedProductType } from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-truenas-logo',
@@ -24,7 +25,7 @@ export class TruenasLogoComponent {
   readonly color = input<'primary' | 'white'>('primary');
   readonly fullSize = input(false);
   readonly hideText = input(false);
-  private readonly hasEnterpriseBranding = toSignal(this.store$.select(selectHasEnterpriseBranding));
+  private readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
   protected readonly activeTheme = toSignal(this.themeService.activeTheme$);
 
   protected useWhiteLogo = computed(() => {
@@ -49,13 +50,18 @@ export class TruenasLogoComponent {
   });
 
   readonly fullSizeIcon = computed(() => {
-    if (this.hasEnterpriseBranding()) {
-      return this.useWhite()
-        ? tnIconMarker('truenas-logo-enterprise', 'custom')
-        : tnIconMarker('truenas-logo-enterprise-color', 'custom');
+    switch (this.brandedProductType()) {
+      case ProductType.Enterprise:
+        return this.useWhite()
+          ? tnIconMarker('truenas-logo-enterprise', 'custom')
+          : tnIconMarker('truenas-logo-enterprise-color', 'custom');
+      case ProductType.CommunityEdition:
+        return this.useWhite()
+          ? tnIconMarker('truenas-logo-ce', 'custom')
+          : tnIconMarker('truenas-logo-ce-color', 'custom');
+      default:
+        // Edition not known yet: plain logo without an edition banner.
+        return tnIconMarker('truenas-logo', 'custom');
     }
-    return this.useWhite()
-      ? tnIconMarker('truenas-logo-ce', 'custom')
-      : tnIconMarker('truenas-logo-ce-color', 'custom');
   });
 }

--- a/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.ts
+++ b/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.ts
@@ -60,7 +60,8 @@ export class TruenasLogoComponent {
           ? tnIconMarker('truenas-logo-ce', 'custom')
           : tnIconMarker('truenas-logo-ce-color', 'custom');
       default:
-        // Edition not known yet: plain logo without an edition banner.
+        // Edition not known yet: plain logo without an edition banner. This asset
+        // only ships in one variant (no `-color` counterpart), so it ignores `useWhite()`.
         return tnIconMarker('truenas-logo', 'custom');
     }
   });

--- a/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.ts
+++ b/src/app/modules/layout/topbar/truenas-logo/truenas-logo.component.ts
@@ -3,9 +3,10 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { tnIconMarker, TnIconComponent } from '@truenas/ui-components';
+import { ProductType } from 'app/enums/product-type.enum';
 import { ThemeService } from 'app/modules/theme/theme.service';
 import { AppState } from 'app/store';
-import { selectIsEnterprise } from 'app/store/system-info/system-info.selectors';
+import { selectBrandedProductType } from 'app/store/system-info/system-info.selectors';
 
 @Component({
   selector: 'ix-truenas-logo',
@@ -24,7 +25,7 @@ export class TruenasLogoComponent {
   readonly color = input<'primary' | 'white'>('primary');
   readonly fullSize = input(false);
   readonly hideText = input(false);
-  readonly isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
+  private readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
   protected readonly activeTheme = toSignal(this.themeService.activeTheme$);
 
   protected useWhiteLogo = computed(() => {
@@ -49,7 +50,7 @@ export class TruenasLogoComponent {
   });
 
   readonly fullSizeIcon = computed(() => {
-    if (this.isEnterprise()) {
+    if (this.brandedProductType() === ProductType.Enterprise) {
       return this.useWhite()
         ? tnIconMarker('truenas-logo-enterprise', 'custom')
         : tnIconMarker('truenas-logo-enterprise-color', 'custom');

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -88,7 +88,7 @@
             <strong>{{ 'Edition' | translate }}:</strong>
             @if (isLoaded()) {
               <span>
-                @if (isEnterprise()) {
+                @if (hasEnterpriseBranding()) {
                   {{ 'Enterprise' | translate }}
                 } @else {
                   {{ 'Community' | translate }}
@@ -174,7 +174,7 @@
             }
           </tn-list-item>
 
-          @if (!isEnterprise()) {
+          @if (!hasEnterpriseBranding()) {
             <!-- The marketing message is a sentence, not a label: let it wrap instead of ellipsizing. -->
             <tn-list-item class="use-enterprise" [wrap]="true">
               <ix-use-enterprise-marketing-link></ix-use-enterprise-marketing-link>

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.html
@@ -6,6 +6,7 @@
           <tn-icon [name]="isIxHardware() ? tnIconMarker('truenas-logo', 'custom') : tnIconMarker('truenas-logo-type', 'custom')" [fullSize]="true"></tn-icon>
         </div>
 
+        <!-- isEnterprise here is a hardware-support question, not branding: it tracks the real product type on purpose. -->
         <ix-product-image
           class="product-image"
           [systemProduct]="systemInfo()?.platform"
@@ -86,9 +87,9 @@
 
           <tn-list-item>
             <strong>{{ 'Edition' | translate }}:</strong>
-            @if (isLoaded()) {
+            @if (isLoaded() && brandedProductType(); as productType) {
               <span>
-                @if (hasEnterpriseBranding()) {
+                @if (productType === ProductType.Enterprise) {
                   {{ 'Enterprise' | translate }}
                 } @else {
                   {{ 'Community' | translate }}
@@ -174,7 +175,7 @@
             }
           </tn-list-item>
 
-          @if (!hasEnterpriseBranding()) {
+          @if (brandedProductType() === ProductType.CommunityEdition) {
             <!-- The marketing message is a sentence, not a label: let it wrap instead of ellipsizing. -->
             <tn-list-item class="use-enterprise" [wrap]="true">
               <ix-use-enterprise-marketing-link></ix-use-enterprise-marketing-link>

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
@@ -17,7 +17,7 @@ import { WidgetSysInfoActiveComponent } from 'app/pages/dashboard/widgets/system
 import { selectIsHaLicensed, selectIsHaEnabled } from 'app/store/ha-info/ha-info.selectors';
 import {
   selectIsIxHardware, selectProductType,
-  selectHasEnclosureSupport,
+  selectHasEnclosureSupport, selectHasEnterpriseBranding,
 } from 'app/store/system-info/system-info.selectors';
 
 describe('WidgetSysInfoActiveComponent', () => {
@@ -67,6 +67,10 @@ describe('WidgetSysInfoActiveComponent', () => {
           {
             selector: selectProductType,
             value: ProductType.Enterprise,
+          },
+          {
+            selector: selectHasEnterpriseBranding,
+            value: true,
           },
           {
             selector: selectHasEnclosureSupport,

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.spec.ts
@@ -17,7 +17,7 @@ import { WidgetSysInfoActiveComponent } from 'app/pages/dashboard/widgets/system
 import { selectIsHaLicensed, selectIsHaEnabled } from 'app/store/ha-info/ha-info.selectors';
 import {
   selectIsIxHardware, selectProductType,
-  selectHasEnclosureSupport, selectHasEnterpriseBranding,
+  selectHasEnclosureSupport, selectBrandedProductType,
 } from 'app/store/system-info/system-info.selectors';
 
 describe('WidgetSysInfoActiveComponent', () => {
@@ -69,8 +69,8 @@ describe('WidgetSysInfoActiveComponent', () => {
             value: ProductType.Enterprise,
           },
           {
-            selector: selectHasEnterpriseBranding,
-            value: true,
+            selector: selectBrandedProductType,
+            value: ProductType.Enterprise,
           },
           {
             selector: selectHasEnclosureSupport,

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@truenas/ui-components';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { filter, map } from 'rxjs';
+import { ProductType } from 'app/enums/product-type.enum';
 import { getLabelForContractType } from 'app/interfaces/system-info.interface';
 import { CopyButtonComponent } from 'app/modules/buttons/copy-button/copy-button.component';
 import { selectUpdateJobForActiveNode } from 'app/modules/jobs/store/job.selectors';
@@ -26,7 +27,7 @@ import {
 import { AppState } from 'app/store';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
-  selectHasEnclosureSupport, selectHasEnterpriseBranding, selectIsEnterprise, selectIsIxHardware,
+  selectHasEnclosureSupport, selectBrandedProductType, selectIsEnterprise, selectIsIxHardware,
 } from 'app/store/system-info/system-info.selectors';
 
 @Component({
@@ -61,7 +62,8 @@ export class WidgetSysInfoActiveComponent {
 
   isIxHardware = toSignal(this.store$.select(selectIsIxHardware));
   isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
-  protected readonly hasEnterpriseBranding = toSignal(this.store$.select(selectHasEnterpriseBranding));
+  protected readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
+  protected readonly ProductType = ProductType;
   isHaLicensed = toSignal(this.store$.select(selectIsHaLicensed));
   hasEnclosureSupport = toSignal(this.store$.select(selectHasEnclosureSupport));
   isUpdateRunning = toSignal(this.store$.select(selectUpdateJobForActiveNode));

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-active/widget-sys-info-active.component.ts
@@ -26,7 +26,7 @@ import {
 import { AppState } from 'app/store';
 import { selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
-  selectHasEnclosureSupport, selectIsEnterprise, selectIsIxHardware,
+  selectHasEnclosureSupport, selectHasEnterpriseBranding, selectIsEnterprise, selectIsIxHardware,
 } from 'app/store/system-info/system-info.selectors';
 
 @Component({
@@ -61,6 +61,7 @@ export class WidgetSysInfoActiveComponent {
 
   isIxHardware = toSignal(this.store$.select(selectIsIxHardware));
   isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
+  protected readonly hasEnterpriseBranding = toSignal(this.store$.select(selectHasEnterpriseBranding));
   isHaLicensed = toSignal(this.store$.select(selectIsHaLicensed));
   hasEnclosureSupport = toSignal(this.store$.select(selectHasEnclosureSupport));
   isUpdateRunning = toSignal(this.store$.select(selectUpdateJobForActiveNode));

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -6,6 +6,7 @@
           <tn-icon [name]="isIxHardware() ? tnIconMarker('truenas-logo', 'custom') : tnIconMarker('truenas-logo-type', 'custom')" [fullSize]="true"></tn-icon>
         </div>
 
+        <!-- isEnterprise here is a hardware-support question, not branding: it tracks the real product type on purpose. -->
         <ix-product-image
           class="passive product-image"
           [systemProduct]="systemInfo()?.platform"
@@ -87,9 +88,9 @@
 
           <tn-list-item>
             <strong>{{ 'Edition' | translate }}:</strong>
-            @if (isLoaded()) {
+            @if (isLoaded() && brandedProductType(); as productType) {
               <span>
-                @if (hasEnterpriseBranding()) {
+                @if (productType === ProductType.Enterprise) {
                   {{ 'Enterprise' | translate }}
                 } @else {
                   {{ 'Community' | translate }}

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.html
@@ -89,7 +89,7 @@
             <strong>{{ 'Edition' | translate }}:</strong>
             @if (isLoaded()) {
               <span>
-                @if (isEnterprise()) {
+                @if (hasEnterpriseBranding()) {
                   {{ 'Enterprise' | translate }}
                 } @else {
                   {{ 'Community' | translate }}

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
@@ -18,6 +18,7 @@ import {
   selectIsIxHardware,
   selectProductType,
   selectHasEnclosureSupport,
+  selectHasEnterpriseBranding,
 } from 'app/store/system-info/system-info.selectors';
 
 describe('WidgetSysInfoPassiveComponent', () => {
@@ -58,6 +59,10 @@ describe('WidgetSysInfoPassiveComponent', () => {
           {
             selector: selectProductType,
             value: ProductType.Enterprise,
+          },
+          {
+            selector: selectHasEnterpriseBranding,
+            value: true,
           },
           {
             selector: selectHasEnclosureSupport,

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.spec.ts
@@ -18,7 +18,7 @@ import {
   selectIsIxHardware,
   selectProductType,
   selectHasEnclosureSupport,
-  selectHasEnterpriseBranding,
+  selectBrandedProductType,
 } from 'app/store/system-info/system-info.selectors';
 
 describe('WidgetSysInfoPassiveComponent', () => {
@@ -61,8 +61,8 @@ describe('WidgetSysInfoPassiveComponent', () => {
             value: ProductType.Enterprise,
           },
           {
-            selector: selectHasEnterpriseBranding,
-            value: true,
+            selector: selectBrandedProductType,
+            value: ProductType.Enterprise,
           },
           {
             selector: selectHasEnclosureSupport,

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
@@ -13,6 +13,7 @@ import {
   filter, map,
 } from 'rxjs';
 import { RequiresRolesDirective } from 'app/directives/requires-roles/requires-roles.directive';
+import { ProductType } from 'app/enums/product-type.enum';
 import { Role } from 'app/enums/role.enum';
 import { helptextSystemFailover } from 'app/helptext/system/failover';
 import { getLabelForContractType } from 'app/interfaces/system-info.interface';
@@ -31,7 +32,7 @@ import {
 import { AppState } from 'app/store';
 import { selectCanFailover, selectIsHaEnabled, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
-  selectIsIxHardware, selectIsEnterprise, selectHasEnclosureSupport, selectHasEnterpriseBranding,
+  selectIsIxHardware, selectIsEnterprise, selectHasEnclosureSupport, selectBrandedProductType,
 } from 'app/store/system-info/system-info.selectors';
 
 @Component({
@@ -71,7 +72,8 @@ export class WidgetSysInfoPassiveComponent {
   canFailover = toSignal(this.store$.select(selectCanFailover));
   isIxHardware = toSignal(this.store$.select(selectIsIxHardware));
   isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
-  protected readonly hasEnterpriseBranding = toSignal(this.store$.select(selectHasEnterpriseBranding));
+  protected readonly brandedProductType = toSignal(this.store$.select(selectBrandedProductType));
+  protected readonly ProductType = ProductType;
   isHaLicensed = toSignal(this.store$.select(selectIsHaLicensed));
   isHaEnabled = toSignal(this.store$.select(selectIsHaEnabled));
   hasEnclosureSupport = toSignal(this.store$.select(selectHasEnclosureSupport));

--- a/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
+++ b/src/app/pages/dashboard/widgets/system/widget-sys-info-passive/widget-sys-info-passive.component.ts
@@ -31,7 +31,7 @@ import {
 import { AppState } from 'app/store';
 import { selectCanFailover, selectIsHaEnabled, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
 import {
-  selectIsIxHardware, selectIsEnterprise, selectHasEnclosureSupport,
+  selectIsIxHardware, selectIsEnterprise, selectHasEnclosureSupport, selectHasEnterpriseBranding,
 } from 'app/store/system-info/system-info.selectors';
 
 @Component({
@@ -71,6 +71,7 @@ export class WidgetSysInfoPassiveComponent {
   canFailover = toSignal(this.store$.select(selectCanFailover));
   isIxHardware = toSignal(this.store$.select(selectIsIxHardware));
   isEnterprise = toSignal(this.store$.select(selectIsEnterprise));
+  protected readonly hasEnterpriseBranding = toSignal(this.store$.select(selectHasEnterpriseBranding));
   isHaLicensed = toSignal(this.store$.select(selectIsHaLicensed));
   isHaEnabled = toSignal(this.store$.select(selectIsHaEnabled));
   hasEnclosureSupport = toSignal(this.store$.select(selectHasEnclosureSupport));

--- a/src/app/pages/system-tasks/config-reset/config-reset.component.spec.ts
+++ b/src/app/pages/system-tasks/config-reset/config-reset.component.spec.ts
@@ -12,7 +12,7 @@ import { ApiService } from 'app/modules/websocket/api.service';
 import { WebSocketHandlerService } from 'app/modules/websocket/websocket-handler.service';
 import { ConfigResetComponent } from 'app/pages/system-tasks/config-reset/config-reset.component';
 import { WebSocketStatusService } from 'app/services/websocket-status.service';
-import { selectIsEnterprise, selectProductType } from 'app/store/system-info/system-info.selectors';
+import { selectBrandedProductType, selectProductType } from 'app/store/system-info/system-info.selectors';
 
 describe('ConfigResetComponent', () => {
   let spectator: Spectator<ConfigResetComponent>;
@@ -23,7 +23,7 @@ describe('ConfigResetComponent', () => {
       provideMockStore({
         selectors: [
           { selector: selectProductType, value: ProductType.CommunityEdition },
-          { selector: selectIsEnterprise, value: false },
+          { selector: selectBrandedProductType, value: ProductType.CommunityEdition },
         ],
       }),
       mockApi([

--- a/src/app/pages/system-tasks/failover/failover.component.spec.ts
+++ b/src/app/pages/system-tasks/failover/failover.component.spec.ts
@@ -12,7 +12,7 @@ import { WebSocketHandlerService } from 'app/modules/websocket/websocket-handler
 import { FailoverComponent } from 'app/pages/system-tasks/failover/failover.component';
 import { WebSocketStatusService } from 'app/services/websocket-status.service';
 import { passiveNodeReplaced } from 'app/store/system-info/system-info.actions';
-import { selectIsEnterprise, selectProductType } from 'app/store/system-info/system-info.selectors';
+import { selectBrandedProductType, selectProductType } from 'app/store/system-info/system-info.selectors';
 
 describe('FailoverComponent', () => {
   let spectator: Spectator<FailoverComponent>;
@@ -24,7 +24,7 @@ describe('FailoverComponent', () => {
       provideMockStore({
         selectors: [
           { selector: selectProductType, value: ProductType.CommunityEdition },
-          { selector: selectIsEnterprise, value: false },
+          { selector: selectBrandedProductType, value: ProductType.CommunityEdition },
         ],
       }),
       mockApi([

--- a/src/app/pages/system-tasks/restart/restart.component.spec.ts
+++ b/src/app/pages/system-tasks/restart/restart.component.spec.ts
@@ -15,7 +15,7 @@ import { RestartComponent } from 'app/pages/system-tasks/restart/restart.compone
 import { ErrorHandlerService } from 'app/services/errors/error-handler.service';
 import { WebSocketStatusService } from 'app/services/websocket-status.service';
 import { selectIsHaEnabled, selectIsHaLicensed } from 'app/store/ha-info/ha-info.selectors';
-import { selectIsEnterprise, selectProductType } from 'app/store/system-info/system-info.selectors';
+import { selectBrandedProductType, selectProductType } from 'app/store/system-info/system-info.selectors';
 
 describe('RestartComponent', () => {
   let spectator: Spectator<RestartComponent>;
@@ -28,7 +28,7 @@ describe('RestartComponent', () => {
           { selector: selectIsHaLicensed, value: false },
           { selector: selectIsHaEnabled, value: false },
           { selector: selectProductType, value: ProductType.CommunityEdition },
-          { selector: selectIsEnterprise, value: false },
+          { selector: selectBrandedProductType, value: ProductType.CommunityEdition },
         ],
       }),
       mockApi([

--- a/src/app/pages/system-tasks/shutdown/shutdown.component.spec.ts
+++ b/src/app/pages/system-tasks/shutdown/shutdown.component.spec.ts
@@ -10,7 +10,7 @@ import { AuthService } from 'app/modules/auth/auth.service';
 import { ApiService } from 'app/modules/websocket/api.service';
 import { WebSocketHandlerService } from 'app/modules/websocket/websocket-handler.service';
 import { ShutdownComponent, blackoutDelay } from 'app/pages/system-tasks/shutdown/shutdown.component';
-import { selectIsEnterprise, selectProductType } from 'app/store/system-info/system-info.selectors';
+import { selectBrandedProductType, selectProductType } from 'app/store/system-info/system-info.selectors';
 
 describe('ShutdownComponent', () => {
   let spectator: Spectator<ShutdownComponent>;
@@ -20,7 +20,7 @@ describe('ShutdownComponent', () => {
       provideMockStore({
         selectors: [
           { selector: selectProductType, value: ProductType.CommunityEdition },
-          { selector: selectIsEnterprise, value: false },
+          { selector: selectBrandedProductType, value: ProductType.CommunityEdition },
         ],
       }),
       mockApi([

--- a/src/app/pages/system-tasks/system-task-splash/system-task-splash.component.spec.ts
+++ b/src/app/pages/system-tasks/system-task-splash/system-task-splash.component.spec.ts
@@ -3,7 +3,7 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { ProductType } from 'app/enums/product-type.enum';
 import { ignoreTranslation } from 'app/modules/translate/translate.helper';
 import { SystemTaskSplashComponent } from 'app/pages/system-tasks/system-task-splash/system-task-splash.component';
-import { selectIsEnterprise, selectProductType } from 'app/store/system-info/system-info.selectors';
+import { selectBrandedProductType, selectProductType } from 'app/store/system-info/system-info.selectors';
 
 describe('SystemTaskSplashComponent', () => {
   let spectator: Spectator<SystemTaskSplashComponent>;
@@ -13,7 +13,7 @@ describe('SystemTaskSplashComponent', () => {
       provideMockStore({
         selectors: [
           { selector: selectProductType, value: ProductType.CommunityEdition },
-          { selector: selectIsEnterprise, value: false },
+          { selector: selectBrandedProductType, value: ProductType.CommunityEdition },
         ],
       }),
     ],

--- a/src/app/pages/system/network/components/interface-form/interface-form.component.spec.ts
+++ b/src/app/pages/system/network/components/interface-form/interface-form.component.spec.ts
@@ -130,6 +130,7 @@ describe('InterfaceFormComponent', () => {
             },
             isIxHardware: false,
             buildYear: 2024,
+            licenseLoadFailed: false,
           },
         },
       }),

--- a/src/app/pages/system/network/components/ipmi-card/ipmi-form/ipmi-form.component.spec.ts
+++ b/src/app/pages/system/network/components/ipmi-card/ipmi-form/ipmi-form.component.spec.ts
@@ -56,6 +56,7 @@ describe('IpmiFormComponent', () => {
             },
             isIxHardware: false,
             buildYear: 2024,
+            licenseLoadFailed: false,
           },
         },
       }),

--- a/src/app/store/system-info/system-info.actions.ts
+++ b/src/app/store/system-info/system-info.actions.ts
@@ -4,7 +4,7 @@ import { SystemInfo } from 'app/interfaces/system-info.interface';
 
 export const systemInfoLoaded = createAction(
   '[System Info API] Info Loaded',
-  props<{ systemInfo: SystemInfo }>(),
+  props<{ systemInfo: SystemInfo; licenseLoadFailed?: boolean }>(),
 );
 
 export const productTypeLoaded = createAction(

--- a/src/app/store/system-info/system-info.actions.ts
+++ b/src/app/store/system-info/system-info.actions.ts
@@ -4,7 +4,7 @@ import { SystemInfo } from 'app/interfaces/system-info.interface';
 
 export const systemInfoLoaded = createAction(
   '[System Info API] Info Loaded',
-  props<{ systemInfo: SystemInfo; licenseLoadFailed?: boolean }>(),
+  props<{ systemInfo: SystemInfo; licenseLoadFailed: boolean }>(),
 );
 
 export const productTypeLoaded = createAction(

--- a/src/app/store/system-info/system-info.effects.spec.ts
+++ b/src/app/store/system-info/system-info.effects.spec.ts
@@ -83,10 +83,11 @@ describe('SystemInfoEffects', () => {
       expect(api.call).toHaveBeenCalledWith('truenas.license.info');
       expect(action).toEqual(systemInfoLoaded({
         systemInfo: { ...baseSystemInfo, license: baseLicense },
+        licenseLoadFailed: false,
       }));
     });
 
-    it('emits systemInfoLoaded with license: null when truenas.license.info errors', async () => {
+    it('emits systemInfoLoaded with license: null and licenseLoadFailed when truenas.license.info errors', async () => {
       jest.spyOn(console, 'error').mockImplementation();
       stubLoadCalls(null, new Error('license fetch failed'));
 
@@ -95,6 +96,7 @@ describe('SystemInfoEffects', () => {
 
       expect(action).toEqual(systemInfoLoaded({
         systemInfo: { ...baseSystemInfo, license: null },
+        licenseLoadFailed: true,
       }));
     });
 

--- a/src/app/store/system-info/system-info.effects.ts
+++ b/src/app/store/system-info/system-info.effects.ts
@@ -47,16 +47,19 @@ export class SystemInfoEffects {
       return forkJoin({
         systemInfo: this.api.call('system.info'),
         // A license fetch failure must not take the dashboard down. Recover to
-        // null so `systemInfoLoaded` still fires with the rest of the payload.
-        license: this.api.call('truenas.license.info').pipe(
+        // null so `systemInfoLoaded` still fires with the rest of the payload,
+        // but flag it so a failed fetch is not mistaken for an unlicensed system.
+        licenseResult: this.api.call('truenas.license.info').pipe(
+          map((license) => ({ license, failed: false })),
           catchError((error: unknown) => {
             console.error(error);
-            return of(null);
+            return of({ license: null as License | null, failed: true });
           }),
         ),
       }).pipe(
-        map(({ systemInfo, license }) => systemInfoLoaded({
-          systemInfo: { ...systemInfo, license: normalizeLicense(license) },
+        map(({ systemInfo, licenseResult }) => systemInfoLoaded({
+          systemInfo: { ...systemInfo, license: normalizeLicense(licenseResult.license) },
+          licenseLoadFailed: licenseResult.failed,
         })),
         catchError((error: unknown) => {
           // TODO: Basically a fatal error. Handle it.

--- a/src/app/store/system-info/system-info.reducer.ts
+++ b/src/app/store/system-info/system-info.reducer.ts
@@ -29,11 +29,7 @@ const initialState: SystemInfoState = {
 
 export const systemInfoReducer = createReducer(
   initialState,
-  on(systemInfoLoaded, (state, { systemInfo, licenseLoadFailed }) => ({
-    ...state,
-    systemInfo,
-    licenseLoadFailed: Boolean(licenseLoadFailed),
-  })),
+  on(systemInfoLoaded, (state, { systemInfo, licenseLoadFailed }) => ({ ...state, systemInfo, licenseLoadFailed })),
   on(productTypeLoaded, (state, { productType }) => ({ ...state, productType })),
   on(ixHardwareLoaded, (state, { isIxHardware }) => ({ ...state, isIxHardware })),
 );

--- a/src/app/store/system-info/system-info.reducer.ts
+++ b/src/app/store/system-info/system-info.reducer.ts
@@ -12,6 +12,11 @@ export interface SystemInfoState {
   productType: ProductType | null;
   isIxHardware: boolean;
   buildYear: number;
+  /**
+   * `truenas.license.info` failed, so `systemInfo.license === null` means
+   * "unknown" rather than "no license".
+   */
+  licenseLoadFailed: boolean;
 }
 
 const initialState: SystemInfoState = {
@@ -19,11 +24,16 @@ const initialState: SystemInfoState = {
   productType: null,
   isIxHardware: false,
   buildYear: environment.buildYear,
+  licenseLoadFailed: false,
 };
 
 export const systemInfoReducer = createReducer(
   initialState,
-  on(systemInfoLoaded, (state, { systemInfo }) => ({ ...state, systemInfo })),
+  on(systemInfoLoaded, (state, { systemInfo, licenseLoadFailed }) => ({
+    ...state,
+    systemInfo,
+    licenseLoadFailed: Boolean(licenseLoadFailed),
+  })),
   on(productTypeLoaded, (state, { productType }) => ({ ...state, productType })),
   on(ixHardwareLoaded, (state, { isIxHardware }) => ({ ...state, isIxHardware })),
 );

--- a/src/app/store/system-info/system-info.selectors.spec.ts
+++ b/src/app/store/system-info/system-info.selectors.spec.ts
@@ -3,61 +3,89 @@ import { ProductType } from 'app/enums/product-type.enum';
 import { License, SystemInfo } from 'app/interfaces/system-info.interface';
 import { SystemInfoState } from 'app/store/system-info/system-info.reducer';
 import {
-  selectBrandedProductType, selectCopyrightHtml, selectHasCommunityBranding,
+  selectBrandedProductType, selectCopyrightHtml, selectHasCommunityBranding, selectHasEnterpriseBranding,
 } from 'app/store/system-info/system-info.selectors';
 
 describe('system-info selectors', () => {
   const license = { id: 'license-1' } as License;
+  const licensed = { license } as SystemInfo;
+  const unlicensed = { license: null } as SystemInfo;
 
-  const makeState = (productType: ProductType | null, systemLicense: License | null): SystemInfoState => ({
+  const makeState = (
+    productType: ProductType | null,
+    systemInfo: SystemInfo | null,
+    licenseLoadFailed = false,
+  ): SystemInfoState => ({
     productType,
-    systemInfo: { license: systemLicense } as SystemInfo,
+    systemInfo,
     isIxHardware: false,
     buildYear: 2026,
+    licenseLoadFailed,
   });
 
   describe('selectBrandedProductType', () => {
-    it('keeps Community Edition as is', () => {
-      expect(selectBrandedProductType.projector(ProductType.CommunityEdition, null))
+    it('keeps Community Edition as is, even before system info is loaded', () => {
+      expect(selectBrandedProductType.projector(ProductType.CommunityEdition, null, false))
         .toBe(ProductType.CommunityEdition);
-      expect(selectBrandedProductType.projector(ProductType.CommunityEdition, license))
+      expect(selectBrandedProductType.projector(ProductType.CommunityEdition, licensed, false))
         .toBe(ProductType.CommunityEdition);
     });
 
     it('keeps licensed Enterprise as Enterprise', () => {
-      expect(selectBrandedProductType.projector(ProductType.Enterprise, license)).toBe(ProductType.Enterprise);
+      expect(selectBrandedProductType.projector(ProductType.Enterprise, licensed, false)).toBe(ProductType.Enterprise);
     });
 
     it('brands unlicensed Enterprise as Community Edition', () => {
-      expect(selectBrandedProductType.projector(ProductType.Enterprise, null)).toBe(ProductType.CommunityEdition);
+      expect(selectBrandedProductType.projector(ProductType.Enterprise, unlicensed, false))
+        .toBe(ProductType.CommunityEdition);
+    });
+
+    it('returns null for Enterprise until system info (and so the license) is loaded', () => {
+      expect(selectBrandedProductType.projector(ProductType.Enterprise, null, false)).toBeNull();
+    });
+
+    it('keeps Enterprise branding when the license fetch failed', () => {
+      expect(selectBrandedProductType.projector(ProductType.Enterprise, unlicensed, true)).toBe(ProductType.Enterprise);
     });
 
     it('returns null while product type is unknown', () => {
-      expect(selectBrandedProductType.projector(null, null)).toBeNull();
+      expect(selectBrandedProductType.projector(null, null, false)).toBeNull();
+      expect(selectBrandedProductType.projector(null, licensed, false)).toBeNull();
     });
 
-    it('derives license from system info state', () => {
-      expect(selectBrandedProductType({ systemInfo: makeState(ProductType.Enterprise, null) }))
+    it('derives inputs from system info state', () => {
+      expect(selectBrandedProductType({ systemInfo: makeState(ProductType.Enterprise, unlicensed) }))
         .toBe(ProductType.CommunityEdition);
-      expect(selectBrandedProductType({ systemInfo: makeState(ProductType.Enterprise, license) }))
+      expect(selectBrandedProductType({ systemInfo: makeState(ProductType.Enterprise, licensed) }))
+        .toBe(ProductType.Enterprise);
+      expect(selectBrandedProductType({ systemInfo: makeState(ProductType.Enterprise, unlicensed, true) }))
         .toBe(ProductType.Enterprise);
     });
   });
 
-  describe('selectHasCommunityBranding', () => {
-    it('is true only for a Community Edition branded product type', () => {
+  describe('selectHasCommunityBranding / selectHasEnterpriseBranding', () => {
+    it('reflect the branded product type', () => {
       expect(selectHasCommunityBranding.projector(ProductType.CommunityEdition)).toBe(true);
       expect(selectHasCommunityBranding.projector(ProductType.Enterprise)).toBe(false);
       expect(selectHasCommunityBranding.projector(null)).toBe(false);
+
+      expect(selectHasEnterpriseBranding.projector(ProductType.Enterprise)).toBe(true);
+      expect(selectHasEnterpriseBranding.projector(ProductType.CommunityEdition)).toBe(false);
+      expect(selectHasEnterpriseBranding.projector(null)).toBe(false);
     });
   });
 
   describe('selectCopyrightHtml', () => {
     it('uses the branded product type', () => {
-      expect(selectCopyrightHtml({ systemInfo: makeState(ProductType.Enterprise, null) }))
+      expect(selectCopyrightHtml({ systemInfo: makeState(ProductType.Enterprise, unlicensed) }))
         .toBe(`TrueNAS® Community Edition <br /> © ${environment.buildYear}`);
-      expect(selectCopyrightHtml({ systemInfo: makeState(ProductType.Enterprise, license) }))
+      expect(selectCopyrightHtml({ systemInfo: makeState(ProductType.Enterprise, licensed) }))
         .toBe(`TrueNAS® Enterprise <br /> © ${environment.buildYear}`);
+    });
+
+    it('omits the edition while an Enterprise license is still unknown', () => {
+      expect(selectCopyrightHtml({ systemInfo: makeState(ProductType.Enterprise, null) }))
+        .toBe(`TrueNAS® <br /> © ${environment.buildYear}`);
     });
   });
 });

--- a/src/app/store/system-info/system-info.selectors.spec.ts
+++ b/src/app/store/system-info/system-info.selectors.spec.ts
@@ -1,0 +1,40 @@
+import { ProductType } from 'app/enums/product-type.enum';
+import { License, SystemInfo } from 'app/interfaces/system-info.interface';
+import { SystemInfoState } from 'app/store/system-info/system-info.reducer';
+import { selectHasCommunityBranding } from 'app/store/system-info/system-info.selectors';
+
+describe('system-info selectors', () => {
+  describe('selectHasCommunityBranding', () => {
+    const makeState = (productType: ProductType | null, license: License | null): SystemInfoState => ({
+      productType,
+      systemInfo: { license } as SystemInfo,
+      isIxHardware: false,
+      buildYear: 2026,
+    });
+
+    it('returns true for Community Edition', () => {
+      expect(selectHasCommunityBranding.projector(ProductType.CommunityEdition, null)).toBe(true);
+      expect(selectHasCommunityBranding.projector(ProductType.CommunityEdition, { id: 'l1' } as License)).toBe(true);
+    });
+
+    it('returns true for Enterprise without a license', () => {
+      expect(selectHasCommunityBranding.projector(ProductType.Enterprise, null)).toBe(true);
+    });
+
+    it('returns false for licensed Enterprise', () => {
+      expect(selectHasCommunityBranding.projector(ProductType.Enterprise, { id: 'l1' } as License)).toBe(false);
+    });
+
+    it('returns false while product type is unknown', () => {
+      expect(selectHasCommunityBranding.projector(null, null)).toBe(false);
+    });
+
+    it('derives license from system info state', () => {
+      const unlicensedEnterprise = { systemInfo: makeState(ProductType.Enterprise, null) };
+      const licensedEnterprise = { systemInfo: makeState(ProductType.Enterprise, { id: 'l1' } as License) };
+
+      expect(selectHasCommunityBranding(unlicensedEnterprise)).toBe(true);
+      expect(selectHasCommunityBranding(licensedEnterprise)).toBe(false);
+    });
+  });
+});

--- a/src/app/store/system-info/system-info.selectors.spec.ts
+++ b/src/app/store/system-info/system-info.selectors.spec.ts
@@ -1,40 +1,63 @@
+import { environment } from 'environments/environment';
 import { ProductType } from 'app/enums/product-type.enum';
 import { License, SystemInfo } from 'app/interfaces/system-info.interface';
 import { SystemInfoState } from 'app/store/system-info/system-info.reducer';
-import { selectHasCommunityBranding } from 'app/store/system-info/system-info.selectors';
+import {
+  selectBrandedProductType, selectCopyrightHtml, selectHasCommunityBranding,
+} from 'app/store/system-info/system-info.selectors';
 
 describe('system-info selectors', () => {
-  describe('selectHasCommunityBranding', () => {
-    const makeState = (productType: ProductType | null, license: License | null): SystemInfoState => ({
-      productType,
-      systemInfo: { license } as SystemInfo,
-      isIxHardware: false,
-      buildYear: 2026,
+  const license = { id: 'license-1' } as License;
+
+  const makeState = (productType: ProductType | null, systemLicense: License | null): SystemInfoState => ({
+    productType,
+    systemInfo: { license: systemLicense } as SystemInfo,
+    isIxHardware: false,
+    buildYear: 2026,
+  });
+
+  describe('selectBrandedProductType', () => {
+    it('keeps Community Edition as is', () => {
+      expect(selectBrandedProductType.projector(ProductType.CommunityEdition, null))
+        .toBe(ProductType.CommunityEdition);
+      expect(selectBrandedProductType.projector(ProductType.CommunityEdition, license))
+        .toBe(ProductType.CommunityEdition);
     });
 
-    it('returns true for Community Edition', () => {
-      expect(selectHasCommunityBranding.projector(ProductType.CommunityEdition, null)).toBe(true);
-      expect(selectHasCommunityBranding.projector(ProductType.CommunityEdition, { id: 'l1' } as License)).toBe(true);
+    it('keeps licensed Enterprise as Enterprise', () => {
+      expect(selectBrandedProductType.projector(ProductType.Enterprise, license)).toBe(ProductType.Enterprise);
     });
 
-    it('returns true for Enterprise without a license', () => {
-      expect(selectHasCommunityBranding.projector(ProductType.Enterprise, null)).toBe(true);
+    it('brands unlicensed Enterprise as Community Edition', () => {
+      expect(selectBrandedProductType.projector(ProductType.Enterprise, null)).toBe(ProductType.CommunityEdition);
     });
 
-    it('returns false for licensed Enterprise', () => {
-      expect(selectHasCommunityBranding.projector(ProductType.Enterprise, { id: 'l1' } as License)).toBe(false);
-    });
-
-    it('returns false while product type is unknown', () => {
-      expect(selectHasCommunityBranding.projector(null, null)).toBe(false);
+    it('returns null while product type is unknown', () => {
+      expect(selectBrandedProductType.projector(null, null)).toBeNull();
     });
 
     it('derives license from system info state', () => {
-      const unlicensedEnterprise = { systemInfo: makeState(ProductType.Enterprise, null) };
-      const licensedEnterprise = { systemInfo: makeState(ProductType.Enterprise, { id: 'l1' } as License) };
+      expect(selectBrandedProductType({ systemInfo: makeState(ProductType.Enterprise, null) }))
+        .toBe(ProductType.CommunityEdition);
+      expect(selectBrandedProductType({ systemInfo: makeState(ProductType.Enterprise, license) }))
+        .toBe(ProductType.Enterprise);
+    });
+  });
 
-      expect(selectHasCommunityBranding(unlicensedEnterprise)).toBe(true);
-      expect(selectHasCommunityBranding(licensedEnterprise)).toBe(false);
+  describe('selectHasCommunityBranding', () => {
+    it('is true only for a Community Edition branded product type', () => {
+      expect(selectHasCommunityBranding.projector(ProductType.CommunityEdition)).toBe(true);
+      expect(selectHasCommunityBranding.projector(ProductType.Enterprise)).toBe(false);
+      expect(selectHasCommunityBranding.projector(null)).toBe(false);
+    });
+  });
+
+  describe('selectCopyrightHtml', () => {
+    it('uses the branded product type', () => {
+      expect(selectCopyrightHtml({ systemInfo: makeState(ProductType.Enterprise, null) }))
+        .toBe(`TrueNAS® Community Edition <br /> © ${environment.buildYear}`);
+      expect(selectCopyrightHtml({ systemInfo: makeState(ProductType.Enterprise, license) }))
+        .toBe(`TrueNAS® Enterprise <br /> © ${environment.buildYear}`);
     });
   });
 });

--- a/src/app/store/system-info/system-info.selectors.spec.ts
+++ b/src/app/store/system-info/system-info.selectors.spec.ts
@@ -3,7 +3,7 @@ import { ProductType } from 'app/enums/product-type.enum';
 import { License, SystemInfo } from 'app/interfaces/system-info.interface';
 import { SystemInfoState } from 'app/store/system-info/system-info.reducer';
 import {
-  selectBrandedProductType, selectCopyrightHtml, selectHasCommunityBranding, selectHasEnterpriseBranding,
+  selectBrandedProductType, selectCopyrightHtml, selectHasCommunityBranding,
 } from 'app/store/system-info/system-info.selectors';
 
 describe('system-info selectors', () => {
@@ -63,15 +63,11 @@ describe('system-info selectors', () => {
     });
   });
 
-  describe('selectHasCommunityBranding / selectHasEnterpriseBranding', () => {
-    it('reflect the branded product type', () => {
+  describe('selectHasCommunityBranding', () => {
+    it('is true only for a confirmed Community Edition branding', () => {
       expect(selectHasCommunityBranding.projector(ProductType.CommunityEdition)).toBe(true);
       expect(selectHasCommunityBranding.projector(ProductType.Enterprise)).toBe(false);
       expect(selectHasCommunityBranding.projector(null)).toBe(false);
-
-      expect(selectHasEnterpriseBranding.projector(ProductType.Enterprise)).toBe(true);
-      expect(selectHasEnterpriseBranding.projector(ProductType.CommunityEdition)).toBe(false);
-      expect(selectHasEnterpriseBranding.projector(null)).toBe(false);
     });
   });
 

--- a/src/app/store/system-info/system-info.selectors.ts
+++ b/src/app/store/system-info/system-info.selectors.ts
@@ -38,25 +38,47 @@ export const selectLicense = createSelector(
   (systemInfo) => systemInfo?.license ?? null,
 );
 
+export const selectLicenseLoadFailed = createSelector(
+  selectSystemInfoState,
+  (state) => state.licenseLoadFailed,
+);
+
 /**
  * Product type used for UI branding (logo, copyright line, nav badge).
  * An Enterprise product type without a license (e.g. unlicensed R-series
  * hardware) is branded as Community Edition.
+ *
+ * Returns null while an Enterprise system's license is still unknown, so the
+ * UI never flashes the wrong edition, and falls back to the raw product type
+ * when the license fetch failed rather than silently downgrading a licensed
+ * appliance.
  */
 export const selectBrandedProductType = createSelector(
   selectProductType,
-  selectLicense,
-  (productType, license) => {
-    if (productType === ProductType.Enterprise && license === null) {
-      return ProductType.CommunityEdition;
+  selectSystemInfo,
+  selectLicenseLoadFailed,
+  (productType, systemInfo, licenseLoadFailed) => {
+    if (productType !== ProductType.Enterprise) {
+      return productType;
     }
-    return productType;
+    if (!systemInfo) {
+      return null;
+    }
+    if (licenseLoadFailed) {
+      return productType;
+    }
+    return systemInfo.license === null ? ProductType.CommunityEdition : productType;
   },
 );
 
 export const selectHasCommunityBranding = createSelector(
   selectBrandedProductType,
   (productType) => productType === ProductType.CommunityEdition,
+);
+
+export const selectHasEnterpriseBranding = createSelector(
+  selectBrandedProductType,
+  (productType) => productType === ProductType.Enterprise,
 );
 
 export const selectCopyrightHtml = createSelector(

--- a/src/app/store/system-info/system-info.selectors.ts
+++ b/src/app/store/system-info/system-info.selectors.ts
@@ -43,4 +43,15 @@ export const selectLicense = createSelector(
   (systemInfo) => systemInfo?.license ?? null,
 );
 
+/**
+ * An Enterprise product type without a license (e.g. unlicensed R-series
+ * hardware) is branded as Community Edition in the UI.
+ */
+export const selectHasCommunityBranding = createSelector(
+  selectProductType,
+  selectLicense,
+  (productType, license) => productType === ProductType.CommunityEdition
+    || (productType === ProductType.Enterprise && license === null),
+);
+
 export const waitForSystemInfo = selectNotNull(selectSystemInfo);

--- a/src/app/store/system-info/system-info.selectors.ts
+++ b/src/app/store/system-info/system-info.selectors.ts
@@ -33,25 +33,35 @@ export const selectIsEnterprise = createSelector(
   (productType) => productType === ProductType.Enterprise,
 );
 
-export const selectCopyrightHtml = createSelector(
-  selectProductType,
-  (productType) => getCopyrightHtml(productType || undefined),
-);
-
 export const selectLicense = createSelector(
   selectSystemInfo,
   (systemInfo) => systemInfo?.license ?? null,
 );
 
 /**
+ * Product type used for UI branding (logo, copyright line, nav badge).
  * An Enterprise product type without a license (e.g. unlicensed R-series
- * hardware) is branded as Community Edition in the UI.
+ * hardware) is branded as Community Edition.
  */
-export const selectHasCommunityBranding = createSelector(
+export const selectBrandedProductType = createSelector(
   selectProductType,
   selectLicense,
-  (productType, license) => productType === ProductType.CommunityEdition
-    || (productType === ProductType.Enterprise && license === null),
+  (productType, license) => {
+    if (productType === ProductType.Enterprise && license === null) {
+      return ProductType.CommunityEdition;
+    }
+    return productType;
+  },
+);
+
+export const selectHasCommunityBranding = createSelector(
+  selectBrandedProductType,
+  (productType) => productType === ProductType.CommunityEdition,
+);
+
+export const selectCopyrightHtml = createSelector(
+  selectBrandedProductType,
+  (productType) => getCopyrightHtml(productType || undefined),
 );
 
 export const waitForSystemInfo = selectNotNull(selectSystemInfo);

--- a/src/app/store/system-info/system-info.selectors.ts
+++ b/src/app/store/system-info/system-info.selectors.ts
@@ -48,10 +48,11 @@ export const selectLicenseLoadFailed = createSelector(
  * An Enterprise product type without a license (e.g. unlicensed R-series
  * hardware) is branded as Community Edition.
  *
- * Returns null while an Enterprise system's license is still unknown, so the
- * UI never flashes the wrong edition, and falls back to the raw product type
- * when the license fetch failed rather than silently downgrading a licensed
- * appliance.
+ * Three-state on purpose: returns null while an Enterprise system's license is
+ * still unknown (system info not loaded yet), so consumers must render a
+ * neutral state rather than assume Community. Falls back to the raw product
+ * type when the license fetch failed rather than silently downgrading a
+ * licensed appliance.
  */
 export const selectBrandedProductType = createSelector(
   selectProductType,
@@ -74,11 +75,6 @@ export const selectBrandedProductType = createSelector(
 export const selectHasCommunityBranding = createSelector(
   selectBrandedProductType,
   (productType) => productType === ProductType.CommunityEdition,
-);
-
-export const selectHasEnterpriseBranding = createSelector(
-  selectBrandedProductType,
-  (productType) => productType === ProductType.Enterprise,
 );
 
 export const selectCopyrightHtml = createSelector(


### PR DESCRIPTION
**Changes:**

An Enterprise product type without a license (e.g. an unlicensed R-series upgraded to 26.0.0-RC.1) was branded as Enterprise in the UI. Branding now follows a single derived, three-state product type:

- New `selectBrandedProductType` selector: `COMMUNITY_EDITION` resolves immediately; `ENTERPRISE` returns `null` until `system.info` + `truenas.license.info` have loaded, then becomes Community Edition when the license is `null` and stays Enterprise otherwise. A failed `truenas.license.info` fetch is recorded as `licenseLoadFailed` in the store so branding falls back to the raw product type instead of downgrading a licensed appliance.
- Consumers of the branded type: nav menu badge and copyright line (`admin-layout`, `copyright-line`), the dashboard System Information widgets' `Edition` row and enterprise marketing row, and the `truenas-logo` full-size variant. Each renders a neutral state while the edition is unknown (empty badge, edition-less copyright, skeleton loader) rather than guessing.
- `selectIsEnterprise` is unchanged; its consumers are behavioural (EULA gating, update page, product image hardware check, reboot dialog), not branding.

Note: the edition-specific full-size logo is not reachable in the running app today (nothing passes `fullSize` to `ix-truenas-logo` since NAS-135344); the logo change is covered by spec only and there is no visible logo difference to QA.

**Testing:**

Verified in the running app with the websocket debug panel mocks for `system.product_type` × `truenas.license.info`:

| Product type | License | Badge | Copyright | Dashboard Edition row |
|---|---|---|---|---|
| Community | null | Community Edition (link) | TrueNAS® Community Edition | Community + marketing row |
| Enterprise | present | Enterprise | TrueNAS® Enterprise | Enterprise |
| Enterprise | null | Community Edition (link) | TrueNAS® Community Edition | Community + marketing row |
| Community | present | Community Edition (link) | TrueNAS® Community Edition | Community + marketing row |
| Enterprise | fetch error | Enterprise | TrueNAS® Enterprise | Enterprise |
| Enterprise | not loaded yet | (empty) | TrueNAS® (no edition) | skeleton |

New/updated specs: `system-info.selectors.spec.ts`, `system-info.effects.spec.ts`, `copyright-line.component.spec.ts`, `truenas-logo.component.spec.ts`, `widget-sys-info-{active,passive}.component.spec.ts`.

### Downstream

|Affects         |Reasoning
|----------------|-------------------------------
|Documentation   |No
|Testing         |Unlicensed Enterprise hardware should be labelled Community Edition in the nav badge, copyright line and dashboard Edition row